### PR TITLE
feat(api): add brand identity post filter

### DIFF
--- a/apps/api/src/routes/content.ts
+++ b/apps/api/src/routes/content.ts
@@ -26,7 +26,7 @@ import {
   posts,
   repositoryOutputs,
 } from "@notra/db/schema";
-import { and, asc, count, desc, eq, inArray, ne } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, ne, sql } from "drizzle-orm";
 
 import {
   ALL_POST_CONTENT_TYPES,
@@ -1659,7 +1659,7 @@ contentRoutes.openapi(getPostsRoute, async (c) => {
 
   const query = c.req.valid("query");
   const db = c.get("db");
-  const { limit, page, sort, status, contentType } = query;
+  const { limit, page, sort, status, contentType, brandIdentityId } = query;
   const organization = await getOrganizationResponse(db, orgId);
 
   if (!organization) {
@@ -1674,6 +1674,12 @@ contentRoutes.openapi(getPostsRoute, async (c) => {
       : undefined,
     shouldApplyFilter(contentType, ALL_POST_CONTENT_TYPES)
       ? inArray(posts.contentType, contentType)
+      : undefined,
+    brandIdentityId.length > 0
+      ? inArray(
+          sql<string>`${posts.sourceMetadata} ->> 'brandVoiceId'`,
+          brandIdentityId
+        )
       : undefined
   );
 

--- a/apps/api/src/schemas/content.ts
+++ b/apps/api/src/schemas/content.ts
@@ -37,17 +37,13 @@ function normalizeFilterValues<T extends string>(
   return Array.from(new Set(normalized));
 }
 
-function splitQueryFilterValues(
-  values: string | string[] | undefined
-): string[] {
+function splitQueryFilterValues(values: string | undefined): string[] {
   if (!values) {
     return [];
   }
 
-  const normalized = Array.isArray(values) ? values : [values];
-
-  return normalized
-    .flatMap((value) => value.split(","))
+  return values
+    .split(",")
     .map((value) => value.trim())
     .filter((value) => value.length > 0);
 }
@@ -83,7 +79,7 @@ function validateEnumFilterValues<T extends string>(
   }
 }
 
-function createQueryEnumFilterSchema<T extends string>(
+function createBaseEnumFilterSchema<T extends string>(
   valueSchema: z.ZodType<T>,
   defaultValues: readonly T[],
   maxItems: number
@@ -106,32 +102,28 @@ function createQueryEnumFilterSchema<T extends string>(
     });
 }
 
+function createQueryEnumFilterSchema<T extends string>(
+  valueSchema: z.ZodType<T>,
+  defaultValues: readonly T[],
+  maxItems: number
+) {
+  return createBaseEnumFilterSchema(valueSchema, defaultValues, maxItems);
+}
+
 function createOpenApiEnumFilterSchema<T extends string>(
   valueSchema: z.ZodType<T>,
   defaultValues: readonly T[],
   maxItems: number,
   description: string
 ) {
-  return z
-    .string()
-    .optional()
-    .superRefine((values, ctx) => {
-      const parsedValues = splitQueryFilterValues(values);
-      validateFilterItemCount(parsedValues, maxItems, ctx);
-      validateEnumFilterValues(parsedValues, valueSchema, ctx);
-    })
-    .transform((values: string | undefined) => {
-      const parsedValues = splitQueryFilterValues(values);
-
-      return normalizeFilterValues(
-        parsedValues.map((value) => valueSchema.parse(value)),
-        defaultValues
-      );
-    })
-    .openapi({ description });
+  return createBaseEnumFilterSchema(
+    valueSchema,
+    defaultValues,
+    maxItems
+  ).openapi({ description });
 }
 
-function createQueryStringFilterSchema(maxItems: number) {
+function createBaseStringFilterSchema(maxItems: number) {
   return z
     .string()
     .optional()
@@ -145,22 +137,15 @@ function createQueryStringFilterSchema(maxItems: number) {
     });
 }
 
+function createQueryStringFilterSchema(maxItems: number) {
+  return createBaseStringFilterSchema(maxItems);
+}
+
 function createOpenApiStringFilterSchema(
   maxItems: number,
   description: string
 ) {
-  return z
-    .string()
-    .optional()
-    .superRefine((values, ctx) => {
-      validateFilterItemCount(splitQueryFilterValues(values), maxItems, ctx);
-    })
-    .transform((values: string | undefined) => {
-      const parsedValues = splitQueryFilterValues(values);
-
-      return Array.from(new Set(parsedValues));
-    })
-    .openapi({ description });
+  return createBaseStringFilterSchema(maxItems).openapi({ description });
 }
 
 const statusFilterSchema = createQueryEnumFilterSchema(

--- a/apps/api/src/schemas/content.ts
+++ b/apps/api/src/schemas/content.ts
@@ -37,18 +37,73 @@ function normalizeFilterValues<T extends string>(
   return Array.from(new Set(normalized));
 }
 
+function splitQueryFilterValues(
+  values: string | string[] | undefined
+): string[] {
+  if (!values) {
+    return [];
+  }
+
+  const normalized = Array.isArray(values) ? values : [values];
+
+  return normalized
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function validateFilterItemCount(
+  parsedValues: readonly string[],
+  maxItems: number,
+  ctx: z.RefinementCtx
+) {
+  if (parsedValues.length > maxItems) {
+    ctx.addIssue({
+      code: "custom",
+      message: `Expected at most ${maxItems} items`,
+    });
+  }
+}
+
+function validateEnumFilterValues<T extends string>(
+  parsedValues: readonly string[],
+  valueSchema: z.ZodType<T>,
+  ctx: z.RefinementCtx
+) {
+  for (const value of parsedValues) {
+    const parsedValue = valueSchema.safeParse(value);
+
+    if (!parsedValue.success) {
+      const message = parsedValue.error.issues[0]?.message ?? "Invalid value";
+      ctx.addIssue({
+        code: "custom",
+        message,
+      });
+    }
+  }
+}
+
 function createQueryEnumFilterSchema<T extends string>(
   valueSchema: z.ZodType<T>,
   defaultValues: readonly T[],
   maxItems: number
 ) {
   return z
-    .array(valueSchema)
-    .max(maxItems)
+    .string()
     .optional()
-    .transform((values: T[] | undefined) =>
-      normalizeFilterValues(values, defaultValues)
-    );
+    .superRefine((values, ctx) => {
+      const parsedValues = splitQueryFilterValues(values);
+      validateFilterItemCount(parsedValues, maxItems, ctx);
+      validateEnumFilterValues(parsedValues, valueSchema, ctx);
+    })
+    .transform((values: string | undefined) => {
+      const parsedValues = splitQueryFilterValues(values);
+
+      return normalizeFilterValues(
+        parsedValues.map((value) => valueSchema.parse(value)),
+        defaultValues
+      );
+    });
 }
 
 function createOpenApiEnumFilterSchema<T extends string>(
@@ -58,11 +113,53 @@ function createOpenApiEnumFilterSchema<T extends string>(
   description: string
 ) {
   return z
-    .union([valueSchema, z.array(valueSchema).max(maxItems)])
+    .string()
     .optional()
-    .transform((values: T | T[] | undefined) =>
-      normalizeFilterValues(values, defaultValues)
-    )
+    .superRefine((values, ctx) => {
+      const parsedValues = splitQueryFilterValues(values);
+      validateFilterItemCount(parsedValues, maxItems, ctx);
+      validateEnumFilterValues(parsedValues, valueSchema, ctx);
+    })
+    .transform((values: string | undefined) => {
+      const parsedValues = splitQueryFilterValues(values);
+
+      return normalizeFilterValues(
+        parsedValues.map((value) => valueSchema.parse(value)),
+        defaultValues
+      );
+    })
+    .openapi({ description });
+}
+
+function createQueryStringFilterSchema(maxItems: number) {
+  return z
+    .string()
+    .optional()
+    .superRefine((values, ctx) => {
+      validateFilterItemCount(splitQueryFilterValues(values), maxItems, ctx);
+    })
+    .transform((values: string | undefined) => {
+      const parsedValues = splitQueryFilterValues(values);
+
+      return Array.from(new Set(parsedValues));
+    });
+}
+
+function createOpenApiStringFilterSchema(
+  maxItems: number,
+  description: string
+) {
+  return z
+    .string()
+    .optional()
+    .superRefine((values, ctx) => {
+      validateFilterItemCount(splitQueryFilterValues(values), maxItems, ctx);
+    })
+    .transform((values: string | undefined) => {
+      const parsedValues = splitQueryFilterValues(values);
+
+      return Array.from(new Set(parsedValues));
+    })
     .openapi({ description });
 }
 
@@ -78,26 +175,34 @@ const contentTypeFilterSchema = createQueryEnumFilterSchema(
   ALL_POST_CONTENT_TYPES.length
 );
 
+const brandIdentityIdFilterSchema = createQueryStringFilterSchema(100);
+
 const getPostsQuerySchema = z.object({
   sort: z.enum(["asc", "desc"]).default("desc"),
   limit: z.coerce.number().int().min(1).max(100).default(10),
   page: z.coerce.number().int().min(1).default(1),
   status: statusFilterSchema,
   contentType: contentTypeFilterSchema,
+  brandIdentityId: brandIdentityIdFilterSchema,
 });
 
 const openApiStatusFilterSchema = createOpenApiEnumFilterSchema(
   postStatusSchema,
   ["published"],
   ALL_POST_STATUSES.length,
-  "Filter by status. Repeat the query param to pass multiple values."
+  "Filter by status using a comma-separated list."
 );
 
 const openApiContentTypeFilterSchema = createOpenApiEnumFilterSchema(
   postContentTypeSchema,
   ALL_POST_CONTENT_TYPES,
   ALL_POST_CONTENT_TYPES.length,
-  "Filter by content type. Repeat the query param to pass multiple values."
+  "Filter by content type using a comma-separated list."
+);
+
+const openApiBrandIdentityIdFilterSchema = createOpenApiStringFilterSchema(
+  100,
+  "Filter by brand identity ID using a comma-separated list."
 );
 
 export const getPostsOpenApiQuerySchema = z.object({
@@ -115,6 +220,7 @@ export const getPostsOpenApiQuerySchema = z.object({
   }),
   status: openApiStatusFilterSchema,
   contentType: openApiContentTypeFilterSchema,
+  brandIdentityId: openApiBrandIdentityIdFilterSchema,
 });
 
 export const getPostParamsSchema = z.object({


### PR DESCRIPTION
### Description
Add `brandIdentityId` filtering to the posts API and switch post list filters to comma-separated query values. This keeps the filtering syntax cleaner while preserving proper 400-level validation for invalid filter input.

### Screenshot/Recording (if applicable)
Not applicable.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did use AI to write the code in this PR and have disclosed that here

</details>