### PR TITLE
fix(chat): treat new user message as decline of pending approval

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -544,12 +544,17 @@ function StandaloneChatPageClient({
           continue;
         }
         for (const part of message.parts) {
-          if (isToolUIPart(part) && part.state === "approval-requested") {
-            addToolApprovalResponse({
-              id: part.approval.id,
-              approved: false,
-            });
+          if (!(isToolUIPart(part) && part.state === "approval-requested")) {
+            continue;
           }
+          const approvalId = part.approval?.id;
+          if (!approvalId) {
+            continue;
+          }
+          addToolApprovalResponse({
+            id: approvalId,
+            approved: false,
+          });
         }
       }
       await sendMessage({ text });

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -532,11 +532,17 @@ function StandaloneChatPageClient({
     );
   }, []);
 
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
   const handleSend = useCallback(
     async (text: string) => {
       const isFirstMessage = !initialChatId;
       setWasStoppedByUser(false);
-      for (const message of messages) {
+      for (const message of messagesRef.current) {
+        if (message.role !== "assistant") {
+          continue;
+        }
         for (const part of message.parts) {
           if (isToolUIPart(part) && part.state === "approval-requested") {
             addToolApprovalResponse({
@@ -557,7 +563,6 @@ function StandaloneChatPageClient({
     [
       addToolApprovalResponse,
       initialChatId,
-      messages,
       organizationId,
       organizationSlug,
       queryClient,

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -18,6 +18,7 @@ import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   DefaultChatTransport,
+  isToolUIPart,
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from "ai";
 import { nanoid } from "nanoid";
@@ -535,6 +536,16 @@ function StandaloneChatPageClient({
     async (text: string) => {
       const isFirstMessage = !initialChatId;
       setWasStoppedByUser(false);
+      for (const message of messages) {
+        for (const part of message.parts) {
+          if (isToolUIPart(part) && part.state === "approval-requested") {
+            addToolApprovalResponse({
+              id: part.approval.id,
+              approved: false,
+            });
+          }
+        }
+      }
       await sendMessage({ text });
       if (isFirstMessage) {
         router.replace(`/${organizationSlug}/chat/${stableChatId}`);
@@ -544,7 +555,9 @@ function StandaloneChatPageClient({
       }
     },
     [
+      addToolApprovalResponse,
       initialChatId,
+      messages,
       organizationId,
       organizationSlug,
       queryClient,


### PR DESCRIPTION
### Description
When the agent showed an accept/decline UI (e.g. a draft post preview awaiting approval) and the user sent a new message instead of clicking a button, the pending approval was left dangling and blocked the chat from progressing. This PR treats a new user message as an implicit decline of any outstanding approval request: before sending, `handleSend` scans `messages` for tool parts in `"approval-requested"` state and calls `addToolApprovalResponse({ approved: false })` on each.

### Screenshot/Recording (if applicable)
N/A — behavioral fix.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>