### PR TITLE
feat(chat): queue messages while assistant is generating

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -903,7 +903,10 @@ function StandaloneChatPageClient({
     isDrainingRef.current = true;
 
     stopActiveResponse().catch((error) => {
-      console.error("[Chat] Failed to stop active response for queue drain:", error);
+      console.error(
+        "[Chat] Failed to stop active response for queue drain:",
+        error
+      );
       isDrainingRef.current = false;
     });
   }, [

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -39,6 +39,7 @@ import {
   ChatInputAdvanced,
   type ThinkingLevel,
 } from "@/components/chat/chat-input";
+import { ChatQueue, type QueuedMessage } from "@/components/chat/chat-queue";
 import { ChatSuggestions } from "@/components/chat/chat-suggestions";
 import { renderTextWithIntegrationReferences } from "@/components/chat/integration-reference";
 import { useAiChatExperiment } from "@/components/providers/databuddy-flags-provider";
@@ -194,6 +195,20 @@ function getCreateToolContentType(
   return CREATE_TOOL_TYPES[type];
 }
 
+function hasPendingApproval(messages: readonly ChatUIMessage[]): boolean {
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    for (const part of message.parts) {
+      if (isToolUIPart(part) && part.state === "approval-requested") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function StandaloneChatPageClient({
   organizationSlug,
   chatId: initialChatId,
@@ -216,6 +231,7 @@ function StandaloneChatPageClient({
   const [context, setContext] = useState<ContextItem[]>([]);
   const [hasCustomizedContext, setHasCustomizedContext] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
+  const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
   const [selectedModel, setSelectedModel] = useState(
     DEFAULT_CHAT_PREFERENCES.model
   );
@@ -343,12 +359,17 @@ function StandaloneChatPageClient({
 
   const [wasStoppedByUser, setWasStoppedByUser] = useState(false);
 
+  const drainQueueRef = useRef<() => void>(() => {
+    // Populated after dispatchMessage is defined below.
+  });
+
   const handleFinish = useCallback(() => {
     setPendingMessageId(null);
     queryClient.invalidateQueries({ queryKey: ["autumn", "customer"] });
     queryClient.invalidateQueries({
       queryKey: ["chat-sessions", organizationId],
     });
+    drainQueueRef.current();
   }, [organizationId, queryClient]);
 
   const {
@@ -444,9 +465,7 @@ function StandaloneChatPageClient({
     });
   }, [initialChatId, selectedModel, thinkingLevel]);
 
-  const handleStop = useCallback(async () => {
-    setIsStopping(true);
-    setWasStoppedByUser(true);
+  const stopActiveResponse = useCallback(async () => {
     try {
       if (organizationId && stableChatId) {
         await fetch(
@@ -460,6 +479,12 @@ function StandaloneChatPageClient({
       stop();
     }
   }, [organizationId, stableChatId, stop]);
+
+  const handleStop = useCallback(async () => {
+    setIsStopping(true);
+    setWasStoppedByUser(true);
+    await stopActiveResponse();
+  }, [stopActiveResponse]);
 
   const chatHistoryQuery = useQuery<{
     messages: ChatUIMessage[] | null;
@@ -540,6 +565,7 @@ function StandaloneChatPageClient({
   useEffect(() => {
     setPendingMessageId(null);
     setChatError(null);
+    setQueuedMessages([]);
 
     if (initialChatId) {
       return;
@@ -550,6 +576,56 @@ function StandaloneChatPageClient({
     setContext([]);
     setHasCustomizedContext(false);
   }, [initialChatId, setMessages]);
+
+  const queueStorageKey = `chat-queue:${stableChatId}`;
+  const loadedQueueKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (loadedQueueKeyRef.current === queueStorageKey) {
+      return;
+    }
+    loadedQueueKeyRef.current = queueStorageKey;
+    try {
+      const raw = window.localStorage.getItem(queueStorageKey);
+      if (!raw) {
+        setQueuedMessages([]);
+        return;
+      }
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        setQueuedMessages([]);
+        return;
+      }
+      const restored = parsed.filter(
+        (m): m is QueuedMessage =>
+          typeof m === "object" &&
+          m !== null &&
+          typeof (m as { id?: unknown }).id === "string" &&
+          typeof (m as { text?: unknown }).text === "string"
+      );
+      setQueuedMessages(restored);
+    } catch {
+      setQueuedMessages([]);
+    }
+  }, [queueStorageKey]);
+
+  useEffect(() => {
+    if (loadedQueueKeyRef.current !== queueStorageKey) {
+      return;
+    }
+    try {
+      if (queuedMessages.length === 0) {
+        window.localStorage.removeItem(queueStorageKey);
+      } else {
+        window.localStorage.setItem(
+          queueStorageKey,
+          JSON.stringify(queuedMessages)
+        );
+      }
+    } catch {
+      // noop
+    }
+  }, [queueStorageKey, queuedMessages]);
 
   const pendingHistoryMessages = chatHistoryQuery.data?.messages?.length ?? 0;
   const isLoadingHistory =
@@ -647,7 +723,7 @@ function StandaloneChatPageClient({
     setGeneratedChatId(nanoid(16));
   }, [pathname, organizationSlug, initialChatId, setMessages]);
 
-  const handleSend = useCallback(
+  const dispatchMessage = useCallback(
     async (text: string) => {
       const isFirstMessage = !initialChatId && !hasUpdatedUrlRef.current;
       if (messagesRef.current.length === 0) {
@@ -673,7 +749,6 @@ function StandaloneChatPageClient({
         }
       }
       if (isFirstMessage) {
-        hasUpdatedUrlRef.current = true;
         window.history.replaceState(
           null,
           "",
@@ -698,6 +773,135 @@ function StandaloneChatPageClient({
       triggerFirstMessageTransition,
     ]
   );
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      if (isLoading) {
+        setQueuedMessages((prev) => [...prev, { id: nanoid(10), text }]);
+        return;
+      }
+      await dispatchMessage(text);
+    },
+    [dispatchMessage, isLoading]
+  );
+
+  const handleRemoveQueued = useCallback((id: string) => {
+    setQueuedMessages((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  const handleEditQueued = useCallback((message: QueuedMessage) => {
+    setQueuedMessages((prev) => prev.filter((m) => m.id !== message.id));
+    chatInputRef.current?.setText(message.text);
+  }, []);
+
+  const queuedMessagesRef = useRef(queuedMessages);
+  queuedMessagesRef.current = queuedMessages;
+
+  const isDrainingRef = useRef(false);
+  const seenToolOutputsRef = useRef<Set<string>>(new Set());
+  const prevIsLoadingRef = useRef(false);
+
+  drainQueueRef.current = () => {
+    if (wasStoppedByUserRef.current) {
+      return;
+    }
+    if (hasPendingApproval(messagesRef.current)) {
+      return;
+    }
+    const queue = queuedMessagesRef.current;
+    const next = queue[0];
+    if (!next) {
+      return;
+    }
+    setQueuedMessages(queue.slice(1));
+    dispatchMessage(next.text);
+  };
+
+  useEffect(() => {
+    if (isLoading && !prevIsLoadingRef.current) {
+      const snapshot = new Set<string>();
+      for (const message of messagesRef.current) {
+        if (message.role !== "assistant") {
+          continue;
+        }
+        for (const part of message.parts) {
+          if (isToolUIPart(part) && part.state === "output-available") {
+            snapshot.add(part.toolCallId);
+          }
+        }
+      }
+      seenToolOutputsRef.current = snapshot;
+      isDrainingRef.current = false;
+    }
+    prevIsLoadingRef.current = isLoading;
+  }, [isLoading]);
+
+  useEffect(() => {
+    if (!isLoading) {
+      return;
+    }
+    if (isDrainingRef.current) {
+      return;
+    }
+    if (wasStoppedByUser) {
+      return;
+    }
+    if (queuedMessages.length === 0) {
+      return;
+    }
+    if (hasPendingApproval(messages)) {
+      return;
+    }
+
+    let hasNewToolOutput = false;
+    for (const message of messages) {
+      if (message.role !== "assistant") {
+        continue;
+      }
+      for (const part of message.parts) {
+        if (
+          isToolUIPart(part) &&
+          part.state === "output-available" &&
+          !seenToolOutputsRef.current.has(part.toolCallId)
+        ) {
+          seenToolOutputsRef.current.add(part.toolCallId);
+          hasNewToolOutput = true;
+        }
+      }
+    }
+
+    if (!hasNewToolOutput) {
+      return;
+    }
+
+    const next = queuedMessagesRef.current[0];
+    if (!next) {
+      return;
+    }
+
+    isDrainingRef.current = true;
+    setQueuedMessages((prev) => prev.slice(1));
+
+    const drainQueuedMessage = async () => {
+      try {
+        await stopActiveResponse();
+      } catch {
+        // Stream already closed; proceed to dispatch.
+      }
+      await dispatchMessage(next.text);
+    };
+
+    drainQueuedMessage().catch((error) => {
+      console.error("[Chat] Failed to drain queued message:", error);
+    });
+  }, [
+    isLoading,
+    messages,
+    queuedMessages.length,
+    wasStoppedByUser,
+    stopActiveResponse,
+    dispatchMessage,
+  ]);
 
   const messageCount = messages.length;
   const lastPartCount = messages.at(-1)?.parts?.length ?? 0;
@@ -1054,7 +1258,13 @@ function StandaloneChatPageClient({
           >
             <div className="-inset-x-4 pointer-events-none absolute bottom-full h-12 bg-linear-to-t from-background to-transparent" />
             <div className="mx-auto w-full max-w-2xl">
+              <ChatQueue
+                messages={queuedMessages}
+                onEdit={handleEditQueued}
+                onRemove={handleRemoveQueued}
+              />
               <ChatInputAdvanced
+                connectedTop={queuedMessages.length > 0}
                 context={context}
                 error={chatError}
                 isLoading={isLoading}
@@ -1069,6 +1279,7 @@ function StandaloneChatPageClient({
                 onThinkingLevelChange={handleThinkingLevelChange}
                 organizationId={organizationId}
                 organizationSlug={organizationSlug}
+                ref={chatInputRef}
                 thinkingLevel={thinkingLevel}
               />
             </div>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -209,6 +209,14 @@ function hasPendingApproval(messages: readonly ChatUIMessage[]): boolean {
   return false;
 }
 
+function isTerminalToolState(state: string): boolean {
+  return (
+    state === "output-available" ||
+    state === "output-error" ||
+    state === "output-denied"
+  );
+}
+
 function StandaloneChatPageClient({
   organizationSlug,
   chatId: initialChatId,
@@ -358,6 +366,8 @@ function StandaloneChatPageClient({
   }, []);
 
   const [wasStoppedByUser, setWasStoppedByUser] = useState(false);
+  const wasStoppedByUserRef = useRef(wasStoppedByUser);
+  wasStoppedByUserRef.current = wasStoppedByUser;
 
   const drainQueueRef = useRef<() => void>(() => {
     // Populated after dispatchMessage is defined below.
@@ -369,6 +379,7 @@ function StandaloneChatPageClient({
     queryClient.invalidateQueries({
       queryKey: ["chat-sessions", organizationId],
     });
+    isDrainingRef.current = false;
     drainQueueRef.current();
   }, [organizationId, queryClient]);
 
@@ -808,6 +819,9 @@ function StandaloneChatPageClient({
   const prevIsLoadingRef = useRef(false);
 
   drainQueueRef.current = () => {
+    if (isDrainingRef.current) {
+      return;
+    }
     if (wasStoppedByUserRef.current) {
       return;
     }
@@ -819,8 +833,14 @@ function StandaloneChatPageClient({
     if (!next) {
       return;
     }
+
+    isDrainingRef.current = true;
     setQueuedMessages(queue.slice(1));
-    dispatchMessage(next.text);
+    dispatchMessage(next.text).catch((error) => {
+      console.error("[Chat] Failed to drain queued message:", error);
+      isDrainingRef.current = false;
+      setQueuedMessages((prev) => [next, ...prev]);
+    });
   };
 
   useEffect(() => {
@@ -831,7 +851,7 @@ function StandaloneChatPageClient({
           continue;
         }
         for (const part of message.parts) {
-          if (isToolUIPart(part) && part.state === "output-available") {
+          if (isToolUIPart(part) && isTerminalToolState(part.state)) {
             snapshot.add(part.toolCallId);
           }
         }
@@ -867,7 +887,7 @@ function StandaloneChatPageClient({
       for (const part of message.parts) {
         if (
           isToolUIPart(part) &&
-          part.state === "output-available" &&
+          isTerminalToolState(part.state) &&
           !seenToolOutputsRef.current.has(part.toolCallId)
         ) {
           seenToolOutputsRef.current.add(part.toolCallId);
@@ -880,25 +900,11 @@ function StandaloneChatPageClient({
       return;
     }
 
-    const next = queuedMessagesRef.current[0];
-    if (!next) {
-      return;
-    }
-
     isDrainingRef.current = true;
-    setQueuedMessages((prev) => prev.slice(1));
 
-    const drainQueuedMessage = async () => {
-      try {
-        await stopActiveResponse();
-      } catch {
-        // Stream already closed; proceed to dispatch.
-      }
-      await dispatchMessage(next.text);
-    };
-
-    drainQueuedMessage().catch((error) => {
-      console.error("[Chat] Failed to drain queued message:", error);
+    stopActiveResponse().catch((error) => {
+      console.error("[Chat] Failed to stop active response for queue drain:", error);
+      isDrainingRef.current = false;
     });
   }, [
     isLoading,
@@ -906,7 +912,6 @@ function StandaloneChatPageClient({
     queuedMessages.length,
     wasStoppedByUser,
     stopActiveResponse,
-    dispatchMessage,
   ]);
 
   const messageCount = messages.length;

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -794,6 +794,12 @@ function StandaloneChatPageClient({
     chatInputRef.current?.setText(message.text);
   }, []);
 
+  const handleUpdateQueued = useCallback((id: string, text: string) => {
+    setQueuedMessages((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, text } : m))
+    );
+  }, []);
+
   const queuedMessagesRef = useRef(queuedMessages);
   queuedMessagesRef.current = queuedMessages;
 
@@ -1173,8 +1179,10 @@ function StandaloneChatPageClient({
               onSend={handleSend}
               onStop={handleStop}
               onThinkingLevelChange={handleThinkingLevelChange}
+              onUpdateQueued={handleUpdateQueued}
               organizationId={organizationId}
               organizationSlug={organizationSlug}
+              queuedMessages={queuedMessages}
               ref={chatInputRef}
               thinkingLevel={thinkingLevel}
             />
@@ -1277,8 +1285,10 @@ function StandaloneChatPageClient({
                 onSend={handleSend}
                 onStop={handleStop}
                 onThinkingLevelChange={handleThinkingLevelChange}
+                onUpdateQueued={handleUpdateQueued}
                 organizationId={organizationId}
                 organizationSlug={organizationSlug}
+                queuedMessages={queuedMessages}
                 ref={chatInputRef}
                 thinkingLevel={thinkingLevel}
               />

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -40,8 +40,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
 import { Loader2Icon } from "lucide-react";
 import Link from "next/link";
+import type { Ref } from "react";
 import {
-  type Ref,
   useCallback,
   useImperativeHandle,
   useMemo,
@@ -121,18 +121,30 @@ export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 function SubmitButtonContent({
   isLoading,
   isStopping,
+  isEmpty,
 }: {
   isLoading: boolean;
   isStopping: boolean;
+  isEmpty: boolean;
 }) {
   if (isLoading && isStopping) {
     return <Loader2Icon className="size-4 animate-spin" />;
   }
-  if (isLoading) {
+  if (isLoading && isEmpty) {
     return (
       <>
         <HugeiconsIcon className="size-3.5" icon={StopIcon} />
         <div className="px-0.5 text-sm leading-0">Stop</div>
+      </>
+    );
+  }
+  if (isLoading) {
+    return (
+      <>
+        <div className="px-0.5 text-sm leading-0">Queue</div>
+        <div className="hidden h-4 items-center rounded border border-border bg-background px-1 text-[10px] text-muted-foreground shadow-xs sm:inline-flex">
+          ↵
+        </div>
       </>
     );
   }
@@ -146,14 +158,43 @@ function SubmitButtonContent({
   );
 }
 
-function getSubmitTooltipText(isLoading: boolean, isStopping: boolean): string {
+function getSubmitTooltipText(
+  isLoading: boolean,
+  isStopping: boolean,
+  isEmpty: boolean
+): string {
   if (isLoading && isStopping) {
     return "Stopping...";
   }
-  if (isLoading) {
+  if (isLoading && isEmpty) {
     return "Stop generating";
   }
+  if (isLoading) {
+    return "Enter to queue this message. It will send once the AI finishes.";
+  }
   return "Enter to send. Shift+Enter for a new line.";
+}
+
+function computeSubmitDisabled({
+  isEmpty,
+  isLoading,
+  isStopping,
+  isUsageBlocked,
+  hasStopHandler,
+}: {
+  isEmpty: boolean;
+  isLoading: boolean;
+  isStopping: boolean;
+  isUsageBlocked: boolean;
+  hasStopHandler: boolean;
+}): boolean {
+  if (!isEmpty) {
+    return isUsageBlocked;
+  }
+  if (isLoading) {
+    return !hasStopHandler || isStopping;
+  }
+  return true;
 }
 
 function contextItemsEqual(a: ContextItem, b: ContextItem): boolean {
@@ -185,6 +226,7 @@ interface ChatInputAdvancedProps {
   onModelChange?: (model: string) => void;
   thinkingLevel?: ThinkingLevel;
   onThinkingLevelChange?: (level: ThinkingLevel) => void;
+  connectedTop?: boolean;
   ref?: Ref<ChatInputHandle>;
 }
 
@@ -211,6 +253,7 @@ export function ChatInputAdvanced({
   onModelChange,
   thinkingLevel = "medium",
   onThinkingLevelChange,
+  connectedTop = false,
   ref,
 }: ChatInputAdvancedProps) {
   const [isFocused, setIsFocused] = useState(false);
@@ -597,7 +640,7 @@ export function ChatInputAdvanced({
 
   const handleSend = useCallback(() => {
     const editor = editorRef.current;
-    if (!editor || readEditorText().trim().length === 0 || isLoading) {
+    if (!editor || readEditorText().trim().length === 0) {
       return;
     }
     const outbound = serializeEditorWithReferences(editor).trim();
@@ -629,13 +672,37 @@ export function ChatInputAdvanced({
   }, [
     onSend,
     readEditorText,
-    isLoading,
     check,
     customer,
     isUsageBlocked,
     clearError,
     onRemoveContext,
   ]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      setText: (text: string) => {
+        const editor = editorRef.current;
+        if (!editor) {
+          return;
+        }
+        editor.textContent = text;
+        setIsEmpty(text.trim().length === 0);
+        editor.focus();
+        const range = document.createRange();
+        range.selectNodeContents(editor);
+        range.collapse(false);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+      },
+      focus: () => {
+        editorRef.current?.focus();
+      },
+    }),
+    []
+  );
 
   const handlePaste = useCallback(
     (event: React.ClipboardEvent<HTMLDivElement>) => {
@@ -848,7 +915,7 @@ export function ChatInputAdvanced({
 
   return (
     <Card
-      className="w-full gap-0 overflow-visible rounded-[14px] border-0 bg-background py-0 shadow-none ring-0 transition-shadow duration-200 ease-out-expo"
+      className={`w-full gap-0 overflow-visible rounded-[14px] border-0 bg-background py-0 shadow-none ring-0 transition-shadow duration-200 ease-out-expo ${connectedTop ? "rounded-t-none" : ""}`}
       data-focused={isFocused ? "true" : "false"}
     >
       <CardHeader className="sr-only">
@@ -856,10 +923,12 @@ export function ChatInputAdvanced({
       </CardHeader>
       <CardContent className="p-0">
         <div
-          className="rounded-[14px] border border-border bg-background shadow-sm"
+          className={`rounded-[14px] border border-border bg-background shadow-sm ${connectedTop ? "rounded-t-none border-t-0" : ""}`}
           tabIndex={-1}
         >
-          <div className="rounded-[13px] p-0.5">
+          <div
+            className={`p-0.5 ${connectedTop ? "rounded-b-[13px]" : "rounded-[13px]"}`}
+          >
             {usageLimitError && (
               <div className="mx-2 mt-2 mb-1 flex w-fit max-w-full flex-wrap items-center gap-1 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-xs">
                 <span>{usageLimitError}</span>
@@ -878,15 +947,15 @@ export function ChatInputAdvanced({
                 <div className="relative flex flex-1 cursor-text transition-colors [--lh:1lh]">
                   {/* biome-ignore lint/a11y/useSemanticElements: rich mention editor requires a contentEditable host instead of a native textarea. */}
                   <div
-                    aria-disabled={isLoading || isUsageBlocked}
+                    aria-disabled={isUsageBlocked}
                     aria-label="Send a message"
                     aria-multiline="true"
                     className="wrap-break-word relative max-h-50 min-h-12 w-full overflow-y-auto whitespace-pre-wrap rounded-t-[12px] px-3 py-2 text-foreground text-sm leading-6 caret-foreground outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 data-[empty=true]:before:pointer-events-none data-[empty=true]:before:absolute data-[empty=true]:before:top-2 data-[empty=true]:before:left-3 data-[empty=true]:before:text-muted-foreground data-[empty=true]:before:content-[attr(data-placeholder)]"
-                    contentEditable={!(isLoading || isUsageBlocked)}
+                    contentEditable={!isUsageBlocked}
                     data-empty={isEmpty ? "true" : "false"}
                     data-placeholder={
                       isLoading
-                        ? "AI is working..."
+                        ? "Queue a message while AI is working..."
                         : "Send a message... (type @ to add context)"
                     }
                     onBlur={() => {
@@ -911,7 +980,7 @@ export function ChatInputAdvanced({
                     ref={editorRef}
                     role="textbox"
                     suppressContentEditableWarning
-                    tabIndex={isLoading || isUsageBlocked ? -1 : 0}
+                    tabIndex={isUsageBlocked ? -1 : 0}
                   />
                 </div>
               </div>
@@ -1339,12 +1408,14 @@ export function ChatInputAdvanced({
                   render={
                     <Button
                       className="group/button ml-auto h-7 shrink-0 rounded-lg bg-muted px-1.5 transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={
-                        isLoading
-                          ? !onStop || isStopping
-                          : isUsageBlocked || isEmpty
-                      }
-                      onClick={isLoading ? onStop : handleSend}
+                      disabled={computeSubmitDisabled({
+                        isEmpty,
+                        isLoading,
+                        isStopping,
+                        isUsageBlocked,
+                        hasStopHandler: Boolean(onStop),
+                      })}
+                      onClick={isEmpty && isLoading ? onStop : handleSend}
                       size="sm"
                       tabIndex={0}
                       type="button"
@@ -1354,13 +1425,14 @@ export function ChatInputAdvanced({
                 >
                   <div className="flex items-center gap-1 text-foreground text-sm">
                     <SubmitButtonContent
+                      isEmpty={isEmpty}
                       isLoading={isLoading}
                       isStopping={isStopping}
                     />
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>
-                  {getSubmitTooltipText(isLoading, isStopping)}
+                  {getSubmitTooltipText(isLoading, isStopping, isEmpty)}
                 </TooltipContent>
               </Tooltip>
             </CardFooter>

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -43,6 +43,7 @@ import Link from "next/link";
 import type { Ref } from "react";
 import {
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -54,6 +55,7 @@ import { INPUT_SOURCES } from "@/lib/integrations/catalog";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { ChatInputHandle, ContextItem } from "@/types/chat";
 import type { GitHubRepository } from "@/types/integrations";
+import type { QueuedMessage } from "./chat-queue";
 import {
   buildIntegrationReferenceElement,
   INTEGRATION_REFERENCE_SELECTOR,
@@ -227,6 +229,8 @@ interface ChatInputAdvancedProps {
   thinkingLevel?: ThinkingLevel;
   onThinkingLevelChange?: (level: ThinkingLevel) => void;
   connectedTop?: boolean;
+  queuedMessages?: QueuedMessage[];
+  onUpdateQueued?: (id: string, text: string) => void;
   ref?: Ref<ChatInputHandle>;
 }
 
@@ -254,8 +258,11 @@ export function ChatInputAdvanced({
   thinkingLevel = "medium",
   onThinkingLevelChange,
   connectedTop = false,
+  queuedMessages,
+  onUpdateQueued,
   ref,
 }: ChatInputAdvancedProps) {
+  const [editingQueuedId, setEditingQueuedId] = useState<string | null>(null);
   const [isFocused, setIsFocused] = useState(false);
   const [isEmpty, setIsEmpty] = useState(true);
   const [internalError, setInternalError] = useState<string | null>(null);
@@ -638,6 +645,42 @@ export function ChatInputAdvanced({
     [onRemoveContext, readEditorText]
   );
 
+  const loadTextIntoEditor = useCallback((text: string) => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    editor.textContent = text;
+    setIsEmpty(text.trim().length === 0);
+    editor.focus();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }, []);
+
+  const clearEditor = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    editor.innerHTML = "";
+    setIsEmpty(true);
+  }, []);
+
+  useEffect(() => {
+    if (!editingQueuedId) {
+      return;
+    }
+    const stillExists = queuedMessages?.some((m) => m.id === editingQueuedId);
+    if (!stillExists) {
+      setEditingQueuedId(null);
+      clearEditor();
+    }
+  }, [editingQueuedId, queuedMessages, clearEditor]);
+
   const handleSend = useCallback(() => {
     const editor = editorRef.current;
     if (!editor || readEditorText().trim().length === 0) {
@@ -652,6 +695,17 @@ export function ChatInputAdvanced({
       setInternalError(limitMessage);
       return;
     }
+
+    if (editingQueuedId && onUpdateQueued) {
+      onUpdateQueued(editingQueuedId, outbound);
+      setEditingQueuedId(null);
+      clearEditor();
+      for (const item of contextRef.current) {
+        onRemoveContext?.(item);
+      }
+      return;
+    }
+
     if (customer) {
       const result = check({
         featureId: FEATURES.AI_CREDITS,
@@ -677,6 +731,9 @@ export function ChatInputAdvanced({
     isUsageBlocked,
     clearError,
     onRemoveContext,
+    editingQueuedId,
+    onUpdateQueued,
+    clearEditor,
   ]);
 
   useImperativeHandle(
@@ -839,6 +896,67 @@ export function ChatInputAdvanced({
         }
       }
 
+      const queue = queuedMessages ?? [];
+      if (event.key === "ArrowUp" && !event.shiftKey && queue.length > 0) {
+        const canStartEditing = editingQueuedId === null && isEmpty;
+        if (canStartEditing || editingQueuedId !== null) {
+          const editor = editorRef.current;
+          if (editingQueuedId && editor && onUpdateQueued) {
+            const currentText = serializeEditorWithReferences(editor).trim();
+            if (currentText) {
+              onUpdateQueued(editingQueuedId, currentText);
+            }
+          }
+          let targetIndex: number;
+          if (editingQueuedId === null) {
+            targetIndex = queue.length - 1;
+          } else {
+            const currentIndex = queue.findIndex(
+              (m) => m.id === editingQueuedId
+            );
+            targetIndex = currentIndex <= 0 ? 0 : currentIndex - 1;
+          }
+          const target = queue[targetIndex];
+          if (target) {
+            event.preventDefault();
+            setEditingQueuedId(target.id);
+            loadTextIntoEditor(target.text);
+            return;
+          }
+        }
+      }
+
+      if (event.key === "ArrowDown" && !event.shiftKey && editingQueuedId) {
+        const editor = editorRef.current;
+        if (editor && onUpdateQueued) {
+          const currentText = serializeEditorWithReferences(editor).trim();
+          if (currentText) {
+            onUpdateQueued(editingQueuedId, currentText);
+          }
+        }
+        const currentIndex = queue.findIndex((m) => m.id === editingQueuedId);
+        const nextIndex = currentIndex + 1;
+        event.preventDefault();
+        if (currentIndex === -1 || nextIndex >= queue.length) {
+          setEditingQueuedId(null);
+          clearEditor();
+        } else {
+          const target = queue[nextIndex];
+          if (target) {
+            setEditingQueuedId(target.id);
+            loadTextIntoEditor(target.text);
+          }
+        }
+        return;
+      }
+
+      if (event.key === "Escape" && editingQueuedId) {
+        event.preventDefault();
+        setEditingQueuedId(null);
+        clearEditor();
+        return;
+      }
+
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
         handleSend();
@@ -907,6 +1025,12 @@ export function ChatInputAdvanced({
       mentionIndex,
       insertMention,
       handleSend,
+      queuedMessages,
+      editingQueuedId,
+      isEmpty,
+      onUpdateQueued,
+      loadTextIntoEditor,
+      clearEditor,
     ]
   );
 

--- a/apps/dashboard/src/components/chat/chat-queue.tsx
+++ b/apps/dashboard/src/components/chat/chat-queue.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Cancel01Icon, Edit02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+
+export interface QueuedMessage {
+  id: string;
+  text: string;
+}
+
+interface ChatQueueProps {
+  messages: QueuedMessage[];
+  onEdit: (message: QueuedMessage) => void;
+  onRemove: (id: string) => void;
+}
+
+const INSTANT = { duration: 0 } as const;
+const CONTAINER_SPRING = {
+  type: "spring",
+  stiffness: 380,
+  damping: 34,
+  mass: 0.7,
+} as const;
+const ITEM_SPRING = { type: "spring", stiffness: 420, damping: 32 } as const;
+
+export function ChatQueue({ messages, onEdit, onRemove }: ChatQueueProps) {
+  const reduceMotion = useReducedMotion();
+  const hasMessages = messages.length > 0;
+  const containerTransition = reduceMotion ? INSTANT : CONTAINER_SPRING;
+  const itemTransition = reduceMotion ? INSTANT : ITEM_SPRING;
+
+  return (
+    <AnimatePresence initial={false}>
+      {hasMessages && (
+        <motion.div
+          animate={{ height: "auto", opacity: 1, y: 0 }}
+          aria-label="Queued messages"
+          className="overflow-hidden rounded-t-[14px] border border-border border-b-0 bg-background px-1.5 pt-1.5 pb-1 shadow-sm"
+          exit={{ height: 0, opacity: 0, y: 12 }}
+          initial={{ height: 0, opacity: 0, y: 12 }}
+          transition={containerTransition}
+        >
+          <div className="flex items-center justify-between px-2 pt-0.5 pb-1.5">
+            <span className="font-medium text-muted-foreground text-xs">
+              Queued · {messages.length}
+            </span>
+            <span className="text-[10px] text-muted-foreground/60">
+              Sends after next tool
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <AnimatePresence initial={false}>
+              {messages.map((message) => (
+                <motion.div
+                  animate={{ height: "auto", opacity: 1, y: 0 }}
+                  className="overflow-hidden"
+                  exit={{ height: 0, opacity: 0, y: -4 }}
+                  initial={{ height: 0, opacity: 0, y: -4 }}
+                  key={message.id}
+                  layout={!reduceMotion}
+                  transition={itemTransition}
+                >
+                  <div className="group flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-foreground text-xs transition-colors">
+                    <p className="line-clamp-1 flex-1 font-medium">
+                      {message.text}
+                    </p>
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      <button
+                        aria-label="Edit queued message"
+                        className="ml-0.5 cursor-pointer rounded p-0.5 transition-colors hover:bg-accent"
+                        onClick={() => onEdit(message)}
+                        type="button"
+                      >
+                        <HugeiconsIcon className="size-3" icon={Edit02Icon} />
+                      </button>
+                      <button
+                        aria-label="Remove from queue"
+                        className="cursor-pointer rounded p-0.5 transition-colors hover:bg-accent"
+                        onClick={() => onRemove(message.id)}
+                        type="button"
+                      >
+                        <HugeiconsIcon className="size-3" icon={Cancel01Icon} />
+                      </button>
+                    </div>
+                  </div>
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/ai/src/model.ts
+++ b/packages/ai/src/model.ts
@@ -4,13 +4,13 @@ import {
   wrapModelWithObservability,
 } from "@notra/ai/observability";
 import type { GatewayArgs, GatewayResult } from "@notra/ai/types/gateway";
-import type { SupermemoryOptions } from "@notra/ai/types/model";
+import type { CreateModelOptions } from "@notra/ai/types/model";
 import { withSupermemory } from "@supermemory/tools/ai-sdk";
 
 export function createModel(
   organizationId: string | undefined,
   modelId: GatewayArgs[0],
-  options?: Omit<SupermemoryOptions, "mode" | "addMemory">,
+  options?: CreateModelOptions,
   log?: AILogTarget
 ): GatewayResult {
   const base = gateway(modelId);
@@ -19,17 +19,20 @@ export function createModel(
     return wrapModelWithObservability(base, log);
   }
 
-  const supermemoryDisabled =
-    process.env.NODE_ENV === "development" && !process.env.SUPERMEMORY_API_KEY;
+  const supermemoryApiKey = process.env.SUPERMEMORY_API_KEY?.trim();
+  if (!supermemoryApiKey) {
+    return wrapModelWithObservability(base, log);
+  }
 
-  if (supermemoryDisabled) {
+  if (options?.enabled === false) {
     return wrapModelWithObservability(base, log);
   }
 
   const model = withSupermemory(base, organizationId, {
+    apiKey: supermemoryApiKey,
     mode: "full",
     addMemory: "always",
-    ...options,
+    ...options?.supermemory,
   });
 
   return wrapModelWithObservability(model, log);


### PR DESCRIPTION
### Description
this is just an idea but while the agent is working you can queue multiple messages 

### Screenshot/Recording (if applicable)
<img width="699" height="178" alt="image" src="https://github.com/user-attachments/assets/63538713-765f-442a-b4ed-2b9d71d13d3f" />
<img width="689" height="126" alt="Screenshot 2026-04-17 at 21 38 52" src="https://github.com/user-attachments/assets/95a875de-f09a-4b35-8267-ff7b2a36ebdb" />

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>
