### PR TITLE
fix: ensure db schedule only created after QStash success

### DIFF
--- a/apps/dashboard/src/app/api/organizations/[organizationId]/automation/schedules/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/automation/schedules/route.ts
@@ -275,7 +275,11 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
       ),
     });
 
-    const oldQstashScheduleId = existing?.qstashScheduleId ?? null;
+    if (!existing) {
+      return NextResponse.json({ error: "Schedule not found" }, { status: 404 });
+    }
+
+    const oldQstashScheduleId = existing.qstashScheduleId ?? null;
     let newQstashScheduleId: string | null = null;
 
     if (sourceConfig.cron) {

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/triggers/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/triggers/route.ts
@@ -260,7 +260,11 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
       ),
     });
 
-    const oldQstashScheduleId = existing?.qstashScheduleId ?? null;
+    if (!existing) {
+      return NextResponse.json({ error: "Trigger not found" }, { status: 404 });
+    }
+
+    const oldQstashScheduleId = existing.qstashScheduleId ?? null;
     let newQstashScheduleId: string | null = null;
 
     if (sourceType === "cron" && sourceConfig.cron) {


### PR DESCRIPTION

---
## EntelligenceAI PR Summary 
 Enhanced error handling and type safety in automation schedules and triggers PATCH endpoints with null-check validation.
- Added guard clauses to validate schedule and trigger existence before update operations
- Return 404 error responses with appropriate error messages when resources are not found
- Improved TypeScript type narrowing to eliminate optional chaining when accessing `qstashScheduleId`
- Applied consistent validation pattern across both endpoints 

