### PR TITLE
fix(billing): preserve event properties in credits activity

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/credits/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/credits/page-client.tsx
@@ -22,11 +22,8 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@notra/ui/components/ui/tabs";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { cn } from "@notra/ui/lib/utils";
-import {
-  useAggregateEvents,
-  useCustomer,
-  useListEvents,
-} from "autumn-js/react";
+import { useQuery } from "@tanstack/react-query";
+import { useAggregateEvents, useCustomer } from "autumn-js/react";
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -39,6 +36,7 @@ import {
   CREDIT_RANGES,
   type CreditRangeOption,
 } from "@/types/billing/credits";
+import type { CreditEvent, CreditEventsResponse } from "@/types/billing/events";
 import {
   formatDollars,
   formatFullDate,
@@ -55,7 +53,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-function renderEventRows(events: ReturnType<typeof useListEvents>["list"]) {
+function renderEventRows(events: CreditEvent[] | undefined) {
   if (!events?.length) {
     return (
       <TableRow>
@@ -71,8 +69,7 @@ function renderEventRows(events: ReturnType<typeof useListEvents>["list"]) {
 
   return events.map((event) => {
     const outputType =
-      "output_type" in event.properties &&
-      typeof event.properties.output_type === "string"
+      typeof event.properties?.output_type === "string"
         ? event.properties.output_type
         : undefined;
 
@@ -110,10 +107,22 @@ export default function CreditsPageClient() {
     binSize: "day",
   });
 
-  const { list: eventsList, isLoading: eventsLoading } = useListEvents({
-    featureId: FEATURES.AI_CREDITS,
-    limit: 20,
+  const { data: eventsData, isLoading: eventsLoading } = useQuery({
+    queryKey: ["credit-events", FEATURES.AI_CREDITS],
+    queryFn: async () => {
+      const res = await fetch("/api/autumn/events/list", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feature_id: FEATURES.AI_CREDITS,
+          limit: 20,
+        }),
+      });
+      return res.json() as Promise<CreditEventsResponse>;
+    },
   });
+  const eventsList = eventsData?.list;
 
   const aiCredits = customer?.balances?.[FEATURES.AI_CREDITS];
   const aiCreditsBalance =

--- a/apps/dashboard/src/app/(dashboard)/[slug]/credits/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/credits/page-client.tsx
@@ -108,7 +108,7 @@ export default function CreditsPageClient() {
   });
 
   const { data: eventsData, isLoading: eventsLoading } = useQuery({
-    queryKey: ["credit-events", FEATURES.AI_CREDITS],
+    queryKey: ["credit-events", FEATURES.AI_CREDITS, slug],
     queryFn: async () => {
       const res = await fetch("/api/autumn/events/list", {
         method: "POST",
@@ -119,6 +119,9 @@ export default function CreditsPageClient() {
           limit: 20,
         }),
       });
+      if (!res.ok) {
+        throw new Error(`Failed to fetch events: ${res.status}`);
+      }
       return res.json() as Promise<CreditEventsResponse>;
     },
   });

--- a/apps/dashboard/src/types/billing/events.ts
+++ b/apps/dashboard/src/types/billing/events.ts
@@ -1,0 +1,16 @@
+export type CreditEvent = {
+  id: string;
+  timestamp: number;
+  feature_id: string;
+  customer_id: string;
+  value: number;
+  properties: Record<string, unknown>;
+};
+
+export type CreditEventsResponse = {
+  list: CreditEvent[];
+  total: number;
+  has_more: boolean;
+  offset: number;
+  limit: number;
+};


### PR DESCRIPTION
## Summary
- The Autumn SDK's `useListEvents` hook uses `z.object({})` for the `properties` field, which strips all custom properties (including `output_type`) during Zod response parsing — this caused the "Type" column in Recent Activity to always show "—"
- Replaced `useListEvents` with a direct `fetch` via `react-query` to the same `/api/autumn/events/list` proxy endpoint, bypassing the SDK's schema validation so `properties.output_type` is preserved

## Test plan
- [ ] Go to `/credits` page and verify the "Type" column in Recent Activity shows the correct output type (e.g. "Blog Post", "Twitter Post") instead of "—"
- [ ] Verify events without properties still show "—" gracefully
- [ ] Verify loading skeletons still appear while fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)