### PR TITLE
Fix Breadcrumb Rendering

### DIFF
--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -19,22 +19,29 @@ export function SiteHeader() {
 
   const breadcrumbSegments = segments.slice(1);
 
-  const breadcrumbs = breadcrumbSegments.map((segment, index) => {
+  const breadcrumbs = breadcrumbSegments.flatMap((segment, index) => {
     const href = `/${segments.slice(0, index + 2).join("/")}`;
+    const isLast = index === breadcrumbSegments.length - 1;
 
-    return (
+    const item = (
       <BreadcrumbItem className="hover:underline" key={`${id}-${index}`}>
         <Link href={href}>
           {segment.charAt(0).toUpperCase() +
             segment.slice(1).replace(/-/g, " ")}
         </Link>
-        {index < breadcrumbSegments.length - 1 && (
-          <BreadcrumbSeparator key={`${id}-separator-${index}`}>
-            <HugeiconsIcon icon={ArrowRight01Icon} />
-          </BreadcrumbSeparator>
-        )}
       </BreadcrumbItem>
     );
+
+    if (isLast) {
+      return [item];
+    }
+
+    return [
+      item,
+      <BreadcrumbSeparator key={`${id}-separator-${index}`}>
+        <HugeiconsIcon icon={ArrowRight01Icon} />
+      </BreadcrumbSeparator>,
+    ];
   });
 
   return (


### PR DESCRIPTION
## Summary
Refactored breadcrumb rendering to resolve potential nested `<li>` hydration issues by using `flatMap()` instead of `map()`. 

Key changes:
- Replaced `map()` with `flatMap()` to prevent nested list item rendering
- Separated breadcrumb item and separator creation logic
- Ensured each breadcrumb segment is rendered correctly without nested `<li>` elements 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/bdf4136f-5828-4ac9-afd1-a4458195debd)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)