### PR TITLE
feat: replace pg with @neondatabase/serverless driver

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -60,7 +60,6 @@
     "next": "^16.1.6",
     "next-themes": "^0.4.6",
     "nuqs": "^2.8.6",
-    "pg": "^8.16.3",
     "postprocessing": "^6.36.0",
     "react": "^19.2.4",
     "react-diff-viewer-continued": "^3.4.0",

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,6 @@
         "next": "^16.1.6",
         "next-themes": "^0.4.6",
         "nuqs": "^2.8.6",
-        "pg": "^8.16.3",
         "postprocessing": "^6.36.0",
         "react": "^19.2.4",
         "react-diff-viewer-continued": "^3.4.0",
@@ -115,6 +114,7 @@
       "name": "@notra/db",
       "version": "0.0.1",
       "dependencies": {
+        "@neondatabase/serverless": "^1.0.0",
         "drizzle-orm": "^0.45.1",
         "nanoid": "^5.1.6",
       },
@@ -594,6 +594,8 @@
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.40.0", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ=="],
 
+    "@neondatabase/serverless": ["@neondatabase/serverless@1.0.2", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw=="],
+
     "@next/env": ["@next/env@16.1.6", "", {}, "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw=="],
@@ -1031,6 +1033,8 @@
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
+
+    "@types/pg": ["@types/pg@8.16.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ=="],
 
     "@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,6 +10,7 @@
     "./schema": "./src/schema.ts"
   },
   "dependencies": {
+    "@neondatabase/serverless": "^1.0.0",
     "drizzle-orm": "^0.45.1",
     "nanoid": "^5.1.6"
   },

--- a/packages/db/scripts/seed-automation.ts
+++ b/packages/db/scripts/seed-automation.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
+import { neon } from "@neondatabase/serverless";
 import { eq } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/node-postgres";
+import { drizzle } from "drizzle-orm/neon-http";
 import { nanoid } from "nanoid";
 // biome-ignore lint/performance/noNamespaceImport: Required for drizzle schema
 import * as schema from "../src/schema";
@@ -12,7 +13,8 @@ if (!databaseUrl) {
   process.exit(1);
 }
 
-const db = drizzle(databaseUrl, { schema });
+const sql = neon(databaseUrl);
+const db = drizzle({ client: sql, schema });
 
 async function seed() {
   console.log("Starting automation seed...");

--- a/packages/db/scripts/seed-automation.ts
+++ b/packages/db/scripts/seed-automation.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
-import { neon } from "@neondatabase/serverless";
+import { Pool } from "@neondatabase/serverless";
 import { eq } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle } from "drizzle-orm/neon-serverless";
 import { nanoid } from "nanoid";
 // biome-ignore lint/performance/noNamespaceImport: Required for drizzle schema
 import * as schema from "../src/schema";
@@ -13,8 +13,8 @@ if (!databaseUrl) {
   process.exit(1);
 }
 
-const sql = neon(databaseUrl);
-const db = drizzle({ client: sql, schema });
+const pool = new Pool({ connectionString: databaseUrl });
+const db = drizzle({ client: pool, schema });
 
 async function seed() {
   console.log("Starting automation seed...");

--- a/packages/db/scripts/seed-posts.ts
+++ b/packages/db/scripts/seed-posts.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
-import { neon } from "@neondatabase/serverless";
+import { Pool } from "@neondatabase/serverless";
 import { eq } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle } from "drizzle-orm/neon-serverless";
 import { nanoid } from "nanoid";
 // biome-ignore lint/performance/noNamespaceImport: Required for drizzle schema
 import * as schema from "../src/schema";
@@ -13,8 +13,8 @@ if (!databaseUrl) {
   process.exit(1);
 }
 
-const sql = neon(databaseUrl);
-const db = drizzle({ client: sql, schema });
+const pool = new Pool({ connectionString: databaseUrl });
+const db = drizzle({ client: pool, schema });
 
 interface SeedPost {
   title: string;

--- a/packages/db/scripts/seed-posts.ts
+++ b/packages/db/scripts/seed-posts.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
+import { neon } from "@neondatabase/serverless";
 import { eq } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/node-postgres";
+import { drizzle } from "drizzle-orm/neon-http";
 import { nanoid } from "nanoid";
 // biome-ignore lint/performance/noNamespaceImport: Required for drizzle schema
 import * as schema from "../src/schema";
@@ -12,7 +13,8 @@ if (!databaseUrl) {
   process.exit(1);
 }
 
-const db = drizzle(databaseUrl, { schema });
+const sql = neon(databaseUrl);
+const db = drizzle({ client: sql, schema });
 
 interface SeedPost {
   title: string;

--- a/packages/db/src/drizzle.ts
+++ b/packages/db/src/drizzle.ts
@@ -1,5 +1,6 @@
+import { neon } from "@neondatabase/serverless";
 import { upstashCache } from "drizzle-orm/cache/upstash";
-import { drizzle } from "drizzle-orm/node-postgres";
+import { drizzle } from "drizzle-orm/neon-http";
 // biome-ignore lint/performance/noNamespaceImport: Required for drizzle-kit
 import * as schema from "./schema";
 
@@ -8,10 +9,15 @@ const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
   throw new Error("[ENV]: DATABASE_URL is not defined");
 }
+
 const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
 const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 
-export const db = drizzle(databaseUrl, {
+const sql = neon(databaseUrl);
+
+export const db = drizzle({
+  client: sql,
+  schema,
   cache:
     upstashUrl && upstashToken
       ? upstashCache({
@@ -20,5 +26,4 @@ export const db = drizzle(databaseUrl, {
           global: true,
         })
       : undefined,
-  schema,
 });

--- a/packages/db/src/drizzle.ts
+++ b/packages/db/src/drizzle.ts
@@ -1,6 +1,6 @@
-import { neon } from "@neondatabase/serverless";
+import { Pool } from "@neondatabase/serverless";
 import { upstashCache } from "drizzle-orm/cache/upstash";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle } from "drizzle-orm/neon-serverless";
 // biome-ignore lint/performance/noNamespaceImport: Required for drizzle-kit
 import * as schema from "./schema";
 
@@ -13,10 +13,10 @@ if (!databaseUrl) {
 const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
 const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 
-const sql = neon(databaseUrl);
+const pool = new Pool({ connectionString: databaseUrl });
 
 export const db = drizzle({
-  client: sql,
+  client: pool,
   schema,
   cache:
     upstashUrl && upstashToken


### PR DESCRIPTION
## Summary
- Replace `pg` package with `@neondatabase/serverless` HTTP driver
- Update Drizzle ORM to use `drizzle-orm/neon-http` instead of `drizzle-orm/node-postgres`
- Remove `pg` dependency from dashboard app

## Test plan
- [ ] Run `bun install`
- [ ] Run `bun run check-types` (db package passes)
- [ ] Run `bun run dev` and verify dashboard loads with DB operations working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## EntelligenceAI PR Summary 
 Migrates database connection from standard PostgreSQL client to Neon's serverless driver for edge runtime compatibility.
- Removed `pg` dependency from dashboard application package.json
- Added `@neondatabase/serverless` ^1.0.0 to database package dependencies
- Updated drizzle.ts to import and initialize neon SQL client
- Restructured Drizzle configuration to object-based format with explicit client and schema properties
- Upstash caching configuration preserved in new structure
- Lockfile updated with new driver and transitive dependencies 

