### PR TITLE
fix: centralize app URL normalization and trailing slash handling

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
@@ -24,6 +24,7 @@ import type { GitHubIntegration, GitHubRepository } from "@/types/integrations";
 import type { Trigger } from "@/types/triggers";
 import { getOutputTypeLabel } from "@/utils/output-types";
 import { QUERY_KEYS } from "@/utils/query-keys";
+import { getConfiguredAppUrl, normalizeUrl } from "@/utils/url";
 import { GitHubIntegrationDetailSkeleton } from "./skeleton";
 
 const EditIntegrationDialog = dynamic(
@@ -54,8 +55,8 @@ function buildWebhookUrl(
   const baseUrl =
     typeof window !== "undefined"
       ? window.location.origin
-      : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-  return `${baseUrl}/api/webhooks/github/${organizationId}/${integrationId}/${repositoryId}`;
+      : (getConfiguredAppUrl() ?? "http://localhost:3000");
+  return `${normalizeUrl(baseUrl)}/api/webhooks/github/${organizationId}/${integrationId}/${repositoryId}`;
 }
 
 function CopyableWebhookUrl({ url }: { url: string }) {

--- a/apps/dashboard/src/lib/services/github-integration.ts
+++ b/apps/dashboard/src/lib/services/github-integration.ts
@@ -11,6 +11,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { customAlphabet } from "nanoid";
 import { decryptToken, encryptToken } from "@/lib/crypto/token-encryption";
 import type { OutputContentType } from "@/utils/schemas/integrations";
+import { getConfiguredAppUrl } from "@/utils/url";
 import { createOctokit } from "../octokit";
 
 const nanoid = customAlphabet("abcdefghijklmnopqrstuvwxyz0123456789", 16);
@@ -642,10 +643,6 @@ function buildWebhookUrl(
   organizationId: string,
   repositoryId: string
 ): string {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    (process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : "http://localhost:3000");
+  const baseUrl = getConfiguredAppUrl() ?? "http://localhost:3000";
   return `${baseUrl}/api/webhooks/github/${organizationId}/${integrationId}/${repositoryId}`;
 }

--- a/apps/dashboard/src/lib/triggers/qstash.ts
+++ b/apps/dashboard/src/lib/triggers/qstash.ts
@@ -1,6 +1,7 @@
 import { Client as QStashClient } from "@upstash/qstash";
 import { Client as WorkflowClient } from "@upstash/workflow";
 import type { TriggerSourceConfig } from "@/types/triggers";
+import { getConfiguredAppUrl, requireConfiguredAppUrl } from "@/utils/url";
 
 function getQstashToken() {
   const token = process.env.QSTASH_TOKEN;
@@ -11,29 +12,11 @@ function getQstashToken() {
 }
 
 export function getAppUrl() {
-  const url =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.APP_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null);
-  if (!url) {
-    throw new Error(
-      "App URL not configured. Set NEXT_PUBLIC_APP_URL, APP_URL, or VERCEL_URL."
-    );
-  }
-  return url;
+  return requireConfiguredAppUrl();
 }
 
 export function getBaseUrl() {
-  const url =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.APP_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
-
-  if (!url) {
-    return undefined;
-  }
-
-  return url.replace(/\/+$/, "");
+  return getConfiguredAppUrl();
 }
 
 function getQStashClient() {

--- a/apps/dashboard/src/utils/url.ts
+++ b/apps/dashboard/src/utils/url.ts
@@ -1,0 +1,28 @@
+export function normalizeUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+export function getConfiguredAppUrl(): string | undefined {
+  const url =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.APP_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
+
+  if (!url) {
+    return undefined;
+  }
+
+  return normalizeUrl(url);
+}
+
+export function requireConfiguredAppUrl(): string {
+  const url = getConfiguredAppUrl();
+
+  if (!url) {
+    throw new Error(
+      "App URL not configured. Set NEXT_PUBLIC_APP_URL, APP_URL, or VERCEL_URL."
+    );
+  }
+
+  return url;
+}

--- a/packages/email/src/utils/config.ts
+++ b/packages/email/src/utils/config.ts
@@ -1,10 +1,16 @@
+function normalizeUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
 export const EMAIL_CONFIG = {
   /**
    * Site URL for marketing site (logo, assets, etc.)
    * Falls back to production URL if not set
    */
   getSiteUrl(): string {
-    return process.env.NEXT_PUBLIC_SITE_URL || "https://usenotra.com";
+    return normalizeUrl(
+      process.env.NEXT_PUBLIC_SITE_URL || "https://usenotra.com"
+    );
   },
 
   /**
@@ -12,7 +18,9 @@ export const EMAIL_CONFIG = {
    * Falls back to production URL if not set
    */
   getAppUrl(): string {
-    return process.env.NEXT_PUBLIC_APP_URL || "https://app.usenotra.com";
+    return normalizeUrl(
+      process.env.NEXT_PUBLIC_APP_URL || "https://app.usenotra.com"
+    );
   },
 
   /**


### PR DESCRIPTION
## Summary
- centralize dashboard app URL resolution and trailing-slash normalization in a shared `utils/url` module
- update QStash and GitHub webhook URL builders to reuse the shared helpers so endpoint URLs are consistently composed
- normalize email `getSiteUrl` and `getAppUrl` outputs to avoid accidental double slashes in generated links

---
## EntelligenceAI PR Summary 
 This PR centralizes URL configuration logic by introducing reusable utility functions, eliminating code duplication across the dashboard application.
- Created new `utils/url.ts` module with `normalizeUrl()`, `getConfiguredAppUrl()`, and `requireConfiguredAppUrl()` functions
- Refactored GitHub integration webhook URL building to use centralized utilities
- Updated QStash trigger URL configuration to leverage new helper functions
- Integrated URL normalization into email service configuration methods
- Maintains existing fallback behavior (NEXT_PUBLIC_APP_URL → APP_URL → VERCEL_URL → localhost:3000)
- Ensures consistent trailing slash removal across all URL handling 

