### PR TITLE
Update Dialog Components

### DIFF
--- a/src/components/dashboard/create-org-modal.tsx
+++ b/src/components/dashboard/create-org-modal.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -222,14 +223,12 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
           </div>
 
           <DialogFooter>
-            <Button
+            <DialogClose
               disabled={isCreating}
-              onClick={() => onOpenChange(false)}
-              type="button"
-              variant="outline"
+              render={<Button variant="outline" />}
             >
               Cancel
-            </Button>
+            </DialogClose>
             <Button disabled={isCreating} type="submit">
               {isCreating ? "Creating..." : "Create Organization"}
             </Button>

--- a/src/components/integrations/add-integration-dialog.tsx
+++ b/src/components/integrations/add-integration-dialog.tsx
@@ -8,10 +8,10 @@ import { isValidElement, useState } from "react";
 import { toast } from "sonner";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
-  DialogAction,
-  DialogCancel,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -247,10 +247,15 @@ export function AddIntegrationDialog({
               </form.Field>
             </div>
             <DialogFooter>
-              <DialogCancel disabled={mutation.isPending}>Cancel</DialogCancel>
+              <DialogClose
+                disabled={mutation.isPending}
+                render={<Button variant="outline" />}
+              >
+                Cancel
+              </DialogClose>
               <form.Subscribe selector={(state) => [state.canSubmit]}>
                 {([canSubmit]) => (
-                  <DialogAction
+                  <Button
                     disabled={!canSubmit || mutation.isPending}
                     onClick={(e) => {
                       e.preventDefault();
@@ -259,7 +264,7 @@ export function AddIntegrationDialog({
                     type="button"
                   >
                     {mutation.isPending ? "Adding..." : "Add Integration"}
-                  </DialogAction>
+                  </Button>
                 )}
               </form.Subscribe>
             </DialogFooter>

--- a/src/components/integrations/add-repository-dialog.tsx
+++ b/src/components/integrations/add-repository-dialog.tsx
@@ -9,8 +9,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
-  DialogAction,
-  DialogCancel,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -232,11 +231,13 @@ export function AddRepositoryDialog({
       {trigger !== undefined && isValidElement(trigger) ? (
         <DialogTrigger render={trigger as React.ReactElement} />
       ) : (
-        <DialogTrigger>
-          <Button size="sm" variant="outline">
-            Add Repository
-          </Button>
-        </DialogTrigger>
+        <DialogTrigger
+          render={
+            <Button size="sm" variant="outline">
+              Add Repository
+            </Button>
+          }
+        />
       )}
       <DialogContent>
         <DialogHeader>
@@ -311,10 +312,15 @@ export function AddRepositoryDialog({
             </form.Field>
           </div>
           <DialogFooter>
-            <DialogCancel disabled={mutation.isPending}>Cancel</DialogCancel>
+            <DialogClose
+              disabled={mutation.isPending}
+              render={<Button variant="outline" />}
+            >
+              Cancel
+            </DialogClose>
             <form.Subscribe selector={(state) => [state.canSubmit]}>
               {([canSubmit]) => (
-                <DialogAction
+                <Button
                   disabled={!canSubmit || mutation.isPending || loadingRepos}
                   onClick={(e) => {
                     e.preventDefault();
@@ -323,7 +329,7 @@ export function AddRepositoryDialog({
                   type="button"
                 >
                   {mutation.isPending ? "Adding..." : "Add Repository"}
-                </DialogAction>
+                </Button>
               )}
             </form.Subscribe>
           </DialogFooter>

--- a/src/components/integrations/edit-integration-dialog.tsx
+++ b/src/components/integrations/edit-integration-dialog.tsx
@@ -5,10 +5,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
 import { isValidElement, useState } from "react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
-  DialogAction,
-  DialogCancel,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -165,10 +165,15 @@ export function EditIntegrationDialog({
               </form.Field>
             </div>
             <DialogFooter>
-              <DialogCancel disabled={mutation.isPending}>Cancel</DialogCancel>
+              <DialogClose
+                disabled={mutation.isPending}
+                render={<Button variant="outline" />}
+              >
+                Cancel
+              </DialogClose>
               <form.Subscribe selector={(state) => [state.canSubmit]}>
                 {([canSubmit]) => (
-                  <DialogAction
+                  <Button
                     disabled={!canSubmit || mutation.isPending}
                     onClick={(e) => {
                       e.preventDefault();
@@ -177,7 +182,7 @@ export function EditIntegrationDialog({
                     type="button"
                   >
                     {mutation.isPending ? "Saving..." : "Save Changes"}
-                  </DialogAction>
+                  </Button>
                 )}
               </form.Subscribe>
             </DialogFooter>


### PR DESCRIPTION
## Summary
Updated multiple dialog components to use new dialog syntax:
- Replaced `DialogCancel` and `DialogAction` with `DialogClose`
- Updated dialog trigger to use `render` prop
- Migrated dialog footer buttons to use new component structure
- Ensured compatibility with updated dialog component API

### Changes
- `create-org-modal.tsx`: Replaced cancel button with `DialogClose`
- `add-integration-dialog.tsx`: Updated dialog actions and close button
- `add-repository-dialog.tsx`: Refactored dialog triggers and actions
- `edit-integration-dialog.tsx`: Migrated dialog footer buttons

### Notes
- No changes were made to the core `dialog.tsx` component
- Maintained existing functionality while updating syntax 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/213ebd66-829b-4de3-80b3-71efd5dc811f)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)