### PR TITLE
fix(chat): update URL instantly on first message

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -198,7 +198,6 @@ function StandaloneChatPageClient({
   const organizationId = organization?.id ?? "";
   const { data: session } = authClient.useSession();
   const queryClient = useQueryClient();
-  const router = useRouter();
   const [pendingMessageId, setPendingMessageId] = useState<string | null>(null);
   const [isHydrated, setIsHydrated] = useState(false);
 
@@ -557,9 +556,15 @@ function StandaloneChatPageClient({
           });
         }
       }
+      if (isFirstMessage) {
+        window.history.replaceState(
+          null,
+          "",
+          `/${organizationSlug}/chat/${stableChatId}`
+        );
+      }
       await sendMessage({ text });
       if (isFirstMessage) {
-        router.replace(`/${organizationSlug}/chat/${stableChatId}`);
         queryClient.invalidateQueries({
           queryKey: ["chat-sessions", organizationId],
         });
@@ -571,7 +576,6 @@ function StandaloneChatPageClient({
       organizationId,
       organizationSlug,
       queryClient,
-      router,
       sendMessage,
       stableChatId,
     ]

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -534,9 +534,11 @@ function StandaloneChatPageClient({
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
 
+  const hasUpdatedUrlRef = useRef(false);
+
   const handleSend = useCallback(
     async (text: string) => {
-      const isFirstMessage = !initialChatId;
+      const isFirstMessage = !initialChatId && !hasUpdatedUrlRef.current;
       setWasStoppedByUser(false);
       for (const message of messagesRef.current) {
         if (message.role !== "assistant") {
@@ -557,6 +559,7 @@ function StandaloneChatPageClient({
         }
       }
       if (isFirstMessage) {
+        hasUpdatedUrlRef.current = true;
         window.history.replaceState(
           null,
           "",


### PR DESCRIPTION
## Summary
- Replace `router.replace` with `window.history.replaceState` so swapping `/chat` → `/chat/[id]` doesn't re-run the route and flicker the UI.
- Move the URL update *before* `await sendMessage(...)` so the id appears in the URL the moment the user sends, not after the full assistant response finishes streaming.
- Sidebar invalidation still runs after `sendMessage` resolves so the new session shows up once persisted.

`window.history.replaceState` is the App Router-native pattern for URL updates without re-render (shallow routing was never ported from the Pages Router) — see https://nextjs.org/docs/app/getting-started/linking-and-navigating.

## Test plan
- [ ] Send the first message on `/[slug]/chat` and confirm the URL flips to `/[slug]/chat/[id]` immediately, not after the response streams in.
- [ ] Confirm the page does not flash/re-render when the URL changes.
- [ ] Confirm the new chat appears in the sidebar after the response finishes.
- [ ] Confirm the redirect at line ~983 (when ai chat experiment is off) still works.