### PR TITLE
fix: missing space on mobile rendering of faq section

### DIFF
--- a/apps/web/src/components/faq-section.tsx
+++ b/apps/web/src/components/faq-section.tsx
@@ -71,8 +71,8 @@ export default function FAQSection() {
           </div>
           <div className="w-full font-normal font-sans text-base text-muted-foreground leading-7">
             Common questions about how Notra
-            <br className="hidden md:block" />
-            {" "}turns your team's work into content.
+            <br className="hidden md:block" /> turns your team's work into
+            content.
           </div>
         </div>
 

--- a/apps/web/src/components/faq-section.tsx
+++ b/apps/web/src/components/faq-section.tsx
@@ -72,7 +72,7 @@ export default function FAQSection() {
           <div className="w-full font-normal font-sans text-base text-muted-foreground leading-7">
             Common questions about how Notra
             <br className="hidden md:block" />
-            turns your team's work into content.
+            {" "}turns your team's work into content.
           </div>
         </div>
 


### PR DESCRIPTION
### Description
Under the FAQ section on mobile, the line "Common questions about how Notra turns your team's work into content." shows no space between "Notra" and "turns"

### Screenshot
<img width="1272" height="875" alt="image" src="https://github.com/user-attachments/assets/90128616-5325-443d-912e-78c51b323736" />


<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
[N/A] I updated docs when behavior or setup changed
[N/A] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>
