### PR TITLE
fix: improve auth pages UX

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -20,7 +20,7 @@ export default async function AuthLayout({
     }
   }
   return (
-    <div className="flex h-screen w-full lg:grid lg:grid-cols-2">
+    <div className="flex h-screen w-full justify-center lg:grid lg:grid-cols-2">
       <div className="relative hidden lg:flex">
         <div className="absolute inset-0 flex items-center justify-center p-8">
           <div className="corner-squircle relative h-full w-full overflow-hidden rounded-xl supports-[corner-shape:squircle]:rounded-2xl">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -56,6 +56,9 @@ export default function Login() {
     });
 
     if (result.error) {
+      toast.error(
+        result.error.message ?? "Failed to sign in. Please try again."
+      );
       setIsAuthLoading(false);
       return;
     }


### PR DESCRIPTION
## Summary
- Center login/signup forms on medium screen sizes when the left image is hidden
- Replace inline validation errors with toast notifications on signup page (removes extra reserved space for error messages)
- Add toast error feedback for failed email login attempts

## Test plan
- [ ] Test login page centering on medium screen sizes (resize browser or use dev tools)
- [ ] Test signup form validation shows toast errors
- [ ] Test login form shows toast on invalid credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)