### PR TITLE
feat(auth): enforce team member limits for organization membership

### DIFF
--- a/apps/dashboard/src/app/(auth-public)/invitation/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(auth-public)/invitation/[id]/page-client.tsx
@@ -34,7 +34,10 @@ import { useEffect, useState } from "react";
 import { LoginForm } from "@/components/auth/login-form";
 import { SignupForm } from "@/components/auth/signup-form";
 import { authClient } from "@/lib/auth/client";
-import { mapInviteLimitErrorMessage } from "@/lib/billing/limits";
+import {
+  isTeamMemberLimitError,
+  mapBillingLimitErrorMessage,
+} from "@/lib/billing/limits";
 
 interface InvitationData {
   id: string;
@@ -100,7 +103,7 @@ function PageClient({
 
       if (res.error) {
         setError(
-          mapInviteLimitErrorMessage(
+          mapBillingLimitErrorMessage(
             res.error.message,
             "Failed to accept invitation"
           )
@@ -196,7 +199,20 @@ function PageClient({
           </Tabs>
           {error && (
             <div className="mt-4 rounded-sm border border-destructive bg-destructive/10 p-3">
-              <p className="text-center text-destructive text-sm">{error}</p>
+              <p className="text-center text-destructive text-sm">
+                {error}
+                {isTeamMemberLimitError(error) && (
+                  <>
+                    {" "}
+                    <Link
+                      className="font-medium underline underline-offset-2"
+                      href={`/${invitation.organizationSlug}/billing`}
+                    >
+                      View plans
+                    </Link>
+                  </>
+                )}
+              </p>
             </div>
           )}
         </CardContent>
@@ -307,7 +323,20 @@ function PageClient({
       </CardContent>
       {error && inviteStatus === "pending" && (
         <div className="mt-4 rounded-sm border border-destructive bg-destructive/10 p-3">
-          <p className="text-center text-destructive text-sm">{error}</p>
+          <p className="text-center text-destructive text-sm">
+            {error}
+            {isTeamMemberLimitError(error) && (
+              <>
+                {" "}
+                <Link
+                  className="font-medium underline underline-offset-2"
+                  href={`/${invitation.organizationSlug}/billing`}
+                >
+                  View plans
+                </Link>
+              </>
+            )}
+          </p>
         </div>
       )}
       {inviteStatus === "pending" && (

--- a/apps/dashboard/src/components/members/invitation-actions.tsx
+++ b/apps/dashboard/src/components/members/invitation-actions.tsx
@@ -41,7 +41,7 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { authClient } from "@/lib/auth/client";
 import {
   isTeamMemberLimitError,
-  mapInviteLimitErrorMessage,
+  mapBillingLimitErrorMessage,
 } from "@/lib/billing/limits";
 
 interface InvitationActionsProps {
@@ -77,7 +77,7 @@ export function InvitationActions({ invitation }: InvitationActionsProps) {
       });
 
       if (error) {
-        const message = mapInviteLimitErrorMessage(
+        const message = mapBillingLimitErrorMessage(
           error.message,
           "Failed to resend invitation"
         );

--- a/apps/dashboard/src/components/members/invite-member-modal.tsx
+++ b/apps/dashboard/src/components/members/invite-member-modal.tsx
@@ -27,7 +27,7 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { authClient } from "@/lib/auth/client";
 import {
   isTeamMemberLimitError,
-  mapInviteLimitErrorMessage,
+  mapBillingLimitErrorMessage,
 } from "@/lib/billing/limits";
 
 interface InviteMemberModalProps {
@@ -75,7 +75,10 @@ export function InviteMemberModal({
       });
     },
     onError: (error) => {
-      const message = mapInviteLimitErrorMessage(error.message);
+      const message = mapBillingLimitErrorMessage(
+        error.message,
+        "Failed to send invitation"
+      );
 
       if (isTeamMemberLimitError(error.message) && activeOrganization?.slug) {
         toast.error(message, {

--- a/apps/dashboard/src/components/members/member-actions.tsx
+++ b/apps/dashboard/src/components/members/member-actions.tsx
@@ -47,7 +47,7 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { authClient } from "@/lib/auth/client";
 import {
   isTeamMemberLimitError,
-  mapInviteLimitErrorMessage,
+  mapBillingLimitErrorMessage,
 } from "@/lib/billing/limits";
 import type { Member } from "./columns";
 
@@ -100,7 +100,7 @@ export function MemberActions({ member }: MemberActionsProps) {
       });
 
       if (error) {
-        const message = mapInviteLimitErrorMessage(
+        const message = mapBillingLimitErrorMessage(
           error.message,
           "Failed to update member role"
         );

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -17,6 +17,10 @@ import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
 import { FEATURES } from "@/constants/features";
 import { autumn } from "@/lib/billing/autumn";
 import {
+  TEAM_MEMBER_LIMIT_CHECK_UNAVAILABLE_MESSAGE,
+  TEAM_MEMBER_LIMIT_ERROR_MESSAGE,
+} from "@/lib/billing/limits";
+import {
   sendInviteEmailAction,
   sendResetPasswordAction,
   sendVerificationEmailAction,
@@ -44,13 +48,15 @@ async function enforceTeamMembersLimit(organizationId?: string | null) {
       organizationId,
       error,
     });
-    return;
+
+    throw new APIError("INTERNAL_SERVER_ERROR", {
+      message: TEAM_MEMBER_LIMIT_CHECK_UNAVAILABLE_MESSAGE,
+    });
   }
 
   if (data?.allowed === false) {
     throw new APIError("BAD_REQUEST", {
-      message:
-        "You have reached your team member limit for this plan. Upgrade to invite more members.",
+      message: TEAM_MEMBER_LIMIT_ERROR_MESSAGE,
     });
   }
 }

--- a/apps/dashboard/src/lib/billing/limits.ts
+++ b/apps/dashboard/src/lib/billing/limits.ts
@@ -1,26 +1,32 @@
-const TEAM_MEMBER_LIMIT_MATCHERS = [
-  "team member limit",
-  "invite more members",
-  "team_members",
-];
+export const TEAM_MEMBER_LIMIT_ERROR_MESSAGE =
+  "You have reached your team member limit for this plan. Upgrade to invite more members.";
 
 export const TEAM_MEMBER_LIMIT_TOAST_MESSAGE =
   "Team member limit reached on your current plan.";
+
+export const TEAM_MEMBER_LIMIT_CHECK_UNAVAILABLE_MESSAGE =
+  "We could not verify your team member limits right now. Please try again.";
+
+function normalizeErrorMessage(errorMessage: string) {
+  return errorMessage.trim().toLowerCase();
+}
 
 export function isTeamMemberLimitError(errorMessage?: string | null): boolean {
   if (!errorMessage) {
     return false;
   }
 
-  const normalized = errorMessage.toLowerCase();
-  return TEAM_MEMBER_LIMIT_MATCHERS.some((matcher) =>
-    normalized.includes(matcher)
+  const normalized = normalizeErrorMessage(errorMessage);
+
+  return (
+    normalized === normalizeErrorMessage(TEAM_MEMBER_LIMIT_ERROR_MESSAGE) ||
+    normalized === normalizeErrorMessage(TEAM_MEMBER_LIMIT_TOAST_MESSAGE)
   );
 }
 
-export function mapInviteLimitErrorMessage(
+export function mapBillingLimitErrorMessage(
   errorMessage?: string | null,
-  fallback = "Failed to send invitation"
+  fallback = "Action failed"
 ): string {
   if (isTeamMemberLimitError(errorMessage)) {
     return TEAM_MEMBER_LIMIT_TOAST_MESSAGE;


### PR DESCRIPTION
## Summary
- enforce `team_members` limits in Better Auth organization hooks before invitations and member additions
- return consistent team-member-limit messaging across invite, resend, role-update, and invitation-accept flows
- add an in-toast `View plans` action that routes users to organization billing when they hit the limit

## Validation
- `bun run --filter=dashboard check-types`

Closes #159