### PR TITLE
feat(dashboard): hide chat history when sidebar is collapsed

### DIFF
--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -80,7 +80,7 @@ export function DashboardSidebar({
             >
               <SidebarMenu>
                 <SidebarMenuButton
-                  className="border border-transparent transition-colors duration-200 hover:bg-sidebar-accent"
+                  className="[&>*]:group-data-[collapsible=icon]:-translate-x-px transition-colors duration-200 hover:bg-sidebar-accent"
                   render={
                     <Link href={`/${slug}`}>
                       <HugeiconsIcon icon={ArrowLeft01Icon} />

--- a/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
+++ b/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
@@ -39,6 +39,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@notra/ui/components/ui/sidebar";
 import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
@@ -62,6 +63,8 @@ export function ChatHistoryNav() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const aiChatExperiment = useAiChatExperiment();
+  const { state: sidebarState, isMobile } = useSidebar();
+  const isCollapsed = sidebarState === "collapsed" && !isMobile;
   const [editingChatId, setEditingChatId] = useState<string | null>(null);
   const [draftTitle, setDraftTitle] = useState("");
   const [renamingChatId, setRenamingChatId] = useState<string | null>(null);
@@ -349,10 +352,12 @@ export function ChatHistoryNav() {
         </SidebarGroupContent>
       </SidebarGroup>
 
-      <div className="flex-1 overflow-y-auto">
-        {renderSessions("Pinned", pinnedSessions)}
-        {renderSessions("Recents", recentSessions)}
-      </div>
+      {!isCollapsed && (
+        <div className="flex-1 overflow-y-auto">
+          {renderSessions("Pinned", pinnedSessions)}
+          {renderSessions("Recents", recentSessions)}
+        </div>
+      )}
 
       <ResponsiveAlertDialog
         onOpenChange={(open) => {

--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -135,7 +135,7 @@ function OrgSelectorTrigger({
         <SidebarMenuButton
           className={cn(
             "cursor-pointer data-popup-open:bg-sidebar-accent/90 data-popup-open:text-sidebar-accent-foreground data-popup-open:ring-1 data-popup-open:ring-sidebar-border/70",
-            isCollapsed ? "size-10 min-w-0 justify-center p-1" : ""
+            isCollapsed ? "min-w-0 justify-center" : ""
           )}
           disabled={isSwitching}
           size="lg"
@@ -144,7 +144,7 @@ function OrgSelectorTrigger({
           <Avatar
             className={cn(
               "size-8 rounded-lg after:rounded-lg",
-              isCollapsed ? "size-6.5" : ""
+              isCollapsed ? "size-6" : ""
             )}
           >
             <AvatarImage


### PR DESCRIPTION
### Description
i dont like how the sidebar looks collpased alos because it doesnt really give you more information so (this is just an idea ofc) it would maybe make sense to just not show the chats if the sidebar is collapsed 

### Screenshot/Recording (if applicable)
before:
<img width="309" height="835" alt="Screenshot 2026-04-19 at 17 25 41" src="https://github.com/user-attachments/assets/cbd10a0f-bd51-47d4-8b96-a6e8d09cb249" />


after:
<img width="372" height="816" alt="Screenshot 2026-04-19 at 17 25 31" src="https://github.com/user-attachments/assets/c74b7df6-9ba4-487d-8dad-36f6b3db67fe" />


<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>
