### PR TITLE
feat(api): add schedule management endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ opencode.json
 # Openlogs
 .openlogs/
 .opencode/package-lock.json
+.mcp.json

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { trimTrailingSlash } from "hono/trailing-slash";
 import { authMiddleware } from "./middleware/auth";
 import { subscriptionMiddleware } from "./middleware/subscription";
 import { contentRoutes } from "./routes/content";
+import { schedulesRoutes } from "./routes/schedules";
 
 const FRAMER_PLUGIN_ID = "8d4wmwtko6960jsu3ojmalvqm";
 
@@ -104,6 +105,7 @@ app.get("/ping", (c) => {
 });
 
 app.route("/v1", contentRoutes);
+app.route("/v1", schedulesRoutes);
 
 app.openAPIRegistry.registerComponent("securitySchemes", "BearerAuth", {
   type: "http",
@@ -132,6 +134,11 @@ app.doc31("/openapi.json", (_c) => ({
       name: "Content",
       description:
         "Read content. Organization is inferred from the API key (identity.externalId).",
+    },
+    {
+      name: "Schedules",
+      description:
+        "Manage scheduled content generation. Organization is inferred from the API key (identity.externalId).",
     },
   ],
 }));

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -1,0 +1,862 @@
+import crypto from "node:crypto";
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import type { createDb } from "@notra/db/drizzle-http";
+import {
+  contentTriggerLookbackWindows,
+  contentTriggers,
+  githubIntegrations,
+  organizations,
+} from "@notra/db/schema";
+import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import { z } from "zod";
+import {
+  createScheduleRequestSchema,
+  deleteScheduleResponseSchema,
+  getSchedulesQuerySchema,
+  getSchedulesResponseSchema,
+  patchScheduleRequestSchema,
+  scheduleOutputConfigSchema,
+  scheduleParamsSchema,
+  scheduleSourceConfigSchema,
+  scheduleTargetsSchema,
+  scheduleResponseSchema,
+} from "../schemas/schedules";
+import { errorResponseSchema } from "../schemas/content";
+import { getOrganizationId } from "../utils/auth";
+import {
+  buildCronExpression,
+  createQstashSchedule,
+  deleteQstashSchedule,
+} from "../utils/qstash";
+import {
+  ORGANIZATION_SCHEDULE_PATH_REGEX,
+  ORGANIZATION_SCHEDULES_PATH_REGEX,
+} from "../utils/regex";
+
+export const schedulesRoutes = new OpenAPIHono();
+
+type DbClient = ReturnType<typeof createDb>;
+type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;
+type ScheduleLookbackWindow = CreateScheduleBody["lookbackWindow"];
+
+const DEFAULT_SCHEDULE_NAME = "Untitled Schedule";
+
+function normalizeCronConfig(
+  config: CreateScheduleBody["sourceConfig"]["cron"]
+) {
+  const base = {
+    frequency: config.frequency,
+    hour: config.hour,
+    minute: config.minute,
+  } as const;
+
+  if (config.frequency === "weekly") {
+    return {
+      ...base,
+      dayOfWeek: config.dayOfWeek ?? 1,
+    };
+  }
+
+  if (config.frequency === "monthly") {
+    return {
+      ...base,
+      dayOfMonth: config.dayOfMonth ?? 1,
+    };
+  }
+
+  return base;
+}
+
+function normalizeSchedule(input: CreateScheduleBody) {
+  return {
+    ...input,
+    sourceConfig: {
+      cron: normalizeCronConfig(input.sourceConfig.cron),
+    },
+    targets: {
+      repositoryIds: [...input.targets.repositoryIds].sort(),
+    },
+  };
+}
+
+function hashSchedule(input: CreateScheduleBody) {
+  const normalized = normalizeSchedule(input);
+
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        sourceType: normalized.sourceType,
+        sourceConfig: normalized.sourceConfig,
+        targets: normalized.targets,
+        outputType: normalized.outputType,
+        lookbackWindow: normalized.lookbackWindow,
+      })
+    )
+    .digest("hex");
+}
+
+async function getOrganizationResponse(db: DbClient, organizationId: string) {
+  return db.query.organizations.findFirst({
+    where: eq(organizations.id, organizationId),
+    columns: {
+      id: true,
+      slug: true,
+      name: true,
+      logo: true,
+    },
+  });
+}
+
+async function ensureScheduleTargetsExist(
+  db: DbClient,
+  organizationId: string,
+  repositoryIds: string[],
+  message: string
+) {
+  if (repositoryIds.length === 0) {
+    return null;
+  }
+
+  const integrations = await db.query.githubIntegrations.findMany({
+    where: and(
+      eq(githubIntegrations.organizationId, organizationId),
+      inArray(githubIntegrations.id, repositoryIds)
+    ),
+    columns: { id: true },
+  });
+
+  const existingIds = new Set(
+    integrations.map((integration) => integration.id)
+  );
+  const missingIds = repositoryIds.filter((id) => !existingIds.has(id));
+
+  if (missingIds.length > 0) {
+    return { error: message, missingIntegrationIds: missingIds };
+  }
+
+  return null;
+}
+
+function serializeSchedule(trigger: {
+  id: string;
+  organizationId: string;
+  name: string;
+  sourceType: string;
+  sourceConfig: unknown;
+  targets: unknown;
+  outputType: string;
+  outputConfig: unknown;
+  enabled: boolean;
+  autoPublish: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  lookbackWindow: ScheduleLookbackWindow;
+}) {
+  return {
+    id: trigger.id,
+    organizationId: trigger.organizationId,
+    name: trigger.name,
+    sourceType: "cron" as const,
+    sourceConfig: scheduleSourceConfigSchema.parse(trigger.sourceConfig),
+    targets: scheduleTargetsSchema.parse(trigger.targets),
+    outputType: createScheduleRequestSchema.shape.outputType.parse(
+      trigger.outputType
+    ),
+    outputConfig:
+      trigger.outputConfig == null
+        ? null
+        : scheduleOutputConfigSchema.parse(trigger.outputConfig),
+    enabled: trigger.enabled,
+    autoPublish: trigger.autoPublish,
+    createdAt: trigger.createdAt.toISOString(),
+    updatedAt: trigger.updatedAt.toISOString(),
+    lookbackWindow: trigger.lookbackWindow,
+  };
+}
+
+function mapQstashError(error: unknown) {
+  const message = error instanceof Error ? error.message : "Unknown error";
+
+  if (
+    message.includes("invalid destination") ||
+    message.includes("unable to resolve host") ||
+    message.includes("WORKFLOW_BASE_URL is not configured")
+  ) {
+    return { error: "External URL not configured", status: 400 as const };
+  }
+
+  return { error: "Failed to configure schedule", status: 500 as const };
+}
+
+function filterByRepositoryIds<T extends { targets: unknown }>(
+  triggers: T[],
+  repositoryIds: string[]
+) {
+  if (repositoryIds.length === 0) {
+    return triggers;
+  }
+
+  const repositoryIdSet = new Set(repositoryIds);
+
+  return triggers.filter((trigger) => {
+    const parsed = z
+      .object({ repositoryIds: z.array(z.string()) })
+      .safeParse(trigger.targets);
+
+    if (!parsed.success) {
+      return false;
+    }
+
+    return parsed.data.repositoryIds.some((repositoryId) =>
+      repositoryIdSet.has(repositoryId)
+    );
+  });
+}
+
+schedulesRoutes.get("/:organizationId/schedules", async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const pathOrg = c.req.param("organizationId");
+  if (orgId !== pathOrg) {
+    return c.json({ error: "Forbidden: organization access denied" }, 403);
+  }
+
+  const url = new URL(c.req.url);
+  const canonicalPath = url.pathname.replace(
+    ORGANIZATION_SCHEDULES_PATH_REGEX,
+    "/schedules"
+  );
+  return c.redirect(`${canonicalPath}${url.search}`, 308);
+});
+
+schedulesRoutes.post("/:organizationId/schedules", async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const pathOrg = c.req.param("organizationId");
+  if (orgId !== pathOrg) {
+    return c.json({ error: "Forbidden: organization access denied" }, 403);
+  }
+
+  const url = new URL(c.req.url);
+  const canonicalPath = url.pathname.replace(
+    ORGANIZATION_SCHEDULES_PATH_REGEX,
+    "/schedules"
+  );
+  return c.redirect(`${canonicalPath}${url.search}`, 308);
+});
+
+schedulesRoutes.patch("/:organizationId/schedules/:scheduleId", async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const pathOrg = c.req.param("organizationId");
+  if (orgId !== pathOrg) {
+    return c.json({ error: "Forbidden: organization access denied" }, 403);
+  }
+
+  const scheduleId = c.req.param("scheduleId");
+  const url = new URL(c.req.url);
+  const canonicalPath = url.pathname.replace(
+    ORGANIZATION_SCHEDULE_PATH_REGEX,
+    `/schedules/${scheduleId}`
+  );
+  return c.redirect(`${canonicalPath}${url.search}`, 308);
+});
+
+schedulesRoutes.delete("/:organizationId/schedules/:scheduleId", async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const pathOrg = c.req.param("organizationId");
+  if (orgId !== pathOrg) {
+    return c.json({ error: "Forbidden: organization access denied" }, 403);
+  }
+
+  const scheduleId = c.req.param("scheduleId");
+  const url = new URL(c.req.url);
+  const canonicalPath = url.pathname.replace(
+    ORGANIZATION_SCHEDULE_PATH_REGEX,
+    `/schedules/${scheduleId}`
+  );
+  return c.redirect(`${canonicalPath}${url.search}`, 308);
+});
+
+const getSchedulesRoute = createRoute({
+  method: "get",
+  path: "/schedules",
+  tags: ["Schedules"],
+  operationId: "listSchedules",
+  summary: "List schedules",
+  request: {
+    query: getSchedulesQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Schedules fetched successfully",
+      content: {
+        "application/json": {
+          schema: getSchedulesResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: "Missing or invalid API key",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "Organization not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+});
+
+const createScheduleRoute = createRoute({
+  method: "post",
+  path: "/schedules",
+  tags: ["Schedules"],
+  operationId: "createSchedule",
+  summary: "Create a schedule",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: createScheduleRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Schedule created successfully",
+      content: {
+        "application/json": {
+          schema: scheduleResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    401: {
+      description: "Missing or invalid API key",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "Organization not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "Duplicate schedule",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    500: {
+      description: "Failed to create schedule",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+});
+
+const patchScheduleRoute = createRoute({
+  method: "patch",
+  path: "/schedules/{scheduleId}",
+  tags: ["Schedules"],
+  operationId: "updateSchedule",
+  summary: "Update a schedule",
+  request: {
+    params: scheduleParamsSchema,
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: patchScheduleRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Schedule updated successfully",
+      content: {
+        "application/json": {
+          schema: scheduleResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    401: {
+      description: "Missing or invalid API key",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "Schedule or organization not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "Duplicate schedule",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    500: {
+      description: "Failed to update schedule",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+});
+
+const deleteScheduleRoute = createRoute({
+  method: "delete",
+  path: "/schedules/{scheduleId}",
+  tags: ["Schedules"],
+  operationId: "deleteSchedule",
+  summary: "Delete a schedule",
+  request: {
+    params: scheduleParamsSchema,
+  },
+  responses: {
+    200: {
+      description: "Schedule deleted successfully",
+      content: {
+        "application/json": {
+          schema: deleteScheduleResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: "Missing or invalid API key",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "Schedule or organization not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+});
+
+schedulesRoutes.openapi(getSchedulesRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const db = c.get("db") as DbClient;
+  const organization = await getOrganizationResponse(db, orgId);
+
+  if (!organization) {
+    return c.json({ error: "Organization not found" }, 404);
+  }
+
+  const { repositoryIds } = c.req.valid("query");
+  const triggers = await db.query.contentTriggers.findMany({
+    where: and(
+      eq(contentTriggers.organizationId, orgId),
+      eq(contentTriggers.sourceType, "cron")
+    ),
+    orderBy: [desc(contentTriggers.createdAt)],
+  });
+
+  const triggerIds = triggers.map((trigger) => trigger.id);
+  const lookbackWindows =
+    triggerIds.length > 0
+      ? await db.query.contentTriggerLookbackWindows.findMany({
+          where: inArray(contentTriggerLookbackWindows.triggerId, triggerIds),
+        })
+      : [];
+
+  const lookbackWindowByTriggerId = new Map(
+    lookbackWindows.map((item) => [item.triggerId, item.window])
+  );
+  const filteredTriggers = filterByRepositoryIds(triggers, repositoryIds);
+
+  const schedules = filteredTriggers.map((trigger) =>
+    serializeSchedule({
+      ...trigger,
+      lookbackWindow: (lookbackWindowByTriggerId.get(trigger.id) ??
+        "last_7_days") as ScheduleLookbackWindow,
+    })
+  );
+
+  const allRepositoryIds = [
+    ...new Set(schedules.flatMap((schedule) => schedule.targets.repositoryIds)),
+  ];
+  const repositories =
+    allRepositoryIds.length > 0
+      ? await db
+          .select({
+            id: githubIntegrations.id,
+            owner: githubIntegrations.owner,
+            repo: githubIntegrations.repo,
+            defaultBranch: githubIntegrations.defaultBranch,
+          })
+          .from(githubIntegrations)
+          .where(inArray(githubIntegrations.id, allRepositoryIds))
+      : [];
+
+  const repositoryMap = Object.fromEntries(
+    repositories
+      .filter((repository) => repository.owner && repository.repo)
+      .map((repository) => [
+        repository.id,
+        repository.defaultBranch?.trim()
+          ? `${repository.owner}/${repository.repo} · ${repository.defaultBranch.trim()}`
+          : `${repository.owner}/${repository.repo}`,
+      ])
+  );
+
+  return c.json({ schedules, repositoryMap, organization }, 200);
+});
+
+schedulesRoutes.openapi(createScheduleRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const db = c.get("db") as DbClient;
+  const organization = await getOrganizationResponse(db, orgId);
+
+  if (!organization) {
+    return c.json({ error: "Organization not found" }, 404);
+  }
+
+  const input = c.req.valid("json");
+  const env = (c.env ?? {}) as {
+    QSTASH_TOKEN?: string;
+    WORKFLOW_BASE_URL?: string;
+  };
+  const normalized = normalizeSchedule(input);
+  const dedupeHash = hashSchedule(input);
+  const existing = await db.query.contentTriggers.findFirst({
+    where: and(
+      eq(contentTriggers.organizationId, orgId),
+      eq(contentTriggers.dedupeHash, dedupeHash)
+    ),
+  });
+
+  if (existing) {
+    return c.json({ error: "Duplicate schedule" }, 409);
+  }
+
+  if (input.enabled) {
+    const missingTargets = await ensureScheduleTargetsExist(
+      db,
+      orgId,
+      normalized.targets.repositoryIds,
+      "Cannot create enabled schedule: one or more integrations not found"
+    );
+
+    if (missingTargets) {
+      return c.json({ error: missingTargets.error }, 400);
+    }
+  }
+
+  const triggerId = crypto.randomUUID();
+  const persistedName = input.name.trim() || DEFAULT_SCHEDULE_NAME;
+  const cronExpression = buildCronExpression(normalized.sourceConfig.cron);
+  let qstashScheduleId: string | null = null;
+
+  try {
+    qstashScheduleId = await createQstashSchedule(env, {
+      triggerId,
+      cron: cronExpression,
+    });
+  } catch (error) {
+    const mapped = mapQstashError(error);
+    if (mapped.status === 400) {
+      return c.json({ error: mapped.error }, 400);
+    }
+
+    return c.json({ error: mapped.error }, 500);
+  }
+
+  try {
+    const schedule = await db.transaction(async (tx) => {
+      const [createdTrigger] = await tx
+        .insert(contentTriggers)
+        .values({
+          id: triggerId,
+          organizationId: orgId,
+          name: persistedName,
+          sourceType: "cron",
+          sourceConfig: normalized.sourceConfig,
+          targets: normalized.targets,
+          outputType: input.outputType,
+          outputConfig: input.outputConfig ?? null,
+          dedupeHash,
+          enabled: input.enabled,
+          autoPublish: input.autoPublish,
+          qstashScheduleId,
+        })
+        .returning();
+
+      if (!createdTrigger) {
+        throw new Error("Failed to create schedule");
+      }
+
+      await tx.insert(contentTriggerLookbackWindows).values({
+        triggerId,
+        window: input.lookbackWindow,
+      });
+
+      return serializeSchedule({
+        ...createdTrigger,
+        lookbackWindow: input.lookbackWindow,
+      });
+    });
+
+    return c.json({ schedule, organization }, 201);
+  } catch (error) {
+    if (qstashScheduleId) {
+      await deleteQstashSchedule(env, qstashScheduleId).catch(() => null);
+    }
+
+    console.error("Failed to create schedule:", error);
+    return c.json({ error: "Failed to create schedule" }, 500);
+  }
+});
+
+schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const db = c.get("db") as DbClient;
+  const organization = await getOrganizationResponse(db, orgId);
+
+  if (!organization) {
+    return c.json({ error: "Organization not found" }, 404);
+  }
+
+  const { scheduleId } = c.req.valid("param");
+  const input = c.req.valid("json");
+  const env = (c.env ?? {}) as {
+    QSTASH_TOKEN?: string;
+    WORKFLOW_BASE_URL?: string;
+  };
+  const normalized = normalizeSchedule(input);
+  const dedupeHash = hashSchedule(input);
+  const duplicate = await db.query.contentTriggers.findFirst({
+    where: and(
+      eq(contentTriggers.organizationId, orgId),
+      eq(contentTriggers.dedupeHash, dedupeHash),
+      ne(contentTriggers.id, scheduleId)
+    ),
+  });
+
+  if (duplicate) {
+    return c.json({ error: "Duplicate schedule" }, 409);
+  }
+
+  const existing = await db.query.contentTriggers.findFirst({
+    where: and(
+      eq(contentTriggers.id, scheduleId),
+      eq(contentTriggers.organizationId, orgId),
+      eq(contentTriggers.sourceType, "cron")
+    ),
+  });
+
+  if (!existing) {
+    return c.json({ error: "Schedule not found" }, 404);
+  }
+
+  if (input.enabled) {
+    const missingTargets = await ensureScheduleTargetsExist(
+      db,
+      orgId,
+      normalized.targets.repositoryIds,
+      "Cannot enable schedule: one or more integrations have been deleted"
+    );
+
+    if (missingTargets) {
+      return c.json({ error: missingTargets.error }, 400);
+    }
+  }
+
+  const persistedName =
+    input.name.trim() || existing.name || DEFAULT_SCHEDULE_NAME;
+  const cronExpression = buildCronExpression(normalized.sourceConfig.cron);
+  const existingScheduleId = existing.qstashScheduleId ?? undefined;
+  let qstashScheduleId: string | null = null;
+
+  try {
+    qstashScheduleId = await createQstashSchedule(env, {
+      triggerId: scheduleId,
+      cron: cronExpression,
+      scheduleId: existingScheduleId,
+    });
+  } catch (error) {
+    const mapped = mapQstashError(error);
+    if (mapped.status === 400) {
+      return c.json({ error: mapped.error }, 400);
+    }
+
+    return c.json({ error: mapped.error }, 500);
+  }
+
+  try {
+    const schedule = await db.transaction(async (tx) => {
+      const [updatedTrigger] = await tx
+        .update(contentTriggers)
+        .set({
+          name: persistedName,
+          sourceType: "cron",
+          sourceConfig: normalized.sourceConfig,
+          targets: normalized.targets,
+          outputType: input.outputType,
+          outputConfig: input.outputConfig ?? null,
+          dedupeHash,
+          enabled: input.enabled,
+          autoPublish: input.autoPublish,
+          qstashScheduleId,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(contentTriggers.id, scheduleId),
+            eq(contentTriggers.organizationId, orgId)
+          )
+        )
+        .returning();
+
+      if (!updatedTrigger) {
+        throw new Error("Failed to update schedule");
+      }
+
+      await tx
+        .insert(contentTriggerLookbackWindows)
+        .values({
+          triggerId: scheduleId,
+          window: input.lookbackWindow,
+        })
+        .onConflictDoUpdate({
+          target: contentTriggerLookbackWindows.triggerId,
+          set: {
+            window: input.lookbackWindow,
+            updatedAt: new Date(),
+          },
+        });
+
+      return serializeSchedule({
+        ...updatedTrigger,
+        lookbackWindow: input.lookbackWindow,
+      });
+    });
+
+    return c.json({ schedule, organization }, 200);
+  } catch (error) {
+    if (qstashScheduleId && qstashScheduleId !== existingScheduleId) {
+      await deleteQstashSchedule(env, qstashScheduleId).catch(() => null);
+    }
+
+    console.error("Failed to update schedule:", error);
+    return c.json({ error: "Failed to update schedule" }, 500);
+  }
+});
+
+schedulesRoutes.openapi(deleteScheduleRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  if (!orgId) {
+    return c.json(
+      { error: "Forbidden: API key must be scoped to an organization" },
+      403
+    );
+  }
+
+  const db = c.get("db") as DbClient;
+  const organization = await getOrganizationResponse(db, orgId);
+
+  if (!organization) {
+    return c.json({ error: "Organization not found" }, 404);
+  }
+
+  const { scheduleId } = c.req.valid("param");
+  const env = (c.env ?? {}) as {
+    QSTASH_TOKEN?: string;
+    WORKFLOW_BASE_URL?: string;
+  };
+  const existing = await db.query.contentTriggers.findFirst({
+    where: and(
+      eq(contentTriggers.id, scheduleId),
+      eq(contentTriggers.organizationId, orgId),
+      eq(contentTriggers.sourceType, "cron")
+    ),
+  });
+
+  if (!existing) {
+    return c.json({ error: "Schedule not found" }, 404);
+  }
+
+  if (existing.qstashScheduleId) {
+    await deleteQstashSchedule(env, existing.qstashScheduleId).catch(
+      (error) => {
+        console.error(
+          `Failed to delete qstash schedule ${existing.qstashScheduleId}:`,
+          error
+        );
+      }
+    );
+  }
+
+  await db
+    .delete(contentTriggers)
+    .where(
+      and(
+        eq(contentTriggers.id, scheduleId),
+        eq(contentTriggers.organizationId, orgId)
+      )
+    );
+
+  return c.json({ id: scheduleId, organization }, 200);
+});

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -90,6 +90,7 @@ function hashSchedule(input: CreateScheduleBody) {
         sourceConfig: normalized.sourceConfig,
         targets: normalized.targets,
         outputType: normalized.outputType,
+        outputConfig: normalized.outputConfig ?? null,
         lookbackWindow: normalized.lookbackWindow,
       })
     )
@@ -603,18 +604,20 @@ schedulesRoutes.openapi(createScheduleRoute, async (c) => {
   const cronExpression = buildCronExpression(normalized.sourceConfig.cron);
   let qstashScheduleId: string | null = null;
 
-  try {
-    qstashScheduleId = await createQstashSchedule(env, {
-      triggerId,
-      cron: cronExpression,
-    });
-  } catch (error) {
-    const mapped = mapQstashError(error);
-    if (mapped.status === 400) {
-      return c.json({ error: mapped.error }, 400);
-    }
+  if (input.enabled) {
+    try {
+      qstashScheduleId = await createQstashSchedule(env, {
+        triggerId,
+        cron: cronExpression,
+      });
+    } catch (error) {
+      const mapped = mapQstashError(error);
+      if (mapped.status === 400) {
+        return c.json({ error: mapped.error }, 400);
+      }
 
-    return c.json({ error: mapped.error }, 500);
+      return c.json({ error: mapped.error }, 500);
+    }
   }
 
   try {
@@ -727,22 +730,23 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
   const persistedName =
     input.name.trim() || existing.name || DEFAULT_SCHEDULE_NAME;
   const cronExpression = buildCronExpression(normalized.sourceConfig.cron);
-  const existingScheduleId = existing.qstashScheduleId ?? undefined;
+  const previousQstashScheduleId = existing.qstashScheduleId ?? null;
   let qstashScheduleId: string | null = null;
 
-  try {
-    qstashScheduleId = await createQstashSchedule(env, {
-      triggerId: scheduleId,
-      cron: cronExpression,
-      scheduleId: existingScheduleId,
-    });
-  } catch (error) {
-    const mapped = mapQstashError(error);
-    if (mapped.status === 400) {
-      return c.json({ error: mapped.error }, 400);
-    }
+  if (input.enabled) {
+    try {
+      qstashScheduleId = await createQstashSchedule(env, {
+        triggerId: scheduleId,
+        cron: cronExpression,
+      });
+    } catch (error) {
+      const mapped = mapQstashError(error);
+      if (mapped.status === 400) {
+        return c.json({ error: mapped.error }, 400);
+      }
 
-    return c.json({ error: mapped.error }, 500);
+      return c.json({ error: mapped.error }, 500);
+    }
   }
 
   try {
@@ -794,9 +798,13 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
       });
     });
 
+    if (previousQstashScheduleId) {
+      await deleteQstashSchedule(env, previousQstashScheduleId);
+    }
+
     return c.json({ schedule, organization }, 200);
   } catch (error) {
-    if (qstashScheduleId && qstashScheduleId !== existingScheduleId) {
+    if (qstashScheduleId) {
       await deleteQstashSchedule(env, qstashScheduleId).catch(() => null);
     }
 
@@ -839,14 +847,7 @@ schedulesRoutes.openapi(deleteScheduleRoute, async (c) => {
   }
 
   if (existing.qstashScheduleId) {
-    await deleteQstashSchedule(env, existing.qstashScheduleId).catch(
-      (error) => {
-        console.error(
-          `Failed to delete qstash schedule ${existing.qstashScheduleId}:`,
-          error
-        );
-      }
-    );
+    await deleteQstashSchedule(env, existing.qstashScheduleId);
   }
 
   await db

--- a/apps/api/src/schemas/schedules.ts
+++ b/apps/api/src/schemas/schedules.ts
@@ -1,0 +1,142 @@
+import { z } from "@hono/zod-openapi";
+import {
+  LOOKBACK_WINDOWS,
+  SUPPORTED_CONTENT_GENERATION_TYPES,
+} from "@notra/content-generation/schemas";
+
+const CRON_FREQUENCIES = ["daily", "weekly", "monthly"] as const;
+const MAX_SCHEDULE_NAME_LENGTH = 120;
+
+function splitCommaSeparatedValues(value: string | undefined) {
+  if (!value) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0)
+    )
+  );
+}
+
+export const scheduleParamsSchema = z.object({
+  scheduleId: z
+    .string()
+    .trim()
+    .min(1, "scheduleId is required")
+    .openapi({
+      param: {
+        in: "path",
+        name: "scheduleId",
+      },
+      example: "sched_123",
+    }),
+});
+
+export const getSchedulesQuerySchema = z.object({
+  repositoryIds: z
+    .string()
+    .optional()
+    .transform((value) => splitCommaSeparatedValues(value))
+    .openapi({
+      description: "Filter by repository IDs using a comma-separated list",
+      example: "repo_123,repo_456",
+    }),
+});
+
+export const cronConfigSchema = z
+  .object({
+    frequency: z.enum(CRON_FREQUENCIES),
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+    dayOfWeek: z.number().int().min(0).max(6).optional(),
+    dayOfMonth: z.number().int().min(1).max(31).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.frequency === "weekly" && value.dayOfWeek === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["dayOfWeek"],
+        message: "dayOfWeek is required for weekly schedules",
+      });
+    }
+
+    if (value.frequency === "monthly" && value.dayOfMonth === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["dayOfMonth"],
+        message: "dayOfMonth is required for monthly schedules",
+      });
+    }
+  });
+
+export const scheduleSourceConfigSchema = z.object({
+  cron: cronConfigSchema,
+});
+
+export const scheduleTargetsSchema = z.object({
+  repositoryIds: z.array(z.string().trim().min(1)).min(1),
+});
+
+export const scheduleOutputConfigSchema = z
+  .object({
+    publishDestination: z.enum(["webflow", "framer", "custom"]).optional(),
+    brandVoiceId: z.string().trim().min(1).optional(),
+  })
+  .optional();
+
+export const createScheduleRequestSchema = z.object({
+  name: z.string().trim().min(1).max(MAX_SCHEDULE_NAME_LENGTH),
+  sourceType: z.literal("cron"),
+  sourceConfig: scheduleSourceConfigSchema,
+  targets: scheduleTargetsSchema,
+  outputType: z.enum(SUPPORTED_CONTENT_GENERATION_TYPES),
+  outputConfig: scheduleOutputConfigSchema,
+  enabled: z.boolean(),
+  autoPublish: z.boolean().default(false),
+  lookbackWindow: z.enum(LOOKBACK_WINDOWS).default("last_7_days"),
+});
+
+export const patchScheduleRequestSchema = createScheduleRequestSchema;
+
+const scheduleSchema = z.object({
+  id: z.string(),
+  organizationId: z.string(),
+  name: z.string(),
+  sourceType: z.literal("cron"),
+  sourceConfig: scheduleSourceConfigSchema,
+  targets: scheduleTargetsSchema,
+  outputType: z.enum(SUPPORTED_CONTENT_GENERATION_TYPES),
+  outputConfig: scheduleOutputConfigSchema.nullable().optional(),
+  enabled: z.boolean(),
+  autoPublish: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  lookbackWindow: z.enum(LOOKBACK_WINDOWS),
+});
+
+const organizationSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  logo: z.string().nullable(),
+});
+
+export const getSchedulesResponseSchema = z.object({
+  schedules: z.array(scheduleSchema),
+  repositoryMap: z.record(z.string(), z.string()),
+  organization: organizationSchema,
+});
+
+export const scheduleResponseSchema = z.object({
+  schedule: scheduleSchema,
+  organization: organizationSchema,
+});
+
+export const deleteScheduleResponseSchema = z.object({
+  id: z.string(),
+  organization: organizationSchema,
+});

--- a/apps/api/src/utils/qstash.ts
+++ b/apps/api/src/utils/qstash.ts
@@ -1,5 +1,88 @@
 interface QstashEnv {
   QSTASH_TOKEN?: string;
+  WORKFLOW_BASE_URL?: string;
+}
+
+function trimTrailingSlash(value: string) {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function getScheduleDestinationUrl(env: QstashEnv) {
+  if (!env.WORKFLOW_BASE_URL) {
+    throw new Error("WORKFLOW_BASE_URL is not configured");
+  }
+
+  return `${trimTrailingSlash(env.WORKFLOW_BASE_URL)}/api/workflows/schedule`;
+}
+
+export function buildCronExpression(config: {
+  frequency: "daily" | "weekly" | "monthly";
+  hour: number;
+  minute: number;
+  dayOfWeek?: number;
+  dayOfMonth?: number;
+}) {
+  if (config.frequency === "weekly") {
+    return `${config.minute} ${config.hour} * * ${config.dayOfWeek ?? 1}`;
+  }
+
+  if (config.frequency === "monthly") {
+    return `${config.minute} ${config.hour} ${config.dayOfMonth ?? 1} * *`;
+  }
+
+  return `${config.minute} ${config.hour} * * *`;
+}
+
+export async function createQstashSchedule(
+  env: QstashEnv,
+  {
+    triggerId,
+    cron,
+    scheduleId,
+  }: {
+    triggerId: string;
+    cron: string;
+    scheduleId?: string;
+  }
+) {
+  const token = env.QSTASH_TOKEN;
+
+  if (!token) {
+    throw new Error("QSTASH_TOKEN is not configured");
+  }
+
+  const destination = getScheduleDestinationUrl(env);
+  const response = await fetch(
+    `https://qstash.upstash.io/v2/schedules/${encodeURIComponent(destination)}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Upstash-Cron": cron,
+        ...(scheduleId ? { "Upstash-Schedule-Id": scheduleId } : {}),
+      },
+      body: JSON.stringify({ triggerId }),
+    }
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Failed to create QStash schedule: ${response.status} ${body}`.trim()
+    );
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    scheduleId?: string;
+  } | null;
+  const resolvedScheduleId = payload?.scheduleId ?? scheduleId;
+
+  if (!resolvedScheduleId) {
+    throw new Error("QStash schedule id was not returned");
+  }
+
+  return resolvedScheduleId;
 }
 
 export async function deleteQstashSchedule(env: QstashEnv, scheduleId: string) {

--- a/apps/api/src/utils/regex.ts
+++ b/apps/api/src/utils/regex.ts
@@ -1,2 +1,4 @@
 export const ORGANIZATION_POSTS_PATH_REGEX = /\/[^/]+\/posts$/;
 export const ORGANIZATION_POST_PATH_REGEX = /\/[^/]+\/posts\/[^/]+$/;
+export const ORGANIZATION_SCHEDULES_PATH_REGEX = /\/[^/]+\/schedules$/;
+export const ORGANIZATION_SCHEDULE_PATH_REGEX = /\/[^/]+\/schedules\/[^/]+$/;


### PR DESCRIPTION
## Summary
- add authenticated API schedule endpoints for listing, creating, updating, and deleting cron schedules
- persist schedule lookback windows and mirror dashboard dedupe, integration validation, and QStash sync behavior
- register the new schedules routes in the API app and expose the schedule schema in OpenAPI

## Testing
- bun run check-types --cwd apps/api