### PR TITLE
Fix Brand Analysis Stepper Visibility

### DIFF
--- a/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -578,8 +578,8 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
   const { data, isLoading: isLoadingSettings } =
     useBrandSettings(organizationId);
-  const { progress } = useBrandAnalysisProgress(organizationId);
-  const analyzeMutation = useAnalyzeBrand(organizationId);
+  const { progress, startPolling } = useBrandAnalysisProgress(organizationId);
+  const analyzeMutation = useAnalyzeBrand(organizationId, startPolling);
 
   const [url, setUrl] = useState("");
   const effectiveUrl = url.trim() || organization?.websiteUrl || "";


### PR DESCRIPTION
## Summary
Resolved issue with brand analysis stepper not immediately showing after analysis starts. Implemented a force polling mechanism to ensure the stepper view is displayed correctly on first analysis.

Key changes:
- Added `forcePollUntilMs` ref to maintain non-idle state temporarily
- Modified `useBrandAnalysisProgress` hook to handle initial analysis state
- Updated `useAnalyzeBrand` to pass `startPolling` method explicitly
- Ensured stepper is visible immediately after analysis begins

### Technical Details
- Introduced a 15-second force polling window to maintain non-idle state
- Prevents UI from reverting to idle state immediately after analysis starts
- Fixes the bug where users had to click twice to see the stepper view 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=6)](https://app.tembo.io/tasks/4e00c959-bb0e-4649-ae9e-02c17098c6f4)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/opencode:gpt-5.2?v=1)](https://app.tembo.io/settings/agents)