### PR TITLE
fix: restore chat model/reasoning from history

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -387,6 +387,10 @@ function StandaloneChatPageClient({
   }, []);
 
   useEffect(() => {
+    if (initialChatId) {
+      return;
+    }
+
     function syncChatPreferencesFromStorage() {
       const storedPreferences = readStoredChatPreferences();
       if (!storedPreferences) {
@@ -421,14 +425,18 @@ function StandaloneChatPageClient({
         syncChatPreferencesFromStorage
       );
     };
-  }, []);
+  }, [initialChatId]);
 
   useEffect(() => {
+    if (initialChatId) {
+      return;
+    }
+
     writeStoredChatPreferences({
       model: selectedModel,
       thinkingLevel,
     });
-  }, [selectedModel, thinkingLevel]);
+  }, [initialChatId, selectedModel, thinkingLevel]);
 
   const handleStop = useCallback(async () => {
     setIsStopping(true);
@@ -447,7 +455,11 @@ function StandaloneChatPageClient({
     }
   }, [organizationId, stableChatId, stop]);
 
-  const chatHistoryQuery = useQuery({
+  const chatHistoryQuery = useQuery<{
+    messages: ChatUIMessage[] | null;
+    lastResponseStopped: boolean;
+    activeStreamId: string | null;
+  } | null>({
     queryKey: ["chat-history", organizationId, initialChatId],
     queryFn: async () => {
       if (!initialChatId) {
@@ -475,8 +487,25 @@ function StandaloneChatPageClient({
     if (!chatHistoryQuery.data) {
       return;
     }
-    if (chatHistoryQuery.data.messages?.length) {
-      setMessages(chatHistoryQuery.data.messages);
+    const historyMessages = chatHistoryQuery.data.messages;
+    if (historyMessages?.length) {
+      setMessages(historyMessages);
+
+      for (let index = historyMessages.length - 1; index >= 0; index -= 1) {
+        const metadata = historyMessages[index]?.metadata;
+        if (!metadata) {
+          continue;
+        }
+        if (metadata.model) {
+          setSelectedModel(metadata.model);
+        }
+        if (metadata.thinkingLevel) {
+          setThinkingLevel(metadata.thinkingLevel);
+        }
+        if (metadata.model || metadata.thinkingLevel) {
+          break;
+        }
+      }
     }
     setWasStoppedByUser(Boolean(chatHistoryQuery.data.lastResponseStopped));
     if (chatHistoryQuery.data.activeStreamId) {

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -491,19 +491,35 @@ function StandaloneChatPageClient({
     if (historyMessages?.length) {
       setMessages(historyMessages);
 
+      let modelRestored = false;
+      let thinkingLevelRestored = false;
+
       for (let index = historyMessages.length - 1; index >= 0; index -= 1) {
+        if (modelRestored && thinkingLevelRestored) {
+          break;
+        }
+
         const metadata = historyMessages[index]?.metadata;
         if (!metadata) {
           continue;
         }
-        if (metadata.model) {
-          setSelectedModel(metadata.model);
+
+        if (!modelRestored && metadata.model) {
+          const parsedModel = parseStoredChatModel(metadata.model);
+          if (parsedModel) {
+            setSelectedModel(parsedModel);
+            modelRestored = true;
+          }
         }
-        if (metadata.thinkingLevel) {
-          setThinkingLevel(metadata.thinkingLevel);
-        }
-        if (metadata.model || metadata.thinkingLevel) {
-          break;
+
+        if (!thinkingLevelRestored && metadata.thinkingLevel) {
+          const parsedThinkingLevel = parseStoredThinkingLevel(
+            metadata.thinkingLevel
+          );
+          if (parsedThinkingLevel) {
+            setThinkingLevel(parsedThinkingLevel);
+            thinkingLevelRestored = true;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Existing chats (`/chat/[id]`) now restore the model and thinking level from the last message's metadata instead of falling back to localStorage.
- localStorage read/write is scoped to the new-chat page only, so opening an old chat no longer overwrites the user's default preference.

## Test plan
- [ ] Open a chat that used a non-default model/thinking level — toolbar reflects those values
- [ ] Switch the model on the new-chat page, open an existing chat, go back — new-chat default is unchanged
- [ ] Start a fresh chat — default (or last localStorage value) still applies