### PR TITLE
fix(ai): ignore incomplete tool calls when switching models

### DIFF
--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -113,7 +113,9 @@ export async function orchestrateStandaloneChat(
   const stream = streamText({
     model: modelWithMemory,
     system: systemPrompt,
-    messages: await convertToModelMessages(messages),
+    messages: await convertToModelMessages(messages, {
+      ignoreIncompleteToolCalls: true,
+    }),
     tools,
     stopWhen: stepCountIs(maxSteps),
     experimental_transform: smoothStream(),

--- a/packages/ai/src/orchestration/orchestrate.ts
+++ b/packages/ai/src/orchestration/orchestrate.ts
@@ -115,7 +115,9 @@ export async function orchestrateChat(
   const stream = streamText({
     model: modelWithMemory,
     system: systemPrompt,
-    messages: await convertToModelMessages(messages),
+    messages: await convertToModelMessages(messages, {
+      ignoreIncompleteToolCalls: true,
+    }),
     tools,
     stopWhen: stepCountIs(maxSteps),
     onFinish({ totalUsage }) {


### PR DESCRIPTION
### Description
before orphaned/incomplete toolcalls caused an error where the chat was then basically broken this should hopefully fix this

i wasnt able to reproduce it since then with the same history sooooo 

### Screenshot/Recording (if applicable)
<img width="506" height="240" alt="image" src="https://github.com/user-attachments/assets/583cce47-b559-4f79-aa77-36cc3613b8c1" />
this was the error i was getting before

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>
