### PR TITLE
fix: restrict schedule output to changelog only

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/triggers/trigger-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/triggers/trigger-dialog.tsx
@@ -52,12 +52,16 @@ const EVENT_OPTIONS: Array<{ value: WebhookEventType; label: string }> = [
 	{ value: "star", label: "New star" },
 ];
 
-const OUTPUT_OPTIONS: Array<{ value: OutputContentType; label: string }> = [
+const OUTPUT_OPTIONS: Array<{
+	value: OutputContentType;
+	label: string;
+	disabled?: boolean;
+}> = [
 	{ value: "changelog", label: "Changelog" },
-	{ value: "blog_post", label: "Blog Post" },
-	{ value: "twitter_post", label: "Twitter Post" },
-	{ value: "linkedin_post", label: "LinkedIn Post" },
-	{ value: "investor_update", label: "Investor Update" },
+	{ value: "blog_post", label: "Blog Post", disabled: true },
+	{ value: "twitter_post", label: "Twitter Post", disabled: true },
+	{ value: "linkedin_post", label: "LinkedIn Post", disabled: true },
+	{ value: "investor_update", label: "Investor Update", disabled: true },
 ];
 
 interface TriggerFormValues {
@@ -469,8 +473,13 @@ export function AddTriggerDialog({
 											</SelectTrigger>
 											<SelectContent>
 												{OUTPUT_OPTIONS.map((option) => (
-													<SelectItem key={option.value} value={option.value}>
+													<SelectItem
+														key={option.value}
+														value={option.value}
+														disabled={option.disabled}
+													>
 														{option.label}
+														{option.disabled ? " (Coming soon)" : ""}
 													</SelectItem>
 												))}
 											</SelectContent>

--- a/apps/dashboard/src/utils/schemas/integrations.ts
+++ b/apps/dashboard/src/utils/schemas/integrations.ts
@@ -190,3 +190,21 @@ export const configureTriggerBodySchema = z.object({
   enabled: z.boolean(),
 });
 export type ConfigureTriggerBody = z.infer<typeof configureTriggerBodySchema>;
+
+export const SUPPORTED_SCHEDULE_OUTPUT_TYPES = ["changelog"] as const;
+export type ScheduleOutputType = (typeof SUPPORTED_SCHEDULE_OUTPUT_TYPES)[number];
+
+export const configureScheduleBodySchema = configureTriggerBodySchema.extend({
+  sourceType: z.literal("cron"),
+  sourceConfig: z.object({
+    cron: z.object({
+      frequency: z.enum(CRON_FREQUENCIES),
+      hour: z.number().min(0).max(23),
+      minute: z.number().min(0).max(59),
+      dayOfWeek: z.number().min(0).max(6).optional(),
+      dayOfMonth: z.number().min(1).max(31).optional(),
+    }),
+  }),
+  outputType: z.enum(SUPPORTED_SCHEDULE_OUTPUT_TYPES),
+});
+export type ConfigureScheduleBody = z.infer<typeof configureScheduleBodySchema>;


### PR DESCRIPTION
## Summary
- Disable non-changelog output options (Blog Post, Twitter Post, LinkedIn Post, Investor Update) in the Add Schedule drawer with "Coming soon" labels
- Add `configureScheduleBodySchema` Zod schema that enforces `sourceType: "cron"` and `outputType: "changelog"` on the backend
- Replace generic `configureTriggerBodySchema` with the stricter schedule-specific schema in the schedules API route, removing redundant manual checks

## Test plan
- [ ] Open the Add Schedule drawer and verify only Changelog is selectable
- [ ] Verify other output options show as disabled with "(Coming soon)"
- [ ] Confirm creating a schedule with outputType "changelog" works
- [ ] Confirm API rejects non-changelog outputType with a 400 validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## EntelligenceAI PR Summary 
 This PR restricts scheduled automation to changelog output type only and refactors schedule configuration with dedicated schema validation.
- Added `SUPPORTED_SCHEDULE_OUTPUT_TYPES` constant and `configureScheduleBodySchema` with cron-specific fields (frequency, hour, minute, day constraints) in integrations schema
- Disabled four output options in trigger dialog UI (Blog Post, Twitter Post, LinkedIn Post, Investor Update) with '(Coming soon)' labels
- Refactored schedule route handlers to use specific `configureScheduleBodySchema` and removed redundant validation checks
- Simplified Qstash schedule creation/update logic by streamlining cron expression handling and removing conditional schedule deletion 

