### PR TITLE
chore: codebase cleanup pass

### DIFF
--- a/apps/api/src/routes/content.ts
+++ b/apps/api/src/routes/content.ts
@@ -22,7 +22,6 @@ import {
   contentTriggers,
   githubIntegrations,
   linearIntegrations,
-  organizations,
   posts,
   repositoryOutputs,
 } from "@notra/db/schema";
@@ -40,7 +39,6 @@ import {
   deleteBrandIdentityResponseSchema,
   deleteIntegrationResponseSchema,
   deletePostResponseSchema,
-  errorResponseSchema,
   generationQueueErrorResponseSchema,
   getBrandAnalysisJobParamsSchema,
   getBrandAnalysisJobResponseSchema,
@@ -83,6 +81,8 @@ import {
   extractTitleFromMarkdown,
   renderMarkdownToHtml,
 } from "../utils/markdown";
+import { errorResponse } from "../utils/openapi-responses";
+import { getOrganizationResponse } from "../utils/organizations";
 import { deleteQstashSchedule } from "../utils/qstash";
 import { getRedis } from "../utils/redis";
 import {
@@ -93,37 +93,6 @@ import {
 export const contentRoutes = new OpenAPIHono();
 
 type DbClient = ReturnType<typeof createDb>;
-
-async function getOrganizationResponse(
-  db: DbClient,
-  organizationId: string
-): Promise<{
-  id: string;
-  slug: string;
-  name: string;
-  logo: string | null;
-} | null> {
-  const organization = await db.query.organizations.findFirst({
-    where: eq(organizations.id, organizationId),
-    columns: {
-      id: true,
-      slug: true,
-      name: true,
-      logo: true,
-    },
-  });
-
-  if (!organization) {
-    return null;
-  }
-
-  return {
-    id: organization.id,
-    slug: organization.slug,
-    name: organization.name,
-    logo: organization.logo,
-  };
-}
 
 function shouldApplyFilter(
   selectedValues: readonly string[],
@@ -353,8 +322,8 @@ async function disableTriggersAndDeleteIntegration(
 }
 
 async function deleteQstashSchedulesForTriggers(
-  runtimeEnv: Record<string, unknown>,
-  affectedTriggers: IntegrationTrigger[]
+  runtimeEnv: { QSTASH_TOKEN?: string; WORKFLOW_BASE_URL?: string },
+  affectedTriggers: readonly { qstashScheduleId: string | null }[]
 ) {
   for (const trigger of affectedTriggers) {
     if (!trigger.qstashScheduleId) {
@@ -679,46 +648,11 @@ const getPostsRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid path params or query",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid path params or query"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -740,46 +674,11 @@ const getPostRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid path params",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Post or organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid path params"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Post or organization not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -801,54 +700,12 @@ const deletePostRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid path params",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Post not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    409: {
-      description: "Post slug already exists",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid path params"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Post not found"),
+    409: errorResponse("Post slug already exists"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -878,54 +735,12 @@ const patchPostRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid path params or request body",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Post not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    409: {
-      description: "Post slug already exists",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid path params or request body"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Post not found"),
+    409: errorResponse("Post slug already exists"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -954,38 +769,10 @@ const createPostGenerationRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid request body",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid request body"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
     503: {
       description: "Content generation is unavailable",
       content: {
@@ -1012,38 +799,10 @@ const getBrandIdentitiesRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -1072,54 +831,12 @@ const createBrandIdentityRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid request body",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    409: {
-      description: "Brand identity name already exists",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid request body"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
+    409: errorResponse("Brand identity name already exists"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -1141,46 +858,11 @@ const getBrandAnalysisJobRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid path params",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Brand identity analysis job not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Brand analysis is unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid path params"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Brand identity analysis job not found"),
+    503: errorResponse("Brand analysis is unavailable"),
   },
 });
 
@@ -1202,46 +884,11 @@ const getBrandIdentityRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid path params",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid path params"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -1300,54 +947,12 @@ const patchBrandIdentityRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid path params or request body",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Brand identity not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    409: {
-      description: "Brand identity name already exists",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Invalid path params or request body"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Brand identity not found"),
+    409: errorResponse("Brand identity name already exists"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -1371,46 +976,11 @@ const deleteBrandIdentityRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Cannot delete the default brand identity",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Brand identity not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse("Cannot delete the default brand identity"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Brand identity not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -1429,38 +999,10 @@ const getIntegrationsRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -1489,54 +1031,14 @@ const createGitHubIntegrationRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid request body or GitHub repository access error",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Organization not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    409: {
-      description: "Repository already connected",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication or integration service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    400: errorResponse(
+      "Invalid request body or GitHub repository access error"
+    ),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
+    409: errorResponse("Repository already connected"),
+    503: errorResponse("Authentication or integration service unavailable"),
   },
 });
 
@@ -1560,38 +1062,10 @@ const deleteIntegrationRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Integration not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Authentication service unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Integration not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -1613,38 +1087,10 @@ const getPostGenerationRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Generation job not found",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
-    503: {
-      description: "Content generation is unavailable",
-      content: {
-        "application/json": {
-          schema: errorResponseSchema,
-        },
-      },
-    },
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Generation job not found"),
+    503: errorResponse("Content generation is unavailable"),
   },
 });
 
@@ -2555,20 +2001,7 @@ contentRoutes.openapi(deleteBrandIdentityRoute, async (c) => {
     brandIdentityId
   );
 
-  for (const trigger of affectedTriggers) {
-    if (!trigger.qstashScheduleId) {
-      continue;
-    }
-
-    await deleteQstashSchedule(runtimeEnv, trigger.qstashScheduleId).catch(
-      (error) => {
-        console.error(
-          `Failed to delete qstash schedule ${trigger.qstashScheduleId}:`,
-          error
-        );
-      }
-    );
-  }
+  await deleteQstashSchedulesForTriggers(runtimeEnv, affectedTriggers);
 
   if (affectedTriggers.length > 0) {
     await db.batch([

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -5,11 +5,9 @@ import {
   contentTriggerLookbackWindows,
   contentTriggers,
   githubIntegrations,
-  organizations,
 } from "@notra/db/schema";
 import { and, desc, eq, inArray, ne } from "drizzle-orm";
 import { z } from "zod";
-import { errorResponseSchema } from "../schemas/content";
 import {
   createScheduleRequestSchema,
   deleteScheduleResponseSchema,
@@ -23,6 +21,8 @@ import {
   scheduleTargetsSchema,
 } from "../schemas/schedules";
 import { getOrganizationId } from "../utils/auth";
+import { errorResponse } from "../utils/openapi-responses";
+import { getOrganizationResponse } from "../utils/organizations";
 import {
   buildCronExpression,
   createQstashSchedule,
@@ -95,18 +95,6 @@ function hashSchedule(input: CreateScheduleBody) {
       })
     )
     .digest("hex");
-}
-
-async function getOrganizationResponse(db: DbClient, organizationId: string) {
-  return db.query.organizations.findFirst({
-    where: eq(organizations.id, organizationId),
-    columns: {
-      id: true,
-      slug: true,
-      name: true,
-      logo: true,
-    },
-  });
 }
 
 async function ensureScheduleTargetsExist(
@@ -323,18 +311,9 @@ const getSchedulesRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Missing or invalid API key",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    403: {
-      description: "Forbidden",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    404: {
-      description: "Organization not found",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
   },
 });
 
@@ -363,30 +342,12 @@ const createScheduleRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid request",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    403: {
-      description: "Forbidden",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    404: {
-      description: "Organization not found",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    409: {
-      description: "Duplicate schedule",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    500: {
-      description: "Failed to create schedule",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
+    400: errorResponse("Invalid request"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Organization not found"),
+    409: errorResponse("Duplicate schedule"),
+    500: errorResponse("Failed to create schedule"),
   },
 });
 
@@ -416,30 +377,12 @@ const patchScheduleRoute = createRoute({
         },
       },
     },
-    400: {
-      description: "Invalid request",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    401: {
-      description: "Missing or invalid API key",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    403: {
-      description: "Forbidden",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    404: {
-      description: "Schedule or organization not found",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    409: {
-      description: "Duplicate schedule",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    500: {
-      description: "Failed to update schedule",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
+    400: errorResponse("Invalid request"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Schedule or organization not found"),
+    409: errorResponse("Duplicate schedule"),
+    500: errorResponse("Failed to update schedule"),
   },
 });
 
@@ -461,18 +404,9 @@ const deleteScheduleRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Missing or invalid API key",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    403: {
-      description: "Forbidden",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
-    404: {
-      description: "Schedule or organization not found",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse("Schedule or organization not found"),
   },
 });
 

--- a/apps/api/src/utils/openapi-responses.ts
+++ b/apps/api/src/utils/openapi-responses.ts
@@ -1,0 +1,12 @@
+import { errorResponseSchema } from "../schemas/content";
+
+export function errorResponse(description: string) {
+  return {
+    description,
+    content: {
+      "application/json": {
+        schema: errorResponseSchema,
+      },
+    },
+  };
+}

--- a/apps/api/src/utils/organizations.ts
+++ b/apps/api/src/utils/organizations.ts
@@ -1,0 +1,20 @@
+import type { createDb } from "@notra/db/drizzle-http";
+import { organizations } from "@notra/db/schema";
+import { eq } from "drizzle-orm";
+
+type DbClient = ReturnType<typeof createDb>;
+
+export async function getOrganizationResponse(
+  db: DbClient,
+  organizationId: string
+) {
+  return db.query.organizations.findFirst({
+    where: eq(organizations.id, organizationId),
+    columns: {
+      id: true,
+      slug: true,
+      name: true,
+      logo: true,
+    },
+  });
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -25,10 +25,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import remend from "remend";
 import { toast } from "sonner";
-import ChatInput, {
-  type ContextItem,
-  type TextSelection,
-} from "@/components/chat-input";
+import ChatInput from "@/components/chat-input";
 import { getContentTypeLabel } from "@/components/content/content-card";
 import type { EditorRefHandle } from "@/components/content/editor/plugins/editor-ref-plugin";
 import { ContentEditorSwitch } from "@/components/content/editors";
@@ -37,7 +34,11 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { LINKEDIN_BRAND_PRIMARY } from "@/constants/linkedin";
 import { TWITTER_BRAND_COLOR } from "@/constants/twitter";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import { sourceMetadataSchema } from "@/schemas/content";
+import {
+  type ContextItem,
+  sourceMetadataSchema,
+  type TextSelection,
+} from "@/schemas/content";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
 import { getBrandFaviconUrl } from "@/utils/brand";
 import { formatSnakeCaseLabel } from "@/utils/format";

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
@@ -27,11 +27,8 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import type {
-  GitHubIntegration,
-  GitHubRepository,
-  WebhookConfig,
-} from "@/types/integrations";
+import type { GitHubIntegration, GitHubRepository } from "@/types/integrations";
+import type { WebhookConfig } from "@/types/services/integrations";
 import type { Trigger } from "@/types/triggers/triggers";
 import { getOutputTypeLabel } from "@/utils/output-types";
 import { GitHubIntegrationDetailSkeleton } from "./skeleton";

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
@@ -39,6 +39,7 @@ import { UsageSection } from "@/components/billing/usage-section";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { FEATURES } from "@/constants/features";
+import type { BillingPlan } from "@/types/billing/plan";
 import type { ProductFeature } from "@/types/hooks/billing";
 
 const BILLING_SECTION_VALUES = ["billing", "usage"] as const;
@@ -65,11 +66,6 @@ const INVOICE_PRODUCT_NAME_MAP: Record<string, string> = {
 };
 
 const INVOICE_TABLE_COLUMN_COUNT = 4;
-
-type BillingPlan = Exclude<
-  ReturnType<typeof useListPlans>["data"],
-  undefined
->[number];
 
 function formatInvoiceProductName(productId: string): string {
   return INVOICE_PRODUCT_NAME_MAP[productId] ?? productId;

--- a/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts
+++ b/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts
@@ -19,23 +19,12 @@ import { getFirecrawlClient } from "@/lib/firecrawl";
 import { redis } from "@/lib/redis";
 import { getBaseUrl } from "@/lib/triggers/qstash";
 import { brandSettingsSchema, getValidLanguage } from "@/schemas/brand";
+import type {
+  ProgressData,
+  ProgressStatus,
+} from "@/types/hooks/brand-analysis";
 
 const PROGRESS_TTL = 300;
-
-type ProgressStatus =
-  | "idle"
-  | "scraping"
-  | "extracting"
-  | "saving"
-  | "completed"
-  | "failed";
-
-interface ProgressData {
-  status: ProgressStatus;
-  currentStep: number;
-  totalSteps: number;
-  error?: string;
-}
 
 interface ErrorDetail {
   code: string;

--- a/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
+++ b/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
@@ -42,24 +42,10 @@ import {
   formatUtcTodayContext,
   resolveLookbackRange,
 } from "@/lib/workflows/shared/lookback";
-
-interface RepositoryData {
-  id: string;
-  owner: string;
-  repo: string;
-  defaultBranch: string | null;
-}
-
-type BrandSettingsData = {
-  id: string;
-  name: string;
-  toneProfile: string | null;
-  companyName: string | null;
-  companyDescription: string | null;
-  audience: string | null;
-  customInstructions: string | null;
-  language: string | null;
-} | null;
+import type {
+  ScheduleBrandSettingsData as BrandSettingsData,
+  ScheduleRepositoryData as RepositoryData,
+} from "@/types/workflows/workflows";
 
 async function setTrackedJobStatus(
   jobId: string | undefined,

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -59,6 +59,10 @@ import {
   type ScheduleWorkflowPayload,
   scheduleWorkflowPayloadSchema,
 } from "@/schemas/workflows";
+import type {
+  ScheduleBrandSettingsData as BrandSettingsData,
+  ScheduleRepositoryData as RepositoryData,
+} from "@/types/workflows/workflows";
 
 interface TriggerData {
   id: string;
@@ -72,24 +76,6 @@ interface TriggerData {
   enabled: boolean;
   autoPublish: boolean;
 }
-
-interface RepositoryData {
-  id: string;
-  owner: string;
-  repo: string;
-  defaultBranch: string | null;
-}
-
-type BrandSettingsData = {
-  id: string;
-  name: string;
-  toneProfile: string | null;
-  companyName: string | null;
-  companyDescription: string | null;
-  audience: string | null;
-  customInstructions: string | null;
-  language: string | null;
-} | null;
 
 export const { POST } = serve<ScheduleWorkflowPayload>(
   async (context: WorkflowContext<ScheduleWorkflowPayload>) => {

--- a/apps/dashboard/src/app/onboarding/pricing-client.tsx
+++ b/apps/dashboard/src/app/onboarding/pricing-client.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { OnboardingAccountMenu } from "@/components/onboarding/account-menu";
 import { FEATURES, PLANS } from "@/constants/features";
+import type { BillingPlan } from "@/types/billing/plan";
 import type { ProductFeature } from "@/types/hooks/billing";
 
 interface PricingClientProps {
@@ -19,11 +20,6 @@ interface PricingClientProps {
 }
 
 const PRICE_REGEX = /^\d+([.,]\d+)?$/;
-
-type BillingPlan = Exclude<
-  ReturnType<typeof useListPlans>["data"],
-  undefined
->[number];
 
 function getProductPrice(plan: BillingPlan | undefined): number {
   return plan?.price?.amount ?? 0;

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -44,22 +44,8 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { FEATURES } from "@/constants/features";
 import { ALL_INTEGRATIONS } from "@/lib/integrations/catalog";
 import { dashboardOrpc } from "@/lib/orpc/query";
+import type { ContextItem, TextSelection } from "@/schemas/content";
 import type { GitHubRepository } from "@/types/integrations";
-
-export interface TextSelection {
-  text: string;
-  startLine: number;
-  startChar: number;
-  endLine: number;
-  endChar: number;
-}
-
-export interface ContextItem {
-  type: "github-repo";
-  owner: string;
-  repo: string;
-  integrationId: string;
-}
 
 interface ChatInputProps {
   onSend?: (value: string) => void;

--- a/apps/dashboard/src/components/content/editor/lexical-editor.tsx
+++ b/apps/dashboard/src/components/content/editor/lexical-editor.tsx
@@ -16,6 +16,7 @@ import { TablePlugin } from "@lexical/react/LexicalTablePlugin";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
 import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
+import type { TextSelection } from "@/schemas/content";
 import { editorTheme } from "./editor-theme";
 import { EDITOR_TRANSFORMERS } from "./markdown-transformers";
 import { KiboCodeBlockNode } from "./nodes/kibo-code-block-node";
@@ -29,10 +30,7 @@ import {
 import { FloatingToolbarPlugin } from "./plugins/floating-toolbar-plugin";
 import { HorizontalRulePlugin } from "./plugins/horizontal-rule-plugin";
 import { MarkdownSyncPlugin } from "./plugins/markdown-sync-plugin";
-import {
-  SelectionPlugin,
-  type TextSelection,
-} from "./plugins/selection-plugin";
+import { SelectionPlugin } from "./plugins/selection-plugin";
 import { TabFocusPlugin } from "./plugins/tab-focus-plugin";
 import { TableActionMenuPlugin } from "./plugins/table-action-menu-plugin";
 

--- a/apps/dashboard/src/components/content/editor/nodes/kibo-code-block-guard.ts
+++ b/apps/dashboard/src/components/content/editor/nodes/kibo-code-block-guard.ts
@@ -1,0 +1,14 @@
+import type { LexicalNode } from "lexical";
+
+const KIBO_CODE_BLOCK_TYPE = "kibo-code-block";
+
+export interface KiboCodeBlockLike extends LexicalNode {
+  setCode(code: string): void;
+  setLanguage(language: string): void;
+}
+
+export function $isKiboCodeBlockNode(
+  node: LexicalNode | null | undefined
+): node is KiboCodeBlockLike {
+  return node?.getType() === KIBO_CODE_BLOCK_TYPE;
+}

--- a/apps/dashboard/src/components/content/editor/plugins/selection-plugin.tsx
+++ b/apps/dashboard/src/components/content/editor/plugins/selection-plugin.tsx
@@ -9,14 +9,7 @@ import {
   SELECTION_CHANGE_COMMAND,
 } from "lexical";
 import { useEffect } from "react";
-
-export interface TextSelection {
-  text: string;
-  startLine: number;
-  startChar: number;
-  endLine: number;
-  endChar: number;
-}
+import type { TextSelection } from "@/schemas/content";
 
 interface SelectionPluginProps {
   onSelectionChange: (selection: TextSelection | null) => void;

--- a/apps/dashboard/src/components/content/editors/types.ts
+++ b/apps/dashboard/src/components/content/editors/types.ts
@@ -1,5 +1,5 @@
-import type { TextSelection } from "@/components/chat-input";
 import type { EditorRefHandle } from "@/components/content/editor/plugins/editor-ref-plugin";
+import type { TextSelection } from "@/schemas/content";
 
 export interface ContentData {
   id: string;

--- a/apps/dashboard/src/components/integrations/wehook-setup-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/wehook-setup-dialog.tsx
@@ -20,10 +20,8 @@ import type React from "react";
 import { isValidElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import type {
-  WebhookConfig,
-  WebhookSetupDialogProps,
-} from "@/types/integrations";
+import type { WebhookSetupDialogProps } from "@/types/integrations";
+import type { WebhookConfig } from "@/types/services/integrations";
 
 function CopyButton({ value, label }: { value: string; label: string }) {
   const [copied, setCopied] = useState(false);

--- a/apps/dashboard/src/components/linkedin-post.tsx
+++ b/apps/dashboard/src/components/linkedin-post.tsx
@@ -29,9 +29,9 @@ import {
 import Image from "next/image";
 import type * as React from "react";
 import { useEffect, useRef, useState } from "react";
-import type { TextSelection } from "@/components/chat-input";
 import { LINKEDIN_TRUNCATION_LIMIT } from "@/constants/linkedin";
 import { cn } from "@/lib/utils";
+import type { TextSelection } from "@/schemas/content";
 
 interface LinkedInPostProps extends React.ComponentProps<"div"> {
   author: {

--- a/apps/dashboard/src/components/twitter-post.tsx
+++ b/apps/dashboard/src/components/twitter-post.tsx
@@ -25,9 +25,9 @@ import {
 import { Textarea } from "@notra/ui/components/ui/textarea";
 import type * as React from "react";
 import { useEffect, useRef, useState } from "react";
-import type { TextSelection } from "@/components/chat-input";
 import { TWITTER_CHAR_LIMIT } from "@/constants/twitter";
 import { cn } from "@/lib/utils";
+import type { TextSelection } from "@/schemas/content";
 import { formatTweetContent } from "@/utils/format-tweet-content";
 
 interface TwitterPostMenuItem {

--- a/apps/dashboard/src/lib/hooks/use-brand-analysis.ts
+++ b/apps/dashboard/src/lib/hooks/use-brand-analysis.ts
@@ -10,7 +10,6 @@ import type {
 import type {
   BrandSettings,
   BrandSettingsResponse,
-  Progress,
   ProgressResponse,
 } from "@/types/hooks/brand-analysis";
 import { QUERY_KEYS } from "@/utils/query-keys";

--- a/apps/dashboard/src/lib/orpc/routers/brand.ts
+++ b/apps/dashboard/src/lib/orpc/routers/brand.ts
@@ -26,7 +26,10 @@ import {
   updateBrandSettingsSchema,
   updateReferenceSchema,
 } from "@/schemas/brand";
-import type { BrandSettings as BrandVoiceOutput } from "@/types/hooks/brand-analysis";
+import type {
+  BrandSettings as BrandVoiceOutput,
+  ProgressData,
+} from "@/types/hooks/brand-analysis";
 import type {
   ApplicablePlatform,
   BrandReference as BrandReferenceOutput,
@@ -84,19 +87,6 @@ const analyzeInputSchema = organizationIdInputSchema.extend({
 const setDefaultVoiceInputSchema = organizationIdInputSchema.extend({
   voiceId: z.string().min(1, "Voice ID is required"),
 });
-
-export interface ProgressData {
-  status:
-    | "idle"
-    | "scraping"
-    | "extracting"
-    | "saving"
-    | "completed"
-    | "failed";
-  currentStep: number;
-  totalSteps: number;
-  error?: string;
-}
 
 const typeDefaults: Record<string, ApplicablePlatform[]> = {
   twitter_post: ["twitter"],

--- a/apps/dashboard/src/types/billing/plan.ts
+++ b/apps/dashboard/src/types/billing/plan.ts
@@ -1,0 +1,6 @@
+import type { useListPlans } from "autumn-js/react";
+
+export type BillingPlan = Exclude<
+  ReturnType<typeof useListPlans>["data"],
+  undefined
+>[number];

--- a/apps/dashboard/src/types/components/members.ts
+++ b/apps/dashboard/src/types/components/members.ts
@@ -1,0 +1,11 @@
+export interface Member {
+  id: string;
+  userId: string;
+  role: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    image?: string | null;
+  };
+}

--- a/apps/dashboard/src/types/hooks/brand-analysis.ts
+++ b/apps/dashboard/src/types/hooks/brand-analysis.ts
@@ -27,7 +27,7 @@ export type ProgressStatus =
   | "completed"
   | "failed";
 
-export interface Progress {
+export interface ProgressData {
   status: ProgressStatus;
   currentStep: number;
   totalSteps: number;
@@ -35,5 +35,5 @@ export interface Progress {
 }
 
 export interface ProgressResponse {
-  progress: Progress;
+  progress: ProgressData;
 }

--- a/apps/dashboard/src/types/integrations.ts
+++ b/apps/dashboard/src/types/integrations.ts
@@ -62,20 +62,6 @@ export interface IntegrationWebhookLog {
   createdAt: string;
 }
 
-export interface GitHubIntegration {
-  id: string;
-  displayName: string;
-  enabled: boolean;
-  createdAt: string;
-  createdByUser?: {
-    id: string;
-    name: string;
-    email: string;
-    image: string | null;
-  };
-  repositories: GitHubRepository[];
-}
-
 export interface GitHubRepoInfo {
   owner: string;
   repo: string;
@@ -138,14 +124,6 @@ export interface IntegrationCardProps {
 export interface RepositoryListProps {
   integrationId: string;
   organizationId: string;
-}
-
-export interface WebhookConfig {
-  webhookUrl: string;
-  webhookSecret: string;
-  repositoryId: string;
-  owner: string;
-  repo: string;
 }
 
 export interface WebhookSetupDialogProps {

--- a/apps/dashboard/src/types/workflows/workflows.ts
+++ b/apps/dashboard/src/types/workflows/workflows.ts
@@ -33,6 +33,24 @@ export interface WorkflowBrandSettings {
   language: string | null;
 }
 
+export interface ScheduleRepositoryData {
+  id: string;
+  owner: string;
+  repo: string;
+  defaultBranch: string | null;
+}
+
+export type ScheduleBrandSettingsData = {
+  id: string;
+  name: string;
+  toneProfile: string | null;
+  companyName: string | null;
+  companyDescription: string | null;
+  audience: string | null;
+  customInstructions: string | null;
+  language: string | null;
+} | null;
+
 export interface EventGenerationContext {
   organizationId: string;
   triggerId: string;


### PR DESCRIPTION
### Description
Cleanup pass focused on consolidation and dead-weight removal. Net **-659 lines** across 26 files.

**API routes** — Added `errorResponse()` helper (`apps/api/src/utils/openapi-responses.ts`) and replaced 93 inline OpenAPI error-response blocks across `content.ts` and `schedules.ts`. Moved shared `getOrganizationResponse` to `apps/api/src/utils/organizations.ts`. `content.ts`: 2971 → ~2235 lines. `schedules.ts`: 863 → ~750 lines.

**Type consolidation** — Merged duplicate type declarations into shared `types/` modules:
- `TextSelection`, `ContextItem` → already in `schemas/content.ts`, removed inline copies
- `WebhookConfig` → canonical in `types/services/integrations.ts`
- `ProgressData` / `ProgressStatus` → `types/hooks/brand-analysis.ts` (renamed from `Progress`)
- `BillingPlan` → new `types/billing/plan.ts`
- `ScheduleRepositoryData`, `ScheduleBrandSettingsData` → `types/workflows/workflows.ts`
- Removed accidental duplicate `GitHubIntegration` declaration

**Circular dependencies broken** (3 of 4):
- `members/columns ↔ member-actions` — extracted `Member` to `types/components/members.ts`
- Kibo code block `node ↔ component` — extracted structural type guard
- `packages/ai` `types/tools ↔ types/agents` — moved tool-scoped types into `tools.ts`, re-exported from `agents.ts` for backwards compatibility

### Screenshot/Recording (if applicable)
N/A — no UI changes.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>