### PR TITLE
Reuse empty states across dashboard

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedule/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedule/page-client.tsx
@@ -1,46 +1,46 @@
 "use client";
 
 import {
-  Calendar03Icon,
-  Delete02Icon,
-  Edit02Icon,
-  MoreVerticalIcon,
-  PauseIcon,
-  PlayCircleIcon,
-  PlayIcon,
+	Calendar03Icon,
+	Delete02Icon,
+	Edit02Icon,
+	MoreVerticalIcon,
+	PauseIcon,
+	PlayCircleIcon,
+	PlayIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
 } from "@notra/ui/components/ui/alert-dialog";
 import { Button } from "@notra/ui/components/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
 } from "@notra/ui/components/ui/table";
 import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
 } from "@notra/ui/components/ui/tabs";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2Icon, PlusIcon } from "lucide-react";
@@ -59,593 +59,593 @@ import { SchedulePageSkeleton } from "./skeleton";
 const CRON_SOURCE_TYPES: TriggerSourceType[] = ["cron"];
 
 function formatFrequency(cron?: Trigger["sourceConfig"]["cron"]) {
-  if (!cron) return "Not set";
-  const time = `${String(cron.hour).padStart(2, "0")}:${String(cron.minute).padStart(2, "0")} UTC`;
-  if (cron.frequency === "weekly") {
-    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    return `Weekly - ${days[cron.dayOfWeek ?? 0]} @ ${time}`;
-  }
-  if (cron.frequency === "monthly") {
-    return `Monthly - Day ${cron.dayOfMonth} @ ${time}`;
-  }
-  return `Daily @ ${time}`;
+	if (!cron) return "Not set";
+	const time = `${String(cron.hour).padStart(2, "0")}:${String(cron.minute).padStart(2, "0")} UTC`;
+	if (cron.frequency === "weekly") {
+		const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+		return `Weekly - ${days[cron.dayOfWeek ?? 0]} @ ${time}`;
+	}
+	if (cron.frequency === "monthly") {
+		return `Monthly - Day ${cron.dayOfMonth} @ ${time}`;
+	}
+	return `Daily @ ${time}`;
 }
 
 function formatDate(dateString: string) {
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date(dateString));
+	return new Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	}).format(new Date(dateString));
 }
 
 interface PageClientProps {
-  organizationSlug: string;
+	organizationSlug: string;
 }
 
 export default function PageClient({ organizationSlug }: PageClientProps) {
-  const { getOrganization } = useOrganizationsContext();
-  const organization = getOrganization(organizationSlug);
-  const organizationId = organization?.id;
-  const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<"active" | "paused">("active");
-  const [deleteTriggerId, setDeleteTriggerId] = useState<string | null>(null);
-  const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
+	const { getOrganization } = useOrganizationsContext();
+	const organization = getOrganization(organizationSlug);
+	const organizationId = organization?.id;
+	const queryClient = useQueryClient();
+	const [activeTab, setActiveTab] = useState<"active" | "paused">("active");
+	const [deleteTriggerId, setDeleteTriggerId] = useState<string | null>(null);
+	const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
 
-  const { data, isPending } = useQuery({
-    queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-    queryFn: async () => {
-      if (!organizationId) {
-        throw new Error("Organization ID is required");
-      }
-      const response = await fetch(
-        `/api/organizations/${organizationId}/automation/schedules`,
-      );
+	const { data, isPending } = useQuery({
+		queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+		queryFn: async () => {
+			if (!organizationId) {
+				throw new Error("Organization ID is required");
+			}
+			const response = await fetch(
+				`/api/organizations/${organizationId}/automation/schedules`,
+			);
 
-      if (!response.ok) {
-        throw new Error("Failed to fetch triggers");
-      }
+			if (!response.ok) {
+				throw new Error("Failed to fetch triggers");
+			}
 
-      return response.json() as Promise<{ triggers: Trigger[] }>;
-    },
-    enabled: !!organizationId,
-  });
+			return response.json() as Promise<{ triggers: Trigger[] }>;
+		},
+		enabled: !!organizationId,
+	});
 
-  const updateMutation = useMutation({
-    mutationFn: async (trigger: Trigger) => {
-      if (!organizationId) {
-        throw new Error("Organization ID is required");
-      }
-      const response = await fetch(
-        `/api/organizations/${organizationId}/automation/schedules?triggerId=${trigger.id}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            sourceType: trigger.sourceType,
-            sourceConfig: trigger.sourceConfig,
-            targets: trigger.targets,
-            outputType: trigger.outputType,
-            outputConfig: trigger.outputConfig,
-            enabled: !trigger.enabled,
-          }),
-        },
-      );
+	const updateMutation = useMutation({
+		mutationFn: async (trigger: Trigger) => {
+			if (!organizationId) {
+				throw new Error("Organization ID is required");
+			}
+			const response = await fetch(
+				`/api/organizations/${organizationId}/automation/schedules?triggerId=${trigger.id}`,
+				{
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						sourceType: trigger.sourceType,
+						sourceConfig: trigger.sourceConfig,
+						targets: trigger.targets,
+						outputType: trigger.outputType,
+						outputConfig: trigger.outputConfig,
+						enabled: !trigger.enabled,
+					}),
+				},
+			);
 
-      if (!response.ok) {
-        throw new Error("Failed to update schedule");
-      }
+			if (!response.ok) {
+				throw new Error("Failed to update schedule");
+			}
 
-      return response.json();
-    },
-    onMutate: async (trigger) => {
-      await queryClient.cancelQueries({
-        queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-      });
+			return response.json();
+		},
+		onMutate: async (trigger) => {
+			await queryClient.cancelQueries({
+				queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+			});
 
-      const previousData = queryClient.getQueryData<{ triggers: Trigger[] }>(
-        QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-      );
+			const previousData = queryClient.getQueryData<{ triggers: Trigger[] }>(
+				QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+			);
 
-      queryClient.setQueryData<{ triggers: Trigger[] }>(
-        QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-        (old) => {
-          if (!old) return old;
-          return {
-            triggers: old.triggers.map((t) =>
-              t.id === trigger.id ? { ...t, enabled: !t.enabled } : t,
-            ),
-          };
-        },
-      );
+			queryClient.setQueryData<{ triggers: Trigger[] }>(
+				QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+				(old) => {
+					if (!old) return old;
+					return {
+						triggers: old.triggers.map((t) =>
+							t.id === trigger.id ? { ...t, enabled: !t.enabled } : t,
+						),
+					};
+				},
+			);
 
-      return { previousData };
-    },
-    onError: (_error, _trigger, context) => {
-      if (context?.previousData) {
-        queryClient.setQueryData(
-          QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-          context.previousData,
-        );
-      }
-      toast.error("Failed to update schedule");
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-      });
-    },
-  });
+			return { previousData };
+		},
+		onError: (_error, _trigger, context) => {
+			if (context?.previousData) {
+				queryClient.setQueryData(
+					QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+					context.previousData,
+				);
+			}
+			toast.error("Failed to update schedule");
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({
+				queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+			});
+		},
+	});
 
-  const deleteMutation = useMutation({
-    mutationFn: async (triggerId: string) => {
-      if (!organizationId) {
-        throw new Error("Organization ID is required");
-      }
-      const response = await fetch(
-        `/api/organizations/${organizationId}/automation/schedules?triggerId=${triggerId}`,
-        { method: "DELETE" },
-      );
+	const deleteMutation = useMutation({
+		mutationFn: async (triggerId: string) => {
+			if (!organizationId) {
+				throw new Error("Organization ID is required");
+			}
+			const response = await fetch(
+				`/api/organizations/${organizationId}/automation/schedules?triggerId=${triggerId}`,
+				{ method: "DELETE" },
+			);
 
-      if (!response.ok) {
-        throw new Error("Failed to delete schedule");
-      }
+			if (!response.ok) {
+				throw new Error("Failed to delete schedule");
+			}
 
-      return response.json();
-    },
-    onMutate: async (triggerId) => {
-      await queryClient.cancelQueries({
-        queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-      });
+			return response.json();
+		},
+		onMutate: async (triggerId) => {
+			await queryClient.cancelQueries({
+				queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+			});
 
-      const previousData = queryClient.getQueryData<{ triggers: Trigger[] }>(
-        QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-      );
+			const previousData = queryClient.getQueryData<{ triggers: Trigger[] }>(
+				QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+			);
 
-      queryClient.setQueryData<{ triggers: Trigger[] }>(
-        QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-        (old) => {
-          if (!old) return old;
-          return {
-            triggers: old.triggers.filter((t) => t.id !== triggerId),
-          };
-        },
-      );
+			queryClient.setQueryData<{ triggers: Trigger[] }>(
+				QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+				(old) => {
+					if (!old) return old;
+					return {
+						triggers: old.triggers.filter((t) => t.id !== triggerId),
+					};
+				},
+			);
 
-      return { previousData };
-    },
-    onError: (_error, _triggerId, context) => {
-      if (context?.previousData) {
-        queryClient.setQueryData(
-          QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-          context.previousData,
-        );
-      }
-      toast.error("Failed to delete schedule");
-    },
-    onSuccess: () => {
-      toast.success("Schedule removed");
-      setDeleteTriggerId(null);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-      });
-    },
-  });
+			return { previousData };
+		},
+		onError: (_error, _triggerId, context) => {
+			if (context?.previousData) {
+				queryClient.setQueryData(
+					QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+					context.previousData,
+				);
+			}
+			toast.error("Failed to delete schedule");
+		},
+		onSuccess: () => {
+			toast.success("Schedule removed");
+			setDeleteTriggerId(null);
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({
+				queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+			});
+		},
+	});
 
-  const runNowMutation = useMutation({
-    mutationFn: async (triggerId: string) => {
-      if (!organizationId) {
-        throw new Error("Organization ID is required");
-      }
-      const response = await fetch(
-        `/api/organizations/${organizationId}/automation/schedules/run?triggerId=${triggerId}`,
-        { method: "POST" },
-      );
+	const runNowMutation = useMutation({
+		mutationFn: async (triggerId: string) => {
+			if (!organizationId) {
+				throw new Error("Organization ID is required");
+			}
+			const response = await fetch(
+				`/api/organizations/${organizationId}/automation/schedules/run?triggerId=${triggerId}`,
+				{ method: "POST" },
+			);
 
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || "Failed to run schedule");
-      }
+			if (!response.ok) {
+				const data = await response.json().catch(() => ({}));
+				throw new Error(data.error || "Failed to run schedule");
+			}
 
-      return response.json();
-    },
-    onSuccess: () => {
-      toast.success("Schedule triggered! Content will be generated shortly.");
-    },
-    onError: (error) => {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to run schedule",
-      );
-    },
-  });
+			return response.json();
+		},
+		onSuccess: () => {
+			toast.success("Schedule triggered! Content will be generated shortly.");
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to run schedule",
+			);
+		},
+	});
 
-  const triggers = data?.triggers ?? [];
-  const scheduleTriggers = useMemo(
-    () => triggers.filter((trigger) => trigger.sourceType === "cron"),
-    [triggers],
-  );
+	const triggers = data?.triggers ?? [];
+	const scheduleTriggers = useMemo(
+		() => triggers.filter((trigger) => trigger.sourceType === "cron"),
+		[triggers],
+	);
 
-  const filteredTriggers = useMemo(() => {
-    return scheduleTriggers.filter((t) =>
-      activeTab === "active" ? t.enabled : !t.enabled,
-    );
-  }, [scheduleTriggers, activeTab]);
+	const filteredTriggers = useMemo(() => {
+		return scheduleTriggers.filter((t) =>
+			activeTab === "active" ? t.enabled : !t.enabled,
+		);
+	}, [scheduleTriggers, activeTab]);
 
-  const activeCounts = useMemo(() => {
-    let active = 0;
-    let paused = 0;
-    for (const t of scheduleTriggers) {
-      if (t.enabled) {
-        active++;
-      } else {
-        paused++;
-      }
-    }
-    return { active, paused };
-  }, [scheduleTriggers]);
+	const activeCounts = useMemo(() => {
+		let active = 0;
+		let paused = 0;
+		for (const t of scheduleTriggers) {
+			if (t.enabled) {
+				active++;
+			} else {
+				paused++;
+			}
+		}
+		return { active, paused };
+	}, [scheduleTriggers]);
 
-  const handleToggle = useCallback(
-    (trigger: Trigger) => updateMutation.mutate(trigger),
-    [updateMutation],
-  );
+	const handleToggle = useCallback(
+		(trigger: Trigger) => updateMutation.mutate(trigger),
+		[updateMutation],
+	);
 
-  const handleDelete = useCallback((id: string) => {
-    setDeleteTriggerId(id);
-  }, []);
+	const handleDelete = useCallback((id: string) => {
+		setDeleteTriggerId(id);
+	}, []);
 
-  const handleEdit = useCallback((trigger: Trigger) => {
-    setEditTrigger(trigger);
-  }, []);
+	const handleEdit = useCallback((trigger: Trigger) => {
+		setEditTrigger(trigger);
+	}, []);
 
-  const confirmDelete = useCallback(() => {
-    if (deleteTriggerId) {
-      deleteMutation.mutate(deleteTriggerId);
-    }
-  }, [deleteTriggerId, deleteMutation]);
+	const confirmDelete = useCallback(() => {
+		if (deleteTriggerId) {
+			deleteMutation.mutate(deleteTriggerId);
+		}
+	}, [deleteTriggerId, deleteMutation]);
 
-  const handleRunNow = useCallback(
-    (triggerId: string) => runNowMutation.mutate(triggerId),
-    [runNowMutation],
-  );
+	const handleRunNow = useCallback(
+		(triggerId: string) => runNowMutation.mutate(triggerId),
+		[runNowMutation],
+	);
 
-  const triggerToDelete = deleteTriggerId
-    ? triggers.find((t) => t.id === deleteTriggerId)
-    : null;
+	const triggerToDelete = deleteTriggerId
+		? triggers.find((t) => t.id === deleteTriggerId)
+		: null;
 
-  return (
-    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-6 px-4 lg:px-6">
-        <div className="flex items-start justify-between">
-          <div className="space-y-1">
-            <h1 className="font-bold text-3xl tracking-tight">
-              Automation Schedules
-            </h1>
-            <p className="text-muted-foreground">
-              Configure cron schedules that run daily, weekly, or monthly.
-            </p>
-          </div>
-          <AddTriggerDialog
-            allowedSourceTypes={CRON_SOURCE_TYPES}
-            apiPath={
-              organizationId
-                ? `/api/organizations/${organizationId}/automation/schedules`
-                : undefined
-            }
-            initialSourceType="cron"
-            onSuccess={() =>
-              queryClient.invalidateQueries({
-                queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-              })
-            }
-            organizationId={organizationId ?? ""}
-            trigger={
-              <Button size="sm" variant="default">
-                <PlusIcon className="size-4" />
-                <span className="ml-1">New Schedule</span>
-              </Button>
-            }
-          />
-        </div>
+	return (
+		<PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+			<div className="w-full space-y-6 px-4 lg:px-6">
+				<div className="flex items-start justify-between">
+					<div className="space-y-1">
+						<h1 className="font-bold text-3xl tracking-tight">
+							Automation Schedules
+						</h1>
+						<p className="text-muted-foreground">
+							Configure cron schedules that run daily, weekly, or monthly.
+						</p>
+					</div>
+					<AddTriggerDialog
+						allowedSourceTypes={CRON_SOURCE_TYPES}
+						apiPath={
+							organizationId
+								? `/api/organizations/${organizationId}/automation/schedules`
+								: undefined
+						}
+						initialSourceType="cron"
+						onSuccess={() =>
+							queryClient.invalidateQueries({
+								queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+							})
+						}
+						organizationId={organizationId ?? ""}
+						trigger={
+							<Button size="sm" variant="default">
+								<PlusIcon className="size-4" />
+								<span className="ml-1">New Schedule</span>
+							</Button>
+						}
+					/>
+				</div>
 
-        {isPending ? (
-          <SchedulePageSkeleton />
-        ) : scheduleTriggers.length === 0 ? (
-          <EmptyState
-            action={
-              <AddTriggerDialog
-                allowedSourceTypes={CRON_SOURCE_TYPES}
-                apiPath={
-                  organizationId
-                    ? `/api/organizations/${organizationId}/automation/schedules`
-                    : undefined
-                }
-                initialSourceType="cron"
-                onSuccess={() =>
-                  queryClient.invalidateQueries({
-                    queryKey: QUERY_KEYS.AUTOMATION.schedules(
-                      organizationId ?? "",
-                    ),
-                  })
-                }
-                organizationId={organizationId ?? ""}
-                trigger={
-                  <Button size="sm" variant="outline">
-                    <PlusIcon className="size-4" />
-                    <span className="ml-1">New Schedule</span>
-                  </Button>
-                }
-              />
-            }
-            description="Create your first schedule to automate recurring content."
-            title="No schedules yet"
-          />
-        ) : (
-          <Tabs
-            defaultValue="active"
-            onValueChange={(value) =>
-              setActiveTab(value as "active" | "paused")
-            }
-          >
-            <TabsList variant="line">
-              <TabsTrigger value="active">
-                Active ({activeCounts.active})
-              </TabsTrigger>
-              <TabsTrigger value="paused">
-                Paused ({activeCounts.paused})
-              </TabsTrigger>
-            </TabsList>
+				{isPending ? (
+					<SchedulePageSkeleton />
+				) : scheduleTriggers.length === 0 ? (
+					<EmptyState
+						action={
+							<AddTriggerDialog
+								allowedSourceTypes={CRON_SOURCE_TYPES}
+								apiPath={
+									organizationId
+										? `/api/organizations/${organizationId}/automation/schedules`
+										: undefined
+								}
+								initialSourceType="cron"
+								onSuccess={() =>
+									queryClient.invalidateQueries({
+										queryKey: QUERY_KEYS.AUTOMATION.schedules(
+											organizationId ?? "",
+										),
+									})
+								}
+								organizationId={organizationId ?? ""}
+								trigger={
+									<Button size="sm" variant="outline">
+										<PlusIcon className="size-4" />
+										<span className="ml-1">New Schedule</span>
+									</Button>
+								}
+							/>
+						}
+						description="Create your first schedule to automate recurring content."
+						title="No schedules yet"
+					/>
+				) : (
+					<Tabs
+						defaultValue="active"
+						onValueChange={(value) =>
+							setActiveTab(value as "active" | "paused")
+						}
+					>
+						<TabsList variant="line">
+							<TabsTrigger value="active">
+								Active ({activeCounts.active})
+							</TabsTrigger>
+							<TabsTrigger value="paused">
+								Paused ({activeCounts.paused})
+							</TabsTrigger>
+						</TabsList>
 
-            <TabsContent className="mt-4" value="active">
-              <ScheduleTable
-                isDeleting={deleteMutation.isPending}
-                isRunning={runNowMutation.isPending}
-                isUpdating={updateMutation.isPending}
-                onDelete={handleDelete}
-                onEdit={handleEdit}
-                onRunNow={handleRunNow}
-                onToggle={handleToggle}
-                runningTriggerId={
-                  runNowMutation.isPending
-                    ? runNowMutation.variables
-                    : undefined
-                }
-                triggers={filteredTriggers}
-                updatingTriggerId={
-                  updateMutation.isPending
-                    ? updateMutation.variables?.id
-                    : undefined
-                }
-              />
-            </TabsContent>
+						<TabsContent className="mt-4" value="active">
+							<ScheduleTable
+								isDeleting={deleteMutation.isPending}
+								isRunning={runNowMutation.isPending}
+								isUpdating={updateMutation.isPending}
+								onDelete={handleDelete}
+								onEdit={handleEdit}
+								onRunNow={handleRunNow}
+								onToggle={handleToggle}
+								runningTriggerId={
+									runNowMutation.isPending
+										? runNowMutation.variables
+										: undefined
+								}
+								triggers={filteredTriggers}
+								updatingTriggerId={
+									updateMutation.isPending
+										? updateMutation.variables?.id
+										: undefined
+								}
+							/>
+						</TabsContent>
 
-            <TabsContent className="mt-4" value="paused">
-              <ScheduleTable
-                isDeleting={deleteMutation.isPending}
-                isRunning={runNowMutation.isPending}
-                isUpdating={updateMutation.isPending}
-                onDelete={handleDelete}
-                onEdit={handleEdit}
-                onRunNow={handleRunNow}
-                onToggle={handleToggle}
-                runningTriggerId={
-                  runNowMutation.isPending
-                    ? runNowMutation.variables
-                    : undefined
-                }
-                triggers={filteredTriggers}
-                updatingTriggerId={
-                  updateMutation.isPending
-                    ? updateMutation.variables?.id
-                    : undefined
-                }
-              />
-            </TabsContent>
-          </Tabs>
-        )}
-      </div>
+						<TabsContent className="mt-4" value="paused">
+							<ScheduleTable
+								isDeleting={deleteMutation.isPending}
+								isRunning={runNowMutation.isPending}
+								isUpdating={updateMutation.isPending}
+								onDelete={handleDelete}
+								onEdit={handleEdit}
+								onRunNow={handleRunNow}
+								onToggle={handleToggle}
+								runningTriggerId={
+									runNowMutation.isPending
+										? runNowMutation.variables
+										: undefined
+								}
+								triggers={filteredTriggers}
+								updatingTriggerId={
+									updateMutation.isPending
+										? updateMutation.variables?.id
+										: undefined
+								}
+							/>
+						</TabsContent>
+					</Tabs>
+				)}
+			</div>
 
-      <AlertDialog
-        onOpenChange={(open) => !open && setDeleteTriggerId(null)}
-        open={!!deleteTriggerId}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete schedule?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete this{" "}
-              {triggerToDelete
-                ? formatFrequency(
-                    triggerToDelete.sourceConfig.cron,
-                  ).toLowerCase()
-                : ""}{" "}
-              schedule. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteMutation.isPending}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              disabled={deleteMutation.isPending}
-              onClick={confirmDelete}
-              variant="destructive"
-            >
-              {deleteMutation.isPending ? (
-                <>
-                  <Loader2Icon className="size-4 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                "Delete"
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+			<AlertDialog
+				onOpenChange={(open) => !open && setDeleteTriggerId(null)}
+				open={!!deleteTriggerId}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete schedule?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will permanently delete this{" "}
+							{triggerToDelete
+								? formatFrequency(
+										triggerToDelete.sourceConfig.cron,
+									).toLowerCase()
+								: ""}{" "}
+							schedule. This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={deleteMutation.isPending}>
+							Cancel
+						</AlertDialogCancel>
+						<AlertDialogAction
+							disabled={deleteMutation.isPending}
+							onClick={confirmDelete}
+							variant="destructive"
+						>
+							{deleteMutation.isPending ? (
+								<>
+									<Loader2Icon className="size-4 animate-spin" />
+									Deleting...
+								</>
+							) : (
+								"Delete"
+							)}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 
-      {editTrigger && (
-        <AddTriggerDialog
-          allowedSourceTypes={CRON_SOURCE_TYPES}
-          apiPath={
-            organizationId
-              ? `/api/organizations/${organizationId}/automation/schedules`
-              : undefined
-          }
-          editTrigger={editTrigger}
-          initialSourceType="cron"
-          onOpenChange={(open) => !open && setEditTrigger(null)}
-          onSuccess={() => {
-            setEditTrigger(null);
-            queryClient.invalidateQueries({
-              queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
-            });
-          }}
-          open={!!editTrigger}
-          organizationId={organizationId ?? ""}
-        />
-      )}
-    </PageContainer>
-  );
+			{editTrigger && (
+				<AddTriggerDialog
+					allowedSourceTypes={CRON_SOURCE_TYPES}
+					apiPath={
+						organizationId
+							? `/api/organizations/${organizationId}/automation/schedules`
+							: undefined
+					}
+					editTrigger={editTrigger}
+					initialSourceType="cron"
+					onOpenChange={(open) => !open && setEditTrigger(null)}
+					onSuccess={() => {
+						setEditTrigger(null);
+						queryClient.invalidateQueries({
+							queryKey: QUERY_KEYS.AUTOMATION.schedules(organizationId ?? ""),
+						});
+					}}
+					open={!!editTrigger}
+					organizationId={organizationId ?? ""}
+				/>
+			)}
+		</PageContainer>
+	);
 }
 
 function ScheduleTable({
-  triggers,
-  onToggle,
-  onDelete,
-  onEdit,
-  onRunNow,
-  isUpdating,
-  isDeleting,
-  isRunning,
-  updatingTriggerId,
-  runningTriggerId,
+	triggers,
+	onToggle,
+	onDelete,
+	onEdit,
+	onRunNow,
+	isUpdating,
+	isDeleting,
+	isRunning,
+	updatingTriggerId,
+	runningTriggerId,
 }: {
-  triggers: Trigger[];
-  onToggle: (trigger: Trigger) => void;
-  onDelete: (triggerId: string) => void;
-  onEdit: (trigger: Trigger) => void;
-  onRunNow: (triggerId: string) => void;
-  isUpdating: boolean;
-  isDeleting: boolean;
-  isRunning: boolean;
-  updatingTriggerId?: string;
-  runningTriggerId?: string;
+	triggers: Trigger[];
+	onToggle: (trigger: Trigger) => void;
+	onDelete: (triggerId: string) => void;
+	onEdit: (trigger: Trigger) => void;
+	onRunNow: (triggerId: string) => void;
+	isUpdating: boolean;
+	isDeleting: boolean;
+	isRunning: boolean;
+	updatingTriggerId?: string;
+	runningTriggerId?: string;
 }) {
-  if (triggers.length === 0) {
-    return (
-      <div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground text-sm">
-        No schedules in this category.
-      </div>
-    );
-  }
+	if (triggers.length === 0) {
+		return (
+			<div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground text-sm">
+				No schedules in this category.
+			</div>
+		);
+	}
 
-  return (
-    <div className="rounded-xl border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Type</TableHead>
-            <TableHead>Frequency</TableHead>
-            <TableHead>Output</TableHead>
-            <TableHead>Targets</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Created</TableHead>
-            <TableHead className="w-12" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {triggers.map((trigger) => {
-            const isThisUpdating =
-              isUpdating && updatingTriggerId === trigger.id;
-            const isThisRunning = isRunning && runningTriggerId === trigger.id;
+	return (
+		<div className="rounded-xl border">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Type</TableHead>
+						<TableHead>Frequency</TableHead>
+						<TableHead>Output</TableHead>
+						<TableHead>Targets</TableHead>
+						<TableHead>Status</TableHead>
+						<TableHead>Created</TableHead>
+						<TableHead className="w-12" />
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{triggers.map((trigger) => {
+						const isThisUpdating =
+							isUpdating && updatingTriggerId === trigger.id;
+						const isThisRunning = isRunning && runningTriggerId === trigger.id;
 
-            return (
-              <TableRow key={trigger.id}>
-                <TableCell>
-                  <div className="flex items-center gap-2">
-                    <span className="flex size-8 items-center justify-center rounded-lg border bg-muted/50">
-                      <HugeiconsIcon
-                        className="size-4 text-muted-foreground"
-                        icon={Calendar03Icon}
-                      />
-                    </span>
-                    <span className="text-sm">Scheduled run</span>
-                  </div>
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {formatFrequency(trigger.sourceConfig.cron)}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {getOutputTypeLabel(trigger.outputType)}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {trigger.targets.repositoryIds.length} repositories
-                </TableCell>
-                <TableCell>
-                  <TriggerStatusBadge enabled={trigger.enabled} />
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {formatDate(trigger.createdAt)}
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      className="flex size-8 items-center justify-center rounded-md hover:bg-accent disabled:opacity-50"
-                      disabled={isThisUpdating || isThisRunning}
-                    >
-                      {isThisUpdating || isThisRunning ? (
-                        <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
-                      ) : (
-                        <HugeiconsIcon
-                          className="size-4 text-muted-foreground"
-                          icon={MoreVerticalIcon}
-                        />
-                      )}
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => onEdit(trigger)}>
-                        <HugeiconsIcon className="size-4" icon={Edit02Icon} />
-                        Edit
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={isRunning || !trigger.enabled}
-                        onClick={() => onRunNow(trigger.id)}
-                      >
-                        <HugeiconsIcon
-                          className="size-4"
-                          icon={PlayCircleIcon}
-                        />
-                        Run now
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={isUpdating}
-                        onClick={() => onToggle(trigger)}
-                      >
-                        <HugeiconsIcon
-                          className="size-4"
-                          icon={trigger.enabled ? PauseIcon : PlayIcon}
-                        />
-                        {trigger.enabled ? "Pause" : "Enable"}
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        disabled={isDeleting}
-                        onClick={() => onDelete(trigger.id)}
-                        variant="destructive"
-                      >
-                        <HugeiconsIcon className="size-4" icon={Delete02Icon} />
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
-  );
+						return (
+							<TableRow key={trigger.id}>
+								<TableCell>
+									<div className="flex items-center gap-2">
+										<span className="flex size-8 items-center justify-center rounded-lg border bg-muted/50">
+											<HugeiconsIcon
+												className="size-4 text-muted-foreground"
+												icon={Calendar03Icon}
+											/>
+										</span>
+										<span className="text-sm">Scheduled run</span>
+									</div>
+								</TableCell>
+								<TableCell className="text-muted-foreground">
+									{formatFrequency(trigger.sourceConfig.cron)}
+								</TableCell>
+								<TableCell className="text-muted-foreground">
+									{getOutputTypeLabel(trigger.outputType)}
+								</TableCell>
+								<TableCell className="text-muted-foreground">
+									{trigger.targets.repositoryIds.length} repositories
+								</TableCell>
+								<TableCell>
+									<TriggerStatusBadge enabled={trigger.enabled} />
+								</TableCell>
+								<TableCell className="text-muted-foreground">
+									{formatDate(trigger.createdAt)}
+								</TableCell>
+								<TableCell>
+									<DropdownMenu>
+										<DropdownMenuTrigger
+											className="flex size-8 items-center justify-center rounded-md hover:bg-accent disabled:opacity-50"
+											disabled={isThisUpdating || isThisRunning}
+										>
+											{isThisUpdating || isThisRunning ? (
+												<Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+											) : (
+												<HugeiconsIcon
+													className="size-4 text-muted-foreground"
+													icon={MoreVerticalIcon}
+												/>
+											)}
+										</DropdownMenuTrigger>
+										<DropdownMenuContent align="end">
+											<DropdownMenuItem onClick={() => onEdit(trigger)}>
+												<HugeiconsIcon className="size-4" icon={Edit02Icon} />
+												Edit
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												disabled={isRunning || !trigger.enabled}
+												onClick={() => onRunNow(trigger.id)}
+											>
+												<HugeiconsIcon
+													className="size-4"
+													icon={PlayCircleIcon}
+												/>
+												Run now
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												disabled={isUpdating}
+												onClick={() => onToggle(trigger)}
+											>
+												<HugeiconsIcon
+													className="size-4"
+													icon={trigger.enabled ? PauseIcon : PlayIcon}
+												/>
+												{trigger.enabled ? "Pause" : "Enable"}
+											</DropdownMenuItem>
+											<DropdownMenuSeparator />
+											<DropdownMenuItem
+												disabled={isDeleting}
+												onClick={() => onDelete(trigger.id)}
+												variant="destructive"
+											>
+												<HugeiconsIcon className="size-4" icon={Delete02Icon} />
+												Delete
+											</DropdownMenuItem>
+										</DropdownMenuContent>
+									</DropdownMenu>
+								</TableCell>
+							</TableRow>
+						);
+					})}
+				</TableBody>
+			</Table>
+		</div>
+	);
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
@@ -11,155 +11,155 @@ import { usePosts } from "../../../../lib/hooks/use-posts";
 import { ContentPageSkeleton } from "./skeleton";
 
 interface PageClientProps {
-  organizationSlug: string;
+	organizationSlug: string;
 }
 
 function formatDateHeading(dateString: string): string {
-  const date = new Date(dateString);
-  return new Intl.DateTimeFormat(undefined, {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(date);
+	const date = new Date(dateString);
+	return new Intl.DateTimeFormat(undefined, {
+		weekday: "long",
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	}).format(date);
 }
 
 function groupPostsByDate(posts: Post[]): Map<string, Post[]> {
-  const groups = new Map<string, Post[]>();
+	const groups = new Map<string, Post[]>();
 
-  for (const post of posts) {
-    const date = new Date(post.createdAt);
-    const dateKey = date.toDateString();
+	for (const post of posts) {
+		const date = new Date(post.createdAt);
+		const dateKey = date.toDateString();
 
-    const existing = groups.get(dateKey);
-    if (existing) {
-      existing.push(post);
-    } else {
-      groups.set(dateKey, [post]);
-    }
-  }
+		const existing = groups.get(dateKey);
+		if (existing) {
+			existing.push(post);
+		} else {
+			groups.set(dateKey, [post]);
+		}
+	}
 
-  return groups;
+	return groups;
 }
 
 function getPreview(markdown: string): string {
-  // Remove markdown headers and get first paragraph-like content
-  const lines = markdown
-    .split("\n")
-    .filter((line) => !line.startsWith("#") && line.trim().length > 0);
+	// Remove markdown headers and get first paragraph-like content
+	const lines = markdown
+		.split("\n")
+		.filter((line) => !line.startsWith("#") && line.trim().length > 0);
 
-  const preview = lines.slice(0, 3).join(" ").trim();
+	const preview = lines.slice(0, 3).join(" ").trim();
 
-  // Clean up markdown formatting
-  return preview
-    .replace(/\*\*/g, "")
-    .replace(/\*/g, "")
-    .replace(/`/g, "")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .slice(0, 200);
+	// Clean up markdown formatting
+	return preview
+		.replace(/\*\*/g, "")
+		.replace(/\*/g, "")
+		.replace(/`/g, "")
+		.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+		.slice(0, 200);
 }
 
 export default function PageClient({ organizationSlug }: PageClientProps) {
-  const { getOrganization, activeOrganization } = useOrganizationsContext();
-  const orgFromList = getOrganization(organizationSlug);
-  const organization =
-    activeOrganization?.slug === organizationSlug
-      ? activeOrganization
-      : orgFromList;
-  const organizationId = organization?.id ?? "";
+	const { getOrganization, activeOrganization } = useOrganizationsContext();
+	const orgFromList = getOrganization(organizationSlug);
+	const organization =
+		activeOrganization?.slug === organizationSlug
+			? activeOrganization
+			: orgFromList;
+	const organizationId = organization?.id ?? "";
 
-  const { data, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    usePosts(organizationId);
+	const { data, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =
+		usePosts(organizationId);
 
-  const loadMoreRef = useRef<HTMLDivElement>(null);
+	const loadMoreRef = useRef<HTMLDivElement>(null);
 
-  // Infinite scroll observer
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
+	// Infinite scroll observer
+	useEffect(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+					fetchNextPage();
+				}
+			},
+			{ threshold: 0.1 },
+		);
 
-    const currentRef = loadMoreRef.current;
-    if (currentRef) {
-      observer.observe(currentRef);
-    }
+		const currentRef = loadMoreRef.current;
+		if (currentRef) {
+			observer.observe(currentRef);
+		}
 
-    return () => {
-      if (currentRef) {
-        observer.unobserve(currentRef);
-      }
-    };
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+		return () => {
+			if (currentRef) {
+				observer.unobserve(currentRef);
+			}
+		};
+	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const allPosts = useMemo(
-    () => data?.pages.flatMap((page) => page.posts) ?? [],
-    [data?.pages],
-  );
+	const allPosts = useMemo(
+		() => data?.pages.flatMap((page) => page.posts) ?? [],
+		[data?.pages],
+	);
 
-  const groupedPosts = useMemo(() => groupPostsByDate(allPosts), [allPosts]);
+	const groupedPosts = useMemo(() => groupPostsByDate(allPosts), [allPosts]);
 
-  // Cache preview results to avoid recomputing for each render
-  const previewsByPostId = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const post of allPosts) {
-      map.set(post.id, getPreview(post.markdown));
-    }
-    return map;
-  }, [allPosts]);
+	// Cache preview results to avoid recomputing for each render
+	const previewsByPostId = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const post of allPosts) {
+			map.set(post.id, getPreview(post.markdown));
+		}
+		return map;
+	}, [allPosts]);
 
-  return (
-    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-6 px-4 lg:px-6">
-        <div className="space-y-1">
-          <h1 className="font-bold text-3xl tracking-tight">Content</h1>
-          <p className="text-muted-foreground">
-            View and manage your generated content
-          </p>
-        </div>
+	return (
+		<PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+			<div className="w-full space-y-6 px-4 lg:px-6">
+				<div className="space-y-1">
+					<h1 className="font-bold text-3xl tracking-tight">Content</h1>
+					<p className="text-muted-foreground">
+						View and manage your generated content
+					</p>
+				</div>
 
-        {isPending && <ContentPageSkeleton />}
+				{isPending && <ContentPageSkeleton />}
 
-        {!isPending && allPosts.length === 0 && (
-          <EmptyState
-            className="p-8"
-            description="Generate your first piece of content to get started."
-            title="No content yet"
-          />
-        )}
+				{!isPending && allPosts.length === 0 && (
+					<EmptyState
+						className="p-8"
+						description="Generate your first piece of content to get started."
+						title="No content yet"
+					/>
+				)}
 
-        {Array.from(groupedPosts.entries()).map(([dateKey, posts]) => (
-          <section className="space-y-4" key={dateKey}>
-            <h2 className="font-semibold text-lg">
-              {formatDateHeading(dateKey)}
-            </h2>
-            <div className="grid gap-3 sm:gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {posts.map((post) => (
-                <ContentCard
-                  contentType={post.contentType as ContentType}
-                  href={`/${organizationSlug}/content/${post.id}`}
-                  key={post.id}
-                  preview={previewsByPostId.get(post.id) ?? ""}
-                  title={post.title}
-                />
-              ))}
-            </div>
-          </section>
-        ))}
+				{Array.from(groupedPosts.entries()).map(([dateKey, posts]) => (
+					<section className="space-y-4" key={dateKey}>
+						<h2 className="font-semibold text-lg">
+							{formatDateHeading(dateKey)}
+						</h2>
+						<div className="grid gap-3 sm:gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+							{posts.map((post) => (
+								<ContentCard
+									contentType={post.contentType as ContentType}
+									href={`/${organizationSlug}/content/${post.id}`}
+									key={post.id}
+									preview={previewsByPostId.get(post.id) ?? ""}
+									title={post.title}
+								/>
+							))}
+						</div>
+					</section>
+				))}
 
-        {/* Infinite scroll trigger */}
-        <div className="h-10" ref={loadMoreRef}>
-          {isFetchingNextPage && (
-            <div className="flex items-center justify-center">
-              <Skeleton className="size-6 rounded-full" />
-            </div>
-          )}
-        </div>
-      </div>
-    </PageContainer>
-  );
+				{/* Infinite scroll trigger */}
+				<div className="h-10" ref={loadMoreRef}>
+					{isFetchingNextPage && (
+						<div className="flex items-center justify-center">
+							<Skeleton className="size-6 rounded-full" />
+						</div>
+					)}
+				</div>
+			</div>
+		</PageContainer>
+	);
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -1,120 +1,120 @@
 "use client";
 
+import { Button } from "@notra/ui/components/ui/button";
 import { useQuery } from "@tanstack/react-query";
 import { EmptyState } from "@/components/empty-state";
 import { AddIntegrationDialog } from "@/components/integrations/add-integration-dialog";
 import { IntegrationCard } from "@/components/integrations/integration-card";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
-import { Button } from "@notra/ui/components/ui/button";
 import type { GitHubIntegration } from "@/types/integrations";
 import { QUERY_KEYS } from "@/utils/query-keys";
 import { GitHubIntegrationsPageSkeleton } from "./skeleton";
 
 interface IntegrationsResponse {
-  integrations: Array<GitHubIntegration & { type: string }>;
-  count: number;
+	integrations: Array<GitHubIntegration & { type: string }>;
+	count: number;
 }
 
 interface PageClientProps {
-  organizationSlug: string;
+	organizationSlug: string;
 }
 
 export default function PageClient({ organizationSlug }: PageClientProps) {
-  const { getOrganization } = useOrganizationsContext();
-  const organization = getOrganization(organizationSlug);
+	const { getOrganization } = useOrganizationsContext();
+	const organization = getOrganization(organizationSlug);
 
-  const {
-    data: response,
-    isPending,
-    refetch,
-  } = useQuery({
-    queryKey: QUERY_KEYS.INTEGRATIONS.all(organization?.id ?? ""),
-    queryFn: async () => {
-      if (!organization?.id) {
-        throw new Error("Organization not found");
-      }
+	const {
+		data: response,
+		isPending,
+		refetch,
+	} = useQuery({
+		queryKey: QUERY_KEYS.INTEGRATIONS.all(organization?.id ?? ""),
+		queryFn: async () => {
+			if (!organization?.id) {
+				throw new Error("Organization not found");
+			}
 
-      const res = await fetch(
-        `/api/organizations/${organization.id}/integrations`,
-      );
+			const res = await fetch(
+				`/api/organizations/${organization.id}/integrations`,
+			);
 
-      if (!res.ok) {
-        throw new Error("Failed to fetch integrations");
-      }
+			if (!res.ok) {
+				throw new Error("Failed to fetch integrations");
+			}
 
-      return res.json() as Promise<IntegrationsResponse>;
-    },
-    enabled: !!organization?.id,
-    staleTime: 1000 * 60 * 5, // 5 minutes
-    gcTime: 1000 * 60 * 10, // 10 minutes
-  });
+			return res.json() as Promise<IntegrationsResponse>;
+		},
+		enabled: !!organization?.id,
+		staleTime: 1000 * 60 * 5, // 5 minutes
+		gcTime: 1000 * 60 * 10, // 10 minutes
+	});
 
-  const integrations = response?.integrations.filter(
-    (i) => i.type === "github",
-  );
+	const integrations = response?.integrations.filter(
+		(i) => i.type === "github",
+	);
 
-  return (
-    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-6 px-4 lg:px-6">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <h1 className="font-bold text-3xl tracking-tight">
-              GitHub Integrations
-            </h1>
-            <p className="text-muted-foreground">
-              Manage your GitHub repository integrations and outputs
-            </p>
-          </div>
-          <AddIntegrationDialog
-            onSuccess={() => refetch()}
-            organizationId={organization?.id ?? ""}
-            organizationSlug={organizationSlug}
-            trigger={
-              <Button size="sm" variant="default">
-                Add Github Integration
-              </Button>
-            }
-          />
-        </div>
+	return (
+		<PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+			<div className="w-full space-y-6 px-4 lg:px-6">
+				<div className="flex items-start justify-between gap-4">
+					<div className="space-y-1">
+						<h1 className="font-bold text-3xl tracking-tight">
+							GitHub Integrations
+						</h1>
+						<p className="text-muted-foreground">
+							Manage your GitHub repository integrations and outputs
+						</p>
+					</div>
+					<AddIntegrationDialog
+						onSuccess={() => refetch()}
+						organizationId={organization?.id ?? ""}
+						organizationSlug={organizationSlug}
+						trigger={
+							<Button size="sm" variant="default">
+								Add Github Integration
+							</Button>
+						}
+					/>
+				</div>
 
-        <div>
-          {isPending ? <GitHubIntegrationsPageSkeleton /> : null}
+				<div>
+					{isPending ? <GitHubIntegrationsPageSkeleton /> : null}
 
-          {!isPending && (!integrations || integrations.length === 0) ? (
-            <EmptyState
-              action={
-                <AddIntegrationDialog
-                  onSuccess={() => refetch()}
-                  organizationId={organization?.id ?? ""}
-                  organizationSlug={organizationSlug}
-                  trigger={
-                    <Button size="sm" variant="outline">
-                      Add Github Integration
-                    </Button>
-                  }
-                />
-              }
-              description="Add your first GitHub integration to get started."
-              title="No integrations yet"
-            />
-          ) : null}
+					{!isPending && (!integrations || integrations.length === 0) ? (
+						<EmptyState
+							action={
+								<AddIntegrationDialog
+									onSuccess={() => refetch()}
+									organizationId={organization?.id ?? ""}
+									organizationSlug={organizationSlug}
+									trigger={
+										<Button size="sm" variant="outline">
+											Add Github Integration
+										</Button>
+									}
+								/>
+							}
+							description="Add your first GitHub integration to get started."
+							title="No integrations yet"
+						/>
+					) : null}
 
-          {!isPending && integrations && integrations.length > 0 ? (
-            <div className="grid gap-4">
-              {integrations.map((integration) => (
-                <IntegrationCard
-                  integration={integration}
-                  key={integration.id}
-                  onUpdate={() => refetch()}
-                  organizationId={organization?.id ?? ""}
-                  organizationSlug={organizationSlug}
-                />
-              ))}
-            </div>
-          ) : null}
-        </div>
-      </div>
-    </PageContainer>
-  );
+					{!isPending && integrations && integrations.length > 0 ? (
+						<div className="grid gap-4">
+							{integrations.map((integration) => (
+								<IntegrationCard
+									integration={integration}
+									key={integration.id}
+									onUpdate={() => refetch()}
+									organizationId={organization?.id ?? ""}
+									organizationSlug={organizationSlug}
+								/>
+							))}
+						</div>
+					) : null}
+				</div>
+			</div>
+		</PageContainer>
+	);
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
@@ -9,84 +9,84 @@ import { useTodayPosts } from "@/lib/hooks/use-posts";
 import type { ContentType } from "@/utils/schemas/content";
 
 interface PageClientProps {
-  organizationSlug: string;
+	organizationSlug: string;
 }
 
 function getPreview(markdown: string): string {
-  const lines = markdown
-    .split("\n")
-    .filter((line) => !line.startsWith("#") && line.trim().length > 0);
+	const lines = markdown
+		.split("\n")
+		.filter((line) => !line.startsWith("#") && line.trim().length > 0);
 
-  const preview = lines.slice(0, 2).join(" ").trim();
+	const preview = lines.slice(0, 2).join(" ").trim();
 
-  return preview
-    .replace(/\*\*/g, "")
-    .replace(/\*/g, "")
-    .replace(/`/g, "")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .slice(0, 160);
+	return preview
+		.replace(/\*\*/g, "")
+		.replace(/\*/g, "")
+		.replace(/`/g, "")
+		.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+		.slice(0, 160);
 }
 
 export default function PageClient({ organizationSlug }: PageClientProps) {
-  const { getOrganization, activeOrganization } = useOrganizationsContext();
-  const orgFromList = getOrganization(organizationSlug);
-  const organization =
-    activeOrganization?.slug === organizationSlug
-      ? activeOrganization
-      : orgFromList;
-  const organizationId = organization?.id ?? "";
-  const skeletonId = useId();
-  const { data, isPending } = useTodayPosts(organizationId);
-  const posts = data?.pages.flatMap((page) => page.posts) ?? [];
-  const previewPosts = posts.slice(0, 3);
+	const { getOrganization, activeOrganization } = useOrganizationsContext();
+	const orgFromList = getOrganization(organizationSlug);
+	const organization =
+		activeOrganization?.slug === organizationSlug
+			? activeOrganization
+			: orgFromList;
+	const organizationId = organization?.id ?? "";
+	const skeletonId = useId();
+	const { data, isPending } = useTodayPosts(organizationId);
+	const posts = data?.pages.flatMap((page) => page.posts) ?? [];
+	const previewPosts = posts.slice(0, 3);
 
-  return (
-    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-6 px-4 lg:px-6">
-        <div className="space-y-1">
-          <h1 className="font-bold text-3xl tracking-tight">👋 Welcome!</h1>
-        </div>
+	return (
+		<PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+			<div className="w-full space-y-6 px-4 lg:px-6">
+				<div className="space-y-1">
+					<h1 className="font-bold text-3xl tracking-tight">👋 Welcome!</h1>
+				</div>
 
-        <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="font-semibold text-lg">Today&apos;s content</h2>
-              <p className="text-muted-foreground text-sm">
-                Latest items created today
-              </p>
-            </div>
-          </div>
+				<section className="space-y-4">
+					<div className="flex items-center justify-between">
+						<div>
+							<h2 className="font-semibold text-lg">Today&apos;s content</h2>
+							<p className="text-muted-foreground text-sm">
+								Latest items created today
+							</p>
+						</div>
+					</div>
 
-          {isPending ? (
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 3 }).map((_, index) => (
-                <div
-                  className="h-[140px] rounded-[20px] border border-border/60 bg-muted/30"
-                  key={`${skeletonId}-${index + 1}`}
-                />
-              ))}
-            </div>
-          ) : previewPosts.length > 0 ? (
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {previewPosts.map((post) => (
-                <ContentCard
-                  contentType={post.contentType as ContentType}
-                  href={`/${organizationSlug}/content/${post.id}`}
-                  key={post.id}
-                  preview={getPreview(post.markdown)}
-                  title={post.title}
-                />
-              ))}
-            </div>
-          ) : (
-            <EmptyState
-              className="p-6"
-              description="Check back later or start a new post from the content page."
-              title="No content created today"
-            />
-          )}
-        </section>
-      </div>
-    </PageContainer>
-  );
+					{isPending ? (
+						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+							{Array.from({ length: 3 }).map((_, index) => (
+								<div
+									className="h-[140px] rounded-[20px] border border-border/60 bg-muted/30"
+									key={`${skeletonId}-${index + 1}`}
+								/>
+							))}
+						</div>
+					) : previewPosts.length > 0 ? (
+						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+							{previewPosts.map((post) => (
+								<ContentCard
+									contentType={post.contentType as ContentType}
+									href={`/${organizationSlug}/content/${post.id}`}
+									key={post.id}
+									preview={getPreview(post.markdown)}
+									title={post.title}
+								/>
+							))}
+						</div>
+					) : (
+						<EmptyState
+							className="p-6"
+							description="Check back later or start a new post from the content page."
+							title="No content created today"
+						/>
+					)}
+				</section>
+			</div>
+		</PageContainer>
+	);
 }

--- a/apps/dashboard/src/components/empty-state.tsx
+++ b/apps/dashboard/src/components/empty-state.tsx
@@ -1,49 +1,52 @@
+import { Button } from "@notra/ui/components/ui/button";
 import type React from "react";
+import { cn } from "@/lib/utils";
+
 interface EmptyStateProps extends React.ComponentProps<"div"> {
-  title: string;
-  description: string;
-  action?: React.ReactNode;
-  actionLabel?: string;
-  actionVariant?: React.ComponentProps<typeof Button>["variant"];
-  onActionClick?: React.ComponentProps<"button">["onClick"];
-  actionIcon?: React.ReactNode;
+	title: string;
+	description: string;
+	action?: React.ReactNode;
+	actionLabel?: string;
+	actionVariant?: React.ComponentProps<typeof Button>["variant"];
+	onActionClick?: React.ComponentProps<"button">["onClick"];
+	actionIcon?: React.ReactNode;
 }
 
 function EmptyState({
-  title,
-  description,
-  action,
-  actionLabel,
-  actionVariant = "default",
-  onActionClick,
-  actionIcon,
-  className,
-  ...props
+	title,
+	description,
+	action,
+	actionLabel,
+	actionVariant = "default",
+	onActionClick,
+	actionIcon,
+	className,
+	...props
 }: EmptyStateProps) {
-  const renderedAction =
-    action ??
-    (actionLabel ? (
-      <Button onClick={onActionClick} size="sm" variant={actionVariant}>
-        {actionIcon ? <span className="mr-2">{actionIcon}</span> : null}
-        {actionLabel}
-      </Button>
-    ) : null);
+	const renderedAction =
+		action ??
+		(actionLabel ? (
+			<Button onClick={onActionClick} size="sm" variant={actionVariant}>
+				{actionIcon ? <span className="mr-2">{actionIcon}</span> : null}
+				{actionLabel}
+			</Button>
+		) : null);
 
-  return (
-    <div
-      className={cn(
-        "rounded-2xl border border-dashed p-12 text-center",
-        className,
-      )}
-      {...props}
-    >
-      <h3 className="font-semibold text-lg">{title}</h3>
-      <p className="mt-1 text-muted-foreground text-sm">{description}</p>
-      {renderedAction ? (
-        <div className="mt-4 flex justify-center">{renderedAction}</div>
-      ) : null}
-    </div>
-  );
+	return (
+		<div
+			className={cn(
+				"rounded-2xl border border-dashed p-12 text-center",
+				className,
+			)}
+			{...props}
+		>
+			<h3 className="font-semibold text-lg">{title}</h3>
+			<p className="mt-1 text-muted-foreground text-sm">{description}</p>
+			{renderedAction ? (
+				<div className="mt-4 flex justify-center">{renderedAction}</div>
+			) : null}
+		</div>
+	);
 }
 
 export { EmptyState };

--- a/apps/dashboard/src/components/integrations/add-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/add-integration-dialog.tsx
@@ -1,308 +1,304 @@
 "use client";
 
-import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
 } from "@notra/ui/components/ui/alert-dialog";
 import { Badge } from "@notra/ui/components/ui/badge";
-import { Button } from "@notra/ui/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldLabel,
+	Field,
+	FieldLabel,
 } from "@notra/ui/components/ui/field";
 import { Input } from "@notra/ui/components/ui/input";
-import { Skeleton } from "@notra/ui/components/ui/skeleton";
-
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import type React from "react";
 import { isValidElement, useState } from "react";
 import { toast } from "sonner";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { parseGitHubUrl } from "@/lib/utils/github";
 import type {
-  AddIntegrationDialogProps,
-  GitHubIntegration,
-  GitHubRepoInfo,
+	AddIntegrationDialogProps,
+	GitHubIntegration,
+	GitHubRepoInfo,
 } from "@/types/integrations";
 import { QUERY_KEYS } from "@/utils/query-keys";
 import {
-  type AddGitHubIntegrationFormValues,
-  addGitHubIntegrationFormSchema,
+	type AddGitHubIntegrationFormValues,
+	addGitHubIntegrationFormSchema,
 } from "@/utils/schemas/integrations";
 import { WebhookSetupDialog } from "./wehook-setup-dialog";
 
 export function AddIntegrationDialog({
-  organizationId: propOrganizationId,
-  organizationSlug: propOrganizationSlug,
-  onSuccess,
-  open: controlledOpen,
-  onOpenChange: controlledOnOpenChange,
-  trigger,
+	organizationId: propOrganizationId,
+	organizationSlug: propOrganizationSlug,
+	onSuccess,
+	open: controlledOpen,
+	onOpenChange: controlledOnOpenChange,
+	trigger,
 }: AddIntegrationDialogProps) {
-  const router = useRouter();
-  const { activeOrganization } = useOrganizationsContext();
-  const organizationId = propOrganizationId ?? activeOrganization?.id;
-  const organizationSlug = propOrganizationSlug ?? activeOrganization?.slug;
-  const [internalOpen, setInternalOpen] = useState(false);
-  const open = controlledOpen ?? internalOpen;
-  const setOpen = controlledOnOpenChange ?? setInternalOpen;
-  const queryClient = useQueryClient();
-  const [createdIntegration, setCreatedIntegration] =
-    useState<GitHubIntegration | null>(null);
-  const [showWebhookDialog, setShowWebhookDialog] = useState(false);
+	const router = useRouter();
+	const { activeOrganization } = useOrganizationsContext();
+	const organizationId = propOrganizationId ?? activeOrganization?.id;
+	const organizationSlug = propOrganizationSlug ?? activeOrganization?.slug;
+	const [internalOpen, setInternalOpen] = useState(false);
+	const open = controlledOpen ?? internalOpen;
+	const setOpen = controlledOnOpenChange ?? setInternalOpen;
+	const queryClient = useQueryClient();
+	const [createdIntegration, setCreatedIntegration] =
+		useState<GitHubIntegration | null>(null);
+	const [showWebhookDialog, setShowWebhookDialog] = useState(false);
 
-  const mutation = useMutation({
-    mutationFn: async (values: AddGitHubIntegrationFormValues) => {
-      if (!organizationId) {
-        throw new Error("Organization ID is required");
-      }
-      const parsed = parseGitHubUrl(values.repoUrl);
-      if (!parsed) {
-        throw new Error("Invalid GitHub repository URL");
-      }
+	const mutation = useMutation({
+		mutationFn: async (values: AddGitHubIntegrationFormValues) => {
+			if (!organizationId) {
+				throw new Error("Organization ID is required");
+			}
+			const parsed = parseGitHubUrl(values.repoUrl);
+			if (!parsed) {
+				throw new Error("Invalid GitHub repository URL");
+			}
 
-      const response = await fetch(
-        `/api/organizations/${organizationId}/integrations`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            owner: parsed.owner,
-            repo: parsed.repo,
-            token: values.token?.trim() || null,
-            type: "github" as const,
-          }),
-        },
-      );
+			const response = await fetch(
+				`/api/organizations/${organizationId}/integrations`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						owner: parsed.owner,
+						repo: parsed.repo,
+						token: values.token?.trim() || null,
+						type: "github" as const,
+					}),
+				},
+			);
 
-      const data = await response.json();
+			const data = await response.json();
 
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to create integration");
-      }
+			if (!response.ok) {
+				throw new Error(data.error || "Failed to create integration");
+			}
 
-      return data;
-    },
-    onSuccess: (integration: GitHubIntegration) => {
-      if (organizationId) {
-        queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.INTEGRATIONS.all(organizationId),
-        });
-      }
-      toast.success("GitHub integration added successfully");
-      setOpen(false);
-      form.reset();
-      onSuccess?.();
+			return data;
+		},
+		onSuccess: (integration: GitHubIntegration) => {
+			if (organizationId) {
+				queryClient.invalidateQueries({
+					queryKey: QUERY_KEYS.INTEGRATIONS.all(organizationId),
+				});
+			}
+			toast.success("GitHub integration added successfully");
+			setOpen(false);
+			form.reset();
+			onSuccess?.();
 
-      // Show webhook setup dialog
-      setCreatedIntegration(integration);
-      setShowWebhookDialog(true);
-    },
-    onError: (error: Error) => {
-      toast.error(error.message);
-    },
-  });
+			// Show webhook setup dialog
+			setCreatedIntegration(integration);
+			setShowWebhookDialog(true);
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
 
-  const form = useForm({
-    defaultValues: {
-      repoUrl: "",
-      token: "",
-    },
-    onSubmit: ({ value }) => {
-      // Validate with Zod before submitting
-      const validationResult = addGitHubIntegrationFormSchema.safeParse(value);
-      if (!validationResult.success) {
-        return;
-      }
-      mutation.mutate(validationResult.data);
-    },
-  });
+	const form = useForm({
+		defaultValues: {
+			repoUrl: "",
+			token: "",
+		},
+		onSubmit: ({ value }) => {
+			// Validate with Zod before submitting
+			const validationResult = addGitHubIntegrationFormSchema.safeParse(value);
+			if (!validationResult.success) {
+				return;
+			}
+			mutation.mutate(validationResult.data);
+		},
+	});
 
-  const [repoInfo, setRepoInfo] = useState<GitHubRepoInfo | null>(null);
+	const [repoInfo, setRepoInfo] = useState<GitHubRepoInfo | null>(null);
 
-  if (!organizationId) {
-    return null;
-  }
+	if (!organizationId) {
+		return null;
+	}
 
-  const triggerElement =
-    trigger && isValidElement(trigger) ? (
-      <AlertDialogTrigger render={trigger as React.ReactElement} />
-    ) : null;
+	const triggerElement =
+		trigger && isValidElement(trigger) ? (
+			<AlertDialogTrigger render={trigger as React.ReactElement} />
+		) : null;
 
-  const handleWebhookDialogClose = (isOpen: boolean) => {
-    if (!isOpen) {
-      // Navigate to the integration page when webhook dialog is closed
-      if (organizationSlug && createdIntegration?.id) {
-        router.push(
-          `/${organizationSlug}/integrations/github/${createdIntegration.id}`,
-        );
-      }
-      setShowWebhookDialog(false);
-      setCreatedIntegration(null);
-    }
-  };
+	const handleWebhookDialogClose = (isOpen: boolean) => {
+		if (!isOpen) {
+			// Navigate to the integration page when webhook dialog is closed
+			if (organizationSlug && createdIntegration?.id) {
+				router.push(
+					`/${organizationSlug}/integrations/github/${createdIntegration.id}`,
+				);
+			}
+			setShowWebhookDialog(false);
+			setCreatedIntegration(null);
+		}
+	};
 
-  const firstRepository = createdIntegration?.repositories?.[0];
+	const firstRepository = createdIntegration?.repositories?.[0];
 
-  return (
-    <>
-      <AlertDialog onOpenChange={setOpen} open={open}>
-        {triggerElement}
-        <AlertDialogContent className="sm:max-w-[600px]">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-2xl">
-              Add GitHub Integration
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              Connect a GitHub repository to enable AI-powered outputs like
-              changelogs, blog posts, and tweets.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              form.handleSubmit();
-            }}
-          >
-            <div className="space-y-4 py-4">
-              <form.Field
-                name="repoUrl"
-                validators={{
-                  onChange: addGitHubIntegrationFormSchema.shape.repoUrl,
-                  onChangeAsyncDebounceMs: 300,
-                  onChangeAsync: ({ value }) => {
-                    if (!value.trim()) {
-                      setRepoInfo(null);
-                      return;
-                    }
-                    const parsed = parseGitHubUrl(value);
-                    if (parsed) {
-                      setRepoInfo(parsed);
-                    } else {
-                      setRepoInfo(null);
-                    }
-                  },
-                }}
-              >
-                {(field) => (
-                  <Field>
-                    <FieldLabel>GitHub Repository</FieldLabel>
-                    <Input
-                      disabled={mutation.isPending}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      placeholder="https://github.com/facebook/react or facebook/react"
-                      value={field.state.value}
-                    />
-                    {field.state.meta.errors.length > 0 ? (
-                      <p className="mt-1 text-destructive text-sm">
-                        {typeof field.state.meta.errors[0] === "string"
-                          ? field.state.meta.errors[0]
-                          : ((
-                              field.state.meta.errors[0] as { message?: string }
-                            )?.message ?? "Invalid value")}
-                      </p>
-                    ) : null}
-                    {repoInfo ? (
-                      <div className="mt-2 flex items-center gap-2">
-                        <Badge
-                          className="font-mono text-xs"
-                          variant="secondary"
-                        >
-                          {repoInfo.owner}/{repoInfo.repo}
-                        </Badge>
-                        <a
-                          className="text-primary text-xs hover:underline"
-                          href={repoInfo.fullUrl}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          View on GitHub
-                        </a>
-                      </div>
-                    ) : null}
-                  </Field>
-                )}
-              </form.Field>
+	return (
+		<>
+			<AlertDialog onOpenChange={setOpen} open={open}>
+				{triggerElement}
+				<AlertDialogContent className="sm:max-w-[600px]">
+					<AlertDialogHeader>
+						<AlertDialogTitle className="text-2xl">
+							Add GitHub Integration
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							Connect a GitHub repository to enable AI-powered outputs like
+							changelogs, blog posts, and tweets.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<form
+						onSubmit={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							form.handleSubmit();
+						}}
+					>
+						<div className="space-y-4 py-4">
+							<form.Field
+								name="repoUrl"
+								validators={{
+									onChange: addGitHubIntegrationFormSchema.shape.repoUrl,
+									onChangeAsyncDebounceMs: 300,
+									onChangeAsync: ({ value }) => {
+										if (!value.trim()) {
+											setRepoInfo(null);
+											return;
+										}
+										const parsed = parseGitHubUrl(value);
+										if (parsed) {
+											setRepoInfo(parsed);
+										} else {
+											setRepoInfo(null);
+										}
+									},
+								}}
+							>
+								{(field) => (
+									<Field>
+										<FieldLabel>GitHub Repository</FieldLabel>
+										<Input
+											disabled={mutation.isPending}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											placeholder="https://github.com/facebook/react or facebook/react"
+											value={field.state.value}
+										/>
+										{field.state.meta.errors.length > 0 ? (
+											<p className="mt-1 text-destructive text-sm">
+												{typeof field.state.meta.errors[0] === "string"
+													? field.state.meta.errors[0]
+													: ((
+															field.state.meta.errors[0] as { message?: string }
+														)?.message ?? "Invalid value")}
+											</p>
+										) : null}
+										{repoInfo ? (
+											<div className="mt-2 flex items-center gap-2">
+												<Badge
+													className="font-mono text-xs"
+													variant="secondary"
+												>
+													{repoInfo.owner}/{repoInfo.repo}
+												</Badge>
+												<a
+													className="text-primary text-xs hover:underline"
+													href={repoInfo.fullUrl}
+													rel="noopener noreferrer"
+													target="_blank"
+												>
+													View on GitHub
+												</a>
+											</div>
+										) : null}
+									</Field>
+								)}
+							</form.Field>
 
-              <form.Field name="token">
-                {(field) => (
-                  <Field>
-                    <div className="flex items-baseline gap-2">
-                      <FieldLabel>Personal Access Token</FieldLabel>
-                      <span className="text-muted-foreground text-xs">
-                        (optional)
-                      </span>
-                    </div>
-                    <p className="mb-2 text-muted-foreground text-xs">
-                      Only required for private repositories. Public repos work
-                      without a token.
-                    </p>
-                    <Input
-                      disabled={mutation.isPending}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      placeholder="ghp_... (leave empty for public repos)"
-                      value={field.state.value}
-                    />
-                    <p className="mt-1 text-muted-foreground text-xs">
-                      <a
-                        className="text-primary hover:underline"
-                        href="https://github.com/settings/tokens/new?scopes=repo&description=Notra%20Integration"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Generate a token on GitHub
-                      </a>{" "}
-                      with <code className="text-xs">repo</code> scope
-                    </p>
-                  </Field>
-                )}
-              </form.Field>
-            </div>
-            <AlertDialogFooter>
-              <AlertDialogCancel disabled={mutation.isPending}>
-                Cancel
-              </AlertDialogCancel>
-              <form.Subscribe selector={(state) => [state.canSubmit]}>
-                {([canSubmit]) => (
-                  <AlertDialogAction
-                    disabled={!canSubmit || mutation.isPending}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      form.handleSubmit();
-                    }}
-                    type="button"
-                  >
-                    {mutation.isPending ? "Adding..." : "Add Integration"}
-                  </AlertDialogAction>
-                )}
-              </form.Subscribe>
-            </AlertDialogFooter>
-          </form>
-        </AlertDialogContent>
-      </AlertDialog>
-      {firstRepository && organizationId ? (
-        <WebhookSetupDialog
-          onOpenChange={handleWebhookDialogClose}
-          open={showWebhookDialog}
-          organizationId={organizationId}
-          owner={firstRepository.owner}
-          repo={firstRepository.repo}
-          repositoryId={firstRepository.id}
-        />
-      ) : null}
-    </>
-  );
+							<form.Field name="token">
+								{(field) => (
+									<Field>
+										<div className="flex items-baseline gap-2">
+											<FieldLabel>Personal Access Token</FieldLabel>
+											<span className="text-muted-foreground text-xs">
+												(optional)
+											</span>
+										</div>
+										<p className="mb-2 text-muted-foreground text-xs">
+											Only required for private repositories. Public repos work
+											without a token.
+										</p>
+										<Input
+											disabled={mutation.isPending}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											placeholder="ghp_... (leave empty for public repos)"
+											value={field.state.value}
+										/>
+										<p className="mt-1 text-muted-foreground text-xs">
+											<a
+												className="text-primary hover:underline"
+												href="https://github.com/settings/tokens/new?scopes=repo&description=Notra%20Integration"
+												rel="noopener noreferrer"
+												target="_blank"
+											>
+												Generate a token on GitHub
+											</a>{" "}
+											with <code className="text-xs">repo</code> scope
+										</p>
+									</Field>
+								)}
+							</form.Field>
+						</div>
+						<AlertDialogFooter>
+							<AlertDialogCancel disabled={mutation.isPending}>
+								Cancel
+							</AlertDialogCancel>
+							<form.Subscribe selector={(state) => [state.canSubmit]}>
+								{([canSubmit]) => (
+									<AlertDialogAction
+										disabled={!canSubmit || mutation.isPending}
+										onClick={(e) => {
+											e.preventDefault();
+											form.handleSubmit();
+										}}
+										type="button"
+									>
+										{mutation.isPending ? "Adding..." : "Add Integration"}
+									</AlertDialogAction>
+								)}
+							</form.Subscribe>
+						</AlertDialogFooter>
+					</form>
+				</AlertDialogContent>
+			</AlertDialog>
+			{firstRepository && organizationId ? (
+				<WebhookSetupDialog
+					onOpenChange={handleWebhookDialogClose}
+					open={showWebhookDialog}
+					organizationId={organizationId}
+					owner={firstRepository.owner}
+					repo={firstRepository.repo}
+					repositoryId={firstRepository.id}
+				/>
+			) : null}
+		</>
+	);
 }


### PR DESCRIPTION
## Summary
- add a shared EmptyState component to standardize empty UI
- reuse the empty state on schedules, content, and home pages
- add GitHub integrations CTA buttons (top + empty state) and fix dialog trigger placement

---
## EntelligenceAI PR Summary 
 This PR standardizes empty state UI across the dashboard with a new reusable component and fixes dialog trigger element positioning.
- Created `EmptyState` component in `apps/dashboard/src/components/empty-state.tsx` with configurable title, description, and action props
- Refactored empty states in schedules, content, integrations, and main dashboard pages to use the new component
- Reformatted all modified files from tab to 2-space indentation
- Added explicit trigger buttons to GitHub integrations dialog with different variants for header and empty state
- Fixed `AddIntegrationDialog` component structure by moving trigger element inside AlertDialog
- Updated schedule page button text from 'Add schedule' to 'New Schedule' 

