### PR TITLE
chore: replace loading icons with Lucide Loader2Icon

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -31,7 +31,7 @@ import {
 import { Textarea } from "@notra/ui/components/ui/textarea";
 import { useForm } from "@tanstack/react-form";
 import { useAsyncDebouncedCallback } from "@tanstack/react-pacer";
-import { Check, LoaderCircle, Minus } from "lucide-react";
+import { Check, Loader2Icon, Minus } from "lucide-react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
@@ -130,7 +130,7 @@ type StepIconState = "pending" | "active" | "completed";
 
 const STEP_ICONS: Record<StepIconState, () => React.ReactNode> = {
 	completed: () => <Check className="size-4" strokeWidth={3} />,
-	active: () => <LoaderCircle className="size-4 animate-spin" />,
+	active: () => <Loader2Icon className="size-4 animate-spin" />,
 	pending: () => (
 		<Minus className="size-4 text-muted-foreground" strokeWidth={2} />
 	),
@@ -161,7 +161,7 @@ function ModalContent({
 	if (isPendingSettings) {
 		return (
 			<div className="flex justify-center py-4">
-				<LoaderCircle className="size-8 animate-spin text-primary" />
+				<Loader2Icon className="size-8 animate-spin text-primary" />
 			</div>
 		);
 	}
@@ -232,7 +232,7 @@ function ModalContent({
 				>
 					{isPending ? (
 						<>
-							<LoaderCircle className="size-4 animate-spin" />
+							<Loader2Icon className="size-4 animate-spin" />
 							<span>Analyzing</span>
 						</>
 					) : (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/account/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/account/page.tsx
@@ -19,7 +19,7 @@ import { Github } from "@notra/ui/components/ui/svgs/github";
 import { Google } from "@notra/ui/components/ui/svgs/google";
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
-import { LoaderCircle } from "lucide-react";
+import { Loader2Icon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -214,7 +214,7 @@ function ProfileSection({ user }: ProfileSectionProps) {
 									/>
 									<Button disabled={isUpdating} size="default" type="submit">
 										{isUpdating ? (
-											<LoaderCircle className="size-4 animate-spin" />
+											<Loader2Icon className="size-4 animate-spin" />
 										) : (
 											"Save"
 										)}
@@ -411,7 +411,7 @@ function LoginDetailsSection({
 							>
 								{isChangingPassword ? (
 									<>
-										<LoaderCircle className="size-4 animate-spin" />
+										<Loader2Icon className="size-4 animate-spin" />
 										Changing...
 									</>
 								) : (
@@ -528,7 +528,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "google" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									<>
 										<HugeiconsIcon icon={Cancel01Icon} size={16} />
@@ -544,7 +544,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "google" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									"Connect"
 								)}
@@ -574,7 +574,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "github" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									<>
 										<HugeiconsIcon icon={Cancel01Icon} size={16} />
@@ -590,7 +590,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "github" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									"Connect"
 								)}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/general/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/general/page.tsx
@@ -6,7 +6,7 @@ import { Label } from "@notra/ui/components/ui/label";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { useForm } from "@tanstack/react-form";
 import { useQueryClient } from "@tanstack/react-query";
-import { LoaderCircle } from "lucide-react";
+import { Loader2Icon } from "lucide-react";
 import { use, useState } from "react";
 import { toast } from "sonner";
 import { PageContainer } from "@/components/layout/container";
@@ -132,7 +132,7 @@ export default function GeneralSettingsPage({ params }: PageProps) {
 						<Button disabled={isUpdating} type="submit">
 							{isUpdating ? (
 								<>
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 									Saving...
 								</>
 							) : (

--- a/apps/dashboard/src/app/(dashboard)/account/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/account/page-client.tsx
@@ -19,7 +19,7 @@ import { Github } from "@notra/ui/components/ui/svgs/github";
 import { Google } from "@notra/ui/components/ui/svgs/google";
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
-import { LoaderCircle } from "lucide-react";
+import { Loader2Icon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -216,7 +216,7 @@ function ProfileSection({ user }: ProfileSectionProps) {
 									/>
 									<Button disabled={isUpdating} size="default" type="submit">
 										{isUpdating ? (
-											<LoaderCircle className="size-4 animate-spin" />
+											<Loader2Icon className="size-4 animate-spin" />
 										) : (
 											"Save"
 										)}
@@ -413,7 +413,7 @@ function LoginDetailsSection({
 							>
 								{isChangingPassword ? (
 									<>
-										<LoaderCircle className="size-4 animate-spin" />
+										<Loader2Icon className="size-4 animate-spin" />
 										Changing...
 									</>
 								) : (
@@ -530,7 +530,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "google" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									<>
 										<HugeiconsIcon icon={Cancel01Icon} size={16} />
@@ -546,7 +546,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "google" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									"Connect"
 								)}
@@ -576,7 +576,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "github" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									<>
 										<HugeiconsIcon icon={Cancel01Icon} size={16} />
@@ -592,7 +592,7 @@ function ConnectedAccountsSection({
 								variant="outline"
 							>
 								{loadingProvider === "github" ? (
-									<LoaderCircle className="size-4 animate-spin" />
+									<Loader2Icon className="size-4 animate-spin" />
 								) : (
 									"Connect"
 								)}

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -6,6 +6,7 @@ import {
   TextSelectionIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { Loader2Icon } from "lucide-react";
 import { Alert, AlertDescription } from "@notra/ui/components/ui/alert";
 import { Button } from "@notra/ui/components/ui/button";
 import {
@@ -268,27 +269,7 @@ const ChatInput = ({
           )}
           {isLoading && statusText && (
             <div className="flex items-start gap-2 px-3.5 pt-2 pb-1">
-              <svg
-                className="size-4 shrink-0 mt-0.5 animate-spin text-muted-foreground"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
+              <Loader2Icon className="size-4 shrink-0 mt-0.5 animate-spin text-muted-foreground" />
               <p className="text-sm text-muted-foreground leading-5">
                 {statusText}
               </p>
@@ -576,28 +557,7 @@ const ChatInput = ({
               >
                 <div className="flex items-center gap-1 text-sm text-foreground">
                   {isLoading ? (
-                    <svg
-                      className="size-4 animate-spin"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <title>Loading</title>
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      />
-                    </svg>
+                    <Loader2Icon className="size-4 animate-spin" />
                   ) : (
                     <>
                       <div className="text-sm px-0.5 leading-0 transition-transform">

--- a/apps/dashboard/src/components/settings/delete-account.tsx
+++ b/apps/dashboard/src/components/settings/delete-account.tsx
@@ -12,7 +12,7 @@ import {
 	AlertDialogTrigger,
 } from "@notra/ui/components/ui/alert-dialog";
 import { Button } from "@notra/ui/components/ui/button";
-import { LoaderCircle } from "lucide-react";
+import { Loader2Icon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -77,7 +77,7 @@ export function DeleteAccountSection() {
 								>
 									{isDeleting ? (
 										<>
-											<LoaderCircle className="size-4 animate-spin" />
+											<Loader2Icon className="size-4 animate-spin" />
 											Deleting...
 										</>
 									) : (

--- a/packages/ui/src/components/ai-elements/loader.tsx
+++ b/packages/ui/src/components/ai-elements/loader.tsx
@@ -1,83 +1,6 @@
 import type { HTMLAttributes } from "react";
+import { Loader2Icon } from "lucide-react";
 import { cn } from "@notra/ui/lib/utils";
-
-interface LoaderIconProps {
-  size?: number;
-}
-
-const LoaderIcon = ({ size = 16 }: LoaderIconProps) => (
-  <svg
-    height={size}
-    strokeLinejoin="round"
-    style={{ color: "currentcolor" }}
-    viewBox="0 0 16 16"
-    width={size}
-  >
-    <title>Loader</title>
-    <g clipPath="url(#clip0_2393_1490)">
-      <path d="M8 0V4" stroke="currentColor" strokeWidth="1.5" />
-      <path
-        d="M8 16V12"
-        opacity="0.5"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M3.29773 1.52783L5.64887 4.7639"
-        opacity="0.9"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M12.7023 1.52783L10.3511 4.7639"
-        opacity="0.1"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M12.7023 14.472L10.3511 11.236"
-        opacity="0.4"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M3.29773 14.472L5.64887 11.236"
-        opacity="0.6"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M15.6085 5.52783L11.8043 6.7639"
-        opacity="0.2"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M0.391602 10.472L4.19583 9.23598"
-        opacity="0.7"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M15.6085 10.4722L11.8043 9.2361"
-        opacity="0.3"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M0.391602 5.52783L4.19583 6.7639"
-        opacity="0.8"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-    </g>
-    <defs>
-      <clipPath id="clip0_2393_1490">
-        <rect fill="white" height="16" width="16" />
-      </clipPath>
-    </defs>
-  </svg>
-);
 
 export type LoaderProps = HTMLAttributes<HTMLDivElement> & {
   size?: number;
@@ -85,12 +8,9 @@ export type LoaderProps = HTMLAttributes<HTMLDivElement> & {
 
 export const Loader = ({ className, size = 16, ...props }: LoaderProps) => (
   <div
-    className={cn(
-      "inline-flex animate-spin items-center justify-center",
-      className
-    )}
+    className={cn("inline-flex items-center justify-center", className)}
     {...props}
   >
-    <LoaderIcon size={size} />
+    <Loader2Icon className="animate-spin" size={size} />
   </div>
 );

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -6,7 +6,6 @@ import {
   AttachmentIcon,
   Cancel01Icon,
   Image01Icon,
-  Loading01Icon,
   Mic01Icon,
   Square01Icon,
 } from "@hugeicons/core-free-icons";
@@ -46,6 +45,7 @@ import {
   SelectValue,
 } from "@notra/ui/components/ui/select";
 import type { ChatStatus, FileUIPart } from "ai";
+import { Loader2Icon } from "lucide-react";
 import { nanoid } from "nanoid";
 import Image from "next/image";
 import {
@@ -1028,6 +1028,13 @@ export type PromptInputSubmitProps = ComponentProps<typeof InputGroupButton> & {
   status?: ChatStatus;
 };
 
+const STATUS_ICONS: Record<ChatStatus, ReactNode> = {
+  submitted: <Loader2Icon className="size-4 animate-spin" />,
+  streaming: <HugeiconsIcon className="size-4" icon={Square01Icon} />,
+  error: <HugeiconsIcon className="size-4" icon={Cancel01Icon} />,
+  ready: <HugeiconsIcon className="size-4" icon={ArrowDownLeftIcon} />,
+};
+
 export const PromptInputSubmit = ({
   className,
   variant = "default",
@@ -1036,17 +1043,7 @@ export const PromptInputSubmit = ({
   children,
   ...props
 }: PromptInputSubmitProps) => {
-  let Icon = <HugeiconsIcon className="size-4" icon={ArrowDownLeftIcon} />;
-
-  if (status === "submitted") {
-    Icon = (
-      <HugeiconsIcon className="size-4 animate-spin" icon={Loading01Icon} />
-    );
-  } else if (status === "streaming") {
-    Icon = <HugeiconsIcon className="size-4" icon={Square01Icon} />;
-  } else if (status === "error") {
-    Icon = <HugeiconsIcon className="size-4" icon={Cancel01Icon} />;
-  }
+  const Icon = STATUS_ICONS[status ?? "ready"];
 
   return (
     <InputGroupButton

--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -4,10 +4,10 @@ import {
   Alert02Icon,
   CheckmarkCircle02Icon,
   InformationCircleIcon,
-  Loading03Icon,
   MultiplicationSignCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { Loader2Icon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
@@ -46,13 +46,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             strokeWidth={2}
           />
         ),
-        loading: (
-          <HugeiconsIcon
-            className="size-4 animate-spin"
-            icon={Loading03Icon}
-            strokeWidth={2}
-          />
-        ),
+        loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       style={
         {


### PR DESCRIPTION
## Summary

- Replace all loading/spinner icons with Lucide's `Loader2Icon` for consistency
- Remove Hugeicons `Loading01Icon` and `Loading03Icon` usage
- Replace `LoaderCircle` with `Loader2Icon` across dashboard
- Replace inline SVG spinners with `Loader2Icon`
- Simplify custom `Loader` component in UI package to use `Loader2Icon`
- Use a status map for `PromptInputSubmit` icon states instead of if/else chain

## Test plan

- [ ] Verify loading spinners appear correctly in chat input
- [ ] Verify loading spinners in toast notifications
- [ ] Verify loading spinners in settings pages (account, general)
- [ ] Verify loading spinners in brand identity page
- [ ] Verify loading spinners in delete account dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## EntelligenceAI PR Summary 
 Standardized loading spinner icons across the application by migrating to `Loader2Icon` from lucide-react.
- Replaced deprecated `LoaderCircle` with `Loader2Icon` in 5 dashboard files affecting profile updates, password changes, account connections, brand identity, and settings pages
- Eliminated custom SVG implementations in chat-input and loader components, reducing code by 120+ lines
- Migrated from HugeIcons (`Loading01Icon`, `Loading03Icon`) to `Loader2Icon` in prompt-input and sonner components
- Improved code maintainability in prompt-input by replacing conditional logic with STATUS_ICONS lookup table
- All changes maintain identical visual functionality and animate-spin behavior 

