### PR TITLE
feat: add example use case suggestions to empty chat state

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -39,6 +39,7 @@ import {
   ChatInputAdvanced,
   type ThinkingLevel,
 } from "@/components/chat/chat-input";
+import { ChatSuggestions } from "@/components/chat/chat-suggestions";
 import { renderTextWithIntegrationReferences } from "@/components/chat/integration-reference";
 import { useAiChatExperiment } from "@/components/providers/databuddy-flags-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -48,7 +49,7 @@ import {
   chatErrorPayloadSchema,
   chatTransportRequestInputSchema,
 } from "@/schemas/chat";
-import type { ChatUIMessage, ContextItem } from "@/types/chat";
+import type { ChatInputHandle, ChatUIMessage, ContextItem } from "@/types/chat";
 import {
   CHAT_PREFERENCES_STORAGE_KEY,
   DEFAULT_CHAT_PREFERENCES,
@@ -222,6 +223,11 @@ function StandaloneChatPageClient({
     DEFAULT_CHAT_PREFERENCES.thinkingLevel
   );
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const chatInputRef = useRef<ChatInputHandle | null>(null);
+
+  const handleSuggestionSelect = useCallback((text: string) => {
+    chatInputRef.current?.setText(text);
+  }, []);
 
   const contextRef = useRef(context);
   const hasCustomizedContextRef = useRef(hasCustomizedContext);
@@ -965,9 +971,14 @@ function StandaloneChatPageClient({
               onThinkingLevelChange={handleThinkingLevelChange}
               organizationId={organizationId}
               organizationSlug={organizationSlug}
+              ref={chatInputRef}
               thinkingLevel={thinkingLevel}
             />
           </div>
+          <ChatSuggestions
+            disabled={isLoading}
+            onSelect={handleSuggestionSelect}
+          />
         </div>
       </div>
     );

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -521,6 +521,7 @@ async function createDirectStandaloneChatResponse({
   if (log.fork) {
     log.fork("standalone_chat_stream", async () => {
       try {
+        // biome-ignore lint/correctness/useHookAtTopLevel: useLogger is an async-context accessor, not a React hook
         const response = await runStream(useLogger());
         responseReady.resolve(response);
         await streamDone.promise;

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -377,7 +377,7 @@ export function ChatInputAdvanced({
         editorRef.current?.focus();
       },
     }),
-    [ref]
+    []
   );
 
   const syncContextFromDOM = useCallback(() => {

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -40,12 +40,19 @@ import { useQuery } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
 import { Loader2Icon } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  type Ref,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { FEATURES } from "@/constants/features";
 import { INPUT_SOURCES } from "@/lib/integrations/catalog";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import type { ContextItem } from "@/types/chat";
+import type { ChatInputHandle, ContextItem } from "@/types/chat";
 import type { GitHubRepository } from "@/types/integrations";
 import {
   buildIntegrationReferenceElement,
@@ -178,6 +185,7 @@ interface ChatInputAdvancedProps {
   onModelChange?: (model: string) => void;
   thinkingLevel?: ThinkingLevel;
   onThinkingLevelChange?: (level: ThinkingLevel) => void;
+  ref?: Ref<ChatInputHandle>;
 }
 
 const THINKING_LABELS: Record<ThinkingLevel, string> = {
@@ -203,6 +211,7 @@ export function ChatInputAdvanced({
   onModelChange,
   thinkingLevel = "medium",
   onThinkingLevelChange,
+  ref,
 }: ChatInputAdvancedProps) {
   const [isFocused, setIsFocused] = useState(false);
   const [isEmpty, setIsEmpty] = useState(true);
@@ -345,6 +354,31 @@ export function ChatInputAdvanced({
     }
     return (editor.innerText ?? "").replace(/\u00A0/g, " ");
   }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      setText: (text: string) => {
+        const editor = editorRef.current;
+        if (!editor) {
+          return;
+        }
+        editor.textContent = text;
+        setIsEmpty(text.trim().length === 0);
+        editor.focus();
+        const range = document.createRange();
+        range.selectNodeContents(editor);
+        range.collapse(false);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+      },
+      focus: () => {
+        editorRef.current?.focus();
+      },
+    }),
+    [ref]
+  );
 
   const syncContextFromDOM = useCallback(() => {
     const editor = editorRef.current;

--- a/apps/dashboard/src/components/chat/chat-suggestions.tsx
+++ b/apps/dashboard/src/components/chat/chat-suggestions.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { OutputTypeIcon } from "@/utils/output-types";
+
+type Suggestion = {
+  outputType: "blog_post" | "changelog" | "twitter_post" | "linkedin_post";
+  label: string;
+  prompt: string;
+};
+
+const SUGGESTIONS: Suggestion[] = [
+  {
+    outputType: "blog_post",
+    label: "Write a blog post",
+    prompt:
+      "Help me write a blog post. Ask me 1-2 questions about the topic and audience before drafting.",
+  },
+  {
+    outputType: "changelog",
+    label: "Draft a changelog",
+    prompt:
+      "Help me draft a changelog. Ask me what changed and which release or repo to reference.",
+  },
+  {
+    outputType: "twitter_post",
+    label: "Post on Twitter",
+    prompt:
+      "Help me write a Twitter post. Ask me about the topic and angle before drafting.",
+  },
+  {
+    outputType: "linkedin_post",
+    label: "Post on LinkedIn",
+    prompt:
+      "Help me write a LinkedIn post. Ask me about the topic and audience before drafting.",
+  },
+];
+
+type ChatSuggestionsProps = {
+  onSelect: (prompt: string) => void;
+  disabled?: boolean;
+};
+
+export function ChatSuggestions({ onSelect, disabled }: ChatSuggestionsProps) {
+  return (
+    <div className="grid w-full grid-cols-2 gap-2 sm:grid-cols-4">
+      {SUGGESTIONS.map((suggestion) => (
+        <button
+          className="flex cursor-pointer flex-col items-start gap-2 rounded-[14px] border bg-background p-3 text-left transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={disabled}
+          key={suggestion.outputType}
+          onClick={() => onSelect(suggestion.prompt)}
+          type="button"
+        >
+          <OutputTypeIcon
+            className="size-4 text-muted-foreground"
+            outputType={suggestion.outputType}
+          />
+          <span className="font-medium text-sm">{suggestion.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/chat/chat-suggestions.tsx
+++ b/apps/dashboard/src/components/chat/chat-suggestions.tsx
@@ -3,11 +3,11 @@
 import type { ContentType } from "@notra/ai/schemas/content";
 import { OutputTypeIcon } from "@/utils/output-types";
 
-type Suggestion = {
+interface Suggestion {
   outputType: ContentType;
   label: string;
   prompt: string;
-};
+}
 
 const SUGGESTIONS: Suggestion[] = [
   {
@@ -36,10 +36,10 @@ const SUGGESTIONS: Suggestion[] = [
   },
 ];
 
-type ChatSuggestionsProps = {
+interface ChatSuggestionsProps {
   onSelect: (prompt: string) => void;
   disabled?: boolean;
-};
+}
 
 export function ChatSuggestions({ onSelect, disabled }: ChatSuggestionsProps) {
   return (

--- a/apps/dashboard/src/components/chat/chat-suggestions.tsx
+++ b/apps/dashboard/src/components/chat/chat-suggestions.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import type { ContentType } from "@notra/ai/schemas/content";
 import { OutputTypeIcon } from "@/utils/output-types";
 
 type Suggestion = {
-  outputType: "blog_post" | "changelog" | "twitter_post" | "linkedin_post";
+  outputType: ContentType;
   label: string;
   prompt: string;
 };

--- a/apps/dashboard/src/types/chat.ts
+++ b/apps/dashboard/src/types/chat.ts
@@ -36,10 +36,10 @@ export interface ChatUsageSnapshot {
   totalTokens?: number;
 }
 
-export type ChatInputHandle = {
+export interface ChatInputHandle {
   setText: (text: string) => void;
   focus: () => void;
-};
+}
 
 export interface BuildChatFinishMetadataInput {
   streamStartedAt: number;

--- a/apps/dashboard/src/types/chat.ts
+++ b/apps/dashboard/src/types/chat.ts
@@ -36,6 +36,11 @@ export interface ChatUsageSnapshot {
   totalTokens?: number;
 }
 
+export type ChatInputHandle = {
+  setText: (text: string) => void;
+  focus: () => void;
+};
+
 export interface BuildChatFinishMetadataInput {
   streamStartedAt: number;
   firstChunkAt: number | null;


### PR DESCRIPTION
### Description
On the `/chat` empty state, show four content-type suggestion cards (Blog post, Changelog, Twitter post, LinkedIn post) under the input, inspired by Claude.ai and T3chat.

Clicking a card populates the chat input with a starter prompt (which instructs the model to ask 1–2 clarifying questions) instead of sending immediately — so the user can add their topic or just hit enter. Wired via a new `ChatInputHandle` imperative ref on `ChatInputAdvanced` exposing `setText`/`focus`.

### Screenshot/Recording (if applicable)
_Empty chat state now renders four cards below the input._

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>