### PR TITLE
fix: prevent delete dialog clicks from navigating

### DIFF
--- a/apps/dashboard/src/components/integrations/integration-card.tsx
+++ b/apps/dashboard/src/components/integrations/integration-card.tsx
@@ -139,97 +139,100 @@ export function IntegrationCard({
   };
 
   return (
-    <Card
-      className="cursor-pointer transition-colors hover:bg-accent/50"
-      onClick={handleCardClick}
-    >
-      <CardHeader>
-        <CardTitle>{integration.displayName}</CardTitle>
-        <CardDescription>
-          {integration.createdByUser ? (
-            <>
-              Added by {integration.createdByUser.name} on{" "}
-              {new Date(integration.createdAt).toLocaleDateString()}
-            </>
-          ) : (
-            <>
-              Created on {new Date(integration.createdAt).toLocaleDateString()}
-            </>
-          )}
-        </CardDescription>
-        <CardAction>
-          {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: Event propagation barrier */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: Event propagation barrier */}
-          <div
-            className="flex items-center gap-2"
-            data-no-card-click
-            onClick={(event) => event.stopPropagation()}
-            onKeyDown={(event) => event.stopPropagation()}
-            role="presentation"
-            tabIndex={-1}
-          >
-            <Badge variant={integration.enabled ? "default" : "secondary"}>
-              {integration.enabled ? "Enabled" : "Disabled"}
-            </Badge>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button disabled={isLoading} size="icon-sm" variant="ghost">
-                    <svg
-                      aria-label="More options"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <title>More options</title>
-                      <circle cx="12" cy="12" r="1" />
-                      <circle cx="12" cy="5" r="1" />
-                      <circle cx="12" cy="19" r="1" />
-                    </svg>
-                  </Button>
-                }
-              />
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  className="cursor-pointer"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleToggle();
-                  }}
-                >
-                  {integration.enabled ? "Disable" : "Enable"}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className="cursor-pointer"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleDeleteClick();
-                  }}
-                  variant="destructive"
-                >
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+    <>
+      <Card
+        className="cursor-pointer transition-colors hover:bg-accent/50"
+        onClick={handleCardClick}
+      >
+        <CardHeader>
+          <CardTitle>{integration.displayName}</CardTitle>
+          <CardDescription>
+            {integration.createdByUser ? (
+              <>
+                Added by {integration.createdByUser.name} on{" "}
+                {new Date(integration.createdAt).toLocaleDateString()}
+              </>
+            ) : (
+              <>
+                Created on{" "}
+                {new Date(integration.createdAt).toLocaleDateString()}
+              </>
+            )}
+          </CardDescription>
+          <CardAction>
+            {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: Event propagation barrier */}
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: Event propagation barrier */}
+            <div
+              className="flex items-center gap-2"
+              data-no-card-click
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
+              role="presentation"
+              tabIndex={-1}
+            >
+              <Badge variant={integration.enabled ? "default" : "secondary"}>
+                {integration.enabled ? "Enabled" : "Disabled"}
+              </Badge>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button disabled={isLoading} size="icon-sm" variant="ghost">
+                      <svg
+                        aria-label="More options"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <title>More options</title>
+                        <circle cx="12" cy="12" r="1" />
+                        <circle cx="12" cy="5" r="1" />
+                        <circle cx="12" cy="19" r="1" />
+                      </svg>
+                    </Button>
+                  }
+                />
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleToggle();
+                    }}
+                  >
+                    {integration.enabled ? "Disable" : "Enable"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleDeleteClick();
+                    }}
+                    variant="destructive"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground text-sm">
+            {integration.repositories.length === 0 ? (
+              <p>No repositories configured</p>
+            ) : (
+              <p>
+                {integration.repositories.length} repository
+                {integration.repositories.length !== 1 ? "ies" : ""} configured
+              </p>
+            )}
           </div>
-        </CardAction>
-      </CardHeader>
-      <CardContent>
-        <div className="text-muted-foreground text-sm">
-          {integration.repositories.length === 0 ? (
-            <p>No repositories configured</p>
-          ) : (
-            <p>
-              {integration.repositories.length} repository
-              {integration.repositories.length !== 1 ? "ies" : ""} configured
-            </p>
-          )}
-        </div>
-      </CardContent>
+        </CardContent>
+      </Card>
       <AlertDialog
         onOpenChange={setIsDeleteDialogOpen}
         open={isDeleteDialogOpen}
@@ -279,6 +282,6 @@ export function IntegrationCard({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Card>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- move the delete confirmation dialog outside the clickable integration card
- prevent dialog clicks from bubbling into the card navigation
- keep existing card actions and styling intact

---
## EntelligenceAI PR Summary 
 Refactored integration card component to improve semantic HTML structure by making AlertDialog a sibling of Card rather than a nested child.
- Wrapped Card and AlertDialog components in a React Fragment
- Moved AlertDialog from inside Card to sibling level for proper modal overlay semantics
- Added line break formatting to 'Created on' text for consistency with 'Added by' display 

