### PR TITLE
feat(dashboard): show repo name under custom GitHub integration labels

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
@@ -8,6 +8,7 @@ import {
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
 import { Input } from "@notra/ui/components/ui/input";
+import { Github } from "@notra/ui/components/ui/svgs/github";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowRightIcon,
@@ -327,6 +328,16 @@ export default function PageClient({ integrationId }: PageClientProps) {
     );
   }
 
+  const primaryRepository = integration.repositories[0];
+  const repositoryFullName =
+    integration.repositories.length === 1 && primaryRepository
+      ? `${primaryRepository.owner}/${primaryRepository.repo}`
+      : null;
+  const shouldShowRepositoryFullName =
+    !!repositoryFullName &&
+    repositoryFullName.toLowerCase() !==
+      integration.displayName.trim().toLowerCase();
+
   return (
     <div className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
@@ -335,6 +346,12 @@ export default function PageClient({ integrationId }: PageClientProps) {
             <h1 className="font-bold text-3xl tracking-tight">
               {integration.displayName}
             </h1>
+            {shouldShowRepositoryFullName && repositoryFullName ? (
+              <p className="flex items-center gap-2 text-muted-foreground text-sm">
+                <Github className="size-4 shrink-0" />
+                <span>{repositoryFullName}</span>
+              </p>
+            ) : null}
             <p className="text-muted-foreground">
               Configure your GitHub integration and manage repositories
             </p>

--- a/apps/dashboard/src/components/integrations-card.tsx
+++ b/apps/dashboard/src/components/integrations-card.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
 import { Input } from "@notra/ui/components/ui/input";
+import { Github } from "@notra/ui/components/ui/svgs/github";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -160,6 +161,15 @@ export function InstalledIntegrationCard({
   };
 
   const repositoryCount = integration.repositories.length;
+  const primaryRepository = integration.repositories[0];
+  const repositoryFullName = primaryRepository
+    ? `${primaryRepository.owner}/${primaryRepository.repo}`
+    : null;
+  const shouldShowRepositoryFullName =
+    repositoryCount === 1 &&
+    !!repositoryFullName &&
+    repositoryFullName.toLowerCase() !==
+      integration.displayName.trim().toLowerCase();
   const repositoryText =
     repositoryCount === 0
       ? "No repositories"
@@ -233,6 +243,12 @@ export function InstalledIntegrationCard({
       icon={icon}
       onClick={handleCardClick}
     >
+      {shouldShowRepositoryFullName && repositoryFullName ? (
+        <p className="mb-1 flex items-center gap-1.5 text-muted-foreground text-xs">
+          <Github className="size-3.5 shrink-0" />
+          <span className="truncate">{repositoryFullName}</span>
+        </p>
+      ) : null}
       <p className="text-muted-foreground text-sm">{repositoryText}</p>
       <AlertDialog
         onOpenChange={setIsDeleteDialogOpen}


### PR DESCRIPTION
## Summary
- show the repository full name (`owner/repo`) under the editable GitHub integration display name when they differ
- keep the UI clean by hiding the extra repo line when the display name already matches the repository full name
- use the existing shared GitHub SVG component for icon consistency across integration surfaces