### PR TITLE
chore(lint): allow zod namespace imports

### DIFF
--- a/apps/dashboard/src/lib/ai/tools/github.ts
+++ b/apps/dashboard/src/lib/ai/tools/github.ts
@@ -1,4 +1,5 @@
 import { type Tool, tool } from "ai";
+// biome-ignore lint/performance/noNamespaceImport: zod recommends namespace import style
 import * as z from "zod";
 import { createOctokit } from "@/lib/octokit";
 import { getGitHubToolRepositoryContextByIntegrationId } from "@/lib/services/github-integration";

--- a/apps/dashboard/src/schemas/api-keys.ts
+++ b/apps/dashboard/src/schemas/api-keys.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/performance/noNamespaceImport: zod recommends namespace import style
 import * as z from "zod";
 
 export const API_KEY_PERMISSIONS = ["api.read", "api.write"] as const;


### PR DESCRIPTION
## Summary
- suppress `lint/performance/noNamespaceImport` for `zod` namespace imports in dashboard code
- keep `import * as z from \"zod\"` style where recommended by Zod docs
- preserve existing `noNamespaceImport` warnings for other libraries

## Validation
- `bun run check -- --max-diagnostics=250`
- verified no `noNamespaceImport` diagnostics remain