### PR TITLE
fix(chat): resume active stream after page refresh

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -475,6 +475,8 @@ function StandaloneChatPageClient({
     setWasStoppedByUser(Boolean(chatHistoryQuery.data.lastResponseStopped));
     if (chatHistoryQuery.data.activeStreamId) {
       setPendingMessageId(chatHistoryQuery.data.activeStreamId);
+    } else {
+      setPendingMessageId(null);
     }
   }, [chatHistoryQuery.data, setMessages]);
 

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -457,6 +457,8 @@ function StandaloneChatPageClient({
       return {
         messages: data?.messages ?? null,
         lastResponseStopped: Boolean(data?.lastResponseStopped),
+        activeStreamId:
+          typeof data?.activeStreamId === "string" ? data.activeStreamId : null,
       };
     },
     enabled: Boolean(initialChatId) && Boolean(organizationId),
@@ -471,6 +473,9 @@ function StandaloneChatPageClient({
       setMessages(chatHistoryQuery.data.messages);
     }
     setWasStoppedByUser(Boolean(chatHistoryQuery.data.lastResponseStopped));
+    if (chatHistoryQuery.data.activeStreamId) {
+      setPendingMessageId(chatHistoryQuery.data.activeStreamId);
+    }
   }, [chatHistoryQuery.data, setMessages]);
 
   useEffect(() => {

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/[chatId]/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/[chatId]/route.ts
@@ -4,6 +4,7 @@ import { isAiChatExperimentEnabled } from "@/lib/ai-chat-experiment";
 import { withOrganizationAuth } from "@/lib/auth/organization";
 import {
   deleteChatSession,
+  getActiveChatStream,
   getLastResponseStopped,
   isChatDeleted,
   loadChatHistory,
@@ -41,11 +42,17 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     return NextResponse.json({ error: "Chat not found" }, { status: 404 });
   }
 
-  const [messages, lastResponseStopped] = await Promise.all([
+  const [messages, lastResponseStopped, activeStreamId] = await Promise.all([
     loadChatHistory(organizationId, chatId),
     getLastResponseStopped(organizationId, chatId),
+    getActiveChatStream(organizationId, chatId),
   ]);
-  return NextResponse.json({ chatId, messages, lastResponseStopped });
+  return NextResponse.json({
+    chatId,
+    messages,
+    lastResponseStopped,
+    activeStreamId,
+  });
 }
 
 export async function PATCH(request: NextRequest, { params }: RouteContext) {


### PR DESCRIPTION
## Summary
- Refreshing `/[slug]/chat/[chatId]` while a response was streaming dropped the user back to a static view — the client had no way to know a stream was live, so `useChat`'s `resume` stayed false and never reconnected.
- `GET /api/organizations/[organizationId]/chat/[chatId]` now returns `activeStreamId` (read from the Redis key the POST/workflow/stop paths already maintain).
- When the client's `chatHistoryQuery` sees an `activeStreamId`, it sets `pendingMessageId`, which flips `resume` to true. The AI SDK then calls `prepareReconnectToStreamRequest`, hits `GET /chat/[chatId]/stream`, replays the Realtime channel history, and subscribes for live chunks.

## Caveat
Resumption only works under the Upstash Workflow streaming path (prod, or `FORCE_UPSTASH_CHAT_STREAMING=true`) — the direct dev stream dies when the client disconnects and doesn't publish to Realtime.

## Test plan
- [ ] On prod (or `FORCE_UPSTASH_CHAT_STREAMING=true`): send a long-generating message, refresh mid-stream, confirm the stream continues rendering to completion.
- [ ] Refresh after a stream has finished — no spurious resume, final message shown.
- [ ] Refresh on a chat with no active stream — 204 from `/stream`, no error.
- [ ] Stop mid-stream, then refresh — no resume attempt, "stopped" UI intact.