### PR TITLE
feat(chat): reveal model + perf stats when hovering assistant messages

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -26,6 +26,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatToolBlock } from "@/components/ai/chat-tool-block";
 import { BrailleLoader } from "@/components/braille-loader";
+import { AssistantMetadataHover } from "@/components/chat/assistant-metadata-hover";
 import {
   ChatInputAdvanced,
   type ThinkingLevel,
@@ -38,7 +39,7 @@ import {
   chatErrorPayloadSchema,
   chatTransportRequestInputSchema,
 } from "@/schemas/chat";
-import type { ContextItem } from "@/types/chat";
+import type { ChatUIMessage, ContextItem } from "@/types/chat";
 import {
   CHAT_PREFERENCES_STORAGE_KEY,
   DEFAULT_CHAT_PREFERENCES,
@@ -229,7 +230,7 @@ function StandaloneChatPageClient({
 
   const transport = useMemo(
     () =>
-      new DefaultChatTransport({
+      new DefaultChatTransport<ChatUIMessage>({
         api: `/api/organizations/${organizationId}/chat`,
         prepareSendMessagesRequest: ({ id, messages }) => ({
           body: {
@@ -345,7 +346,7 @@ function StandaloneChatPageClient({
     addToolApprovalResponse,
     status,
     stop,
-  } = useChat({
+  } = useChat<ChatUIMessage>({
     id: stableChatId,
     resume: Boolean(initialChatId && pendingMessageId),
     experimental_throttle: 50,
@@ -894,6 +895,9 @@ function StandaloneChatPageClient({
                       renderPart(part, message.id, index)
                     )}
                   </MessageContent>
+                  {message.role === "assistant" && (
+                    <AssistantMetadataHover metadata={message.metadata} />
+                  )}
                 </Message>
               ))}
               {wasStoppedByUser && !isLoading && (

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -373,8 +373,16 @@ async function createDirectStandaloneChatResponse({
     ]);
   };
 
+  const streamStartedAt = Date.now();
+  let firstChunkAt: number | null = null;
+  const usageSnapshot: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  } = {};
+
   try {
-    const { stream } = await orchestrateStandaloneChat(
+    const { stream, routingDecision } = await orchestrateStandaloneChat(
       {
         organizationId,
         messages: messages as never,
@@ -397,7 +405,16 @@ async function createDirectStandaloneChatResponse({
         },
         resolveContext: getGitHubToolRepositoryContextByIntegrationId,
         resolveLinearContext: getLinearToolContextByIntegrationId,
+        onFirstChunk() {
+          if (firstChunkAt === null) {
+            firstChunkAt = Date.now();
+          }
+        },
         async onUsage(usage, modelId) {
+          usageSnapshot.inputTokens = usage.inputTokens ?? 0;
+          usageSnapshot.outputTokens = usage.outputTokens ?? 0;
+          usageSnapshot.totalTokens = usage.totalTokens ?? 0;
+
           if (!autumnClient) {
             return;
           }
@@ -449,6 +466,39 @@ async function createDirectStandaloneChatResponse({
       generateMessageId: nanoid,
       sendReasoning: enableThinking !== false,
       headers: { "X-Chat-Id": chatId },
+      messageMetadata: ({ part }) => {
+        if (part.type === "start") {
+          return {
+            model: routingDecision.model,
+            thinkingLevel: enableThinking === false ? "off" : thinkingLevel,
+            createdAt: streamStartedAt,
+          };
+        }
+
+        if (part.type === "finish") {
+          const finishedAt = Date.now();
+          const ttftMs =
+            firstChunkAt !== null ? firstChunkAt - streamStartedAt : undefined;
+          const generationDurationMs =
+            firstChunkAt !== null ? finishedAt - firstChunkAt : undefined;
+          const outputTokens = usageSnapshot.outputTokens ?? 0;
+          const tokensPerSecond =
+            generationDurationMs && generationDurationMs > 0 && outputTokens > 0
+              ? (outputTokens / generationDurationMs) * 1000
+              : undefined;
+
+          return {
+            inputTokens: usageSnapshot.inputTokens,
+            outputTokens: usageSnapshot.outputTokens,
+            totalTokens: usageSnapshot.totalTokens,
+            ttftMs,
+            generationDurationMs,
+            tokensPerSecond,
+          };
+        }
+
+        return;
+      },
       onFinish: async ({ messages: responseMessages }) => {
         try {
           await replaceChatHistory(organizationId, chatId, responseMessages);

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -184,6 +184,7 @@ export const POST = withEvlog(async function POST(
         log,
         model: parseResult.data.model,
         enableThinking: parseResult.data.enableThinking,
+        thinkingLevel: parseResult.data.thinkingLevel,
         abortSignal: request.signal,
       });
     }

--- a/apps/dashboard/src/app/api/workflows/chat/route.ts
+++ b/apps/dashboard/src/app/api/workflows/chat/route.ts
@@ -104,6 +104,13 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
 
   const abortController = new AbortController();
   let stopAbortPolling: (() => void) | null = null;
+  const streamStartedAt = Date.now();
+  const timing: { firstChunkAt: number | null } = { firstChunkAt: null };
+  const usageSnapshot: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  } = {};
 
   try {
     stopAbortPolling = startChatAbortPolling({
@@ -134,7 +141,16 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
         },
         resolveContext: getGitHubToolRepositoryContextByIntegrationId,
         resolveLinearContext: getLinearToolContextByIntegrationId,
+        onFirstChunk() {
+          if (timing.firstChunkAt === null) {
+            timing.firstChunkAt = Date.now();
+          }
+        },
         async onUsage(usage, modelId) {
+          usageSnapshot.inputTokens = usage.inputTokens ?? 0;
+          usageSnapshot.outputTokens = usage.outputTokens ?? 0;
+          usageSnapshot.totalTokens = usage.totalTokens ?? 0;
+
           if (!autumn) {
             return;
           }
@@ -190,6 +206,43 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
       originalMessages: messages,
       generateMessageId: nanoid,
       sendReasoning: enableThinking !== false,
+      messageMetadata: ({ part }) => {
+        if (part.type === "start") {
+          return {
+            model: routingDecision.model,
+            thinkingLevel: enableThinking === false ? "off" : thinkingLevel,
+            createdAt: streamStartedAt,
+          };
+        }
+
+        if (part.type === "finish") {
+          const finishedAt = Date.now();
+          const ttftMs =
+            timing.firstChunkAt !== null
+              ? timing.firstChunkAt - streamStartedAt
+              : undefined;
+          const generationDurationMs =
+            timing.firstChunkAt !== null
+              ? finishedAt - timing.firstChunkAt
+              : undefined;
+          const outputTokens = usageSnapshot.outputTokens ?? 0;
+          const tokensPerSecond =
+            generationDurationMs && generationDurationMs > 0 && outputTokens > 0
+              ? (outputTokens / generationDurationMs) * 1000
+              : undefined;
+
+          return {
+            inputTokens: usageSnapshot.inputTokens,
+            outputTokens: usageSnapshot.outputTokens,
+            totalTokens: usageSnapshot.totalTokens,
+            ttftMs,
+            generationDurationMs,
+            tokensPerSecond,
+          };
+        }
+
+        return;
+      },
       onFinish: async ({ messages: responseMessages }) => {
         try {
           await replaceChatHistory(organizationId, chatId, responseMessages);

--- a/apps/dashboard/src/components/chat/assistant-metadata-hover.tsx
+++ b/apps/dashboard/src/components/chat/assistant-metadata-hover.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Clock01Icon, CpuIcon, FlashIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ClaudeAiIcon } from "@notra/ui/components/ui/svgs/claudeAiIcon";
+import { Openai } from "@notra/ui/components/ui/svgs/openai";
+import { OpenaiDark } from "@notra/ui/components/ui/svgs/openaiDark";
+import type { ReactNode } from "react";
+import type {
+  ChatMessageMetadata,
+  ChatModel,
+  ThinkingLevel,
+} from "@/types/chat";
+
+const MODEL_LABELS = {
+  "anthropic/claude-opus-4-7": "Claude Opus 4.7",
+  "anthropic/claude-sonnet-4-6": "Claude Sonnet 4.6",
+  "anthropic/claude-haiku-4-5": "Claude Haiku 4.5",
+  "openai/gpt-5.4": "GPT-5.4",
+} satisfies Record<ChatModel, string>;
+
+const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string | null> = {
+  off: null,
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+};
+
+function getModelLabel(model: string): string {
+  for (const [key, label] of Object.entries(MODEL_LABELS)) {
+    if (key === model) {
+      return label;
+    }
+  }
+  return model;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)} ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 10) {
+    return `${seconds.toFixed(1)} sec`;
+  }
+  return `${Math.round(seconds)} sec`;
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return String(tokens);
+}
+
+function ModelBadgeIcon({ model }: { model: string }) {
+  if (model.startsWith("openai/")) {
+    return (
+      <>
+        <Openai className="block size-3 dark:hidden" />
+        <OpenaiDark className="hidden size-3 dark:block" />
+      </>
+    );
+  }
+  return <ClaudeAiIcon className="size-3" />;
+}
+
+interface AssistantMetadataHoverProps {
+  metadata: ChatMessageMetadata | undefined;
+}
+
+export function AssistantMetadataHover({
+  metadata,
+}: AssistantMetadataHoverProps) {
+  if (!metadata) {
+    return null;
+  }
+
+  const items: ReactNode[] = [];
+
+  if (metadata.model) {
+    const modelLabel = getModelLabel(metadata.model);
+    const thinkingLabel = metadata.thinkingLevel
+      ? THINKING_LEVEL_LABELS[metadata.thinkingLevel]
+      : null;
+
+    items.push(
+      <div className="flex items-center gap-1.5" key="model">
+        <ModelBadgeIcon model={metadata.model} />
+        <span>
+          {modelLabel}
+          {thinkingLabel ? ` (${thinkingLabel})` : ""}
+        </span>
+      </div>
+    );
+  }
+
+  if (typeof metadata.tokensPerSecond === "number") {
+    items.push(
+      <div className="flex items-center gap-1" key="tps">
+        <HugeiconsIcon className="size-3" icon={FlashIcon} />
+        <span>{metadata.tokensPerSecond.toFixed(2)} tok/sec</span>
+      </div>
+    );
+  }
+
+  if (typeof metadata.totalTokens === "number") {
+    items.push(
+      <div className="flex items-center gap-1" key="tokens">
+        <HugeiconsIcon className="size-3" icon={CpuIcon} />
+        <span>{formatTokens(metadata.totalTokens)} tokens</span>
+      </div>
+    );
+  }
+
+  if (typeof metadata.ttftMs === "number") {
+    items.push(
+      <div className="flex items-center gap-1" key="ttft">
+        <HugeiconsIcon className="size-3" icon={Clock01Icon} />
+        <span>Time-to-First: {formatDuration(metadata.ttftMs)}</span>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-xs opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+      {items}
+    </div>
+  );
+}

--- a/apps/dashboard/src/schemas/chat.ts
+++ b/apps/dashboard/src/schemas/chat.ts
@@ -13,6 +13,18 @@ export const chatModelSchema = z.enum([
 
 export const thinkingLevelSchema = z.enum(["off", "low", "medium", "high"]);
 
+export const chatMessageMetadataSchema = z.object({
+  model: chatModelSchema.optional(),
+  thinkingLevel: thinkingLevelSchema.optional(),
+  inputTokens: z.number().int().nonnegative().optional(),
+  outputTokens: z.number().int().nonnegative().optional(),
+  totalTokens: z.number().int().nonnegative().optional(),
+  ttftMs: z.number().nonnegative().optional(),
+  generationDurationMs: z.number().nonnegative().optional(),
+  tokensPerSecond: z.number().nonnegative().optional(),
+  createdAt: z.number().int().nonnegative().optional(),
+});
+
 const uiMessageSchema = z.custom<UIMessage>((value) => {
   if (typeof value !== "object" || value === null) {
     return false;

--- a/apps/dashboard/src/types/chat.ts
+++ b/apps/dashboard/src/types/chat.ts
@@ -2,8 +2,10 @@ import type {
   ContextItem as OrchestrationContextItem,
   TextSelection as OrchestrationTextSelection,
 } from "@notra/ai/types/orchestration";
+import type { UIMessage } from "ai";
 import type { z } from "zod";
 import type {
+  chatMessageMetadataSchema,
   chatModelSchema,
   chatSessionSummarySchema,
   chatTransportRequestInputSchema,
@@ -18,6 +20,8 @@ export type ContextItem = OrchestrationContextItem;
 export type StandaloneChatContextItem = OrchestrationContextItem;
 export type ChatModel = z.infer<typeof chatModelSchema>;
 export type ThinkingLevel = z.infer<typeof thinkingLevelSchema>;
+export type ChatMessageMetadata = z.infer<typeof chatMessageMetadataSchema>;
+export type ChatUIMessage = UIMessage<ChatMessageMetadata>;
 export type StoredChatPreferences = z.infer<typeof storedChatPreferencesSchema>;
 export type ChatSessionSummary = z.infer<typeof chatSessionSummarySchema>;
 export type UpdateChatSessionInput = z.infer<typeof updateChatSessionSchema>;

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -108,6 +108,7 @@ export async function orchestrateStandaloneChat(
     thinkingLevel
   );
 
+  let firstChunkFired = false;
   const stream = streamText({
     model: modelWithMemory,
     system: systemPrompt,
@@ -119,6 +120,15 @@ export async function orchestrateStandaloneChat(
     experimental_transform: smoothStream(),
     providerOptions,
     abortSignal,
+    onChunk({ chunk }) {
+      if (firstChunkFired) {
+        return;
+      }
+      if (chunk.type === "text-delta" || chunk.type === "reasoning-delta") {
+        firstChunkFired = true;
+        deps?.onFirstChunk?.();
+      }
+    },
     onAbort({ steps }) {
       console.log("[Standalone Chat Stream Aborted]", {
         organizationId,

--- a/packages/ai/src/types/standalone-chat.ts
+++ b/packages/ai/src/types/standalone-chat.ts
@@ -27,6 +27,7 @@ export interface StandaloneChatDeps {
     usage: LanguageModelUsage,
     modelId: string
   ) => void | Promise<void>;
+  onFirstChunk?: () => void;
   log?: AILogTarget;
 }
 


### PR DESCRIPTION
## Summary
- Capture model, thinking level, time-to-first-token, tok/sec, and token totals per assistant turn via the AI SDK `messageMetadata` callback (direct stream + QStash workflow paths).
- Plumb an `onFirstChunk` hook through the standalone chat orchestrator so the route can stamp TTFT based on the first text/reasoning delta.
- Render an `AssistantMetadataHover` bar under each assistant message, hidden by default and fading in on hover (uses hugeicons + the existing model SVGs).

## Test plan
- [ ] Open the standalone chat, send a message, hover the assistant reply and confirm the metadata bar shows `Claude Sonnet 4.6 (Medium)`, tok/sec, tokens, and Time-to-First.
- [ ] Switch models (Opus / Haiku / GPT) and confirm the label and icon update correctly.
- [ ] Refresh a chat session and confirm the metadata persists from saved history.
- [ ] Toggle thinking level to `off` and confirm the `(Medium)` suffix disappears.