### PR TITLE
fix: make social providers conditional on env vars

### DIFF
--- a/apps/dashboard/src/app/design-system/page-client.tsx
+++ b/apps/dashboard/src/app/design-system/page-client.tsx
@@ -352,6 +352,11 @@ export default function DesignSystemClientPage() {
   const [collapsibleOpen, setCollapsibleOpen] = useState(false);
   const [dropdownChecked, setDropdownChecked] = useState(true);
   const [dropdownRadio, setDropdownRadio] = useState("team");
+  const [stepperValue, setStepperValue] = useState("review");
+  const stepperSteps = ["details", "review", "launch"] as const;
+  const activeStepIndex = stepperSteps.indexOf(
+    stepperValue as (typeof stepperSteps)[number],
+  );
 
   return (
     <main className="container mx-auto flex flex-col gap-12 py-10">
@@ -1131,9 +1136,31 @@ export default function DesignSystemClientPage() {
               <CardTitle>Stepper</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <Stepper defaultValue="details">
+              <div className="flex flex-wrap gap-2">
+                <ButtonGroup>
+                  <Button
+                    variant={stepperValue === "details" ? "default" : "outline"}
+                    onClick={() => setStepperValue("details")}
+                  >
+                    Details active
+                  </Button>
+                  <Button
+                    variant={stepperValue === "review" ? "default" : "outline"}
+                    onClick={() => setStepperValue("review")}
+                  >
+                    Review active
+                  </Button>
+                  <Button
+                    variant={stepperValue === "launch" ? "default" : "outline"}
+                    onClick={() => setStepperValue("launch")}
+                  >
+                    Launch active
+                  </Button>
+                </ButtonGroup>
+              </div>
+              <Stepper value={stepperValue} onValueChange={setStepperValue}>
                 <StepperList>
-                  <StepperItem value="details">
+                  <StepperItem value="details" completed={activeStepIndex > 0}>
                     <StepperTrigger className="gap-3">
                       <StepperIndicator />
                       <div className="flex flex-col text-left">
@@ -1143,7 +1170,7 @@ export default function DesignSystemClientPage() {
                     </StepperTrigger>
                     <StepperSeparator />
                   </StepperItem>
-                  <StepperItem value="review">
+                  <StepperItem value="review" completed={activeStepIndex > 1}>
                     <StepperTrigger className="gap-3">
                       <StepperIndicator />
                       <div className="flex flex-col text-left">

--- a/packages/ui/src/components/ui/stepper.tsx
+++ b/packages/ui/src/components/ui/stepper.tsx
@@ -643,11 +643,11 @@ function StepperItem(props: StepperItemProps) {
     return () => {
       store.removeStep(itemValue);
     };
-  }, [itemValue, completed, disabled]);
+  }, [itemValue, store]);
 
   useIsomorphicLayoutEffect(() => {
     store.setStep(itemValue, completed, disabled);
-  }, [itemValue, completed, disabled]);
+  }, [itemValue, completed, disabled, store]);
 
   const stepState = useStore((state) => state.steps.get(itemValue));
   const steps = useStore((state) => state.steps);
@@ -1070,7 +1070,7 @@ function StepperSeparator(props: StepperSeparatorProps) {
 
   const stepIndex = Array.from(steps.keys()).indexOf(itemContext.value);
 
-  const isLastStep = stepIndex === steps.size - 1;
+  const isLastStep = steps.size > 0 && stepIndex === steps.size - 1;
 
   const dataState = getDataState(
     value,


### PR DESCRIPTION
Only register OAuth social providers when their client ID and secret are both configured, preventing auth errors in local dev without OAuth credentials.

---
## EntelligenceAI PR Summary 
 This PR adds `.claude/settings.local.json` to gitignore to prevent local Claude configuration from being committed to version control.
- Added `.claude/settings.local.json` entry to `.gitignore` file
- Follows existing pattern for ignoring local development artifacts in the `.claude/` directory
- Enables developers to maintain environment-specific or personal Claude settings locally 

