### PR TITLE
perf(chat): batch upstash realtime emits to restore streaming throughput

### DIFF
--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/[chatId]/stream/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/[chatId]/stream/route.ts
@@ -53,9 +53,18 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 
   let unsubscribe: (() => void) | undefined;
 
+  const toChunks = (data: unknown): UIMessageChunk[] =>
+    Array.isArray(data) ? (data as UIMessageChunk[]) : [data as UIMessageChunk];
+
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const encoder = new TextEncoder();
+
+      const emit = (chunk: UIMessageChunk) => {
+        controller.enqueue(encoder.encode(toSseChunk(chunk)));
+        return chunk.type === "finish" || chunk.type === "abort";
+      };
+
       const history = await channel.history();
 
       for (const item of history) {
@@ -63,24 +72,23 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
           continue;
         }
 
-        const chunk = item.data as UIMessageChunk;
-        controller.enqueue(encoder.encode(toSseChunk(chunk)));
-
-        if (chunk.type === "finish" || chunk.type === "abort") {
-          controller.close();
-          return;
+        for (const chunk of toChunks(item.data)) {
+          if (emit(chunk)) {
+            controller.close();
+            return;
+          }
         }
       }
 
       unsubscribe = await channel.subscribe({
         events: ["ai.chunk"],
         onData: ({ data }) => {
-          const chunk = data as UIMessageChunk;
-          controller.enqueue(encoder.encode(toSseChunk(chunk)));
-
-          if (chunk.type === "finish" || chunk.type === "abort") {
-            unsubscribe?.();
-            controller.close();
+          for (const chunk of toChunks(data)) {
+            if (emit(chunk)) {
+              unsubscribe?.();
+              controller.close();
+              return;
+            }
           }
         },
       });

--- a/apps/dashboard/src/app/api/workflows/chat/route.ts
+++ b/apps/dashboard/src/app/api/workflows/chat/route.ts
@@ -109,6 +109,33 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
   const timing: { firstChunkAt: number | null } = { firstChunkAt: null };
   const usageSnapshot: ChatUsageSnapshot = {};
 
+  let buffer: UIMessageChunk[] = [];
+  let flushPromise: Promise<void> | null = null;
+
+  const flushBuffer = async () => {
+    while (buffer.length > 0) {
+      const batch = buffer;
+      buffer = [];
+      await channel.emit("ai.chunk", batch as never);
+    }
+  };
+
+  const scheduleFlush = () => {
+    if (flushPromise) {
+      return;
+    }
+    flushPromise = flushBuffer().finally(() => {
+      flushPromise = null;
+    });
+  };
+
+  const drainPendingFlushes = async () => {
+    if (flushPromise) {
+      await flushPromise;
+    }
+    await flushBuffer();
+  };
+
   try {
     stopAbortPolling = startChatAbortPolling({
       organizationId,
@@ -240,26 +267,6 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
       },
     });
 
-    let buffer: UIMessageChunk[] = [];
-    let flushPromise: Promise<void> | null = null;
-
-    const flushBuffer = async () => {
-      while (buffer.length > 0) {
-        const batch = buffer;
-        buffer = [];
-        await channel.emit("ai.chunk", batch as never);
-      }
-    };
-
-    const scheduleFlush = () => {
-      if (flushPromise) {
-        return;
-      }
-      flushPromise = flushBuffer().finally(() => {
-        flushPromise = null;
-      });
-    };
-
     for await (const chunk of uiStream) {
       if (abortController.signal.aborted) {
         break;
@@ -276,14 +283,13 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
       scheduleFlush();
     }
 
-    if (flushPromise) {
-      await flushPromise;
-    }
-    await flushBuffer();
+    await drainPendingFlushes();
   } catch (error) {
     const isAbort =
       abortController.signal.aborted ||
       (error instanceof Error && error.name === "AbortError");
+
+    await drainPendingFlushes();
 
     if (isAbort) {
       console.log("[Chat Workflow] Aborted by user:", { requestId, chatId });

--- a/apps/dashboard/src/app/api/workflows/chat/route.ts
+++ b/apps/dashboard/src/app/api/workflows/chat/route.ts
@@ -240,23 +240,46 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
       },
     });
 
+    let buffer: UIMessageChunk[] = [];
+    let flushPromise: Promise<void> | null = null;
+
+    const flushBuffer = async () => {
+      while (buffer.length > 0) {
+        const batch = buffer;
+        buffer = [];
+        await channel.emit("ai.chunk", batch as never);
+      }
+    };
+
+    const scheduleFlush = () => {
+      if (flushPromise) {
+        return;
+      }
+      flushPromise = flushBuffer().finally(() => {
+        flushPromise = null;
+      });
+    };
+
     for await (const chunk of uiStream) {
       if (abortController.signal.aborted) {
         break;
       }
-      await channel.emit("ai.chunk", chunk as UIMessageChunk);
+      buffer.push(chunk as UIMessageChunk);
+      scheduleFlush();
     }
 
     if (abortController.signal.aborted) {
-      await channel.emit("ai.chunk", {
-        type: "abort",
-        reason: "user-stopped",
-      });
-      await channel.emit("ai.chunk", {
-        type: "finish",
-        finishReason: "stop",
-      });
+      buffer.push(
+        { type: "abort", reason: "user-stopped" },
+        { type: "finish", finishReason: "stop" }
+      );
+      scheduleFlush();
     }
+
+    if (flushPromise) {
+      await flushPromise;
+    }
+    await flushBuffer();
   } catch (error) {
     const isAbort =
       abortController.signal.aborted ||


### PR DESCRIPTION
## Summary
- Prod streaming was capped at ~9 tps vs ~50 tps local because the workflow handler awaited `channel.emit()` per token chunk — every chunk paid one Upstash Redis HTTP round-trip.
- Replaced the per-chunk emit with an in-flight buffer: chunks accumulate while one emit is ongoing and ship together in the next emit. Batch size naturally scales with Upstash RTT.
- Updated the SSE stream reader to unwrap array payloads from history + subscribe, so batched emits are fanned back out as individual `UIMessageChunk` frames.

## Test plan
- [ ] Deploy to prod and measure tps against a known prompt (target: close to local ~50 tps)
- [ ] Verify abort/finish chunks still terminate the SSE stream promptly
- [ ] Verify page-refresh resume still replays history correctly (old singular `ai.chunk` entries still readable via `toChunks()` fallback)
- [ ] Confirm no duplicate chunks or out-of-order rendering on the client