### PR TITLE
fix(dashboard): reset standalone chat state on route revisit

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -23,7 +23,7 @@ import {
 } from "ai";
 import { nanoid } from "nanoid";
 import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatToolBlock } from "@/components/ai/chat-tool-block";
 import { BrailleLoader } from "@/components/braille-loader";
@@ -202,10 +202,8 @@ function StandaloneChatPageClient({
   const [pendingMessageId, setPendingMessageId] = useState<string | null>(null);
   const [isHydrated, setIsHydrated] = useState(false);
 
-  const stableChatId = useMemo(
-    () => initialChatId || nanoid(16),
-    [initialChatId]
-  );
+  const [generatedChatId, setGeneratedChatId] = useState(() => nanoid(16));
+  const stableChatId = initialChatId ?? generatedChatId;
 
   const [context, setContext] = useState<ContextItem[]>([]);
   const [hasCustomizedContext, setHasCustomizedContext] = useState(false);
@@ -567,6 +565,25 @@ function StandaloneChatPageClient({
   messagesRef.current = messages;
 
   const hasUpdatedUrlRef = useRef(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (initialChatId) {
+      return;
+    }
+    if (pathname !== `/${organizationSlug}/chat`) {
+      return;
+    }
+
+    hasUpdatedUrlRef.current = false;
+    setMessages([]);
+    setContext([]);
+    setHasCustomizedContext(false);
+    setWasStoppedByUser(false);
+    setPendingMessageId(null);
+    setChatError(null);
+    setGeneratedChatId(nanoid(16));
+  }, [pathname, organizationSlug, initialChatId, setMessages]);
 
   const handleSend = useCallback(
     async (text: string) => {


### PR DESCRIPTION
### Description
i had the issue where when i created a new chat and then pressed new chat i got redirected but the content didnt change this should fix that

### Screenshot/Recording (if applicable)
https://github.com/user-attachments/assets/2d1b2981-139c-4e09-9ee1-c1fcabe2dc38

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>
