### PR TITLE
feat(web): cache databuddy feature flags in localStorage

### DIFF
--- a/apps/web/src/components/landing-page-headline.tsx
+++ b/apps/web/src/components/landing-page-headline.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useFlag } from "@databuddy/sdk/react";
 import {
   getLandingPageH1Copy,
   LANDING_PAGE_H1_EXPERIMENT_KEY,
 } from "@/utils/databuddy";
+import { useCachedFlag } from "@/utils/feature-flag-cache";
 
 export function LandingPageHeadline({ className }: { className?: string }) {
-  const { variant } = useFlag(LANDING_PAGE_H1_EXPERIMENT_KEY);
+  const { variant } = useCachedFlag(LANDING_PAGE_H1_EXPERIMENT_KEY);
 
   return <h1 className={className}>{getLandingPageH1Copy(variant)}</h1>;
 }

--- a/apps/web/src/components/tracked-signup-link.tsx
+++ b/apps/web/src/components/tracked-signup-link.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { track, useFlag } from "@databuddy/sdk/react";
+import { track } from "@databuddy/sdk/react";
 import Link from "next/link";
 import type { ComponentProps, MouseEvent } from "react";
 import {
@@ -10,6 +10,7 @@ import {
   normalizeLandingPageH1Variant,
   serializeSignupAttribution,
 } from "@/utils/databuddy";
+import { useCachedFlag } from "@/utils/feature-flag-cache";
 
 const DEFAULT_SIGNUP_URL = "https://app.usenotra.com/signup";
 
@@ -39,7 +40,7 @@ export function TrackedSignupLink({
   source,
   ...props
 }: TrackedSignupLinkProps) {
-  const { variant } = useFlag(LANDING_PAGE_H1_EXPERIMENT_KEY);
+  const { variant } = useCachedFlag(LANDING_PAGE_H1_EXPERIMENT_KEY);
   const trackedHref = buildTrackedSignupHref(href, source, variant);
 
   function handleClick(event: MouseEvent<HTMLAnchorElement>) {

--- a/apps/web/src/utils/feature-flag-cache.ts
+++ b/apps/web/src/utils/feature-flag-cache.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useFlag } from "@databuddy/sdk/react";
+import { useEffect, useState } from "react";
+
+const STORAGE_PREFIX = "notra_ff_";
+const CACHE_TTL_MS = 1000 * 60 * 60 * 24;
+
+type FlagValue = boolean | string | number | undefined;
+
+type CachedFlag = {
+  on: boolean;
+  value: FlagValue;
+  variant: string | undefined;
+};
+
+type CacheEntry = CachedFlag & { cachedAt: number };
+
+type CachedFlagState = {
+  on: boolean;
+  status: "loading" | "ready" | "error" | "pending";
+  loading: boolean;
+  value: FlagValue;
+  variant: string | undefined;
+};
+
+function readCache(key: string): CachedFlag | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + key);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as CacheEntry;
+
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof parsed.cachedAt !== "number"
+    ) {
+      window.localStorage.removeItem(STORAGE_PREFIX + key);
+      return null;
+    }
+
+    if (Date.now() - parsed.cachedAt > CACHE_TTL_MS) {
+      window.localStorage.removeItem(STORAGE_PREFIX + key);
+      return null;
+    }
+
+    return { on: parsed.on, value: parsed.value, variant: parsed.variant };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(key: string, flag: CachedFlag): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const entry: CacheEntry = { ...flag, cachedAt: Date.now() };
+    window.localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(entry));
+  } catch {
+    return;
+  }
+}
+
+export function clearCachedFlag(key: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(STORAGE_PREFIX + key);
+  } catch {
+    return;
+  }
+}
+
+export function useCachedFlag(key: string): CachedFlagState {
+  const flag = useFlag(key);
+  const [cached, setCached] = useState<CachedFlag | null>(null);
+
+  useEffect(() => {
+    setCached(readCache(key));
+  }, [key]);
+
+  useEffect(() => {
+    if (flag.status !== "ready") {
+      return;
+    }
+
+    const next: CachedFlag = {
+      on: flag.on,
+      value: flag.value,
+      variant: flag.variant,
+    };
+
+    writeCache(key, next);
+    setCached(next);
+  }, [key, flag.status, flag.on, flag.value, flag.variant]);
+
+  if (flag.status === "ready") {
+    return {
+      on: flag.on,
+      status: "ready",
+      loading: false,
+      value: flag.value,
+      variant: flag.variant,
+    };
+  }
+
+  if (cached) {
+    return {
+      on: cached.on,
+      status: "ready",
+      loading: false,
+      value: cached.value,
+      variant: cached.variant,
+    };
+  }
+
+  return {
+    on: flag.on,
+    status: flag.status,
+    loading: flag.loading,
+    value: flag.value,
+    variant: flag.variant,
+  };
+}

