### PR TITLE
feat: add metadata properties to ai credit refund events

### DIFF
--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -309,6 +309,15 @@ export const { POST } = serve<EventWorkflowPayload>(
                 customerId: trigger.organizationId,
                 featureId: FEATURES.AI_CREDITS,
                 value: 0,
+                properties: {
+                  source: "workflow_event",
+                  output_type: trigger.outputType,
+                  trigger_name: trigger.name,
+                  trigger_id: triggerId,
+                  run_id: runId,
+                  event_type: eventType,
+                  refund_reason: "unsupported_output_type",
+                },
               });
             } catch (error) {
               console.error("[Event] Failed to refund AI credit:", error);
@@ -344,6 +353,15 @@ export const { POST } = serve<EventWorkflowPayload>(
                 customerId: trigger.organizationId,
                 featureId: FEATURES.AI_CREDITS,
                 value: 0,
+                properties: {
+                  source: "workflow_event",
+                  output_type: trigger.outputType,
+                  trigger_name: trigger.name,
+                  trigger_id: triggerId,
+                  run_id: runId,
+                  event_type: eventType,
+                  refund_reason: "generation_failed",
+                },
               });
             } catch (error) {
               console.error("[Event] Failed to refund AI credit:", error);
@@ -639,6 +657,15 @@ export const { POST } = serve<EventWorkflowPayload>(
               customerId: trigger.organizationId,
               featureId: FEATURES.AI_CREDITS,
               value: 0,
+              properties: {
+                source: "workflow_event",
+                output_type: trigger.outputType,
+                trigger_name: trigger.name,
+                trigger_id: triggerId,
+                run_id: runId,
+                event_type: eventType,
+                refund_reason: "workflow_error",
+              },
             });
           } catch (refundError) {
             console.error("[Event] Failed to refund AI credit:", refundError);

--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -312,7 +312,7 @@ export const { POST } = serve<EventWorkflowPayload>(
                 properties: {
                   source: "workflow_event",
                   output_type: trigger.outputType,
-                  trigger_name: trigger.name,
+                  trigger_name: trigger.name.trim() || `${eventType} event`,
                   trigger_id: triggerId,
                   run_id: runId,
                   event_type: eventType,
@@ -356,7 +356,7 @@ export const { POST } = serve<EventWorkflowPayload>(
                 properties: {
                   source: "workflow_event",
                   output_type: trigger.outputType,
-                  trigger_name: trigger.name,
+                  trigger_name: trigger.name.trim() || `${eventType} event`,
                   trigger_id: triggerId,
                   run_id: runId,
                   event_type: eventType,
@@ -660,7 +660,7 @@ export const { POST } = serve<EventWorkflowPayload>(
               properties: {
                 source: "workflow_event",
                 output_type: trigger.outputType,
-                trigger_name: trigger.name,
+                trigger_name: trigger.name.trim() || `${eventType} event`,
                 trigger_id: triggerId,
                 run_id: runId,
                 event_type: eventType,

--- a/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
+++ b/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
@@ -200,6 +200,8 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
         await refundReservedAiCredit(organizationId, aiCreditReserved, {
           source: "manual",
           output_type: contentType,
+          trigger_id: "manual_on_demand",
+          trigger_name: contentType,
           refund_reason: "no_sources",
           run_id: runId,
         });
@@ -451,6 +453,8 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
           await refundReservedAiCredit(organizationId, aiCreditReserved, {
             source: "manual",
             output_type: contentType,
+            trigger_id: "manual_on_demand",
+            trigger_name: contentType,
             refund_reason: contentResult.status,
             run_id: runId,
           });
@@ -528,6 +532,8 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
           await refundReservedAiCredit(organizationId, aiCreditReserved, {
             source: "manual",
             output_type: contentType,
+            trigger_id: "manual_on_demand",
+            trigger_name: contentType,
             refund_reason: "no_posts",
             run_id: runId,
           });
@@ -721,6 +727,8 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
         await refundReservedAiCredit(organizationId, aiCreditReserved, {
           source: "manual",
           output_type: contentType,
+          trigger_id: "manual_on_demand",
+          trigger_name: contentType,
           refund_reason: "workflow_error",
           run_id: runId,
         });
@@ -787,6 +795,8 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
           {
             source: "manual",
             output_type: payload.contentType,
+            trigger_id: "manual_on_demand",
+            trigger_name: payload.contentType,
             refund_reason: "workflow_infrastructure_failure",
             run_id: payload.runId,
           }

--- a/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
+++ b/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
@@ -197,7 +197,12 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
         });
       });
       await context.run("refund-no-sources", async () => {
-        await refundReservedAiCredit(organizationId, aiCreditReserved);
+        await refundReservedAiCredit(organizationId, aiCreditReserved, {
+          source: "manual",
+          output_type: contentType,
+          refund_reason: "no_sources",
+          run_id: runId,
+        });
       });
       await context.run("track-content-failed-no-sources", async () => {
         try {
@@ -443,7 +448,12 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
         });
 
         await context.run("refund-failed", async () => {
-          await refundReservedAiCredit(organizationId, aiCreditReserved);
+          await refundReservedAiCredit(organizationId, aiCreditReserved, {
+            source: "manual",
+            output_type: contentType,
+            refund_reason: contentResult.status,
+            run_id: runId,
+          });
         });
 
         await context.run("track-content-failed", async () => {
@@ -515,7 +525,12 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
         });
 
         await context.run("refund-no-posts", async () => {
-          await refundReservedAiCredit(organizationId, aiCreditReserved);
+          await refundReservedAiCredit(organizationId, aiCreditReserved, {
+            source: "manual",
+            output_type: contentType,
+            refund_reason: "no_posts",
+            run_id: runId,
+          });
         });
 
         await context.run("track-content-failed-no-posts", async () => {
@@ -703,7 +718,12 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
       });
 
       await context.run("refund-error", async () => {
-        await refundReservedAiCredit(organizationId, aiCreditReserved);
+        await refundReservedAiCredit(organizationId, aiCreditReserved, {
+          source: "manual",
+          output_type: contentType,
+          refund_reason: "workflow_error",
+          run_id: runId,
+        });
       });
 
       await context.run("track-content-failed-error", async () => {
@@ -763,7 +783,13 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
         );
         await refundReservedAiCredit(
           payload.organizationId,
-          payload.aiCreditReserved
+          payload.aiCreditReserved,
+          {
+            source: "manual",
+            output_type: payload.contentType,
+            refund_reason: "workflow_infrastructure_failure",
+            run_id: payload.runId,
+          }
         );
         await trackScheduledContentFailed({
           triggerId: "manual_on_demand",

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -435,7 +435,7 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
                 properties: {
                   source: "workflow_schedule",
                   output_type: trigger.outputType,
-                  trigger_name: trigger.name,
+                  trigger_name: trigger.name.trim() || trigger.outputType,
                   trigger_id: triggerId,
                   run_id: runId,
                   refund_reason: "rate_limited",
@@ -499,7 +499,7 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
                   properties: {
                     source: "workflow_schedule",
                     output_type: trigger.outputType,
-                    trigger_name: trigger.name,
+                    trigger_name: trigger.name.trim() || trigger.outputType,
                     trigger_id: triggerId,
                     run_id: runId,
                     refund_reason: "unsupported_output_type",
@@ -542,7 +542,7 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
                   properties: {
                     source: "workflow_schedule",
                     output_type: trigger.outputType,
-                    trigger_name: trigger.name,
+                    trigger_name: trigger.name.trim() || trigger.outputType,
                     trigger_id: triggerId,
                     run_id: runId,
                     refund_reason: "generation_failed",
@@ -958,7 +958,7 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
               properties: {
                 source: "workflow_schedule",
                 output_type: trigger.outputType,
-                trigger_name: trigger.name,
+                trigger_name: trigger.name.trim() || trigger.outputType,
                 trigger_id: triggerId,
                 run_id: runId,
                 refund_reason: "workflow_error",

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -432,6 +432,14 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
                 customerId: trigger.organizationId,
                 featureId: FEATURES.AI_CREDITS,
                 value: 0,
+                properties: {
+                  source: "workflow_schedule",
+                  output_type: trigger.outputType,
+                  trigger_name: trigger.name,
+                  trigger_id: triggerId,
+                  run_id: runId,
+                  refund_reason: "rate_limited",
+                },
               });
             } catch (error) {
               console.error(
@@ -488,6 +496,14 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
                   customerId: trigger.organizationId,
                   featureId: FEATURES.AI_CREDITS,
                   value: 0,
+                  properties: {
+                    source: "workflow_schedule",
+                    output_type: trigger.outputType,
+                    trigger_name: trigger.name,
+                    trigger_id: triggerId,
+                    run_id: runId,
+                    refund_reason: "unsupported_output_type",
+                  },
                 });
               } catch (error) {
                 console.error(
@@ -523,6 +539,14 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
                   customerId: trigger.organizationId,
                   featureId: FEATURES.AI_CREDITS,
                   value: 0,
+                  properties: {
+                    source: "workflow_schedule",
+                    output_type: trigger.outputType,
+                    trigger_name: trigger.name,
+                    trigger_id: triggerId,
+                    run_id: runId,
+                    refund_reason: "generation_failed",
+                  },
                 });
               } catch (error) {
                 console.error(
@@ -931,6 +955,14 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
               customerId: trigger.organizationId,
               featureId: FEATURES.AI_CREDITS,
               value: 0,
+              properties: {
+                source: "workflow_schedule",
+                output_type: trigger.outputType,
+                trigger_name: trigger.name,
+                trigger_id: triggerId,
+                run_id: runId,
+                refund_reason: "workflow_error",
+              },
             });
           } catch (refundError) {
             console.error(

--- a/apps/dashboard/src/lib/workflows/on-demand/helpers.ts
+++ b/apps/dashboard/src/lib/workflows/on-demand/helpers.ts
@@ -262,7 +262,8 @@ export function buildDataPointRestrictionInstructions(dataPoints: {
 
 export async function refundReservedAiCredit(
   organizationId: string,
-  reserved: boolean
+  reserved: boolean,
+  properties?: Record<string, unknown>
 ) {
   if (!reserved || !autumn) {
     return;
@@ -273,6 +274,7 @@ export async function refundReservedAiCredit(
       customerId: organizationId,
       featureId: FEATURES.AI_CREDITS,
       value: 0,
+      ...(properties ? { properties } : {}),
     });
   } catch (error) {
     console.error("[OnDemandContent] Failed to refund AI credit", {


### PR DESCRIPTION
## Summary
- Refund events sent to Autumn (`autumn.track` with `value: 0`) previously had no `properties` payload, so they were not filterable alongside successful AI credit usage events.
- Adds `source`, `output_type`, `refund_reason`, `trigger_id`/`run_id`, `trigger_name`, and `event_type` (where applicable) to every refund call site across the on-demand-content, schedule, and event workflows.
- Extends `refundReservedAiCredit` helper with an optional `properties` arg and threads context-specific metadata at each call site.

`refund_reason` values: `no_sources`, `no_posts`, `rate_limited`, `unsupported_output_type`, `generation_failed`, `workflow_error`, `workflow_infrastructure_failure`.

apps/api triggers the dashboard workflow with `aiCreditReserved: false`, so the refund guards short-circuit there — no changes needed in apps/api.

## Test plan
- [x] `bun run build` passes
- [ ] Trigger an on-demand generation that fails (e.g. no sources) and confirm the Autumn event has `properties.source = "manual"` and `properties.refund_reason = "no_sources"`
- [ ] Trigger a schedule run with an unsupported output type and confirm `properties.refund_reason = "unsupported_output_type"`
- [ ] Trigger an event-driven run that fails generation and confirm `properties.event_type` is populated