### PR TITLE
fix: deduct AI credits for scheduled content generation

### DIFF
--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -16,11 +16,11 @@ import { z } from "zod";
 import { generateChangelog } from "@/lib/ai/agents/changelog";
 import { isGitHubRateLimitError } from "@/lib/ai/tools/github";
 import { autumn } from "@/lib/billing/autumn";
-import { FEATURES } from "@/lib/billing/constants";
 import { trackScheduledContentCreated } from "@/lib/databuddy";
 import { getBaseUrl, triggerScheduleNow } from "@/lib/triggers/qstash";
 import { getValidToneProfile } from "@/schemas/brand";
 import type { LookbackWindow } from "@/schemas/integrations";
+import { FEATURES } from "@/utils/constants";
 
 const nanoid = customAlphabet("abcdefghijklmnopqrstuvwxyz0123456789", 16);
 


### PR DESCRIPTION
## Summary
- add an Autumn AI credit entitlement check before schedule workflow generation starts
- cancel scheduled runs early when AI credits are exhausted to avoid generating unpaid content
- deduct 1 AI credit after successful scheduled post creation and Databuddy tracking, with non-fatal logging on track errors