--- a/apps/web/src/utils/feature-flag-cache.ts
+++ b/apps/web/src/utils/feature-flag-cache.ts
@@ -2,25 +2,31 @@
 
 import { useFlag } from "@databuddy/sdk/react";
 import { useEffect, useState } from "react";
+import { z } from "zod";
 
 const STORAGE_PREFIX = "notra_ff_";
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24;
 
-type FlagValue = boolean | string | number | undefined;
+const cacheEntrySchema = z.object({
+  cachedAt: z.number(),
+  on: z.boolean(),
+  value: z.union([z.boolean(), z.string(), z.number()]).optional(),
+  variant: z.string().optional(),
+});
 
 type CachedFlag = {
   on: boolean;
-  value: FlagValue;
+  value: boolean | string | number | undefined;
   variant: string | undefined;
 };
 
-type CacheEntry = CachedFlag & { cachedAt: number };
+type CachedEntry = { key: string; flag: CachedFlag };
 
 type CachedFlagState = {
   on: boolean;
   status: "loading" | "ready" | "error" | "pending";
   loading: boolean;
-  value: FlagValue;
+  value: boolean | string | number | undefined;
   variant: string | undefined;
 };
 
@@ -35,23 +41,23 @@ function readCache(key: string): CachedFlag | null {
       return null;
     }
 
-    const parsed = JSON.parse(raw) as CacheEntry;
+    const result = cacheEntrySchema.safeParse(JSON.parse(raw));
 
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      typeof parsed.cachedAt !== "number"
-    ) {
+    if (!result.success) {
       window.localStorage.removeItem(STORAGE_PREFIX + key);
       return null;
     }
 
-    if (Date.now() - parsed.cachedAt > CACHE_TTL_MS) {
+    if (Date.now() - result.data.cachedAt > CACHE_TTL_MS) {
       window.localStorage.removeItem(STORAGE_PREFIX + key);
       return null;
     }
 
-    return { on: parsed.on, value: parsed.value, variant: parsed.variant };
+    return {
+      on: result.data.on,
+      value: result.data.value,
+      variant: result.data.variant,
+    };
   } catch {
     return null;
   }
@@ -63,7 +69,7 @@ function writeCache(key: string, flag: CachedFlag): void {
   }
 
   try {
-    const entry: CacheEntry = { ...flag, cachedAt: Date.now() };
+    const entry = { ...flag, cachedAt: Date.now() };
     window.localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(entry));
   } catch {
     return;
@@ -84,10 +90,11 @@ export function clearCachedFlag(key: string): void {
 
 export function useCachedFlag(key: string): CachedFlagState {
   const flag = useFlag(key);
-  const [cached, setCached] = useState<CachedFlag | null>(null);
+  const [cachedEntry, setCachedEntry] = useState<CachedEntry | null>(null);
 
   useEffect(() => {
-    setCached(readCache(key));
+    const value = readCache(key);
+    setCachedEntry(value ? { key, flag: value } : null);
   }, [key]);
 
   useEffect(() => {
@@ -102,7 +109,7 @@ export function useCachedFlag(key: string): CachedFlagState {
     };
 
     writeCache(key, next);
-    setCached(next);
+    setCachedEntry({ key, flag: next });
   }, [key, flag.status, flag.on, flag.value, flag.variant]);
 
   if (flag.status === "ready") {
@@ -114,6 +121,8 @@ export function useCachedFlag(key: string): CachedFlagState {
       variant: flag.variant,
     };
   }
+
+  const cached = cachedEntry?.key === key ? cachedEntry.flag : null;
 
   if (cached) {
     return {


### PR DESCRIPTION
### Description
Adds a `useCachedFlag` hook in `apps/web/src/utils/feature-flag-cache.ts` that wraps `useFlag` from `@databuddy/sdk/react` and serves the last known value from `localStorage` so repeat visitors skip the loading state instead of waiting on databuddy to resolve.

How it works:
- First render returns the raw `useFlag` result so SSR markup matches client hydration
- After mount, reads `notra_ff_<key>` from localStorage and returns it as `status: "ready"` until databuddy returns a fresh value
- Once databuddy resolves, writes the fresh value back and switches to it
- 24h TTL, with corrupted/expired entries pruned automatically
- All `localStorage` access is wrapped in try/catch for Safari private mode, quota errors, and SSR
- Also exports `clearCachedFlag(key)` for invalidation

The cache is bounded by databuddy's next response, so any DevTools tampering gets overwritten on the next page load — and the experiment assignment is already deterministic server-side anyway.

Wired up at:
- `apps/web/src/components/landing-page-headline.tsx`
- `apps/web/src/components/tracked-signup-link.tsx`

### Screenshot/Recording (if applicable)
N/A — no visual change, only removes the brief flicker between control and experiment copy on repeat visits.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>