### PR TITLE
feat(dashboard): db-backed skills + unified background-gen agent

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
@@ -208,7 +208,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             }
             organizationId={organizationId ?? ""}
             trigger={
-              <Button size="sm" variant="default">
+              <Button variant="default">
                 <PlusIcon className="size-4" />
                 <span className="ml-1">New Event Trigger</span>
               </Button>
@@ -233,7 +233,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 }
                 organizationId={organizationId ?? ""}
                 trigger={
-                  <Button size="sm" variant="outline">
+                  <Button variant="outline">
                     <PlusIcon className="size-4" />
                     <span className="ml-1">New Event Trigger</span>
                   </Button>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
@@ -399,7 +399,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             }}
             organizationId={organizationId ?? ""}
             trigger={
-              <Button size="sm" variant="default">
+              <Button variant="default">
                 <PlusIcon className="size-4" />
                 <span className="ml-1">New Schedule</span>
               </Button>
@@ -431,7 +431,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 }}
                 organizationId={organizationId ?? ""}
                 trigger={
-                  <Button size="sm" variant="outline">
+                  <Button variant="outline">
                     <PlusIcon className="size-4" />
                     <span className="ml-1">New Schedule</span>
                   </Button>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
@@ -170,29 +170,20 @@ export default function PageClient({ slug, name }: PageClientProps) {
   useEffect(() => {
     if (hasChanges && !saveToastIdRef.current) {
       saveToastIdRef.current = toast.custom(
-        (t) => (
+        () => (
           <div className="rounded-[14px] border border-border bg-background p-0.5 shadow-sm">
             <div className="flex items-center gap-3 rounded-lg bg-background px-4 py-3">
               <span className="text-muted-foreground text-sm">
                 Unsaved changes
               </span>
               <Button
-                onClick={() => {
-                  handleDiscardRef.current?.();
-                  toast.dismiss(t);
-                }}
+                onClick={() => handleDiscardRef.current?.()}
                 size="sm"
                 variant="ghost"
               >
                 Discard
               </Button>
-              <Button
-                onClick={() => {
-                  handleSaveRef.current?.();
-                  toast.dismiss(t);
-                }}
-                size="sm"
-              >
+              <Button onClick={() => handleSaveRef.current?.()} size="sm">
                 Save
               </Button>
             </div>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { ArrowLeft01Icon, Delete02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogAction,
+  ResponsiveAlertDialogCancel,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogDescription,
+  ResponsiveAlertDialogFooter,
+  ResponsiveAlertDialogHeader,
+  ResponsiveAlertDialogTitle,
+} from "@notra/ui/components/shared/responsive-alert-dialog";
+import { Badge } from "@notra/ui/components/ui/badge";
+import { Button } from "@notra/ui/components/ui/button";
+import { Field, FieldLabel } from "@notra/ui/components/ui/field";
+import { Input } from "@notra/ui/components/ui/input";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@notra/ui/components/ui/tabs";
+import { Textarea } from "@notra/ui/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@notra/ui/components/ui/tooltip";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { parseAsStringLiteral, useQueryState } from "nuqs";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { DiffView } from "@/components/content/diff-view";
+import { PageContainer } from "@/components/layout/container";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { dashboardOrpc } from "@/lib/orpc/query";
+import { updateSkillSchema } from "@/schemas/skills";
+
+const VIEW_OPTIONS = ["edit", "diff"] as const;
+
+interface PageClientProps {
+  slug: string;
+  name: string;
+}
+
+export default function PageClient({ slug, name }: PageClientProps) {
+  const { activeOrganization } = useOrganizationsContext();
+  const organizationId = activeOrganization?.id;
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [view, setView] = useQueryState(
+    "view",
+    parseAsStringLiteral(VIEW_OPTIONS).withDefault("edit")
+  );
+
+  const [original, setOriginal] = useState<{
+    description: string;
+    content: string;
+  } | null>(null);
+  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
+
+  const saveToastIdRef = useRef<string | number | null>(null);
+  const handleSaveRef = useRef<(() => void) | null>(null);
+  const handleDiscardRef = useRef<(() => void) | null>(null);
+
+  const { data: skill, isPending } = useQuery({
+    ...dashboardOrpc.skills.getByName.queryOptions({
+      input: { organizationId: organizationId ?? "", name },
+    }),
+    enabled: !!organizationId,
+  });
+
+  useEffect(() => {
+    if (skill && !original) {
+      setOriginal({
+        description: skill.description,
+        content: skill.content,
+      });
+      setDescription(skill.description);
+      setContent(skill.content);
+    }
+  }, [skill, original]);
+
+  const hasChanges =
+    !!original &&
+    (description !== original.description || content !== original.content);
+
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: dashboardOrpc.skills.list.queryKey({
+        input: { organizationId: organizationId ?? "" },
+      }),
+    });
+    queryClient.invalidateQueries({
+      queryKey: dashboardOrpc.skills.getByName.queryKey({
+        input: { organizationId: organizationId ?? "", name },
+      }),
+    });
+  }, [queryClient, organizationId, name]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (!organizationId) {
+        throw new Error("Organization ID is required");
+      }
+      const parsed = updateSkillSchema.safeParse({ description, content });
+      if (!parsed.success) {
+        throw new Error(parsed.error.issues[0]?.message ?? "Invalid input");
+      }
+      return dashboardOrpc.skills.update.call({
+        organizationId,
+        name,
+        payload: parsed.data,
+      });
+    },
+    onSuccess: () => {
+      setOriginal({ description, content });
+      invalidate();
+      toast.success("Skill saved");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      if (!organizationId) {
+        throw new Error("Organization ID is required");
+      }
+      return dashboardOrpc.skills.delete.call({ organizationId, name });
+    },
+    onSuccess: () => {
+      invalidate();
+      toast.success("Skill deleted");
+      router.push(`/${slug}/skills`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const handleSave = useCallback(() => {
+    if (!hasChanges || saveMutation.isPending) {
+      return;
+    }
+    saveMutation.mutate();
+  }, [hasChanges, saveMutation]);
+
+  const handleDiscard = useCallback(() => {
+    if (!original) {
+      return;
+    }
+    setDescription(original.description);
+    setContent(original.content);
+  }, [original]);
+
+  useEffect(() => {
+    handleSaveRef.current = handleSave;
+    handleDiscardRef.current = handleDiscard;
+  }, [handleSave, handleDiscard]);
+
+  useEffect(() => {
+    if (hasChanges && !saveToastIdRef.current) {
+      saveToastIdRef.current = toast.custom(
+        (t) => (
+          <div className="rounded-[14px] border border-border bg-background p-0.5 shadow-sm">
+            <div className="flex items-center gap-3 rounded-lg bg-background px-4 py-3">
+              <span className="text-muted-foreground text-sm">
+                Unsaved changes
+              </span>
+              <Button
+                onClick={() => {
+                  handleDiscardRef.current?.();
+                  toast.dismiss(t);
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                Discard
+              </Button>
+              <Button
+                onClick={() => {
+                  handleSaveRef.current?.();
+                  toast.dismiss(t);
+                }}
+                size="sm"
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        ),
+        { duration: Number.POSITIVE_INFINITY, position: "bottom-right" }
+      );
+    } else if (!hasChanges && saveToastIdRef.current) {
+      toast.dismiss(saveToastIdRef.current);
+      saveToastIdRef.current = null;
+    }
+  }, [hasChanges]);
+
+  useEffect(() => {
+    return () => {
+      if (saveToastIdRef.current) {
+        toast.dismiss(saveToastIdRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasChanges) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [hasChanges]);
+
+  return (
+    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+      <div className="w-full space-y-6 px-4 lg:px-6">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-3">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        onClick={() => router.push(`/${slug}/skills`)}
+                        size="icon"
+                        variant="ghost"
+                      />
+                    }
+                  >
+                    <HugeiconsIcon className="size-4" icon={ArrowLeft01Icon} />
+                  </TooltipTrigger>
+                  <TooltipContent>All skills</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <h1 className="font-bold font-mono text-3xl tracking-tight">
+                {name}
+              </h1>
+              {skill?.isSystem && <Badge variant="secondary">System</Badge>}
+            </div>
+            <p className="text-muted-foreground text-sm">
+              Name cannot be changed after creation.
+            </p>
+          </div>
+          {skill && !skill.isSystem && (
+            <Button
+              disabled={saveMutation.isPending || deleteMutation.isPending}
+              onClick={() => setDeleteOpen(true)}
+              variant="outline"
+            >
+              <HugeiconsIcon className="size-4" icon={Delete02Icon} />
+              Delete
+            </Button>
+          )}
+        </div>
+
+        {organizationId && isPending ? (
+          <div className="space-y-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-96 w-full" />
+          </div>
+        ) : skill ? (
+          <div className="space-y-4">
+            <Field>
+              <FieldLabel>Name</FieldLabel>
+              <Input disabled readOnly value={name} />
+            </Field>
+            <Field>
+              <FieldLabel>
+                Description<span className="-ml-1 text-destructive">*</span>
+              </FieldLabel>
+              <Textarea
+                className="min-h-[5rem]"
+                disabled={saveMutation.isPending}
+                onChange={(e) => setDescription(e.target.value)}
+                value={description}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>
+                Content<span className="-ml-1 text-destructive">*</span>
+              </FieldLabel>
+              <Tabs
+                onValueChange={(v) =>
+                  setView(v as (typeof VIEW_OPTIONS)[number])
+                }
+                value={view}
+              >
+                <TabsList variant="line">
+                  <TabsTrigger value="edit">Edit</TabsTrigger>
+                  <TabsTrigger value="diff">Diff</TabsTrigger>
+                </TabsList>
+                <TabsContent className="mt-2" value="edit">
+                  <Textarea
+                    className="min-h-[24rem] font-mono text-sm"
+                    disabled={saveMutation.isPending}
+                    onChange={(e) => setContent(e.target.value)}
+                    value={content}
+                  />
+                </TabsContent>
+                <TabsContent className="mt-2" value="diff">
+                  <DiffView
+                    currentMarkdown={content}
+                    originalMarkdown={original?.content ?? ""}
+                  />
+                </TabsContent>
+              </Tabs>
+            </Field>
+          </div>
+        ) : null}
+      </div>
+
+      <ResponsiveAlertDialog onOpenChange={setDeleteOpen} open={deleteOpen}>
+        <ResponsiveAlertDialogContent>
+          <ResponsiveAlertDialogHeader>
+            <ResponsiveAlertDialogTitle>
+              Delete skill?
+            </ResponsiveAlertDialogTitle>
+            <ResponsiveAlertDialogDescription>
+              This will permanently delete the skill "{name}". Schedules that
+              reference it by name will stop producing output.
+            </ResponsiveAlertDialogDescription>
+          </ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogFooter>
+            <ResponsiveAlertDialogCancel disabled={deleteMutation.isPending}>
+              Cancel
+            </ResponsiveAlertDialogCancel>
+            <ResponsiveAlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              {deleteMutation.isPending ? "Deleting…" : "Delete skill"}
+            </ResponsiveAlertDialogAction>
+          </ResponsiveAlertDialogFooter>
+        </ResponsiveAlertDialogContent>
+      </ResponsiveAlertDialog>
+    </PageContainer>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
@@ -60,9 +60,11 @@ export default function PageClient({ slug, name }: PageClientProps) {
   );
 
   const [original, setOriginal] = useState<{
+    name: string;
     description: string;
     content: string;
   } | null>(null);
+  const [nameInput, setNameInput] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
 
@@ -80,9 +82,11 @@ export default function PageClient({ slug, name }: PageClientProps) {
   useEffect(() => {
     if (skill && !original) {
       setOriginal({
+        name: skill.name,
         description: skill.description,
         content: skill.content,
       });
+      setNameInput(skill.name);
       setDescription(skill.description);
       setContent(skill.content);
     }
@@ -90,7 +94,9 @@ export default function PageClient({ slug, name }: PageClientProps) {
 
   const hasChanges =
     !!original &&
-    (description !== original.description || content !== original.content);
+    (nameInput !== original.name ||
+      description !== original.description ||
+      content !== original.content);
 
   const invalidate = useCallback(() => {
     queryClient.invalidateQueries({
@@ -110,7 +116,12 @@ export default function PageClient({ slug, name }: PageClientProps) {
       if (!organizationId) {
         throw new Error("Organization ID is required");
       }
-      const parsed = updateSkillSchema.safeParse({ description, content });
+      const willRename = nameInput !== name;
+      const parsed = updateSkillSchema.safeParse({
+        name: willRename ? nameInput : undefined,
+        description,
+        content,
+      });
       if (!parsed.success) {
         throw new Error(parsed.error.issues[0]?.message ?? "Invalid input");
       }
@@ -120,10 +131,14 @@ export default function PageClient({ slug, name }: PageClientProps) {
         payload: parsed.data,
       });
     },
-    onSuccess: () => {
-      setOriginal({ description, content });
+    onSuccess: (data) => {
+      setOriginal({ name: data.name, description, content });
+      setNameInput(data.name);
       invalidate();
       toast.success("Skill saved");
+      if (data.name !== name) {
+        router.replace(`/${slug}/skills/${data.name}`);
+      }
     },
     onError: (error: Error) => {
       toast.error(error.message);
@@ -158,6 +173,7 @@ export default function PageClient({ slug, name }: PageClientProps) {
     if (!original) {
       return;
     }
+    setNameInput(original.name);
     setDescription(original.description);
     setContent(original.content);
   }, [original]);
@@ -242,12 +258,15 @@ export default function PageClient({ slug, name }: PageClientProps) {
               </h1>
               {skill?.isSystem && <Badge variant="secondary">System</Badge>}
             </div>
-            <p className="text-muted-foreground text-sm">
-              Name cannot be changed after creation.
-            </p>
+            {skill?.isSystem && (
+              <p className="text-muted-foreground text-sm">
+                System skills cannot be renamed.
+              </p>
+            )}
           </div>
           {skill && !skill.isSystem && (
             <Button
+              className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
               disabled={saveMutation.isPending || deleteMutation.isPending}
               onClick={() => setDeleteOpen(true)}
               variant="outline"
@@ -268,14 +287,25 @@ export default function PageClient({ slug, name }: PageClientProps) {
           <div className="space-y-4">
             <Field>
               <FieldLabel>Name</FieldLabel>
-              <Input disabled readOnly value={name} />
+              <Input
+                disabled={skill.isSystem || saveMutation.isPending}
+                onChange={(e) => setNameInput(e.target.value)}
+                readOnly={skill.isSystem}
+                value={nameInput}
+              />
+              {!skill.isSystem && (
+                <p className="text-muted-foreground text-xs">
+                  Lowercase letters, digits, and hyphens. Renaming may affect
+                  references to this skill by name.
+                </p>
+              )}
             </Field>
             <Field>
               <FieldLabel>
                 Description<span className="-ml-1 text-destructive">*</span>
               </FieldLabel>
               <Textarea
-                className="min-h-[5rem]"
+                className="max-h-[5rem] min-h-[4rem] overflow-y-auto"
                 disabled={saveMutation.isPending}
                 onChange={(e) => setDescription(e.target.value)}
                 value={description}
@@ -297,7 +327,7 @@ export default function PageClient({ slug, name }: PageClientProps) {
                 </TabsList>
                 <TabsContent className="mt-2" value="edit">
                   <Textarea
-                    className="min-h-[24rem] font-mono text-sm"
+                    className="max-h-[20rem] min-h-[16rem] overflow-y-auto font-mono text-sm"
                     disabled={saveMutation.isPending}
                     onChange={(e) => setContent(e.target.value)}
                     value={content}
@@ -323,7 +353,8 @@ export default function PageClient({ slug, name }: PageClientProps) {
             </ResponsiveAlertDialogTitle>
             <ResponsiveAlertDialogDescription>
               This will permanently delete the skill "{name}". Schedules that
-              reference it by name will stop producing output.
+              reference it will still run, but without its guidance their output
+              may be lower quality.
             </ResponsiveAlertDialogDescription>
           </ResponsiveAlertDialogHeader>
           <ResponsiveAlertDialogFooter>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
@@ -256,13 +256,19 @@ export default function PageClient({ slug, name }: PageClientProps) {
               <h1 className="font-bold font-mono text-3xl tracking-tight">
                 {name}
               </h1>
-              {skill?.isSystem && <Badge variant="secondary">System</Badge>}
+              {skill?.isSystem && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={<Badge variant="secondary">System</Badge>}
+                    />
+                    <TooltipContent>
+                      System skills cannot be renamed or deleted.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
             </div>
-            {skill?.isSystem && (
-              <p className="text-muted-foreground text-sm">
-                System skills cannot be renamed.
-              </p>
-            )}
           </div>
           {skill && !skill.isSystem && (
             <Button

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
@@ -148,11 +148,11 @@ export default function PageClient({ slug, name }: PageClientProps) {
   });
 
   const handleSave = useCallback(() => {
-    if (!hasChanges || saveMutation.isPending) {
+    if (!hasChanges || saveMutation.isPending || deleteMutation.isPending) {
       return;
     }
     saveMutation.mutate();
-  }, [hasChanges, saveMutation]);
+  }, [hasChanges, saveMutation, deleteMutation]);
 
   const handleDiscard = useCallback(() => {
     if (!original) {

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import PageClient from "./page-client";
+
+export const metadata: Metadata = {
+  title: "Skill",
+};
+
+async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string; name: string }>;
+}) {
+  const { slug, name } = await params;
+  return <PageClient name={name} slug={slug} />;
+}
+
+export default Page;

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { PlusSignIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { Badge } from "@notra/ui/components/ui/badge";
+import { Button } from "@notra/ui/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@notra/ui/components/ui/card";
+import { Field, FieldLabel } from "@notra/ui/components/ui/field";
+import { Input } from "@notra/ui/components/ui/input";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { Textarea } from "@notra/ui/components/ui/textarea";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { PageContainer } from "@/components/layout/container";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { dashboardOrpc } from "@/lib/orpc/query";
+import { createSkillSchema } from "@/schemas/skills";
+
+interface PageClientProps {
+  slug: string;
+}
+
+export default function PageClient({ slug }: PageClientProps) {
+  const { activeOrganization } = useOrganizationsContext();
+  const organizationId = activeOrganization?.id;
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+    content: "",
+  });
+
+  const { data: skills = [], isPending } = useQuery({
+    ...dashboardOrpc.skills.list.queryOptions({
+      input: { organizationId: organizationId ?? "" },
+    }),
+    enabled: !!organizationId,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      if (!organizationId) {
+        throw new Error("Organization ID is required");
+      }
+      const parsed = createSkillSchema.safeParse({
+        name: form.name,
+        description: form.description,
+        content: form.content,
+      });
+      if (!parsed.success) {
+        throw new Error(parsed.error.issues[0]?.message ?? "Invalid input");
+      }
+      return dashboardOrpc.skills.create.call({
+        organizationId,
+        payload: parsed.data,
+      });
+    },
+    onSuccess: (data) => {
+      setDialogOpen(false);
+      setForm({ name: "", description: "", content: "" });
+      queryClient.invalidateQueries({
+        queryKey: dashboardOrpc.skills.list.queryKey({
+          input: { organizationId: organizationId ?? "" },
+        }),
+      });
+      toast.success("Skill created");
+      router.push(`/${slug}/skills/${data.name}`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+
+  return (
+    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+      <div className="w-full space-y-6 px-4 lg:px-6">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <h1 className="font-bold text-3xl tracking-tight">Skills</h1>
+            <p className="text-muted-foreground">
+              Reusable instructions your agents load when generating content.
+            </p>
+          </div>
+          <Button onClick={() => setDialogOpen(true)}>
+            <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
+            New skill
+          </Button>
+        </div>
+
+        {organizationId && isPending ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton cards
+              <Card className="gap-3 p-4" key={i}>
+                <Skeleton className="h-5 w-32" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="mt-1 h-3 w-24" />
+              </Card>
+            ))}
+          </div>
+        ) : skills.length === 0 ? (
+          <p className="text-muted-foreground">No skills yet.</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {skills.map((skill) => (
+              <Link
+                className="group block"
+                href={`/${slug}/skills/${skill.name}`}
+                key={skill.id}
+              >
+                <Card className="h-full gap-3 transition-all group-hover:ring-foreground/20">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 font-mono text-base">
+                      {skill.name}
+                      {skill.isSystem && (
+                        <Badge variant="secondary">System</Badge>
+                      )}
+                    </CardTitle>
+                    <CardDescription className="line-clamp-3">
+                      {skill.description}
+                    </CardDescription>
+                    <p className="pt-1 text-muted-foreground text-xs">
+                      Updated {new Date(skill.updatedAt).toLocaleDateString()}
+                    </p>
+                  </CardHeader>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ResponsiveDialog onOpenChange={setDialogOpen} open={dialogOpen}>
+        <ResponsiveDialogContent className="sm:max-w-[32rem]">
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>Create skill</ResponsiveDialogTitle>
+            <ResponsiveDialogDescription>
+              A skill is a reusable prompt your agents load at runtime.
+            </ResponsiveDialogDescription>
+          </ResponsiveDialogHeader>
+          <div className="space-y-4 py-2">
+            <Field>
+              <FieldLabel>
+                Name<span className="-ml-1 text-destructive">*</span>
+              </FieldLabel>
+              <Input
+                disabled={createMutation.isPending}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, name: e.target.value }))
+                }
+                placeholder="my-skill"
+                value={form.name}
+              />
+              <p className="text-muted-foreground text-xs">
+                Lowercase letters, digits, and hyphens. Used by agents to load
+                this skill.
+              </p>
+            </Field>
+            <Field>
+              <FieldLabel>
+                Description<span className="-ml-1 text-destructive">*</span>
+              </FieldLabel>
+              <Textarea
+                className="min-h-[5rem]"
+                disabled={createMutation.isPending}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+                placeholder="What this skill does and when to use it."
+                value={form.description}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>
+                Content<span className="-ml-1 text-destructive">*</span>
+              </FieldLabel>
+              <Textarea
+                className="min-h-[12rem] font-mono text-sm"
+                disabled={createMutation.isPending}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, content: e.target.value }))
+                }
+                placeholder="# My skill\n\nYou are..."
+                value={form.content}
+              />
+            </Field>
+          </div>
+          <ResponsiveDialogFooter>
+            <ResponsiveDialogClose
+              disabled={createMutation.isPending}
+              render={<Button variant="outline">Cancel</Button>}
+            />
+            <Button
+              disabled={createMutation.isPending}
+              onClick={() => createMutation.mutate()}
+            >
+              {createMutation.isPending ? "Creating…" : "Create skill"}
+            </Button>
+          </ResponsiveDialogFooter>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+    </PageContainer>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -11,7 +11,6 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@notra/ui/components/shared/responsive-dialog";
-import { Badge } from "@notra/ui/components/ui/badge";
 import { Button } from "@notra/ui/components/ui/button";
 import {
   Card,
@@ -31,6 +30,7 @@ import { toast } from "sonner";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { dashboardOrpc } from "@/lib/orpc/query";
+import { parseSkillFrontmatter } from "@/lib/skills/parse-frontmatter";
 import { createSkillSchema } from "@/schemas/skills";
 
 interface PageClientProps {
@@ -90,6 +90,23 @@ export default function PageClient({ slug }: PageClientProps) {
     },
   });
 
+  const handlePasteFrontmatter = (
+    e: React.ClipboardEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const pasted = e.clipboardData.getData("text/plain");
+    const parsed = parseSkillFrontmatter(pasted);
+    if (!parsed) {
+      return;
+    }
+
+    e.preventDefault();
+    setForm((f) => ({
+      name: f.name || (parsed.name ?? ""),
+      description: f.description || (parsed.description ?? ""),
+      content: f.content || parsed.body,
+    }));
+  };
+
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
@@ -130,11 +147,8 @@ export default function PageClient({ slug }: PageClientProps) {
               >
                 <Card className="h-full gap-3 transition-all group-hover:ring-foreground/20">
                   <CardHeader>
-                    <CardTitle className="flex items-center gap-2 font-mono text-base">
+                    <CardTitle className="font-mono text-base">
                       {skill.name}
-                      {skill.isSystem && (
-                        <Badge variant="secondary">System</Badge>
-                      )}
                     </CardTitle>
                     <CardDescription className="line-clamp-3">
                       {skill.description}
@@ -168,12 +182,13 @@ export default function PageClient({ slug }: PageClientProps) {
                 onChange={(e) =>
                   setForm((f) => ({ ...f, name: e.target.value }))
                 }
+                onPaste={handlePasteFrontmatter}
                 placeholder="my-skill"
                 value={form.name}
               />
               <p className="text-muted-foreground text-xs">
-                Lowercase letters, digits, and hyphens. Used by agents to load
-                this skill.
+                Lowercase letters, digits, and hyphens. Or paste a full skill
+                (frontmatter + body) here to auto-fill all fields.
               </p>
             </Field>
             <Field>
@@ -181,11 +196,12 @@ export default function PageClient({ slug }: PageClientProps) {
                 Description<span className="-ml-1 text-destructive">*</span>
               </FieldLabel>
               <Textarea
-                className="min-h-[5rem]"
+                className="max-h-[5rem] min-h-[4rem] overflow-y-auto"
                 disabled={createMutation.isPending}
                 onChange={(e) =>
                   setForm((f) => ({ ...f, description: e.target.value }))
                 }
+                onPaste={handlePasteFrontmatter}
                 placeholder="What this skill does and when to use it."
                 value={form.description}
               />
@@ -195,11 +211,12 @@ export default function PageClient({ slug }: PageClientProps) {
                 Content<span className="-ml-1 text-destructive">*</span>
               </FieldLabel>
               <Textarea
-                className="min-h-[12rem] font-mono text-sm"
+                className="max-h-[14rem] min-h-[10rem] overflow-y-auto font-mono text-sm"
                 disabled={createMutation.isPending}
                 onChange={(e) =>
                   setForm((f) => ({ ...f, content: e.target.value }))
                 }
+                onPaste={handlePasteFrontmatter}
                 placeholder="# My skill\n\nYou are..."
                 value={form.content}
               />

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -119,7 +119,7 @@ export default function PageClient({ slug }: PageClientProps) {
           </div>
           <Button onClick={() => setDialogOpen(true)}>
             <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
-            New skill
+            New Skill
           </Button>
         </div>
 

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import PageClient from "./page-client";
+
+export const metadata: Metadata = {
+  title: "Skills",
+};
+
+async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <PageClient slug={slug} />;
+}
+
+export default Page;

--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -5,6 +5,7 @@ import {
   CorporateIcon,
   Home01Icon,
   Key01Icon,
+  MagicWand01Icon,
   Message01Icon,
   NoteIcon,
   Notification03Icon,
@@ -55,6 +56,12 @@ const navMainItems: NavMainItem[] = [
     link: "/content",
     icon: NoteIcon,
     label: "Content",
+    category: "workspace",
+  },
+  {
+    link: "/skills",
+    icon: MagicWand01Icon,
+    label: "Skills",
     category: "workspace",
   },
   {

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -30,6 +30,7 @@ import {
   sendWelcomeEmailAction,
 } from "@/lib/email/actions";
 import { redis } from "@/lib/redis";
+import { seedSystemSkills } from "@/lib/skills/seed";
 import { generateOrganizationAvatar } from "@/lib/utils";
 import { organizationSlugSchema } from "@/schemas/organization";
 
@@ -392,6 +393,18 @@ export const auth = betterAuth({
     organization: {
       create: {
         after: async (org: { id: string; name: string }) => {
+          try {
+            await seedSystemSkills(org.id);
+          } catch (error) {
+            console.error(
+              "[Skills] Failed to seed system skills for new org:",
+              {
+                organizationId: org.id,
+                error,
+              }
+            );
+          }
+
           if (!autumn) {
             console.warn(
               "[Autumn] Skipping customer creation - AUTUMN_SECRET_KEY not configured"

--- a/apps/dashboard/src/lib/chat-history.ts
+++ b/apps/dashboard/src/lib/chat-history.ts
@@ -631,11 +631,13 @@ export async function generateAndSetChatTitle(
     const fallbackTitle = getFallbackTitle(userMessage);
 
     const { text } = await generateText({
-      model: gateway("openai/gpt-oss-120b"),
+      model: gateway("openai/gpt-5.4-nano"),
       system: `Generate a short, descriptive title (max 50 chars) for a chat conversation based on the user's first message. Return ONLY the title text, nothing else. No quotes, no prefix. Be specific and concise.`,
       prompt: userMessage,
       maxOutputTokens: 30,
     });
+
+    console.log()
 
     const aiTitle = text.replace(/^["']|["']$/g, "").trim();
     const title = normalizeChatTitle(aiTitle || fallbackTitle);

--- a/apps/dashboard/src/lib/chat-history.ts
+++ b/apps/dashboard/src/lib/chat-history.ts
@@ -637,8 +637,6 @@ export async function generateAndSetChatTitle(
       maxOutputTokens: 30,
     });
 
-    console.log()
-
     const aiTitle = text.replace(/^["']|["']$/g, "").trim();
     const title = normalizeChatTitle(aiTitle || fallbackTitle);
 

--- a/apps/dashboard/src/lib/chat-history.ts
+++ b/apps/dashboard/src/lib/chat-history.ts
@@ -631,7 +631,7 @@ export async function generateAndSetChatTitle(
     const fallbackTitle = getFallbackTitle(userMessage);
 
     const { text } = await generateText({
-      model: gateway("openai/gpt-oss-20b"),
+      model: gateway("openai/gpt-oss-120b"),
       system: `Generate a short, descriptive title (max 50 chars) for a chat conversation based on the user's first message. Return ONLY the title text, nothing else. No quotes, no prefix. Be specific and concise.`,
       prompt: userMessage,
       maxOutputTokens: 30,

--- a/apps/dashboard/src/lib/orpc/router.ts
+++ b/apps/dashboard/src/lib/orpc/router.ts
@@ -9,6 +9,7 @@ import { logsRouter } from "./routers/logs";
 import { notificationsRouter } from "./routers/notifications";
 import { onboardingRouter } from "./routers/onboarding";
 import { searchRouter } from "./routers/search";
+import { skillsRouter } from "./routers/skills";
 import { socialAccountsRouter } from "./routers/social-accounts";
 import { uploadRouter } from "./routers/upload";
 import { userRouter } from "./routers/user";
@@ -25,6 +26,7 @@ export const dashboardRouter = {
   notifications: notificationsRouter,
   onboarding: onboardingRouter,
   search: searchRouter,
+  skills: skillsRouter,
   socialAccounts: socialAccountsRouter,
   upload: uploadRouter,
   user: userRouter,

--- a/apps/dashboard/src/lib/orpc/routers/skills.ts
+++ b/apps/dashboard/src/lib/orpc/routers/skills.ts
@@ -138,16 +138,38 @@ export const skillsRouter = {
           eq(skills.organizationId, input.organizationId),
           eq(skills.name, input.name)
         ),
-        columns: { id: true },
+        columns: { id: true, isSystem: true },
       });
 
       if (!row) {
         throw notFound("Skill not found");
       }
 
+      const nextName = input.payload.name ?? input.name;
+      const isRename = nextName !== input.name;
+
+      if (isRename && row.isSystem) {
+        throw forbidden("System skills cannot be renamed");
+      }
+
+      if (isRename) {
+        const conflictRow = await db.query.skills.findFirst({
+          where: and(
+            eq(skills.organizationId, input.organizationId),
+            eq(skills.name, nextName)
+          ),
+          columns: { id: true },
+        });
+
+        if (conflictRow) {
+          throw conflict(`A skill named "${nextName}" already exists`);
+        }
+      }
+
       await db
         .update(skills)
         .set({
+          name: nextName,
           description: input.payload.description,
           content: input.payload.content,
         })
@@ -158,7 +180,7 @@ export const skillsRouter = {
           )
         );
 
-      return { success: true as const };
+      return { success: true as const, name: nextName };
     }),
 
   delete: authorizedProcedure

--- a/apps/dashboard/src/lib/orpc/routers/skills.ts
+++ b/apps/dashboard/src/lib/orpc/routers/skills.ts
@@ -1,0 +1,200 @@
+import { db } from "@notra/db/drizzle";
+import { skills } from "@notra/db/schema";
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+import { assertOrganizationAccess } from "@/lib/auth/organization";
+import { authorizedProcedure } from "@/lib/orpc/base";
+import { organizationIdSchema } from "@/schemas/auth/organization";
+import {
+  createSkillSchema,
+  skillNameSchema,
+  updateSkillSchema,
+} from "@/schemas/skills";
+import { conflict, forbidden, notFound } from "../utils/errors";
+
+const listSkillsInput = z.object({
+  organizationId: organizationIdSchema,
+});
+
+const getSkillInput = z.object({
+  organizationId: organizationIdSchema,
+  name: skillNameSchema,
+});
+
+const createSkillInput = z.object({
+  organizationId: organizationIdSchema,
+  payload: createSkillSchema,
+});
+
+const updateSkillInput = z.object({
+  organizationId: organizationIdSchema,
+  name: skillNameSchema,
+  payload: updateSkillSchema,
+});
+
+const deleteSkillInput = z.object({
+  organizationId: organizationIdSchema,
+  name: skillNameSchema,
+});
+
+export const skillsRouter = {
+  list: authorizedProcedure
+    .input(listSkillsInput)
+    .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
+
+      const rows = await db
+        .select({
+          id: skills.id,
+          name: skills.name,
+          description: skills.description,
+          isSystem: skills.isSystem,
+          updatedAt: skills.updatedAt,
+        })
+        .from(skills)
+        .where(eq(skills.organizationId, input.organizationId));
+
+      return rows;
+    }),
+
+  getByName: authorizedProcedure
+    .input(getSkillInput)
+    .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
+
+      const row = await db.query.skills.findFirst({
+        where: and(
+          eq(skills.organizationId, input.organizationId),
+          eq(skills.name, input.name)
+        ),
+      });
+
+      if (!row) {
+        throw notFound("Skill not found");
+      }
+
+      return row;
+    }),
+
+  create: authorizedProcedure
+    .input(createSkillInput)
+    .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
+
+      const existing = await db.query.skills.findFirst({
+        where: and(
+          eq(skills.organizationId, input.organizationId),
+          eq(skills.name, input.payload.name)
+        ),
+        columns: { id: true },
+      });
+
+      if (existing) {
+        throw conflict(`A skill named "${input.payload.name}" already exists`);
+      }
+
+      const [created] = await db
+        .insert(skills)
+        .values({
+          id: nanoid(),
+          organizationId: input.organizationId,
+          name: input.payload.name,
+          description: input.payload.description,
+          content: input.payload.content,
+          isSystem: false,
+        })
+        .returning({
+          name: skills.name,
+        });
+
+      return { name: created?.name ?? input.payload.name };
+    }),
+
+  update: authorizedProcedure
+    .input(updateSkillInput)
+    .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
+
+      const row = await db.query.skills.findFirst({
+        where: and(
+          eq(skills.organizationId, input.organizationId),
+          eq(skills.name, input.name)
+        ),
+        columns: { id: true },
+      });
+
+      if (!row) {
+        throw notFound("Skill not found");
+      }
+
+      await db
+        .update(skills)
+        .set({
+          description: input.payload.description,
+          content: input.payload.content,
+        })
+        .where(
+          and(
+            eq(skills.organizationId, input.organizationId),
+            eq(skills.name, input.name)
+          )
+        );
+
+      return { success: true as const };
+    }),
+
+  delete: authorizedProcedure
+    .input(deleteSkillInput)
+    .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
+
+      const row = await db.query.skills.findFirst({
+        where: and(
+          eq(skills.organizationId, input.organizationId),
+          eq(skills.name, input.name)
+        ),
+        columns: { id: true, isSystem: true },
+      });
+
+      if (!row) {
+        throw notFound("Skill not found");
+      }
+
+      if (row.isSystem) {
+        throw forbidden("System skills cannot be deleted");
+      }
+
+      await db
+        .delete(skills)
+        .where(
+          and(
+            eq(skills.organizationId, input.organizationId),
+            eq(skills.name, input.name)
+          )
+        );
+
+      return { success: true as const };
+    }),
+};

--- a/apps/dashboard/src/lib/skills/backfill.ts
+++ b/apps/dashboard/src/lib/skills/backfill.ts
@@ -1,0 +1,55 @@
+import { db } from "@notra/db/drizzle";
+import { organizations } from "@notra/db/schema";
+import { seedSystemSkills } from "./seed";
+
+export async function backfillSystemSkills(): Promise<{
+  total: number;
+  seeded: number;
+  failed: Array<{ organizationId: string; error: string }>;
+}> {
+  const orgs = await db.select({ id: organizations.id }).from(organizations);
+
+  let seeded = 0;
+  const failed: Array<{ organizationId: string; error: string }> = [];
+
+  for (const org of orgs) {
+    try {
+      await seedSystemSkills(org.id);
+      seeded += 1;
+    } catch (error) {
+      failed.push({
+        organizationId: org.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    total: orgs.length,
+    seeded,
+    failed,
+  };
+}
+
+async function main(): Promise<void> {
+  console.log("[skills backfill] starting...");
+  const result = await backfillSystemSkills();
+  console.log("[skills backfill] done", result);
+  if (result.failed.length > 0) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+const isDirect =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  (process.argv[1].endsWith("backfill.ts") ||
+    process.argv[1].endsWith("backfill.js"));
+
+if (isDirect) {
+  main().catch((error) => {
+    console.error("[skills backfill] fatal", error);
+    process.exit(1);
+  });
+}

--- a/apps/dashboard/src/lib/skills/humanizer-content.ts
+++ b/apps/dashboard/src/lib/skills/humanizer-content.ts
@@ -1,0 +1,504 @@
+export const HUMANIZER_CONTENT = `# Humanizer: Remove AI Writing Patterns
+
+You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+## Your Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** - Scan for the patterns listed below
+2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
+3. **Preserve meaning** - Keep the core message intact
+4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
+5. **Add soul** - Don't just remove bad patterns; inject actual personality
+
+---
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+### Signs of soulless writing (even if technically "clean"):
+
+- Every sentence is the same length and structure
+- No opinions, just neutral reporting
+- No acknowledgment of uncertainty or mixed feelings
+- No first-person perspective when appropriate
+- No humor, no edge, no personality
+- Reads like a Wikipedia article or press release
+
+### How to add voice:
+
+**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+
+**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+
+**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
+
+**Use "I" when it fits.** First person isn't unprofessional - it's honest. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
+
+**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+
+**Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+
+### Before (clean but soulless):
+
+> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+
+### After (has a pulse):
+
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
+
+---
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+
+**Before:**
+
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+
+**After:**
+
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+---
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+
+**Before:**
+
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+**After:**
+
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+---
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+
+**Before:**
+
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+
+**After:**
+
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+---
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+
+**Before:**
+
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+**After:**
+
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+---
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+
+**Before:**
+
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+---
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+
+**Before:**
+
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+
+**After:**
+
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+---
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+
+**Before:**
+
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+
+**After:**
+
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+---
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+
+**Before:**
+
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+**After:**
+
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+---
+
+### 9. Negative Parallelisms
+
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused.
+
+**Before:**
+
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+
+**After:**
+
+> The heavy beat adds to the aggressive tone.
+
+---
+
+### 10. Rule of Three Overuse
+
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+
+**Before:**
+
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+---
+
+### 11. Elegant Variation (Synonym Cycling)
+
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+
+**Before:**
+
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+---
+
+### 12. False Ranges
+
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+
+**Before:**
+
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+**After:**
+
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+---
+
+## STYLE PATTERNS
+
+### 13. Em Dash Overuse
+
+**Problem:** LLMs use em dashes (—) more than humans, mimicking "punchy" sales writing.
+
+**Before:**
+
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+
+**After:**
+
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+---
+
+### 14. Overuse of Boldface
+
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+
+**Before:**
+
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+
+**After:**
+
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+---
+
+### 15. Inline-Header Vertical Lists
+
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+
+**Before:**
+
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+**After:**
+
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+---
+
+### 16. Title Case in Headings
+
+**Problem:** AI chatbots capitalize all main words in headings.
+
+**Before:**
+
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+
+> ## Strategic negotiations and global partnerships
+
+---
+
+### 17. Emojis
+
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+
+**Before:**
+
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+
+**After:**
+
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+---
+
+### 18. Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
+
+**Before:**
+
+> He said “the project is on track” but others disagreed.
+
+**After:**
+
+> He said "the project is on track" but others disagreed.
+
+---
+
+## COMMUNICATION PATTERNS
+
+### 19. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+
+**Before:**
+
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+**After:**
+
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+---
+
+### 20. Knowledge-Cutoff Disclaimers
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
+
+**Problem:** AI disclaimers about incomplete information get left in text.
+
+**Before:**
+
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+
+> The company was founded in 1994, according to its registration documents.
+
+---
+
+### 21. Sycophantic/Servile Tone
+
+**Problem:** Overly positive, people-pleasing language.
+
+**Before:**
+
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+
+**After:**
+
+> The economic factors you mentioned are relevant here.
+
+---
+
+## FILLER AND HEDGING
+
+### 22. Filler Phrases
+
+**Before → After:**
+
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+---
+
+### 23. Excessive Hedging
+
+**Problem:** Over-qualifying statements.
+
+**Before:**
+
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+
+> The policy may affect outcomes.
+
+---
+
+### 24. Generic Positive Conclusions
+
+**Problem:** Vague upbeat endings.
+
+**Before:**
+
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+**After:**
+
+> The company plans to open two more locations next year.
+
+---
+
+## Process
+
+1. Read the input text carefully
+2. Identify all instances of the patterns above
+3. Rewrite each problematic section
+4. Ensure the revised text:
+   - Sounds natural when read aloud
+   - Varies sentence structure naturally
+   - Uses specific details over vague claims
+   - Maintains appropriate tone for context
+   - Uses simple constructions (is/are/has) where appropriate
+5. Present the humanized version
+
+## Output Format
+
+Provide:
+
+1. The rewritten text
+2. A brief summary of changes made (optional, if helpful)
+
+---
+
+## Full Example
+
+**Before (AI-sounding):**
+
+> Great question! Here is an essay on this topic. I hope this helps!
+>
+> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
+>
+> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It's not just about autocomplete; it's about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
+>
+> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
+>
+> - 💡 **Speed:** Code generation is significantly faster, reducing friction and empowering developers.
+> - 🚀 **Quality:** Output quality has been enhanced through improved training, contributing to higher standards.
+> - ✅ **Adoption:** Usage continues to grow, reflecting broader industry trends.
+>
+> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies—including hallucinations, bias, and accountability—the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
+>
+> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you'd like me to expand on any section!
+
+**After (Humanized):**
+
+> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
+>
+> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
+>
+> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
+>
+> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
+>
+> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
+
+**Changes made:**
+
+- Removed chatbot artifacts ("Great question!", "I hope this helps!", "Let me know if...")
+- Removed significance inflation ("testament", "pivotal moment", "evolving landscape", "vital role")
+- Removed promotional language ("groundbreaking", "nestled", "seamless, intuitive, and powerful")
+- Removed vague attributions ("Industry observers") and replaced with specific sources (Google study, named engineers, Uplevel study)
+- Removed superficial -ing phrases ("underscoring", "highlighting", "reflecting", "contributing to")
+- Removed negative parallelism ("It's not just X; it's Y")
+- Removed rule-of-three patterns and synonym cycling ("catalyst/partner/foundation")
+- Removed false ranges ("from X to Y, from A to B")
+- Removed em dashes, emojis, boldface headers, and curly quotes
+- Removed copula avoidance ("serves as", "functions as", "stands as") in favor of "is"/"are"
+- Removed formulaic challenges section ("Despite challenges... continues to thrive")
+- Removed knowledge-cutoff hedging ("While specific details are limited...")
+- Removed excessive hedging ("could potentially be argued that... might have some")
+- Removed filler phrases ("In order to", "At its core")
+- Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
+- Replaced media name-dropping with specific claims from specific sources
+- Used simple sentence structures and concrete examples
+
+---
+
+## Reference
+
+This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+
+Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
+`;

--- a/apps/dashboard/src/lib/skills/parse-frontmatter.ts
+++ b/apps/dashboard/src/lib/skills/parse-frontmatter.ts
@@ -1,0 +1,52 @@
+export interface ParsedSkillFrontmatter {
+  name?: string;
+  description?: string;
+  body: string;
+}
+
+const FRONTMATTER_REGEX = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/;
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export function parseSkillFrontmatter(
+  input: string
+): ParsedSkillFrontmatter | null {
+  const trimmed = input.replace(/^\uFEFF/, "").trimStart();
+  if (!trimmed.startsWith("---")) {
+    return null;
+  }
+
+  const match = trimmed.match(FRONTMATTER_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const [, block = "", body = ""] = match;
+  const fields: Record<string, string> = {};
+
+  for (const line of block.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) {
+      continue;
+    }
+    const key = line.slice(0, colonIdx).trim();
+    const value = stripQuotes(line.slice(colonIdx + 1).trim());
+    if (key) {
+      fields[key] = value;
+    }
+  }
+
+  return {
+    name: fields.name,
+    description: fields.description,
+    body: body.trim(),
+  };
+}

--- a/apps/dashboard/src/lib/skills/parse-frontmatter.ts
+++ b/apps/dashboard/src/lib/skills/parse-frontmatter.ts
@@ -5,6 +5,7 @@ export interface ParsedSkillFrontmatter {
 }
 
 const FRONTMATTER_REGEX = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/;
+const BOM_REGEX = /^\uFEFF/;
 
 function stripQuotes(value: string): string {
   if (
@@ -19,7 +20,7 @@ function stripQuotes(value: string): string {
 export function parseSkillFrontmatter(
   input: string
 ): ParsedSkillFrontmatter | null {
-  const trimmed = input.replace(/^\uFEFF/, "").trimStart();
+  const trimmed = input.replace(BOM_REGEX, "").trimStart();
   if (!trimmed.startsWith("---")) {
     return null;
   }

--- a/apps/dashboard/src/lib/skills/seed.ts
+++ b/apps/dashboard/src/lib/skills/seed.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getConversationalBlogPostPrompt } from "@notra/ai/prompts/blog_post/conversational";
+import { getConversationalChangelogPrompt } from "@notra/ai/prompts/changelog/conversational";
+import { getConversationalLinkedInPrompt } from "@notra/ai/prompts/linkedin/conversational";
+import { getConversationalTwitterPrompt } from "@notra/ai/prompts/twitter/conversational";
+import { db } from "@notra/db/drizzle";
+import { skills } from "@notra/db/schema";
+import matter from "gray-matter";
+import { nanoid } from "nanoid";
+
+export interface SystemSkillDefinition {
+  name: string;
+  description: string;
+  content: string;
+}
+
+function loadHumanizerContent(): string {
+  const candidates = [
+    path.join(
+      process.cwd(),
+      "packages",
+      "ai",
+      "src",
+      "skills",
+      "human-writer",
+      "SKILL.md"
+    ),
+    path.join(
+      process.cwd(),
+      "..",
+      "..",
+      "packages",
+      "ai",
+      "src",
+      "skills",
+      "human-writer",
+      "SKILL.md"
+    ),
+  ];
+
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+
+  if (!found) {
+    throw new Error(
+      `[skills seed] Humanizer SKILL.md not found. Checked: ${candidates.join(", ")}`
+    );
+  }
+
+  const raw = fs.readFileSync(found, "utf-8");
+  return matter(raw).content.trim();
+}
+
+export function buildSystemSkills(): SystemSkillDefinition[] {
+  return [
+    {
+      name: "changelog",
+      description:
+        "Generate a comprehensive changelog from GitHub commits, pull requests, releases, and Linear issues for a given lookback window. Filters for high-signal changes and formats with Highlights + categorized More Updates.",
+      content: getConversationalChangelogPrompt(),
+    },
+    {
+      name: "blog-post",
+      description:
+        "Write a long-form blog post from GitHub and Linear data. Produces narrative prose with structure and voice, not a bullet-list changelog.",
+      content: getConversationalBlogPostPrompt(),
+    },
+    {
+      name: "twitter",
+      description:
+        "Compose a Twitter/X post from recent development activity. Short-form, attention-grabbing, with the brand's voice.",
+      content: getConversationalTwitterPrompt(),
+    },
+    {
+      name: "linkedin",
+      description:
+        "Compose a LinkedIn post from recent development activity. Professional tone, medium-form, optimized for the LinkedIn feed.",
+      content: getConversationalLinkedInPrompt(),
+    },
+    {
+      name: "humanizer",
+      description:
+        "Remove signs of AI-generated writing from text. Use as a sub-skill from other skills to humanize a near-final draft before publishing.",
+      content: loadHumanizerContent(),
+    },
+  ];
+}
+
+export async function seedSystemSkills(organizationId: string): Promise<void> {
+  const definitions = buildSystemSkills();
+
+  const rows = definitions.map((def) => ({
+    id: nanoid(),
+    organizationId,
+    name: def.name,
+    description: def.description,
+    content: def.content,
+    isSystem: true,
+  }));
+
+  await db
+    .insert(skills)
+    .values(rows)
+    .onConflictDoNothing({
+      target: [skills.organizationId, skills.name],
+    });
+}

--- a/apps/dashboard/src/lib/skills/seed.ts
+++ b/apps/dashboard/src/lib/skills/seed.ts
@@ -1,54 +1,16 @@
-import fs from "node:fs";
-import path from "node:path";
 import { getConversationalBlogPostPrompt } from "@notra/ai/prompts/blog_post/conversational";
 import { getConversationalChangelogPrompt } from "@notra/ai/prompts/changelog/conversational";
 import { getConversationalLinkedInPrompt } from "@notra/ai/prompts/linkedin/conversational";
 import { getConversationalTwitterPrompt } from "@notra/ai/prompts/twitter/conversational";
 import { db } from "@notra/db/drizzle";
 import { skills } from "@notra/db/schema";
-import matter from "gray-matter";
 import { nanoid } from "nanoid";
+import { HUMANIZER_CONTENT } from "./humanizer-content";
 
 export interface SystemSkillDefinition {
   name: string;
   description: string;
   content: string;
-}
-
-function loadHumanizerContent(): string {
-  const candidates = [
-    path.join(
-      process.cwd(),
-      "packages",
-      "ai",
-      "src",
-      "skills",
-      "human-writer",
-      "SKILL.md"
-    ),
-    path.join(
-      process.cwd(),
-      "..",
-      "..",
-      "packages",
-      "ai",
-      "src",
-      "skills",
-      "human-writer",
-      "SKILL.md"
-    ),
-  ];
-
-  const found = candidates.find((candidate) => fs.existsSync(candidate));
-
-  if (!found) {
-    throw new Error(
-      `[skills seed] Humanizer SKILL.md not found. Checked: ${candidates.join(", ")}`
-    );
-  }
-
-  const raw = fs.readFileSync(found, "utf-8");
-  return matter(raw).content.trim();
 }
 
 export function buildSystemSkills(): SystemSkillDefinition[] {
@@ -81,7 +43,7 @@ export function buildSystemSkills(): SystemSkillDefinition[] {
       name: "humanizer",
       description:
         "Remove signs of AI-generated writing from text. Use as a sub-skill from other skills to humanize a near-final draft before publishing.",
-      content: loadHumanizerContent(),
+      content: HUMANIZER_CONTENT.trim(),
     },
   ];
 }

--- a/apps/dashboard/src/schemas/skills.ts
+++ b/apps/dashboard/src/schemas/skills.ts
@@ -1,0 +1,37 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+export const skillNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Name is required")
+  .max(64, "Name must be 64 characters or fewer")
+  .regex(
+    /^[a-z0-9][a-z0-9-]*$/,
+    "Name must be lowercase, start with a letter or digit, and contain only letters, digits, and hyphens"
+  );
+
+export const skillDescriptionSchema = z
+  .string()
+  .trim()
+  .min(1, "Description is required")
+  .max(500, "Description must be 500 characters or fewer");
+
+export const skillContentSchema = z
+  .string()
+  .min(1, "Content is required")
+  .max(200_000, "Content is too large");
+
+export const createSkillSchema = z.object({
+  name: skillNameSchema,
+  description: skillDescriptionSchema,
+  content: skillContentSchema,
+});
+
+export const updateSkillSchema = z.object({
+  description: skillDescriptionSchema,
+  content: skillContentSchema,
+});
+
+export type CreateSkillInput = z.infer<typeof createSkillSchema>;
+export type UpdateSkillInput = z.infer<typeof updateSkillSchema>;

--- a/apps/dashboard/src/schemas/skills.ts
+++ b/apps/dashboard/src/schemas/skills.ts
@@ -7,8 +7,8 @@ export const skillNameSchema = z
   .min(1, "Name is required")
   .max(64, "Name must be 64 characters or fewer")
   .regex(
-    /^[a-z0-9][a-z0-9-]*$/,
-    "Name must be lowercase, start with a letter or digit, and contain only letters, digits, and hyphens"
+    /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/,
+    "Name must be lowercase, start and end with a letter or digit, and contain only letters, digits, and hyphens"
   );
 
 export const skillDescriptionSchema = z

--- a/apps/dashboard/src/schemas/skills.ts
+++ b/apps/dashboard/src/schemas/skills.ts
@@ -29,6 +29,7 @@ export const createSkillSchema = z.object({
 });
 
 export const updateSkillSchema = z.object({
+  name: skillNameSchema.optional(),
   description: skillDescriptionSchema,
   content: skillContentSchema,
 });

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -35,11 +35,8 @@ import type {
   GitHubSelectionFilters,
 } from "@notra/ai/types/tools";
 import { addAnthropicPromptCaching } from "@notra/ai/utils/prompt-caching";
-import { db } from "@notra/db/drizzle";
 import type { PostSourceMetadata } from "@notra/db/schema";
-import { skills } from "@notra/db/schema";
 import { stepCountIs, ToolLoopAgent } from "ai";
-import { and, eq } from "drizzle-orm";
 
 export interface BackgroundGenOptions {
   organizationId: string;
@@ -74,24 +71,30 @@ export interface BackgroundGenResult {
   usage?: AgentTokenUsage;
 }
 
-async function loadSkillContent(
-  organizationId: string,
-  skillName: string
-): Promise<string> {
-  const row = await db.query.skills.findFirst({
-    where: and(
-      eq(skills.organizationId, organizationId),
-      eq(skills.name, skillName)
-    ),
-  });
+function buildDispatcherInstructions(options: {
+  contentLabel: string;
+  contentType: string;
+  primarySkillName: string;
+}): string {
+  return `You are a content generation agent for this organization. Your task: produce ${options.contentLabel} (contentType: ${options.contentType}).
 
-  if (!row) {
-    throw new Error(
-      `Skill "${skillName}" not found for organization "${organizationId}". Has the skills table been seeded?`
-    );
-  }
+Skills drive your behavior — skill content is NOT injected into this prompt. You load skills on demand via tools.
 
-  return row.content;
+Do these steps in order:
+
+1. Call listAvailableSkills to see every writing skill this organization has. Study the names and descriptions.
+
+2. Identify the primary skill that matches your task. The hint from the trigger is "${options.primarySkillName}" — confirm it exists and is the right fit. If a differently-named skill looks like a better match based on its description, use that instead.
+
+3. Call getSkillByName to load the primary skill's full instructions. Read them carefully and follow them exactly — they override these dispatcher instructions on any overlap.
+
+4. Execute the primary skill: gather source data via the provided tools (brand references, GitHub, Linear), then draft the post according to the skill's format and rules.
+
+5. Before finalizing, scan the skill list again for supporting skills (e.g. a "humanizer" skill for polishing AI-sounding output, or any org-specific skill whose description applies). Load any that apply via getSkillByName and apply their guidance to your near-final draft.
+
+6. When the content is finalized, call createPost. If you cannot produce meaningful output, call fail with a concise reason. Do not return the content as plain text.
+
+Skills are the source of truth for how to write. This prompt only tells you how to orchestrate them.`;
 }
 
 export async function runBackgroundGen(
@@ -127,7 +130,11 @@ export async function runBackgroundGen(
     );
   }
 
-  const instructions = await loadSkillContent(organizationId, skillName);
+  const instructions = buildDispatcherInstructions({
+    contentLabel,
+    contentType,
+    primarySkillName: skillName,
+  });
 
   const model = createModel(
     organizationId,

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -1,0 +1,248 @@
+import { AGENT_DEFAULT_MODEL } from "@notra/ai/constants/models";
+import { createModel } from "@notra/ai/model";
+import type { AILogTarget } from "@notra/ai/observability";
+import { getUserPrompt } from "@notra/ai/prompts/user";
+import type { ContentType } from "@notra/ai/schemas/content";
+import {
+  createGetBrandReferencesTool,
+  createSearchBrandReferencesTool,
+} from "@notra/ai/tools/brand-references";
+import { buildGitHubDataTools } from "@notra/ai/tools/github";
+import { buildLinearDataTools } from "@notra/ai/tools/linear";
+import {
+  createCreatePostTool,
+  createFailTool,
+  createUpdatePostTool,
+  createViewPostTool,
+} from "@notra/ai/tools/post";
+import { getSkillByName, listAvailableSkills } from "@notra/ai/tools/skills";
+import type {
+  AgentDataPointSettings,
+  AgentTokenUsage,
+  LinearIntegrationRef,
+  ResolveIntegrationContext,
+  ResolveLinearIntegrationContext,
+} from "@notra/ai/types/agents";
+import type { AgentType } from "@notra/ai/types/brand-references";
+import type {
+  PostToolsConfig,
+  PostToolsResult,
+} from "@notra/ai/types/post-tools";
+import type { PostSummary } from "@notra/ai/types/posts";
+import type { BaseTonePromptInput } from "@notra/ai/types/prompts";
+import type {
+  CommitWindow,
+  GitHubSelectionFilters,
+} from "@notra/ai/types/tools";
+import { addAnthropicPromptCaching } from "@notra/ai/utils/prompt-caching";
+import { db } from "@notra/db/drizzle";
+import type { PostSourceMetadata } from "@notra/db/schema";
+import { skills } from "@notra/db/schema";
+import { stepCountIs, ToolLoopAgent } from "ai";
+import { and, eq } from "drizzle-orm";
+
+export interface BackgroundGenOptions {
+  organizationId: string;
+  skillName: string;
+  contentType: ContentType;
+  brandAgentType: AgentType;
+  contentLabel: string;
+  voiceId?: string;
+  repositories: Array<{
+    integrationId: string;
+    owner: string;
+    repo: string;
+    defaultBranch?: string | null;
+  }>;
+  linearIntegrations?: LinearIntegrationRef[];
+  promptInput: BaseTonePromptInput;
+  sourceMetadata?: PostSourceMetadata;
+  dataPointSettings?: AgentDataPointSettings;
+  selectionFilters?: GitHubSelectionFilters;
+  commitWindow?: CommitWindow;
+  autoPublish?: boolean;
+  resolveContext: ResolveIntegrationContext;
+  resolveLinearContext?: ResolveLinearIntegrationContext;
+  log?: AILogTarget;
+  includeSearchBrandReferencesTool?: boolean;
+}
+
+export interface BackgroundGenResult {
+  postId: string;
+  title: string;
+  posts: PostSummary[];
+  usage?: AgentTokenUsage;
+}
+
+async function loadSkillContent(
+  organizationId: string,
+  skillName: string
+): Promise<string> {
+  const row = await db.query.skills.findFirst({
+    where: and(
+      eq(skills.organizationId, organizationId),
+      eq(skills.name, skillName)
+    ),
+  });
+
+  if (!row) {
+    throw new Error(
+      `Skill "${skillName}" not found for organization "${organizationId}". Has the skills table been seeded?`
+    );
+  }
+
+  return row.content;
+}
+
+export async function runBackgroundGen(
+  options: BackgroundGenOptions
+): Promise<BackgroundGenResult> {
+  const {
+    organizationId,
+    skillName,
+    contentType,
+    brandAgentType,
+    contentLabel,
+    voiceId,
+    repositories,
+    linearIntegrations,
+    promptInput,
+    sourceMetadata,
+    dataPointSettings,
+    selectionFilters,
+    commitWindow,
+    autoPublish,
+    resolveContext,
+    resolveLinearContext,
+    log,
+    includeSearchBrandReferencesTool,
+  } = options;
+
+  if (
+    (!repositories || repositories.length === 0) &&
+    (!linearIntegrations || linearIntegrations.length === 0)
+  ) {
+    throw new Error(
+      `At least one repository or Linear integration must be provided to generate ${contentLabel}.`
+    );
+  }
+
+  const instructions = await loadSkillContent(organizationId, skillName);
+
+  const model = createModel(
+    organizationId,
+    AGENT_DEFAULT_MODEL,
+    undefined,
+    log
+  );
+
+  const prompt = getUserPrompt(contentLabel, promptInput);
+
+  const allowedIntegrationIds = Array.from(
+    new Set((repositories ?? []).map((repo) => repo.integrationId))
+  );
+
+  const allowedLinearIntegrationIds = Array.from(
+    new Set((linearIntegrations ?? []).map((li) => li.integrationId))
+  );
+
+  const postToolsResult: PostToolsResult = {};
+  const postToolsConfig: PostToolsConfig = {
+    organizationId,
+    contentType,
+    sourceMetadata,
+    autoPublish,
+  };
+
+  const brandReferenceTools: Record<
+    string,
+    ReturnType<typeof createGetBrandReferencesTool>
+  > = {
+    getBrandReferences: createGetBrandReferencesTool({
+      organizationId,
+      voiceId,
+      agentType: brandAgentType,
+    }),
+  };
+
+  if (includeSearchBrandReferencesTool) {
+    brandReferenceTools.searchBrandReferences = createSearchBrandReferencesTool(
+      {
+        organizationId,
+        voiceId,
+        agentType: brandAgentType,
+      }
+    );
+  }
+
+  const agent = new ToolLoopAgent({
+    model,
+    prepareStep: ({ messages }) => ({
+      messages: addAnthropicPromptCaching(messages, AGENT_DEFAULT_MODEL),
+    }),
+    providerOptions: {
+      anthropic: {
+        thinking: { type: "enabled", budgetTokens: 4096 },
+      },
+    },
+    tools: {
+      ...brandReferenceTools,
+      ...buildGitHubDataTools({
+        organizationId,
+        allowedIntegrationIds,
+        dataPointSettings,
+        selectionFilters,
+        commitWindow,
+        resolveContext,
+      }),
+      ...buildLinearDataTools({
+        organizationId,
+        allowedIntegrationIds: allowedLinearIntegrationIds,
+        dataPointSettings,
+        resolveContext: resolveLinearContext,
+      }),
+      listAvailableSkills: listAvailableSkills({ organizationId }),
+      getSkillByName: getSkillByName({ organizationId }),
+      createPost: createCreatePostTool(postToolsConfig, postToolsResult),
+      updatePost: createUpdatePostTool(postToolsConfig, postToolsResult),
+      viewPost: createViewPostTool(postToolsConfig),
+      fail: createFailTool(postToolsResult),
+    },
+    instructions,
+    stopWhen: stepCountIs(35),
+  });
+
+  const result = await agent.generate({ prompt });
+
+  if (postToolsResult.failReason) {
+    throw new Error(postToolsResult.failReason);
+  }
+
+  if (!postToolsResult.posts?.length) {
+    throw new Error(
+      `${contentLabel} agent completed without creating a post. No createPost tool call was made.`
+    );
+  }
+
+  const primaryPost = postToolsResult.posts[0];
+
+  if (!primaryPost) {
+    throw new Error(`${contentLabel} agent did not return a primary post.`);
+  }
+
+  return {
+    postId: primaryPost.postId,
+    title: primaryPost.title,
+    posts: postToolsResult.posts,
+    usage: {
+      inputTokens: result.totalUsage.inputTokens ?? 0,
+      outputTokens: result.totalUsage.outputTokens ?? 0,
+      totalTokens: result.totalUsage.totalTokens ?? 0,
+      cacheReadTokens:
+        result.totalUsage.inputTokenDetails?.cacheReadTokens ?? 0,
+      cacheWriteTokens:
+        result.totalUsage.inputTokenDetails?.cacheWriteTokens ?? 0,
+      raw: result.totalUsage,
+    },
+  };
+}

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -78,23 +78,26 @@ function buildDispatcherInstructions(options: {
 }): string {
   return `You are a content generation agent for this organization. Your task: produce ${options.contentLabel} (contentType: ${options.contentType}).
 
-Skills drive your behavior — skill content is NOT injected into this prompt. You load skills on demand via tools.
+Skills drive your behavior. Skill content is NOT injected into this prompt. You load skills on demand via tools.
 
 Do these steps in order:
 
 1. Call listAvailableSkills to see every writing skill this organization has. Study the names and descriptions.
 
-2. Identify the primary skill that matches your task. The hint from the trigger is "${options.primarySkillName}" — confirm it exists and is the right fit. If a differently-named skill looks like a better match based on its description, use that instead.
+2. Identify the primary skill that matches your task. The hint from the trigger is "${options.primarySkillName}". Confirm it exists and is the right fit. If a differently-named skill looks like a better match based on its description, use that instead.
 
-3. Call getSkillByName to load the primary skill's full instructions. Read them carefully and follow them exactly — they override these dispatcher instructions on any overlap.
+3. Call getSkillByName to load the primary skill's full instructions. Read them carefully and follow them exactly. They override these dispatcher instructions on any overlap.
 
 4. Execute the primary skill: gather source data via the provided tools (brand references, GitHub, Linear), then draft the post according to the skill's format and rules.
 
-5. Before finalizing, scan the skill list again for supporting skills (e.g. a "humanizer" skill for polishing AI-sounding output, or any org-specific skill whose description applies). Load any that apply via getSkillByName and apply their guidance to your near-final draft.
+5. Before finalizing, scan the skill list again for supporting skills (for example, a "humanizer" skill for polishing AI-sounding output, or any org-specific skill whose description applies). Load any that apply via getSkillByName and apply their guidance to your near-final draft.
 
 6. When the content is finalized, call createPost. If you cannot produce meaningful output, call fail with a concise reason. Do not return the content as plain text.
 
-Skills are the source of truth for how to write. This prompt only tells you how to orchestrate them.`;
+## Output rules (hard)
+- NEVER use em dashes (—) or en dashes (–) anywhere in the post content, title, recommendations, or any text you emit. Use commas, periods, semicolons, parentheses, or a hyphen (-). If a loaded skill's examples contain em/en dashes, ignore that part of the style and substitute safe punctuation.
+
+Skills are the source of truth for how to write. This prompt tells you how to orchestrate them.`;
 }
 
 export async function runBackgroundGen(

--- a/packages/ai/src/agents/blog-post.ts
+++ b/packages/ai/src/agents/blog-post.ts
@@ -1,170 +1,29 @@
-import { AGENT_DEFAULT_MODEL } from "@notra/ai/constants/models";
-import { createModel } from "@notra/ai/model";
-import { getCasualBlogPostPrompt } from "@notra/ai/prompts/blog_post/casual";
-import { getConversationalBlogPostPrompt } from "@notra/ai/prompts/blog_post/conversational";
-import { getFormalBlogPostPrompt } from "@notra/ai/prompts/blog_post/formal";
-import { getProfessionalBlogPostPrompt } from "@notra/ai/prompts/blog_post/professional";
-import { getUserPrompt } from "@notra/ai/prompts/user";
-import { getValidToneProfile, type ToneProfile } from "@notra/ai/schemas/brand";
-import { createGetBrandReferencesTool } from "@notra/ai/tools/brand-references";
-import { buildGitHubDataTools } from "@notra/ai/tools/github";
-import { buildLinearDataTools } from "@notra/ai/tools/linear";
-import {
-  createCreatePostTool,
-  createFailTool,
-  createUpdatePostTool,
-  createViewPostTool,
-} from "@notra/ai/tools/post";
-import { getSkillByName, listAvailableSkills } from "@notra/ai/tools/skills";
+import { runBackgroundGen } from "@notra/ai/agents/background-gen";
 import type {
   BlogPostAgentOptions,
   BlogPostAgentResult,
 } from "@notra/ai/types/agents";
-import type {
-  PostToolsConfig,
-  PostToolsResult,
-} from "@notra/ai/types/post-tools";
-import { addAnthropicPromptCaching } from "@notra/ai/utils/prompt-caching";
-import { stepCountIs, ToolLoopAgent } from "ai";
-
-const blogPostPromptByTone: Record<ToneProfile, () => string> = {
-  Conversational: getConversationalBlogPostPrompt,
-  Professional: getProfessionalBlogPostPrompt,
-  Casual: getCasualBlogPostPrompt,
-  Formal: getFormalBlogPostPrompt,
-};
 
 export async function generateBlogPost(
   options: BlogPostAgentOptions
 ): Promise<BlogPostAgentResult> {
-  const {
-    organizationId,
-    voiceId,
-    repositories,
-    linearIntegrations,
-    tone = "Conversational",
-    promptInput,
-    sourceMetadata,
-    dataPointSettings,
-    selectionFilters,
-    commitWindow,
-    autoPublish,
-    resolveContext,
-    resolveLinearContext,
-    log,
-  } = options;
-
-  if (
-    (!repositories || repositories.length === 0) &&
-    (!linearIntegrations || linearIntegrations.length === 0)
-  ) {
-    throw new Error(
-      "At least one repository or Linear integration must be provided to generate a blog post."
-    );
-  }
-
-  const model = createModel(
-    organizationId,
-    AGENT_DEFAULT_MODEL,
-    undefined,
-    log
-  );
-
-  const resolvedTone = getValidToneProfile(tone, "Conversational");
-
-  const promptFactory =
-    blogPostPromptByTone[resolvedTone] ?? blogPostPromptByTone.Conversational;
-  const instructions = promptFactory();
-  const prompt = getUserPrompt("blog post", promptInput);
-
-  const allowedIntegrationIds = Array.from(
-    new Set((repositories ?? []).map((repo) => repo.integrationId))
-  );
-
-  const allowedLinearIntegrationIds = Array.from(
-    new Set((linearIntegrations ?? []).map((li) => li.integrationId))
-  );
-
-  const postToolsResult: PostToolsResult = {};
-  const postToolsConfig: PostToolsConfig = {
-    organizationId,
+  return runBackgroundGen({
+    organizationId: options.organizationId,
+    skillName: "blog-post",
     contentType: "blog_post",
-    sourceMetadata,
-    autoPublish,
-  };
-
-  const agent = new ToolLoopAgent({
-    model,
-    prepareStep: ({ messages }) => ({
-      messages: addAnthropicPromptCaching(messages, AGENT_DEFAULT_MODEL),
-    }),
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 4096 },
-      },
-    },
-    tools: {
-      getBrandReferences: createGetBrandReferencesTool({
-        organizationId,
-        voiceId,
-        agentType: "blog",
-      }),
-      ...buildGitHubDataTools({
-        organizationId,
-        allowedIntegrationIds,
-        dataPointSettings,
-        selectionFilters,
-        commitWindow,
-        resolveContext,
-      }),
-      ...buildLinearDataTools({
-        organizationId,
-        allowedIntegrationIds: allowedLinearIntegrationIds,
-        dataPointSettings,
-        resolveContext: resolveLinearContext,
-      }),
-      listAvailableSkills: listAvailableSkills(),
-      getSkillByName: getSkillByName(),
-      createPost: createCreatePostTool(postToolsConfig, postToolsResult),
-      updatePost: createUpdatePostTool(postToolsConfig, postToolsResult),
-      viewPost: createViewPostTool(postToolsConfig),
-      fail: createFailTool(postToolsResult),
-    },
-    instructions,
-    stopWhen: stepCountIs(35),
+    brandAgentType: "blog",
+    contentLabel: "blog post",
+    voiceId: options.voiceId,
+    repositories: options.repositories,
+    linearIntegrations: options.linearIntegrations,
+    promptInput: options.promptInput,
+    sourceMetadata: options.sourceMetadata,
+    dataPointSettings: options.dataPointSettings,
+    selectionFilters: options.selectionFilters,
+    commitWindow: options.commitWindow,
+    autoPublish: options.autoPublish,
+    resolveContext: options.resolveContext,
+    resolveLinearContext: options.resolveLinearContext,
+    log: options.log,
   });
-
-  const result = await agent.generate({ prompt });
-
-  if (postToolsResult.failReason) {
-    throw new Error(postToolsResult.failReason);
-  }
-
-  if (!postToolsResult.posts?.length) {
-    throw new Error(
-      "Blog post agent completed without creating a post. No createPost tool call was made."
-    );
-  }
-
-  const primaryPost = postToolsResult.posts[0];
-
-  if (!primaryPost) {
-    throw new Error("Blog post agent did not return a primary post.");
-  }
-
-  return {
-    postId: primaryPost.postId,
-    title: primaryPost.title,
-    posts: postToolsResult.posts,
-    usage: {
-      inputTokens: result.totalUsage.inputTokens ?? 0,
-      outputTokens: result.totalUsage.outputTokens ?? 0,
-      totalTokens: result.totalUsage.totalTokens ?? 0,
-      cacheReadTokens:
-        result.totalUsage.inputTokenDetails?.cacheReadTokens ?? 0,
-      cacheWriteTokens:
-        result.totalUsage.inputTokenDetails?.cacheWriteTokens ?? 0,
-      raw: result.totalUsage,
-    },
-  };
 }

--- a/packages/ai/src/agents/changelog.ts
+++ b/packages/ai/src/agents/changelog.ts
@@ -1,170 +1,29 @@
-import { AGENT_DEFAULT_MODEL } from "@notra/ai/constants/models";
-import { createModel } from "@notra/ai/model";
-import { getCasualChangelogPrompt } from "@notra/ai/prompts/changelog/casual";
-import { getConversationalChangelogPrompt } from "@notra/ai/prompts/changelog/conversational";
-import { getFormalChangelogPrompt } from "@notra/ai/prompts/changelog/formal";
-import { getProfessionalChangelogPrompt } from "@notra/ai/prompts/changelog/professional";
-import { getUserPrompt } from "@notra/ai/prompts/user";
-import { getValidToneProfile, type ToneProfile } from "@notra/ai/schemas/brand";
-import { createGetBrandReferencesTool } from "@notra/ai/tools/brand-references";
-import { buildGitHubDataTools } from "@notra/ai/tools/github";
-import { buildLinearDataTools } from "@notra/ai/tools/linear";
-import {
-  createCreatePostTool,
-  createFailTool,
-  createUpdatePostTool,
-  createViewPostTool,
-} from "@notra/ai/tools/post";
-import { getSkillByName, listAvailableSkills } from "@notra/ai/tools/skills";
+import { runBackgroundGen } from "@notra/ai/agents/background-gen";
 import type {
   ChangelogAgentOptions,
   ChangelogAgentResult,
 } from "@notra/ai/types/agents";
-import type {
-  PostToolsConfig,
-  PostToolsResult,
-} from "@notra/ai/types/post-tools";
-import { addAnthropicPromptCaching } from "@notra/ai/utils/prompt-caching";
-import { stepCountIs, ToolLoopAgent } from "ai";
-
-const changelogPromptByTone: Record<ToneProfile, () => string> = {
-  Conversational: getConversationalChangelogPrompt,
-  Professional: getProfessionalChangelogPrompt,
-  Casual: getCasualChangelogPrompt,
-  Formal: getFormalChangelogPrompt,
-};
 
 export async function generateChangelog(
   options: ChangelogAgentOptions
 ): Promise<ChangelogAgentResult> {
-  const {
-    organizationId,
-    voiceId,
-    repositories,
-    linearIntegrations,
-    tone = "Conversational",
-    promptInput,
-    sourceMetadata,
-    dataPointSettings,
-    selectionFilters,
-    commitWindow,
-    autoPublish,
-    resolveContext,
-    resolveLinearContext,
-    log,
-  } = options;
-
-  if (
-    (!repositories || repositories.length === 0) &&
-    (!linearIntegrations || linearIntegrations.length === 0)
-  ) {
-    throw new Error(
-      "At least one repository or Linear integration must be provided to generate a changelog."
-    );
-  }
-
-  const model = createModel(
-    organizationId,
-    AGENT_DEFAULT_MODEL,
-    undefined,
-    log
-  );
-
-  const resolvedTone = getValidToneProfile(tone, "Conversational");
-
-  const promptFactory =
-    changelogPromptByTone[resolvedTone] ?? changelogPromptByTone.Conversational;
-  const instructions = promptFactory();
-  const prompt = getUserPrompt("changelog", promptInput);
-
-  const allowedIntegrationIds = Array.from(
-    new Set((repositories ?? []).map((repo) => repo.integrationId))
-  );
-
-  const allowedLinearIntegrationIds = Array.from(
-    new Set((linearIntegrations ?? []).map((li) => li.integrationId))
-  );
-
-  const postToolsResult: PostToolsResult = {};
-  const postToolsConfig: PostToolsConfig = {
-    organizationId,
+  return runBackgroundGen({
+    organizationId: options.organizationId,
+    skillName: "changelog",
     contentType: "changelog",
-    sourceMetadata,
-    autoPublish,
-  };
-
-  const agent = new ToolLoopAgent({
-    model,
-    prepareStep: ({ messages }) => ({
-      messages: addAnthropicPromptCaching(messages, AGENT_DEFAULT_MODEL),
-    }),
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 4096 },
-      },
-    },
-    tools: {
-      getBrandReferences: createGetBrandReferencesTool({
-        organizationId,
-        voiceId,
-        agentType: "changelog",
-      }),
-      ...buildGitHubDataTools({
-        organizationId,
-        allowedIntegrationIds,
-        dataPointSettings,
-        selectionFilters,
-        commitWindow,
-        resolveContext,
-      }),
-      ...buildLinearDataTools({
-        organizationId,
-        allowedIntegrationIds: allowedLinearIntegrationIds,
-        dataPointSettings,
-        resolveContext: resolveLinearContext,
-      }),
-      listAvailableSkills: listAvailableSkills(),
-      getSkillByName: getSkillByName(),
-      createPost: createCreatePostTool(postToolsConfig, postToolsResult),
-      updatePost: createUpdatePostTool(postToolsConfig, postToolsResult),
-      viewPost: createViewPostTool(postToolsConfig),
-      fail: createFailTool(postToolsResult),
-    },
-    instructions,
-    stopWhen: stepCountIs(35),
+    brandAgentType: "changelog",
+    contentLabel: "changelog",
+    voiceId: options.voiceId,
+    repositories: options.repositories,
+    linearIntegrations: options.linearIntegrations,
+    promptInput: options.promptInput,
+    sourceMetadata: options.sourceMetadata,
+    dataPointSettings: options.dataPointSettings,
+    selectionFilters: options.selectionFilters,
+    commitWindow: options.commitWindow,
+    autoPublish: options.autoPublish,
+    resolveContext: options.resolveContext,
+    resolveLinearContext: options.resolveLinearContext,
+    log: options.log,
   });
-
-  const result = await agent.generate({ prompt });
-
-  if (postToolsResult.failReason) {
-    throw new Error(postToolsResult.failReason);
-  }
-
-  if (!postToolsResult.posts?.length) {
-    throw new Error(
-      "Changelog agent completed without creating a post. No createPost tool call was made."
-    );
-  }
-
-  const primaryPost = postToolsResult.posts[0];
-
-  if (!primaryPost) {
-    throw new Error("Changelog agent did not return a primary post.");
-  }
-
-  return {
-    postId: primaryPost.postId,
-    title: primaryPost.title,
-    posts: postToolsResult.posts,
-    usage: {
-      inputTokens: result.totalUsage.inputTokens ?? 0,
-      outputTokens: result.totalUsage.outputTokens ?? 0,
-      totalTokens: result.totalUsage.totalTokens ?? 0,
-      cacheReadTokens:
-        result.totalUsage.inputTokenDetails?.cacheReadTokens ?? 0,
-      cacheWriteTokens:
-        result.totalUsage.inputTokenDetails?.cacheWriteTokens ?? 0,
-      raw: result.totalUsage,
-    },
-  };
 }

--- a/packages/ai/src/agents/chat.ts
+++ b/packages/ai/src/agents/chat.ts
@@ -45,12 +45,23 @@ export async function createChatAgent(
       listAvailableSkills: listAvailableSkills({ organizationId }),
       getSkillByName: getSkillByName({ organizationId }),
     },
-    instructions: `You are a content editor assistant. Help users edit their markdown documents.${brandContext}
+    instructions: `You are a content editor assistant for a markdown document. You have two response modes depending on what the user asks.${brandContext}
 
-## Workflow
-1. Use getMarkdown to see the document with line numbers
-2. Call listAvailableSkills. If any skill looks relevant to the user's request (for example, a "humanizer" skill when the user wants more natural writing, or an org-specific skill whose description matches the task), call getSkillByName to load it and follow its guidance before editing.
-3. Use editMarkdown to apply changes (work from bottom to top)
+## Skills are first-class
+This organization has writing skills stored in a database (examples: a "humanizer" skill for removing AI-sounding text, plus content-type skills and any custom skills the user created). You do NOT know them ahead of time — you MUST call listAvailableSkills to discover what exists. NEVER make up skill names or claim to have skills you haven't verified via the tool.
+
+## Mode A — Information queries (no edit needed)
+Triggers: "what skills do you have", "what can you do", "list your skills", "describe skill X", "is there a skill for Y", etc.
+
+1. Call listAvailableSkills. Use the returned name + description for every skill in your answer. If the user asks about a specific skill, also call getSkillByName to load it and summarize its guidance.
+2. Respond in plain text with the accurate list. Do not edit the document.
+
+## Mode B — Edit requests
+Triggers: the user wants the document changed (rewrite, shorten, tone change, cleanup, etc.).
+
+1. Call getMarkdown to see the document with line numbers.
+2. Call listAvailableSkills. If any skill matches what the user asked (e.g. "humanizer" for making writing more natural, or a tone/domain skill whose description fits), call getSkillByName to load it and follow its guidance while editing. When in doubt, load the skill — don't skip.
+3. Call editMarkdown to apply changes (work from bottom to top).
 
 ## Edit Operations
 - replaceLine: { op: "replaceLine", line: number, content: string }

--- a/packages/ai/src/agents/chat.ts
+++ b/packages/ai/src/agents/chat.ts
@@ -42,8 +42,8 @@ export async function createChatAgent(
     tools: {
       getMarkdown,
       editMarkdown,
-      listAvailableSkills: listAvailableSkills(),
-      getSkillByName: getSkillByName(),
+      listAvailableSkills: listAvailableSkills({ organizationId }),
+      getSkillByName: getSkillByName({ organizationId }),
     },
     instructions: `You are a content editor assistant. Help users edit their markdown documents.${brandContext}
 

--- a/packages/ai/src/agents/chat.ts
+++ b/packages/ai/src/agents/chat.ts
@@ -49,7 +49,8 @@ export async function createChatAgent(
 
 ## Workflow
 1. Use getMarkdown to see the document with line numbers
-2. Use editMarkdown to apply changes (work from bottom to top)
+2. Call listAvailableSkills. If any skill looks relevant to the user's request (for example, a "humanizer" skill when the user wants more natural writing, or an org-specific skill whose description matches the task), call getSkillByName to load it and follow its guidance before editing.
+3. Use editMarkdown to apply changes (work from bottom to top)
 
 ## Edit Operations
 - replaceLine: { op: "replaceLine", line: number, content: string }

--- a/packages/ai/src/agents/linkedin.ts
+++ b/packages/ai/src/agents/linkedin.ts
@@ -1,170 +1,29 @@
-import { AGENT_DEFAULT_MODEL } from "@notra/ai/constants/models";
-import { createModel } from "@notra/ai/model";
-import { getCasualLinkedInPrompt } from "@notra/ai/prompts/linkedin/casual";
-import { getConversationalLinkedInPrompt } from "@notra/ai/prompts/linkedin/conversational";
-import { getFormalLinkedInPrompt } from "@notra/ai/prompts/linkedin/formal";
-import { getProfessionalLinkedInPrompt } from "@notra/ai/prompts/linkedin/professional";
-import { getUserPrompt } from "@notra/ai/prompts/user";
-import { getValidToneProfile, type ToneProfile } from "@notra/ai/schemas/brand";
-import { createGetBrandReferencesTool } from "@notra/ai/tools/brand-references";
-import { buildGitHubDataTools } from "@notra/ai/tools/github";
-import { buildLinearDataTools } from "@notra/ai/tools/linear";
-import {
-  createCreatePostTool,
-  createFailTool,
-  createUpdatePostTool,
-  createViewPostTool,
-} from "@notra/ai/tools/post";
-import { getSkillByName, listAvailableSkills } from "@notra/ai/tools/skills";
+import { runBackgroundGen } from "@notra/ai/agents/background-gen";
 import type {
   LinkedInAgentOptions,
   LinkedInAgentResult,
 } from "@notra/ai/types/agents";
-import type {
-  PostToolsConfig,
-  PostToolsResult,
-} from "@notra/ai/types/post-tools";
-import { addAnthropicPromptCaching } from "@notra/ai/utils/prompt-caching";
-import { stepCountIs, ToolLoopAgent } from "ai";
-
-const linkedInPromptByTone: Record<ToneProfile, () => string> = {
-  Conversational: getConversationalLinkedInPrompt,
-  Professional: getProfessionalLinkedInPrompt,
-  Casual: getCasualLinkedInPrompt,
-  Formal: getFormalLinkedInPrompt,
-};
 
 export async function generateLinkedInPost(
   options: LinkedInAgentOptions
 ): Promise<LinkedInAgentResult> {
-  const {
-    organizationId,
-    voiceId,
-    repositories,
-    linearIntegrations,
-    tone = "Conversational",
-    promptInput,
-    sourceMetadata,
-    dataPointSettings,
-    selectionFilters,
-    commitWindow,
-    autoPublish,
-    resolveContext,
-    resolveLinearContext,
-    log,
-  } = options;
-
-  if (
-    (!repositories || repositories.length === 0) &&
-    (!linearIntegrations || linearIntegrations.length === 0)
-  ) {
-    throw new Error(
-      "At least one repository or Linear integration must be provided to generate a LinkedIn post."
-    );
-  }
-
-  const model = createModel(
-    organizationId,
-    AGENT_DEFAULT_MODEL,
-    undefined,
-    log
-  );
-
-  const resolvedTone = getValidToneProfile(tone, "Conversational");
-
-  const promptFactory =
-    linkedInPromptByTone[resolvedTone] ?? linkedInPromptByTone.Conversational;
-  const instructions = promptFactory();
-  const prompt = getUserPrompt("LinkedIn post", promptInput);
-
-  const allowedIntegrationIds = Array.from(
-    new Set((repositories ?? []).map((repo) => repo.integrationId))
-  );
-
-  const allowedLinearIntegrationIds = Array.from(
-    new Set((linearIntegrations ?? []).map((li) => li.integrationId))
-  );
-
-  const postToolsResult: PostToolsResult = {};
-  const postToolsConfig: PostToolsConfig = {
-    organizationId,
+  return runBackgroundGen({
+    organizationId: options.organizationId,
+    skillName: "linkedin",
     contentType: "linkedin_post",
-    sourceMetadata,
-    autoPublish,
-  };
-
-  const agent = new ToolLoopAgent({
-    model,
-    prepareStep: ({ messages }) => ({
-      messages: addAnthropicPromptCaching(messages, AGENT_DEFAULT_MODEL),
-    }),
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 4096 },
-      },
-    },
-    tools: {
-      getBrandReferences: createGetBrandReferencesTool({
-        organizationId,
-        voiceId,
-        agentType: "linkedin",
-      }),
-      ...buildGitHubDataTools({
-        organizationId,
-        allowedIntegrationIds,
-        dataPointSettings,
-        selectionFilters,
-        commitWindow,
-        resolveContext,
-      }),
-      ...buildLinearDataTools({
-        organizationId,
-        allowedIntegrationIds: allowedLinearIntegrationIds,
-        dataPointSettings,
-        resolveContext: resolveLinearContext,
-      }),
-      listAvailableSkills: listAvailableSkills(),
-      getSkillByName: getSkillByName(),
-      createPost: createCreatePostTool(postToolsConfig, postToolsResult),
-      updatePost: createUpdatePostTool(postToolsConfig, postToolsResult),
-      viewPost: createViewPostTool(postToolsConfig),
-      fail: createFailTool(postToolsResult),
-    },
-    instructions,
-    stopWhen: stepCountIs(35),
+    brandAgentType: "linkedin",
+    contentLabel: "LinkedIn post",
+    voiceId: options.voiceId,
+    repositories: options.repositories,
+    linearIntegrations: options.linearIntegrations,
+    promptInput: options.promptInput,
+    sourceMetadata: options.sourceMetadata,
+    dataPointSettings: options.dataPointSettings,
+    selectionFilters: options.selectionFilters,
+    commitWindow: options.commitWindow,
+    autoPublish: options.autoPublish,
+    resolveContext: options.resolveContext,
+    resolveLinearContext: options.resolveLinearContext,
+    log: options.log,
   });
-
-  const result = await agent.generate({ prompt });
-
-  if (postToolsResult.failReason) {
-    throw new Error(postToolsResult.failReason);
-  }
-
-  if (!postToolsResult.posts?.length) {
-    throw new Error(
-      "LinkedIn agent completed without creating a post. No createPost tool call was made."
-    );
-  }
-
-  const primaryPost = postToolsResult.posts[0];
-
-  if (!primaryPost) {
-    throw new Error("LinkedIn agent did not return a primary post.");
-  }
-
-  return {
-    postId: primaryPost.postId,
-    title: primaryPost.title,
-    posts: postToolsResult.posts,
-    usage: {
-      inputTokens: result.totalUsage.inputTokens ?? 0,
-      outputTokens: result.totalUsage.outputTokens ?? 0,
-      totalTokens: result.totalUsage.totalTokens ?? 0,
-      cacheReadTokens:
-        result.totalUsage.inputTokenDetails?.cacheReadTokens ?? 0,
-      cacheWriteTokens:
-        result.totalUsage.inputTokenDetails?.cacheWriteTokens ?? 0,
-      raw: result.totalUsage,
-    },
-  };
 }

--- a/packages/ai/src/agents/twitter.ts
+++ b/packages/ai/src/agents/twitter.ts
@@ -1,178 +1,30 @@
-import { AGENT_DEFAULT_MODEL } from "@notra/ai/constants/models";
-import { createModel } from "@notra/ai/model";
-import { getCasualTwitterPrompt } from "@notra/ai/prompts/twitter/casual";
-import { getConversationalTwitterPrompt } from "@notra/ai/prompts/twitter/conversational";
-import { getFormalTwitterPrompt } from "@notra/ai/prompts/twitter/formal";
-import { getProfessionalTwitterPrompt } from "@notra/ai/prompts/twitter/professional";
-import { getUserPrompt } from "@notra/ai/prompts/user";
-import { getValidToneProfile, type ToneProfile } from "@notra/ai/schemas/brand";
-import {
-  createGetBrandReferencesTool,
-  createSearchBrandReferencesTool,
-} from "@notra/ai/tools/brand-references";
-import { buildGitHubDataTools } from "@notra/ai/tools/github";
-import { buildLinearDataTools } from "@notra/ai/tools/linear";
-import {
-  createCreatePostTool,
-  createFailTool,
-  createUpdatePostTool,
-  createViewPostTool,
-} from "@notra/ai/tools/post";
-import { getSkillByName, listAvailableSkills } from "@notra/ai/tools/skills";
+import { runBackgroundGen } from "@notra/ai/agents/background-gen";
 import type {
   TwitterAgentOptions,
   TwitterAgentResult,
 } from "@notra/ai/types/agents";
-import type {
-  PostToolsConfig,
-  PostToolsResult,
-} from "@notra/ai/types/post-tools";
-import { addAnthropicPromptCaching } from "@notra/ai/utils/prompt-caching";
-import { stepCountIs, ToolLoopAgent } from "ai";
-
-const twitterPromptByTone: Record<ToneProfile, () => string> = {
-  Conversational: getConversationalTwitterPrompt,
-  Professional: getProfessionalTwitterPrompt,
-  Casual: getCasualTwitterPrompt,
-  Formal: getFormalTwitterPrompt,
-};
 
 export async function generateTwitterPost(
   options: TwitterAgentOptions
 ): Promise<TwitterAgentResult> {
-  const {
-    organizationId,
-    voiceId,
-    repositories,
-    linearIntegrations,
-    tone = "Conversational",
-    promptInput,
-    sourceMetadata,
-    dataPointSettings,
-    selectionFilters,
-    commitWindow,
-    autoPublish,
-    resolveContext,
-    resolveLinearContext,
-    log,
-  } = options;
-
-  if (
-    (!repositories || repositories.length === 0) &&
-    (!linearIntegrations || linearIntegrations.length === 0)
-  ) {
-    throw new Error(
-      "At least one repository or Linear integration must be provided to generate a Twitter post."
-    );
-  }
-
-  const model = createModel(
-    organizationId,
-    AGENT_DEFAULT_MODEL,
-    undefined,
-    log
-  );
-
-  const resolvedTone = getValidToneProfile(tone, "Conversational");
-
-  const promptFactory =
-    twitterPromptByTone[resolvedTone] ?? twitterPromptByTone.Conversational;
-  const instructions = promptFactory();
-  const prompt = getUserPrompt("tweet", promptInput);
-
-  const allowedIntegrationIds = Array.from(
-    new Set((repositories ?? []).map((repo) => repo.integrationId))
-  );
-
-  const allowedLinearIntegrationIds = Array.from(
-    new Set((linearIntegrations ?? []).map((li) => li.integrationId))
-  );
-
-  const postToolsResult: PostToolsResult = {};
-  const postToolsConfig: PostToolsConfig = {
-    organizationId,
+  return runBackgroundGen({
+    organizationId: options.organizationId,
+    skillName: "twitter",
     contentType: "twitter_post",
-    sourceMetadata,
-    autoPublish,
-  };
-
-  const agent = new ToolLoopAgent({
-    model,
-    prepareStep: ({ messages }) => ({
-      messages: addAnthropicPromptCaching(messages, AGENT_DEFAULT_MODEL),
-    }),
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 4096 },
-      },
-    },
-    tools: {
-      searchBrandReferences: createSearchBrandReferencesTool({
-        organizationId,
-        voiceId,
-        agentType: "twitter",
-      }),
-      getBrandReferences: createGetBrandReferencesTool({
-        organizationId,
-        voiceId,
-        agentType: "twitter",
-      }),
-      ...buildGitHubDataTools({
-        organizationId,
-        allowedIntegrationIds,
-        dataPointSettings,
-        selectionFilters,
-        commitWindow,
-        resolveContext,
-      }),
-      ...buildLinearDataTools({
-        organizationId,
-        allowedIntegrationIds: allowedLinearIntegrationIds,
-        dataPointSettings,
-        resolveContext: resolveLinearContext,
-      }),
-      listAvailableSkills: listAvailableSkills(),
-      getSkillByName: getSkillByName(),
-      createPost: createCreatePostTool(postToolsConfig, postToolsResult),
-      updatePost: createUpdatePostTool(postToolsConfig, postToolsResult),
-      viewPost: createViewPostTool(postToolsConfig),
-      fail: createFailTool(postToolsResult),
-    },
-    instructions,
-    stopWhen: stepCountIs(35),
+    brandAgentType: "twitter",
+    contentLabel: "tweet",
+    voiceId: options.voiceId,
+    repositories: options.repositories,
+    linearIntegrations: options.linearIntegrations,
+    promptInput: options.promptInput,
+    sourceMetadata: options.sourceMetadata,
+    dataPointSettings: options.dataPointSettings,
+    selectionFilters: options.selectionFilters,
+    commitWindow: options.commitWindow,
+    autoPublish: options.autoPublish,
+    resolveContext: options.resolveContext,
+    resolveLinearContext: options.resolveLinearContext,
+    log: options.log,
+    includeSearchBrandReferencesTool: true,
   });
-
-  const result = await agent.generate({ prompt });
-
-  if (postToolsResult.failReason) {
-    throw new Error(postToolsResult.failReason);
-  }
-
-  if (!postToolsResult.posts?.length) {
-    throw new Error(
-      "Twitter agent completed without creating a post. No createPost tool call was made."
-    );
-  }
-
-  const primaryPost = postToolsResult.posts[0];
-
-  if (!primaryPost) {
-    throw new Error("Twitter agent did not return a primary post.");
-  }
-
-  return {
-    postId: primaryPost.postId,
-    title: primaryPost.title,
-    posts: postToolsResult.posts,
-    usage: {
-      inputTokens: result.totalUsage.inputTokens ?? 0,
-      outputTokens: result.totalUsage.outputTokens ?? 0,
-      totalTokens: result.totalUsage.totalTokens ?? 0,
-      cacheReadTokens:
-        result.totalUsage.inputTokenDetails?.cacheReadTokens ?? 0,
-      cacheWriteTokens:
-        result.totalUsage.inputTokenDetails?.cacheWriteTokens ?? 0,
-      raw: result.totalUsage,
-    },
-  };
 }

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { createModel } from "@notra/ai/model";
 import { getStandaloneChatPrompt } from "@notra/ai/prompts/standalone-chat";
 import {
@@ -38,7 +40,27 @@ import {
 
 const TRIVIAL_HISTORY_LIMIT = 6;
 const MINIMAL_STANDALONE_PROMPT =
-  "You are Notra, an AI assistant for content teams. Reply briefly and warmly. If the user asks what you can do, mention: creating and editing posts (changelogs, blog posts, Twitter, LinkedIn, investor updates), viewing brand identities, and reviewing GitHub/Linear activity. Do not call tools on this turn.";
+  "You are Notra, an AI assistant for content teams. Reply briefly and warmly. Do not call tools on this turn.";
+
+const CHAT_DEBUG_LOG_PATH = path.join(process.cwd(), ".chat-debug.log");
+
+function debugLogChatPrompt(entry: {
+  organizationId: string;
+  routingDecision: unknown;
+  systemPrompt: string;
+  modelMessages: unknown;
+  toolNames: string[];
+}): void {
+  try {
+    const line = `${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      ...entry,
+    })}\n`;
+    fs.appendFile(CHAT_DEBUG_LOG_PATH, line, () => undefined);
+  } catch {
+    // Best-effort debug log; never let logging break chat.
+  }
+}
 
 export async function orchestrateStandaloneChat(
   input: StandaloneChatInput,
@@ -70,6 +92,7 @@ export async function orchestrateStandaloneChat(
 
   const lastUserMessage = getLastUserMessage(messages);
   const isTrivial = isTrivialMessage(lastUserMessage);
+  const mentionsSkills = /\bskills?\b/i.test(lastUserMessage);
   const isAuto = requestedModel === undefined || requestedModel === "auto";
 
   let selectedModel: string;
@@ -97,6 +120,11 @@ export async function orchestrateStandaloneChat(
     decisionReasoning = isTrivial
       ? "Trivial greeting/acknowledgement — minimal prompt, no tools, no thinking"
       : "User selected model explicitly";
+  }
+
+  if (mentionsSkills && !decisionRequiresTools) {
+    decisionRequiresTools = true;
+    decisionReasoning = `${decisionReasoning} (forced tools: message mentions skills)`;
   }
 
   const routingDecision = {
@@ -163,13 +191,23 @@ export async function orchestrateStandaloneChat(
     ? trimTrivialHistory(messages)
     : messages;
 
+  const modelMessages = await convertToModelMessages(messagesForModel, {
+    ignoreIncompleteToolCalls: true,
+  });
+
+  debugLogChatPrompt({
+    organizationId,
+    routingDecision,
+    systemPrompt,
+    modelMessages,
+    toolNames: Object.keys(tools ?? {}),
+  });
+
   let firstChunkFired = false;
   const stream = streamText({
     model: modelWithMemory,
     system: systemPrompt,
-    messages: await convertToModelMessages(messagesForModel, {
-      ignoreIncompleteToolCalls: true,
-    }),
+    messages: modelMessages,
     tools,
     stopWhen: stepCountIs(isSimpleNoTools ? 1 : maxSteps),
     experimental_transform: smoothStream(),

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -38,6 +38,8 @@ import {
   getRepoContextFromIntegrations,
 } from "./standalone-tool-registry";
 
+const SKILLS_MENTION_REGEX = /\bskills?\b/i;
+
 const TRIVIAL_HISTORY_LIMIT = 6;
 const MINIMAL_STANDALONE_PROMPT =
   "You are Notra, an AI assistant for content teams. Reply briefly and warmly. Do not call tools on this turn.";
@@ -92,7 +94,7 @@ export async function orchestrateStandaloneChat(
 
   const lastUserMessage = getLastUserMessage(messages);
   const isTrivial = isTrivialMessage(lastUserMessage);
-  const mentionsSkills = /\bskills?\b/i.test(lastUserMessage);
+  const mentionsSkills = SKILLS_MENTION_REGEX.test(lastUserMessage);
   const isAuto = requestedModel === undefined || requestedModel === "auto";
 
   let selectedModel: string;

--- a/packages/ai/src/orchestration/standalone-tool-registry.ts
+++ b/packages/ai/src/orchestration/standalone-tool-registry.ts
@@ -94,8 +94,8 @@ export function buildStandaloneToolSet(
     "**Organization Data**: Inspect brand identities, brand references, available integrations, and existing posts using listBrandIdentities, getBrandIdentity, getAvailableBrandReferences, getAvailableIntegrations, getAvailablePosts, and getPostById"
   );
 
-  tools.listAvailableSkills = listAvailableSkills();
-  tools.getSkillByName = getSkillByName();
+  tools.listAvailableSkills = listAvailableSkills({ organizationId });
+  tools.getSkillByName = getSkillByName({ organizationId });
   descriptions.push(
     "**Skills**: Access knowledge and writing guidelines using listAvailableSkills and getSkillByName"
   );

--- a/packages/ai/src/orchestration/tool-registry.ts
+++ b/packages/ai/src/orchestration/tool-registry.ts
@@ -56,8 +56,8 @@ export function buildToolSet(
   const tools: Record<string, Tool> = {
     getMarkdown,
     editMarkdown,
-    listAvailableSkills: listAvailableSkills(),
-    getSkillByName: getSkillByName(),
+    listAvailableSkills: listAvailableSkills({ organizationId }),
+    getSkillByName: getSkillByName({ organizationId }),
   };
 
   const descriptions: string[] = [

--- a/packages/ai/src/prompts/standalone-chat.ts
+++ b/packages/ai/src/prompts/standalone-chat.ts
@@ -35,6 +35,11 @@ export function getStandaloneChatPrompt(params: StandaloneChatPromptParams) {
     ## Current Date
     Today is ${currentDate} (${resolvedTimezone}). Use this when users reference relative dates like "today", "yesterday", "this week", or "last month".
 
+    ## Skills
+    Skills are reusable writing instructions stored in this organization's database (for example a "humanizer" skill, plus content-type skills and any custom skills the user created). You do NOT know them ahead of time. NEVER invent skill names or claim skills you have not verified.
+    - When asked what skills are available, what skills you have, or to describe a skill, call listAvailableSkills and answer using the returned names and descriptions. For a specific skill, also call getSkillByName for its full guidance.
+    - Before creating or editing content, call listAvailableSkills and load any skill whose description matches the user's request (tone, format, domain). Apply its guidance.
+
     ## Workflow
     - When asked to create content, use the matching create tool for the requested format: createChangelog, createBlogPost, createTwitterPost, createLinkedInPost, or createInvestorUpdate.
     - When asked to update existing content, use the updatePost tool with the postId.

--- a/packages/ai/src/tools/skills.ts
+++ b/packages/ai/src/tools/skills.ts
@@ -8,36 +8,6 @@ export interface SkillsToolContext {
   organizationId: string;
 }
 
-export interface SkillRecord {
-  name: string;
-  description: string;
-  content: string;
-}
-
-export function formatSkillAsDocument(skill: SkillRecord): string {
-  return `---
-name: ${skill.name}
-description: ${escapeFrontmatterValue(skill.description)}
----
-
-${skill.content.trim()}`;
-}
-
-function escapeFrontmatterValue(value: string): string {
-  const hasNewline = value.includes("\n");
-  const hasQuote = value.includes('"');
-
-  if (!(hasNewline || hasQuote)) {
-    return value;
-  }
-
-  const indented = value
-    .split("\n")
-    .map((line) => `  ${line}`)
-    .join("\n");
-  return `|\n${indented}`;
-}
-
 export function listAvailableSkills(ctx: SkillsToolContext): Tool {
   return tool({
     description:
@@ -82,7 +52,7 @@ export function listAvailableSkills(ctx: SkillsToolContext): Tool {
 export function getSkillByName(ctx: SkillsToolContext): Tool {
   return tool({
     description:
-      "Load a skill's full content by name. Returns a markdown document with YAML frontmatter (name, description) followed by the skill body. Call listAvailableSkills first to discover available names.",
+      "Load a skill's full content by name. Returns name, description, and the skill body. Call listAvailableSkills first to discover available names.",
     inputSchema: z.object({
       name: z.string().describe("The name of the skill to load."),
     }),
@@ -103,11 +73,7 @@ export function getSkillByName(ctx: SkillsToolContext): Tool {
       return {
         name: row.name,
         description: row.description,
-        document: formatSkillAsDocument({
-          name: row.name,
-          description: row.description,
-          content: row.content,
-        }),
+        content: row.content.trim(),
       };
     },
   });

--- a/packages/ai/src/tools/skills.ts
+++ b/packages/ai/src/tools/skills.ts
@@ -1,162 +1,74 @@
-import fs from "node:fs";
-import path from "node:path";
-import type { Skill, SkillMetadata } from "@notra/ai/types/tools";
+import { db } from "@notra/db/drizzle";
+import { skills } from "@notra/db/schema";
 import { type Tool, tool } from "ai";
-import matter from "gray-matter";
+import { and, eq } from "drizzle-orm";
 import z from "zod";
 
-function parseSkillFrontmatter(content: string): Partial<SkillMetadata> {
-  const parsed = matter(content);
-  return {
-    name: parsed.data.name,
-    version: parsed.data.version,
-    description: parsed.data.description,
-    "allowed-tools": parsed.data["allowed-tools"],
-  };
+export interface SkillsToolContext {
+  organizationId: string;
 }
 
-function getSkillMetadata(
-  skillFolder: string,
-  skillsDir: string
-): SkillMetadata {
-  const skillPath = path.join(skillsDir, skillFolder);
-  const skillMdPath = path.join(skillPath, "SKILL.md");
-
-  if (!fs.existsSync(skillMdPath)) {
-    return { name: skillFolder, folder: skillFolder, filename: "SKILL.md" };
-  }
-
-  const content = fs.readFileSync(skillMdPath, "utf-8");
-  const metadata = parseSkillFrontmatter(content);
-
-  return {
-    name: metadata.name || skillFolder,
-    version: metadata.version,
-    description: metadata.description,
-    "allowed-tools": metadata["allowed-tools"],
-    folder: skillFolder,
-    filename: "SKILL.md",
-  };
-}
-
-export function listAvailableSkills(): Tool {
+export function listAvailableSkills(ctx: SkillsToolContext): Tool {
   return tool({
     description:
-      "List available writing skills. Returns name, version, description, and folder for each. Call getSkillByName to load a skill's full content.",
+      "List available writing skills for this organization. Returns name and description for each. Call getSkillByName to load a skill's full content.",
     inputSchema: z.object({
-      limit: z.number().default(10).describe("The number of skills to list"),
+      limit: z.number().default(20).describe("The number of skills to list"),
       offset: z
         .number()
         .default(0)
         .describe("The offset to start listing skills from"),
     }),
     execute: async ({ limit, offset }) => {
-      const skillsDir = getSkillsDir();
-      const skillFolders = fs
-        .readdirSync(skillsDir, { withFileTypes: true })
-        .filter((dirent) => dirent.isDirectory())
-        .map((dirent) => dirent.name);
-
-      const skills = skillFolders
-        .slice(offset, offset + limit)
-        .map((folder) => getSkillMetadata(folder, skillsDir));
+      const rows = await db
+        .select({
+          name: skills.name,
+          description: skills.description,
+          isSystem: skills.isSystem,
+        })
+        .from(skills)
+        .where(eq(skills.organizationId, ctx.organizationId))
+        .limit(limit)
+        .offset(offset);
 
       return {
-        skills,
-        total: skillFolders.length,
+        skills: rows.map((row) => ({
+          name: row.name,
+          description: row.description,
+          isSystem: row.isSystem,
+        })),
+        total: rows.length,
       };
     },
   });
 }
 
-function getSkillsDir(): string {
-  const candidates = [
-    path.join(process.cwd(), "src", "lib", "ai", "skills"),
-    path.join(process.cwd(), "packages", "ai", "src", "skills"),
-    path.join(process.cwd(), "..", "..", "packages", "ai", "src", "skills"),
-  ];
-
-  const skillsDir = candidates.find((candidate) => fs.existsSync(candidate));
-
-  if (!skillsDir) {
-    throw new Error(
-      `Skills directory not found. Checked: ${candidates.join(", ")}`
-    );
-  }
-
-  return skillsDir;
-}
-
-export function getSkillByName(): Tool {
+export function getSkillByName(ctx: SkillsToolContext): Tool {
   return tool({
     description:
-      "Load a skill's full content by name or folder. Call listAvailableSkills first to discover available names.",
+      "Load a skill's full content by name. Call listAvailableSkills first to discover available names.",
     inputSchema: z.object({
-      name: z
-        .string()
-        .describe(
-          "The name of the skill to get. Can be the skill's name from frontmatter or the folder name."
-        ),
+      name: z.string().describe("The name of the skill to load."),
     }),
     execute: async ({ name }) => {
-      const skillsDir = getSkillsDir();
-      const skillFolders = fs
-        .readdirSync(skillsDir, { withFileTypes: true })
-        .filter((dirent) => dirent.isDirectory())
-        .map((dirent) => dirent.name);
+      const row = await db.query.skills.findFirst({
+        where: and(
+          eq(skills.organizationId, ctx.organizationId),
+          eq(skills.name, name)
+        ),
+      });
 
-      let skillFolder: string | undefined;
-
-      for (const folder of skillFolders) {
-        const skillPath = path.join(skillsDir, folder);
-        const skillMdPath = path.join(skillPath, "SKILL.md");
-
-        if (fs.existsSync(skillMdPath)) {
-          const content = fs.readFileSync(skillMdPath, "utf-8");
-          const parsed = matter(content);
-          const skillName = parsed.data.name;
-
-          if (
-            folder.toLowerCase() === name.toLowerCase() ||
-            skillName?.toLowerCase() === name.toLowerCase()
-          ) {
-            skillFolder = folder;
-            break;
-          }
-        } else if (folder.toLowerCase() === name.toLowerCase()) {
-          skillFolder = folder;
-          break;
-        }
-      }
-
-      if (!skillFolder) {
+      if (!row) {
         return {
-          error: `Skill "${name}" not found. Use list_available_skills to see all available skills.`,
+          error: `Skill "${name}" not found. Use listAvailableSkills to see available skills.`,
         };
       }
-
-      const skillPath = path.join(skillsDir, skillFolder);
-      const skillMdPath = path.join(skillPath, "SKILL.md");
-
-      if (!fs.existsSync(skillMdPath)) {
-        return {
-          error: `Skill file not found for "${skillFolder}".`,
-        };
-      }
-
-      const content = fs.readFileSync(skillMdPath, "utf-8");
-      const parsed = matter(content);
-      const metadata = parseSkillFrontmatter(content);
 
       return {
-        name: metadata.name || skillFolder,
-        version: metadata.version,
-        description: metadata.description,
-        "allowed-tools": metadata["allowed-tools"],
-        folder: skillFolder,
-        filename: "SKILL.md",
-        content: parsed.content,
-      } satisfies Skill;
+        name: row.name,
+        description: row.description,
+        content: row.content,
+      };
     },
   });
 }

--- a/packages/ai/src/tools/skills.ts
+++ b/packages/ai/src/tools/skills.ts
@@ -8,6 +8,36 @@ export interface SkillsToolContext {
   organizationId: string;
 }
 
+export interface SkillRecord {
+  name: string;
+  description: string;
+  content: string;
+}
+
+export function formatSkillAsDocument(skill: SkillRecord): string {
+  return `---
+name: ${skill.name}
+description: ${escapeFrontmatterValue(skill.description)}
+---
+
+${skill.content.trim()}`;
+}
+
+function escapeFrontmatterValue(value: string): string {
+  const hasNewline = value.includes("\n");
+  const hasQuote = value.includes('"');
+
+  if (!(hasNewline || hasQuote)) {
+    return value;
+  }
+
+  const indented = value
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n");
+  return `|\n${indented}`;
+}
+
 export function listAvailableSkills(ctx: SkillsToolContext): Tool {
   return tool({
     description:
@@ -46,7 +76,7 @@ export function listAvailableSkills(ctx: SkillsToolContext): Tool {
 export function getSkillByName(ctx: SkillsToolContext): Tool {
   return tool({
     description:
-      "Load a skill's full content by name. Call listAvailableSkills first to discover available names.",
+      "Load a skill's full content by name. Returns a markdown document with YAML frontmatter (name, description) followed by the skill body. Call listAvailableSkills first to discover available names.",
     inputSchema: z.object({
       name: z.string().describe("The name of the skill to load."),
     }),
@@ -67,7 +97,11 @@ export function getSkillByName(ctx: SkillsToolContext): Tool {
       return {
         name: row.name,
         description: row.description,
-        content: row.content,
+        document: formatSkillAsDocument({
+          name: row.name,
+          description: row.description,
+          content: row.content,
+        }),
       };
     },
   });

--- a/packages/ai/src/tools/skills.ts
+++ b/packages/ai/src/tools/skills.ts
@@ -1,7 +1,7 @@
 import { db } from "@notra/db/drizzle";
 import { skills } from "@notra/db/schema";
 import { type Tool, tool } from "ai";
-import { and, eq } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 import z from "zod";
 
 export interface SkillsToolContext {
@@ -50,16 +50,22 @@ export function listAvailableSkills(ctx: SkillsToolContext): Tool {
         .describe("The offset to start listing skills from"),
     }),
     execute: async ({ limit, offset }) => {
-      const rows = await db
-        .select({
-          name: skills.name,
-          description: skills.description,
-          isSystem: skills.isSystem,
-        })
-        .from(skills)
-        .where(eq(skills.organizationId, ctx.organizationId))
-        .limit(limit)
-        .offset(offset);
+      const [rows, totalResult] = await Promise.all([
+        db
+          .select({
+            name: skills.name,
+            description: skills.description,
+            isSystem: skills.isSystem,
+          })
+          .from(skills)
+          .where(eq(skills.organizationId, ctx.organizationId))
+          .limit(limit)
+          .offset(offset),
+        db
+          .select({ total: count() })
+          .from(skills)
+          .where(eq(skills.organizationId, ctx.organizationId)),
+      ]);
 
       return {
         skills: rows.map((row) => ({
@@ -67,7 +73,7 @@ export function listAvailableSkills(ctx: SkillsToolContext): Tool {
           description: row.description,
           isSystem: row.isSystem,
         })),
-        total: rows.length,
+        total: totalResult[0]?.total ?? 0,
       };
     },
   });

--- a/packages/db/migrations/0029_groovy_harry_osborn.sql
+++ b/packages/db/migrations/0029_groovy_harry_osborn.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "skills" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"content" text NOT NULL,
+	"allowed_tools" jsonb NOT NULL,
+	"is_system" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "skills" ADD CONSTRAINT "skills_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "skills_organizationId_idx" ON "skills" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "skills_org_name_uidx" ON "skills" USING btree ("organization_id","name");

--- a/packages/db/migrations/0029_spicy_network.sql
+++ b/packages/db/migrations/0029_spicy_network.sql
@@ -4,7 +4,6 @@ CREATE TABLE "skills" (
 	"name" text NOT NULL,
 	"description" text NOT NULL,
 	"content" text NOT NULL,
-	"allowed_tools" jsonb NOT NULL,
 	"is_system" boolean DEFAULT false NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL

--- a/packages/db/migrations/meta/0029_snapshot.json
+++ b/packages/db/migrations/meta/0029_snapshot.json
@@ -1,0 +1,2267 @@
+{
+  "id": "8fb59cf9-e393-44e4-8627-1fa7c8c95fc9",
+  "prevId": "5d69b3db-185d-4a5e-a142-a1238561b050",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_references": {
+      "name": "brand_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_document_id": {
+          "name": "supermemory_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_memory_id": {
+          "name": "supermemory_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_synced_at": {
+          "name": "supermemory_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_last_sync_error": {
+          "name": "supermemory_last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to": {
+          "name": "applicable_to",
+          "type": "applicable_platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['all']::applicable_platform[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandReferences_brandSettingsId_idx": {
+          "name": "brandReferences_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_references_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_references_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_references",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_settings": {
+      "name": "brand_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_description": {
+          "name": "company_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone_profile": {
+          "name": "tone_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_tone": {
+          "name": "custom_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'English'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSettings_org_name_uidx": {
+          "name": "brandSettings_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_org_default_uidx": {
+          "name": "brandSettings_org_default_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brand_settings\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_organizationId_idx": {
+          "name": "brandSettings_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_settings_organization_id_organizations_id_fk": {
+          "name": "brand_settings_organization_id_organizations_id_fk",
+          "tableFrom": "brand_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_social_accounts": {
+      "name": "connected_social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectedSocialAccounts_organizationId_idx": {
+          "name": "connectedSocialAccounts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connectedSocialAccounts_org_provider_account_uidx": {
+          "name": "connectedSocialAccounts_org_provider_account_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connected_social_accounts_organization_id_organizations_id_fk": {
+          "name": "connected_social_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "connected_social_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_trigger_lookback_windows": {
+      "name": "content_trigger_lookback_windows",
+      "schema": "",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "lookback_window",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk": {
+          "name": "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk",
+          "tableFrom": "content_trigger_lookback_windows",
+          "tableTo": "content_triggers",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_triggers": {
+      "name": "content_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Schedule'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_config": {
+          "name": "output_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_hash": {
+          "name": "dedupe_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_publish": {
+          "name": "auto_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentTriggers_organizationId_idx": {
+          "name": "contentTriggers_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contentTriggers_organization_dedupe_uidx": {
+          "name": "contentTriggers_organization_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_triggers_organization_id_organizations_id_fk": {
+          "name": "content_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "content_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_enabled": {
+          "name": "repository_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubIntegrations_organizationId_idx": {
+          "name": "githubIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_createdByUserId_idx": {
+          "name": "githubIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_organization_owner_repo_uidx": {
+          "name": "githubIntegrations_organization_owner_repo_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_organization_id_organizations_id_fk": {
+          "name": "github_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_created_by_user_id_users_id_fk": {
+          "name": "github_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitations_organizationId_idx": {
+          "name": "invitations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_integrations": {
+      "name": "linear_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_id": {
+          "name": "linear_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_name": {
+          "name": "linear_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linearIntegrations_organizationId_idx": {
+          "name": "linearIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_createdByUserId_idx": {
+          "name": "linearIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_no_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_no_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"linear_integrations\".\"linear_team_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_integrations_organization_id_organizations_id_fk": {
+          "name": "linear_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_integrations_created_by_user_id_users_id_fk": {
+          "name": "linear_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_organizationId_idx": {
+          "name": "members_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_userId_idx": {
+          "name": "members_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_notification_settings": {
+      "name": "organization_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_content_creation": {
+          "name": "scheduled_content_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_content_failed": {
+          "name": "scheduled_content_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orgNotificationSettings_organizationId_uidx": {
+          "name": "orgNotificationSettings_organizationId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_settings_organization_id_organizations_id_fk": {
+          "name": "organization_notification_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_dismissed": {
+          "name": "onboarding_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "organizations_slug_uidx": {
+          "name": "organizations_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_org_slug_uidx": {
+          "name": "posts_org_slug_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_org_createdAt_id_idx": {
+          "name": "posts_org_createdAt_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_organization_id_organizations_id_fk": {
+          "name": "posts_organization_id_organizations_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_outputs": {
+      "name": "repository_outputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositoryOutputs_repositoryId_idx": {
+          "name": "repositoryOutputs_repositoryId_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositoryOutputs_repository_outputType_uidx": {
+          "name": "repositoryOutputs_repository_outputType_uidx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "output_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_outputs_repository_id_github_integrations_id_fk": {
+          "name": "repository_outputs_repository_id_github_integrations_id_fk",
+          "tableFrom": "repository_outputs",
+          "tableTo": "github_integrations",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skills_organizationId_idx": {
+          "name": "skills_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skills_org_name_uidx": {
+          "name": "skills_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_organization_id_organizations_id_fk": {
+          "name": "skills_organization_id_organizations_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_personal_data": {
+          "name": "hide_personal_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_agent_stats": {
+          "name": "show_agent_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.applicable_platform": {
+      "name": "applicable_platform",
+      "schema": "public",
+      "values": [
+        "all",
+        "twitter",
+        "linkedin",
+        "blog"
+      ]
+    },
+    "public.lookback_window": {
+      "name": "lookback_window",
+      "schema": "public",
+      "values": [
+        "current_day",
+        "yesterday",
+        "last_7_days",
+        "last_14_days",
+        "last_30_days"
+      ]
+    },
+    "public.post_status": {
+      "name": "post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.reference_type": {
+      "name": "reference_type",
+      "schema": "public",
+      "values": [
+        "twitter_post",
+        "linkedin_post",
+        "blog_post",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0029_snapshot.json
+++ b/packages/db/migrations/meta/0029_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "8fb59cf9-e393-44e4-8627-1fa7c8c95fc9",
+  "id": "d0b6b92e-4749-48f2-8e10-86de9096f65c",
   "prevId": "5d69b3db-185d-4a5e-a142-a1238561b050",
   "version": "7",
   "dialect": "postgresql",
@@ -1950,12 +1950,6 @@
         "content": {
           "name": "content",
           "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "allowed_tools": {
-          "name": "allowed_tools",
-          "type": "jsonb",
           "primaryKey": false,
           "notNull": true
         },

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -208,8 +208,8 @@
     {
       "idx": 29,
       "version": "7",
-      "when": 1776881435628,
-      "tag": "0029_groovy_harry_osborn",
+      "when": 1776890973194,
+      "tag": "0029_spicy_network",
       "breakpoints": true
     }
   ]

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1776461491141,
       "tag": "0028_previous_tinkerer",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1776881435628,
+      "tag": "0029_groovy_harry_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -470,6 +470,29 @@ export const posts = pgTable(
   ]
 );
 
+export const skills = pgTable(
+  "skills",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    content: text("content").notNull(),
+    isSystem: boolean("is_system").default(false).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("skills_organizationId_idx").on(table.organizationId),
+    uniqueIndex("skills_org_name_uidx").on(table.organizationId, table.name),
+  ]
+);
+
 export interface PostSourceMetadata {
   triggerId: string;
   triggerSourceType: string;
@@ -521,6 +544,7 @@ export const organizationsRelations = relations(
     notificationSettings: one(organizationNotificationSettings),
     connectedSocialAccounts: many(connectedSocialAccounts),
     posts: many(posts),
+    skills: many(skills),
   })
 );
 
@@ -653,6 +677,13 @@ export const organizationNotificationSettingsRelations = relations(
 export const postsRelations = relations(posts, ({ one }) => ({
   organization: one(organizations, {
     fields: [posts.organizationId],
+    references: [organizations.id],
+  }),
+}));
+
+export const skillsRelations = relations(skills, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [skills.organizationId],
     references: [organizations.id],
   }),
 }));


### PR DESCRIPTION
## Summary

- Collapses the 4 content agents (changelog, blog-post, twitter, linkedin) into a single `runBackgroundGen` that loads its instructions from a new org-scoped `skills` table. The 4 existing functions become thin wrappers.
- New `/[slug]/skills` UI: card grid of skills, "New skill" responsive dialog, detail editor with Tabs (edit/diff), unsaved-changes toast, and delete for non-system skills.
- `skills` table seeded (5 skills per org: changelog, blog-post, twitter, linkedin, humanizer) via a shared `seedSystemSkills` helper wired into both the create-org hook and a one-shot backfill script (already run against the test DB for the 7 existing orgs).
- Tone dispatch dropped — one universal skill per content type, per the design doc.

## Architecture decisions

- **Triggers still reference skills by convention**: `contentTriggers.contentType` stays as-is. The unified agent resolves the skill by name at runtime — no schema change on triggers.
- **System skills**: `isSystem=true` flag. Editable, but cannot be deleted or renamed (delete returns 403). Names are immutable for all skills since triggers reference them.
- **Seed source of truth**: the seed module calls the existing `Conversational` prompt factories for the 4 content-type skills (no duplication). Humanizer body is read from `packages/ai/src/skills/human-writer/SKILL.md` at seed time. A follow-up will inline humanizer and delete the source file.
- **Migration flow**: generated `0029_groovy_harry_osborn.sql` via drizzle-kit and shared it for review before applying. Test DB had an empty migration ledger so we applied via `db:push` instead of `db:migrate` (documented in PR comments below).

## What's still coming (not in this PR)

- Delete the old file-based skill sources in `packages/ai/src/skills/` + inline humanizer content into the seed module.
- Stop passing `tone` from trigger options throughout the workflows layer (option is currently ignored by the unified agent; field is still accepted for backwards compatibility).
- Skill deletion integrity check against triggers referencing the skill by name (currently system skills are blocked; user skills can still be deleted).

## Test plan

- [x] `bun run build` passes
- [x] Skills table seeded for all 7 existing orgs (verified in DB)
- [ ] Create a new org end-to-end and confirm the 5 system skills seed automatically
- [ ] Run a scheduled changelog trigger and confirm the unified agent produces output indistinguishable from the old specialized agent
- [ ] Edit a system skill's content, save, confirm persistence + diff view
- [ ] Try to delete a system skill — expect 403
- [ ] Create a new user skill via the dialog + edit it