### PR TITLE
chore(lint): enable useTopLevelRegex and hoist regex literals

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/billing/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/billing/page.tsx
@@ -35,6 +35,8 @@ import { PageContainer } from "@/components/layout/container";
 
 const BILLING_SECTION_VALUES = ["billing", "usage"] as const;
 
+const PRICE_REGEX = /^\d+([.,]\d+)?$/;
+
 const SCENARIO_TEXT: Record<string, string> = {
   scheduled: "Plan Scheduled",
   active: "Current Plan",
@@ -179,7 +181,7 @@ function getProductFeatures(product: Product | undefined): string[] {
     .map((item) => {
       const displayText = item.display?.primary_text ?? "";
       // Remove later: skip price-like display text until Autumn SDK fix
-      if (displayText.startsWith("$") || /^\d+([.,]\d+)?$/.test(displayText)) {
+      if (displayText.startsWith("$") || PRICE_REGEX.test(displayText)) {
         return "";
       }
       if (displayText) {
@@ -617,7 +619,7 @@ export default function BillingPage() {
                                     ).toLocaleDateString()
                                   : "-"}
                               </TableCell>
-                              <TableCell className="whitespace-normal break-words">
+                              <TableCell className="wrap-break-word whitespace-normal">
                                 {getInvoiceDescription(invoice.product_ids)}
                               </TableCell>
                               <TableCell className="w-[120px] tabular-nums">

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -124,8 +124,10 @@ interface ModalContentProps {
   inlineError?: string;
 }
 
+const FULL_URL_REGEX = /^https?:\/\//i;
+
 const sanitizeBrandUrlInput = (value: string) =>
-  value.trim().replace(/^https?:\/\//i, "");
+  value.trim().replace(FULL_URL_REGEX, "");
 
 type StepIconState = "pending" | "active" | "completed";
 

--- a/apps/dashboard/src/app/api/upload/route.ts
+++ b/apps/dashboard/src/app/api/upload/route.ts
@@ -7,6 +7,8 @@ import { getFileExtension } from "@/lib/upload/mime";
 import { R2_BUCKET_NAME, R2_PUBLIC_URL, r2 } from "@/lib/upload/r2";
 import { uploadSchema, validateUpload } from "@/schemas/upload";
 
+const TRAILING_SLASH_REGEX = /\/$/;
+
 export async function POST(request: Request) {
   const sessionData = await getServerSession({
     headers: request.headers,
@@ -93,7 +95,7 @@ export async function POST(request: Request) {
     { expiresIn: 3600 }
   );
 
-  const baseUrl = R2_PUBLIC_URL.replace(/\/$/, "");
+  const baseUrl = R2_PUBLIC_URL.replace(TRAILING_SLASH_REGEX, "");
   const publicUrl = `${baseUrl}/${key}`;
 
   return NextResponse.json({

--- a/apps/dashboard/src/components/content/editor/markdown-transformers.ts
+++ b/apps/dashboard/src/components/content/editor/markdown-transformers.ts
@@ -100,12 +100,16 @@ export const KIBO_CODE_BLOCK: MultilineElementTransformer = {
 
 const TABLE_ROW_REGEX = /^\|(.*)\|\s*$/;
 const TABLE_SEPARATOR_REGEX = /^\|(\s*:?-+:?\s*\|)+\s*$/;
+const LEADING_PIPE_REGEX = /^\|/;
+const TRAILING_PIPE_REGEX = /\|\s*$/;
 
 function parsePipeCells(row: string): string[] {
   const cells: string[] = [];
   let current = "";
   let escaped = false;
-  const inner = row.replace(/^\|/, "").replace(/\|\s*$/, "");
+  const inner = row
+    .replace(LEADING_PIPE_REGEX, "")
+    .replace(TRAILING_PIPE_REGEX, "");
 
   for (const char of inner) {
     if (escaped) {

--- a/apps/dashboard/src/lib/ai/tools/github.ts
+++ b/apps/dashboard/src/lib/ai/tools/github.ts
@@ -11,6 +11,7 @@ import { getAICachedTools } from "./tool-cache";
 
 const GITHUB_PRIMARY_RATE_LIMIT_MESSAGE =
   "GitHub API rate limit reached. Please retry later.";
+const LINK_HEADER_NEXT_PAGE_REGEX = /<([^>]+)>\s*;\s*rel="next"/i;
 
 function parseRetryAfterSeconds(value?: string | number) {
   if (typeof value === "number" && Number.isFinite(value) && value > 0) {
@@ -175,7 +176,7 @@ function getNextPageFromLinkHeader(
   if (typeof linkHeader !== "string" || !linkHeader.trim()) {
     return undefined;
   }
-  const nextMatch = linkHeader.match(/<([^>]+)>\s*;\s*rel="next"/i);
+  const nextMatch = linkHeader.match(LINK_HEADER_NEXT_PAGE_REGEX);
   if (!nextMatch?.[1]) {
     return undefined;
   }

--- a/apps/dashboard/src/utils/url.ts
+++ b/apps/dashboard/src/utils/url.ts
@@ -1,5 +1,7 @@
+const TRAILING_SLASHES_REGEX = /\/+$/;
+
 export function normalizeUrl(url: string): string {
-  return url.replace(/\/+$/, "");
+  return url.replace(TRAILING_SLASHES_REGEX, "");
 }
 
 export function getConfiguredAppUrl(): string | undefined {

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -1,14 +1,19 @@
 import type { MDXComponents } from "mdx/types";
 
+const REL_TOKENS_SPLIT_REGEX = /\s+/;
+const EXTERNAL_HREF_REGEX = /^(https?:)?\/\//;
+
 function withSafeExternalRel(rel?: string) {
-  const tokens = new Set((rel ?? "").split(/\s+/).filter(Boolean));
+  const tokens = new Set(
+    (rel ?? "").split(REL_TOKENS_SPLIT_REGEX).filter(Boolean)
+  );
   tokens.add("noopener");
   tokens.add("noreferrer");
   return [...tokens].join(" ");
 }
 
 function isExternalHref(href?: string) {
-  return typeof href === "string" && /^(https?:)?\/\//.test(href);
+  return typeof href === "string" && EXTERNAL_HREF_REGEX.test(href);
 }
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {

--- a/apps/web/src/utils/changelog.ts
+++ b/apps/web/src/utils/changelog.ts
@@ -73,15 +73,12 @@ export const CHANGELOG_COMPANIES = [
   },
 ] as const;
 
+const MDX_EXTENSION_REGEX = /\.mdx$/;
+
 export function getCompany(slug: string) {
   return CHANGELOG_COMPANIES.find((c) => c.slug === slug);
 }
 
 export function getEntrySlug(infoPath: string) {
-  return (
-    infoPath
-      .split("/")
-      .pop()
-      ?.replace(/\.mdx$/, "") ?? ""
-  );
+  return infoPath.split("/").pop()?.replace(MDX_EXTENSION_REGEX, "") ?? "";
 }

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -1,3 +1,5 @@
+const FRONTMATTER_REGEX = /^---\n[\s\S]*?\n---\n?/;
+
 export function markdownResponse(content: string, status = 200) {
   return new Response(content, {
     status,
@@ -13,7 +15,7 @@ export function markdownSection(title: string, lines: string[]) {
 }
 
 export function stripFrontmatter(source: string) {
-  return source.replace(/^---\n[\s\S]*?\n---\n?/, "").trim();
+  return source.replace(FRONTMATTER_REGEX, "").trim();
 }
 
 export function decodeHtmlEntities(source: string) {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -55,7 +55,6 @@
       },
       "performance": {
         /* Needs more work to fix */
-        "useTopLevelRegex": "off",
         "noNamespaceImport": "warn",
         "noBarrelFile": "warn"
       },

--- a/packages/email/src/utils/config.ts
+++ b/packages/email/src/utils/config.ts
@@ -1,5 +1,7 @@
+const URL_REGEX = /\/+$/;
+
 function normalizeUrl(url: string): string {
-  return url.replace(/\/+$/, "");
+  return url.replace(URL_REGEX, "");
 }
 
 export const EMAIL_CONFIG = {


### PR DESCRIPTION
## Summary
- re-enable Biome `useTopLevelRegex` by removing the top-level override in `biome.jsonc`
- hoist regex literals used inside functions to module-level constants across dashboard, web, and email utils
- keep behavior unchanged while satisfying lint performance requirements and preserving the recent billing/brand updates in this branch

## Validation
- `bun run check -- --max-diagnostics=200`