### PR TITLE
feat(dashboard): structured onboarding flow

### DIFF
--- a/apps/dashboard/src/app/onboarding/layout.tsx
+++ b/apps/dashboard/src/app/onboarding/layout.tsx
@@ -1,0 +1,16 @@
+import { OnboardingAccountMenu } from "@/components/onboarding/account-menu";
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative min-h-screen w-full">
+      <div className="absolute top-4 right-4 z-10">
+        <OnboardingAccountMenu />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/onboarding/pricing-client.tsx
+++ b/apps/dashboard/src/app/onboarding/pricing-client.tsx
@@ -10,7 +10,7 @@ import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { useCustomer, useListPlans } from "autumn-js/react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { OnboardingAccountMenu } from "@/components/onboarding/account-menu";
+import { OnboardingProgress } from "@/components/onboarding/progress";
 import { FEATURES, PLANS } from "@/constants/features";
 import type { BillingPlan } from "@/types/billing/plan";
 import type { ProductFeature } from "@/types/hooks/billing";
@@ -127,8 +127,8 @@ export function PricingClient({ slug }: PricingClientProps) {
 
   return (
     <div className="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col justify-center px-4 py-12">
-      <div className="absolute top-4 right-4">
-        <OnboardingAccountMenu />
+      <div className="mb-6 flex justify-center">
+        <OnboardingProgress current={3} />
       </div>
       <div className="space-y-3 text-center">
         <h1 className="font-bold text-3xl tracking-tight md:text-4xl">

--- a/apps/dashboard/src/app/onboarding/pricing/page.tsx
+++ b/apps/dashboard/src/app/onboarding/pricing/page.tsx
@@ -1,6 +1,3 @@
-import { db } from "@notra/db/drizzle";
-import { brandSettings } from "@notra/db/schema";
-import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
 import {
   getAllUserOrganizations,
@@ -8,8 +5,9 @@ import {
   getSession,
 } from "@/lib/auth/actions";
 import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
+import { PricingClient } from "../pricing-client";
 
-export default async function OnboardingPage() {
+export default async function OnboardingPricingPage() {
   const session = await getSession();
 
   if (!session?.user) {
@@ -24,19 +22,9 @@ export default async function OnboardingPage() {
   }
 
   const organization = await getLastActiveOrganization(session.user.id);
-
   if (!organization) {
     redirect("/onboarding/workspace");
   }
 
-  const brand = await db.query.brandSettings.findFirst({
-    where: eq(brandSettings.organizationId, organization.id),
-    columns: { id: true },
-  });
-
-  if (!brand) {
-    redirect("/onboarding/workspace");
-  }
-
-  redirect("/onboarding/socials");
+  return <PricingClient slug={organization.slug} />;
 }

--- a/apps/dashboard/src/app/onboarding/socials/page.tsx
+++ b/apps/dashboard/src/app/onboarding/socials/page.tsx
@@ -1,0 +1,73 @@
+import { db } from "@notra/db/drizzle";
+import { brandSettings, connectedSocialAccounts } from "@notra/db/schema";
+import { and, desc, eq } from "drizzle-orm";
+import { redirect } from "next/navigation";
+import {
+  getAllUserOrganizations,
+  getLastActiveOrganization,
+  getSession,
+} from "@/lib/auth/actions";
+import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
+import { SocialsClient } from "./socials-client";
+
+export default async function OnboardingSocialsPage() {
+  const session = await getSession();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  const allOrgs = await getAllUserOrganizations(session.user.id);
+  for (const org of allOrgs) {
+    if (await hasPaidSubscriptionHistory(org.id)) {
+      redirect(`/${org.slug}`);
+    }
+  }
+
+  const organization = await getLastActiveOrganization(session.user.id);
+  if (!organization) {
+    redirect("/onboarding/workspace");
+  }
+
+  const [defaultBrand, twitterAccount] = await Promise.all([
+    db.query.brandSettings.findFirst({
+      where: and(
+        eq(brandSettings.organizationId, organization.id),
+        eq(brandSettings.isDefault, true)
+      ),
+      columns: { id: true },
+    }),
+    db.query.connectedSocialAccounts.findFirst({
+      where: and(
+        eq(connectedSocialAccounts.organizationId, organization.id),
+        eq(connectedSocialAccounts.provider, "twitter")
+      ),
+      columns: {
+        createdAt: true,
+        displayName: true,
+        id: true,
+        profileImageUrl: true,
+        provider: true,
+        providerAccountId: true,
+        username: true,
+        verified: true,
+      },
+      orderBy: [desc(connectedSocialAccounts.createdAt)],
+    }),
+  ]);
+
+  return (
+    <SocialsClient
+      initialAccount={
+        twitterAccount
+          ? {
+              ...twitterAccount,
+              createdAt: twitterAccount.createdAt.toISOString(),
+            }
+          : null
+      }
+      organizationId={organization.id}
+      voiceId={defaultBrand?.id ?? null}
+    />
+  );
+}

--- a/apps/dashboard/src/app/onboarding/socials/socials-client.tsx
+++ b/apps/dashboard/src/app/onboarding/socials/socials-client.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import {
+  CheckmarkCircle02Icon,
+  NewTwitterIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@notra/ui/components/ui/button";
+import { Loader2Icon } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { OnboardingProgress } from "@/components/onboarding/progress";
+import { useImportTweets } from "@/lib/hooks/use-brand-references";
+import {
+  type ConnectedAccount,
+  useConnectTwitter,
+} from "@/lib/hooks/use-connected-accounts";
+
+interface SocialsClientProps {
+  organizationId: string;
+  voiceId: string | null;
+  initialAccount: ConnectedAccount | null;
+}
+
+function ImportButtonContent({
+  isPending,
+  isSuccess,
+}: {
+  isPending: boolean;
+  isSuccess: boolean;
+}) {
+  if (isPending) {
+    return (
+      <>
+        <Loader2Icon className="size-4 animate-spin" />
+        Importing tweets...
+      </>
+    );
+  }
+  if (isSuccess) {
+    return (
+      <>
+        <HugeiconsIcon icon={CheckmarkCircle02Icon} size={14} />
+        Tweets imported
+      </>
+    );
+  }
+  return "Import recent tweets";
+}
+
+export function SocialsClient({
+  organizationId,
+  voiceId,
+  initialAccount,
+}: SocialsClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const justConnected = searchParams.get("twitterConnected") === "true";
+
+  const connectTwitter = useConnectTwitter(organizationId);
+  const importTweets = useImportTweets(organizationId, voiceId ?? "");
+
+  useEffect(() => {
+    if (justConnected) {
+      toast.success("X account connected");
+    }
+  }, [justConnected]);
+
+  async function handleConnect() {
+    try {
+      const { url } = await connectTwitter.mutateAsync("/onboarding/socials");
+      window.location.href = url;
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to connect X account"
+      );
+    }
+  }
+
+  async function handleImport() {
+    if (!(initialAccount && voiceId)) {
+      return;
+    }
+    try {
+      const result = await importTweets.mutateAsync({
+        accountId: initialAccount.id,
+        maxResults: 20,
+      });
+      toast.success(`Imported ${result.count} tweets into your brand voice`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to import tweets"
+      );
+    }
+  }
+
+  function handleContinue() {
+    router.push("/onboarding/pricing");
+  }
+
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-4 py-12">
+      <div className="mb-6">
+        <OnboardingProgress current={2} />
+      </div>
+
+      <div className="space-y-2">
+        <h1 className="font-semibold text-2xl tracking-tight">
+          Connect your accounts
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Pull in your recent posts so Notra can write in your voice from day
+          one.
+        </p>
+      </div>
+
+      <div className="mt-8 space-y-3">
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-md bg-foreground text-background">
+              <HugeiconsIcon icon={NewTwitterIcon} size={18} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="font-medium text-sm">X (Twitter)</p>
+              {initialAccount ? (
+                <p className="flex items-center gap-1 text-muted-foreground text-xs">
+                  <HugeiconsIcon
+                    className="text-emerald-500"
+                    icon={CheckmarkCircle02Icon}
+                    size={12}
+                  />
+                  Connected as @{initialAccount.username}
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  Connect to import your tweets
+                </p>
+              )}
+            </div>
+            {initialAccount ? null : (
+              <Button
+                disabled={connectTwitter.isPending}
+                onClick={handleConnect}
+                size="sm"
+                variant="outline"
+              >
+                {connectTwitter.isPending ? (
+                  <Loader2Icon className="size-4 animate-spin" />
+                ) : (
+                  "Connect"
+                )}
+              </Button>
+            )}
+          </div>
+
+          {initialAccount && voiceId ? (
+            <div className="mt-4 border-t pt-4">
+              <Button
+                className="w-full"
+                disabled={importTweets.isPending || importTweets.isSuccess}
+                onClick={handleImport}
+                size="sm"
+                variant="secondary"
+              >
+                <ImportButtonContent
+                  isPending={importTweets.isPending}
+                  isSuccess={importTweets.isSuccess}
+                />
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-8 flex flex-col gap-3">
+        <Button className="w-full" onClick={handleContinue} type="button">
+          Continue
+        </Button>
+        <button
+          className="text-center text-muted-foreground text-sm hover:text-foreground"
+          onClick={handleContinue}
+          type="button"
+        >
+          Skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/onboarding/workspace/actions.ts
+++ b/apps/dashboard/src/app/onboarding/workspace/actions.ts
@@ -47,6 +47,9 @@ export async function triggerOnboardingBrandAnalysis({
       organizationId,
       error,
     });
+    throw new Error(
+      "Couldn't kick off the brand analysis. Please try again in a moment."
+    );
   }
 
   return { success: true };

--- a/apps/dashboard/src/app/onboarding/workspace/actions.ts
+++ b/apps/dashboard/src/app/onboarding/workspace/actions.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { db } from "@notra/db/drizzle";
+import { members } from "@notra/db/schema";
+import { and, eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth/server";
+import { queueBrandAnalysisForOnboarding } from "@/lib/brand-analysis";
+
+interface TriggerOnboardingBrandAnalysisInput {
+  organizationId: string;
+  websiteUrl: string;
+  name?: string;
+}
+
+export async function triggerOnboardingBrandAnalysis({
+  organizationId,
+  websiteUrl,
+  name,
+}: TriggerOnboardingBrandAnalysisInput) {
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  if (!session?.user) {
+    throw new Error("Unauthorized");
+  }
+
+  const membership = await db.query.members.findFirst({
+    where: and(
+      eq(members.userId, session.user.id),
+      eq(members.organizationId, organizationId)
+    ),
+    columns: { id: true },
+  });
+
+  if (!membership) {
+    throw new Error("Forbidden");
+  }
+
+  try {
+    await queueBrandAnalysisForOnboarding({
+      organizationId,
+      websiteUrl,
+      name,
+    });
+  } catch (error) {
+    console.error("[Onboarding] Failed to queue brand analysis", {
+      organizationId,
+      error,
+    });
+  }
+
+  return { success: true };
+}

--- a/apps/dashboard/src/app/onboarding/workspace/page.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import {
+  getAllUserOrganizations,
+  getLastActiveOrganization,
+  getSession,
+} from "@/lib/auth/actions";
+import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
+import { WorkspaceForm } from "./workspace-form";
+
+export default async function OnboardingWorkspacePage() {
+  const session = await getSession();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  const allOrgs = await getAllUserOrganizations(session.user.id);
+  for (const org of allOrgs) {
+    if (await hasPaidSubscriptionHistory(org.id)) {
+      redirect(`/${org.slug}`);
+    }
+  }
+
+  const existing = await getLastActiveOrganization(session.user.id);
+  if (existing) {
+    redirect("/onboarding/socials");
+  }
+
+  return <WorkspaceForm />;
+}

--- a/apps/dashboard/src/app/onboarding/workspace/page.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/page.tsx
@@ -1,3 +1,6 @@
+import { db } from "@notra/db/drizzle";
+import { brandSettings, organizations } from "@notra/db/schema";
+import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
 import {
   getAllUserOrganizations,
@@ -23,7 +26,22 @@ export default async function OnboardingWorkspacePage() {
 
   const existing = await getLastActiveOrganization(session.user.id);
   if (existing) {
-    redirect("/onboarding/socials");
+    const brand = await db.query.brandSettings.findFirst({
+      where: eq(brandSettings.organizationId, existing.id),
+      columns: { id: true },
+    });
+    if (brand) {
+      redirect("/onboarding/socials");
+    }
+
+    const existingOrgRow = await db.query.organizations.findFirst({
+      where: eq(organizations.id, existing.id),
+      columns: { id: true, slug: true, name: true },
+    });
+
+    if (existingOrgRow) {
+      return <WorkspaceForm existingOrg={existingOrgRow} />;
+    }
   }
 
   return <WorkspaceForm />;

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -28,14 +28,25 @@ function normalizeWebsite(value: string): string {
   return WEBSITE_PREFIX_REGEX.test(value) ? value : `https://${value}`;
 }
 
-export function WorkspaceForm() {
+interface ExistingOrg {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+interface WorkspaceFormProps {
+  existingOrg?: ExistingOrg;
+}
+
+export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isResuming = !!existingOrg;
 
   const form = useForm({
     defaultValues: {
-      name: "",
-      slug: "",
+      name: existingOrg?.name ?? "",
+      slug: existingOrg?.slug ?? "",
       websiteUrl: "",
     },
     onSubmit: async ({ value }) => {
@@ -57,28 +68,44 @@ export function WorkspaceForm() {
           return;
         }
 
-        const { data, error } = await authClient.organization.create({
-          name: parsed.data.name,
-          slug: parsed.data.slug,
-          logo: generateOrganizationAvatar(parsed.data.slug),
-        });
+        let organizationId: string;
+        let organizationSlug: string;
 
-        if (error || !data) {
-          toast.error(error?.message ?? "Failed to create org");
-          setIsSubmitting(false);
-          return;
+        if (existingOrg) {
+          organizationId = existingOrg.id;
+          organizationSlug = existingOrg.slug;
+        } else {
+          const { data, error } = await authClient.organization.create({
+            name: parsed.data.name,
+            slug: parsed.data.slug,
+            logo: generateOrganizationAvatar(parsed.data.slug),
+          });
+
+          if (error || !data) {
+            toast.error(error?.message ?? "Failed to create org");
+            setIsSubmitting(false);
+            return;
+          }
+
+          organizationId = data.id;
+          organizationSlug = data.slug;
+
+          await authClient.organization.setActive({
+            organizationId: data.id,
+          });
+          await setLastVisitedOrganization(data.slug);
         }
 
-        await authClient.organization.setActive({ organizationId: data.id });
-        await setLastVisitedOrganization(data.slug);
-
         await triggerOnboardingBrandAnalysis({
-          organizationId: data.id,
+          organizationId,
           websiteUrl: parsed.data.websiteUrl,
           name: parsed.data.name,
         });
 
         router.push("/onboarding/socials");
+        router.refresh();
+        // Keep button in submitting state during navigation
+        return;
       } catch (err) {
         toast.error(
           err instanceof Error ? err.message : "Failed to create org"
@@ -96,11 +123,12 @@ export function WorkspaceForm() {
 
       <div className="space-y-2">
         <h1 className="font-semibold text-2xl tracking-tight">
-          Tell us about your org
+          {isResuming ? "Finish setting up your org" : "Tell us about your org"}
         </h1>
         <p className="text-muted-foreground text-sm">
-          We&apos;ll use your website to learn your brand voice while you set up
-          the rest.
+          {isResuming
+            ? "Your workspace is ready — enter your website so we can finish learning your brand voice."
+            : "We'll use your website to learn your brand voice while you set up the rest."}
         </p>
       </div>
 
@@ -127,8 +155,8 @@ export function WorkspaceForm() {
               </Label>
               <Input
                 aria-invalid={field.state.meta.errors.length > 0}
-                autoFocus
-                disabled={isSubmitting}
+                autoFocus={!isResuming}
+                disabled={isSubmitting || isResuming}
                 id="name"
                 onBlur={field.handleBlur}
                 onChange={(e) => {
@@ -169,7 +197,7 @@ export function WorkspaceForm() {
               </Label>
               <Input
                 aria-invalid={field.state.meta.errors.length > 0}
-                disabled={isSubmitting}
+                disabled={isSubmitting || isResuming}
                 id="slug"
                 onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(slugify(e.target.value))}
@@ -219,6 +247,7 @@ export function WorkspaceForm() {
                   https://
                 </label>
                 <input
+                  autoFocus={isResuming}
                   className="flex-1 bg-transparent px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
                   disabled={isSubmitting}
                   id="website"

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { Button } from "@notra/ui/components/ui/button";
+import { Input } from "@notra/ui/components/ui/input";
+import { Label } from "@notra/ui/components/ui/label";
+import { useForm } from "@tanstack/react-form";
+import { Loader2Icon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+import { OnboardingProgress } from "@/components/onboarding/progress";
+import { authClient } from "@/lib/auth/client";
+import { generateOrganizationAvatar } from "@/lib/utils";
+import { onboardingWorkspaceSchema } from "@/schemas/onboarding/workspace";
+import { setLastVisitedOrganization } from "@/utils/cookies";
+import { triggerOnboardingBrandAnalysis } from "./actions";
+
+const WEBSITE_PREFIX_REGEX = /^https?:\/\//i;
+const slugSchema = z.string().slugify();
+
+function slugify(value: string): string {
+  return slugSchema.safeParse(value).data ?? "";
+}
+
+function normalizeWebsite(value: string): string {
+  return WEBSITE_PREFIX_REGEX.test(value) ? value : `https://${value}`;
+}
+
+export function WorkspaceForm() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm({
+    defaultValues: {
+      name: "",
+      slug: "",
+      websiteUrl: "",
+    },
+    onSubmit: async ({ value }) => {
+      setIsSubmitting(true);
+
+      try {
+        const websiteUrl = normalizeWebsite(value.websiteUrl);
+        const parsed = onboardingWorkspaceSchema.safeParse({
+          name: value.name,
+          slug: value.slug,
+          websiteUrl,
+        });
+
+        if (!parsed.success) {
+          const message =
+            parsed.error.issues[0]?.message ?? "Please check your inputs";
+          toast.error(message);
+          setIsSubmitting(false);
+          return;
+        }
+
+        const { data, error } = await authClient.organization.create({
+          name: parsed.data.name,
+          slug: parsed.data.slug,
+          logo: generateOrganizationAvatar(parsed.data.slug),
+        });
+
+        if (error || !data) {
+          toast.error(error?.message ?? "Failed to create org");
+          setIsSubmitting(false);
+          return;
+        }
+
+        await authClient.organization.setActive({ organizationId: data.id });
+        await setLastVisitedOrganization(data.slug);
+
+        await triggerOnboardingBrandAnalysis({
+          organizationId: data.id,
+          websiteUrl: parsed.data.websiteUrl,
+          name: parsed.data.name,
+        });
+
+        router.push("/onboarding/socials");
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to create org"
+        );
+        setIsSubmitting(false);
+      }
+    },
+  });
+
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-4 py-12">
+      <div className="mb-6">
+        <OnboardingProgress current={1} />
+      </div>
+
+      <div className="space-y-2">
+        <h1 className="font-semibold text-2xl tracking-tight">
+          Tell us about your org
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          We&apos;ll use your website to learn your brand voice while you set up
+          the rest.
+        </p>
+      </div>
+
+      <form
+        className="mt-8 space-y-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          form.handleSubmit();
+        }}
+      >
+        <form.Field
+          name="name"
+          validators={{
+            onChange: ({ value }) =>
+              onboardingWorkspaceSchema.shape.name.safeParse(value).error
+                ?.issues[0]?.message,
+          }}
+        >
+          {(field) => (
+            <div className="grid gap-2">
+              <Label htmlFor="name">
+                Org name <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                aria-invalid={field.state.meta.errors.length > 0}
+                autoFocus
+                disabled={isSubmitting}
+                id="name"
+                onBlur={field.handleBlur}
+                onChange={(e) => {
+                  field.handleChange(e.target.value);
+                  const currentSlug = form.getFieldValue("slug");
+                  if (
+                    !currentSlug ||
+                    currentSlug === slugify(field.state.value)
+                  ) {
+                    form.setFieldValue("slug", slugify(e.target.value));
+                  }
+                }}
+                placeholder="Acme Inc"
+                type="text"
+                value={field.state.value}
+              />
+              {field.state.meta.errors.length > 0 ? (
+                <p className="text-destructive text-sm">
+                  {field.state.meta.errors[0]}
+                </p>
+              ) : null}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field
+          name="slug"
+          validators={{
+            onChange: ({ value }) =>
+              onboardingWorkspaceSchema.shape.slug.safeParse(value).error
+                ?.issues[0]?.message,
+          }}
+        >
+          {(field) => (
+            <div className="grid gap-2">
+              <Label htmlFor="slug">
+                Org URL <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                aria-invalid={field.state.meta.errors.length > 0}
+                disabled={isSubmitting}
+                id="slug"
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(slugify(e.target.value))}
+                placeholder="acme-inc"
+                type="text"
+                value={field.state.value}
+              />
+              {field.state.meta.errors.length > 0 ? (
+                <p className="text-destructive text-sm">
+                  {field.state.meta.errors[0]}
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  app.usenotra.com/{field.state.value || "your-slug"}
+                </p>
+              )}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field
+          name="websiteUrl"
+          validators={{
+            onChange: ({ value }) => {
+              if (!value || value.trim() === "") {
+                return "Website is required";
+              }
+              const candidate = normalizeWebsite(value);
+              return onboardingWorkspaceSchema.shape.websiteUrl.safeParse(
+                candidate
+              ).error?.issues[0]?.message;
+            },
+          }}
+        >
+          {(field) => (
+            <div className="grid gap-2">
+              <Label htmlFor="website">
+                Website <span className="text-destructive">*</span>
+              </Label>
+              <div
+                className={`flex w-full flex-row items-center rounded-md border transition-colors focus-within:border-ring focus-within:ring-ring/50 ${field.state.meta.errors.length > 0 ? "border-destructive" : "border-border"}`}
+              >
+                <label
+                  className="border-border border-r px-2.5 py-1.5 text-muted-foreground text-sm"
+                  htmlFor="website"
+                >
+                  https://
+                </label>
+                <input
+                  className="flex-1 bg-transparent px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={isSubmitting}
+                  id="website"
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  placeholder="acme.com"
+                  type="text"
+                  value={field.state.value.replace(WEBSITE_PREFIX_REGEX, "")}
+                />
+              </div>
+              {field.state.meta.errors.length > 0 ? (
+                <p className="text-destructive text-sm">
+                  {field.state.meta.errors[0]}
+                </p>
+              ) : null}
+            </div>
+          )}
+        </form.Field>
+
+        <Button className="w-full" disabled={isSubmitting} type="submit">
+          {isSubmitting ? (
+            <>
+              <Loader2Icon className="size-4 animate-spin" />
+              Setting up...
+            </>
+          ) : (
+            "Continue"
+          )}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/onboarding/progress.tsx
+++ b/apps/dashboard/src/components/onboarding/progress.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+
+interface OnboardingProgressProps {
+  current: 1 | 2 | 3;
+}
+
+const STEPS = [1, 2, 3] as const;
+
+function getStepClasses(step: number, current: number) {
+  if (step === current) {
+    return "w-6 bg-primary";
+  }
+  if (step < current) {
+    return "w-1.5 bg-primary/60";
+  }
+  return "w-1.5 bg-muted-foreground/30";
+}
+
+export function OnboardingProgress({ current }: OnboardingProgressProps) {
+  return (
+    <div
+      aria-label={`Step ${current} of ${STEPS.length}`}
+      className="flex items-center gap-1.5"
+      role="progressbar"
+    >
+      {STEPS.map((step) => (
+        <span
+          aria-current={step === current ? "step" : undefined}
+          className={cn(
+            "h-1.5 rounded-full transition-all",
+            getStepClasses(step, current)
+          )}
+          key={step}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -14,7 +14,6 @@ import {
 } from "better-auth/plugins";
 import { count, eq } from "drizzle-orm";
 import { isValid as isNotDisposableEmail } from "mailchecker";
-import { customAlphabet } from "nanoid";
 import { cookies } from "next/headers";
 import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
 import { FEATURES } from "@/constants/features";
@@ -31,10 +30,7 @@ import {
 } from "@/lib/email/actions";
 import { redis } from "@/lib/redis";
 import { seedSystemSkills } from "@/lib/skills/seed";
-import { generateOrganizationAvatar } from "@/lib/utils";
 import { organizationSlugSchema } from "@/schemas/organization";
-
-const nanoid = customAlphabet("abcdefghijklmnopqrstuvwxyz0123456789", 6);
 
 async function enforceTeamMembersLimit(organizationId?: string | null) {
   if (!organizationId || !autumn) {
@@ -343,50 +339,8 @@ export const auth = betterAuth({
             });
           }
         },
-        after: async (user, ctx) => {
-          const email = user.email || "";
-          const raw = email.split("@")[0] || "";
-          const base = raw
-            .toLowerCase()
-            .replace(/[^a-z0-9]/g, "")
-            .slice(0, 20);
-
-          const slug = `${base || "notra"}-${nanoid()}`;
-
-          try {
-            await auth.api.createOrganization({
-              body: {
-                name: "Personal",
-                slug,
-                userId: user.id,
-                logo: generateOrganizationAvatar(slug),
-              },
-            });
-          } catch (error) {
-            console.error("[Auth] Failed to auto-create org on signup:", {
-              userId: user.id,
-              slug,
-              error,
-            });
-            throw error;
-          }
-
-          const member = await db.query.members.findFirst({
-            where: eq(members.userId, user.id),
-            columns: { organizationId: true },
-          });
-          const session = await db.query.sessions.findFirst({
-            where: eq(sessions.userId, user.id),
-            orderBy: (s, { desc }) => [desc(s.createdAt)],
-            columns: { token: true },
-          });
-          if (member && session && ctx?.context?.internalAdapter) {
-            await ctx.context.internalAdapter.updateSession(session.token, {
-              activeOrganizationId: member.organizationId,
-            });
-          }
-
-          sendWelcomeEmailAction({ userEmail: email });
+        after: async (user) => {
+          sendWelcomeEmailAction({ userEmail: user.email ?? "" });
         },
       },
     },

--- a/apps/dashboard/src/lib/brand-analysis.ts
+++ b/apps/dashboard/src/lib/brand-analysis.ts
@@ -11,6 +11,85 @@ import { and, eq } from "drizzle-orm";
 import { redis } from "@/lib/redis";
 import { getConfiguredWorkflowUrl } from "@/utils/url";
 
+const DEFAULT_BRAND_CONSTRAINT = "brandSettings_org_default_uidx";
+
+function isDefaultBrandConstraintViolation(error: unknown) {
+  if (!(typeof error === "object" && error !== null)) {
+    return false;
+  }
+  const candidates: unknown[] = [error];
+  if ("cause" in error) {
+    candidates.push((error as { cause: unknown }).cause);
+  }
+  return candidates.some((candidate) => {
+    if (!(typeof candidate === "object" && candidate !== null)) {
+      return false;
+    }
+    if (
+      "constraint_name" in candidate &&
+      candidate.constraint_name === DEFAULT_BRAND_CONSTRAINT
+    ) {
+      return true;
+    }
+    if (
+      "constraint" in candidate &&
+      candidate.constraint === DEFAULT_BRAND_CONSTRAINT
+    ) {
+      return true;
+    }
+    if (candidate instanceof Error) {
+      return candidate.message.includes(DEFAULT_BRAND_CONSTRAINT);
+    }
+    return false;
+  });
+}
+
+async function insertBrandIdentity({
+  organizationId,
+  brandName,
+  websiteUrl,
+}: {
+  organizationId: string;
+  brandName: string;
+  websiteUrl: string;
+}): Promise<{ id: string }> {
+  const hasAnyBrandIdentity = await db.query.brandSettings.findFirst({
+    where: eq(brandSettings.organizationId, organizationId),
+    columns: { id: true },
+  });
+
+  const baseValues = {
+    id: crypto.randomUUID(),
+    organizationId,
+    name: brandName,
+    websiteUrl,
+  };
+
+  try {
+    const [row] = await db
+      .insert(brandSettings)
+      .values({ ...baseValues, isDefault: !hasAnyBrandIdentity })
+      .returning({ id: brandSettings.id });
+    if (row) {
+      return row;
+    }
+  } catch (error) {
+    if (!isDefaultBrandConstraintViolation(error)) {
+      throw error;
+    }
+  }
+
+  const [fallback] = await db
+    .insert(brandSettings)
+    .values({ ...baseValues, id: crypto.randomUUID(), isDefault: false })
+    .returning({ id: brandSettings.id });
+
+  if (!fallback) {
+    throw new Error("Failed to create brand identity");
+  }
+  return fallback;
+}
+
 interface QueueBrandAnalysisInput {
   organizationId: string;
   websiteUrl: string;
@@ -34,30 +113,15 @@ export async function queueBrandAnalysisForOnboarding({
     return null;
   }
 
-  const brandIdentityId = crypto.randomUUID();
   const now = new Date().toISOString();
   const jobId = createBrandAnalysisJobId();
   const brandName = name?.trim() || "Untitled Brand Voice";
 
-  const hasAnyBrandIdentity = await db.query.brandSettings.findFirst({
-    where: eq(brandSettings.organizationId, organizationId),
-    columns: { id: true },
+  const brandIdentity = await insertBrandIdentity({
+    organizationId,
+    brandName,
+    websiteUrl,
   });
-
-  const [brandIdentity] = await db
-    .insert(brandSettings)
-    .values({
-      id: brandIdentityId,
-      organizationId,
-      name: brandName,
-      isDefault: !hasAnyBrandIdentity,
-      websiteUrl,
-    })
-    .returning({ id: brandSettings.id });
-
-  if (!brandIdentity) {
-    throw new Error("Failed to create brand identity");
-  }
 
   try {
     const job = await createBrandAnalysisJob(redis, {

--- a/apps/dashboard/src/lib/brand-analysis.ts
+++ b/apps/dashboard/src/lib/brand-analysis.ts
@@ -1,0 +1,116 @@
+import {
+  createBrandAnalysisJob,
+  createBrandAnalysisJobId,
+  setBrandAnalysisJobStatus,
+  updateBrandAnalysisJob,
+} from "@notra/ai/jobs/brand-analysis";
+import { db } from "@notra/db/drizzle";
+import { brandSettings } from "@notra/db/schema";
+import { Client as WorkflowClient } from "@upstash/workflow";
+import { and, eq } from "drizzle-orm";
+import { redis } from "@/lib/redis";
+import { getConfiguredWorkflowUrl } from "@/utils/url";
+
+interface QueueBrandAnalysisInput {
+  organizationId: string;
+  websiteUrl: string;
+  name?: string;
+}
+
+interface QueueBrandAnalysisResult {
+  jobId: string;
+  brandIdentityId: string;
+}
+
+export async function queueBrandAnalysisForOnboarding({
+  organizationId,
+  websiteUrl,
+  name,
+}: QueueBrandAnalysisInput): Promise<QueueBrandAnalysisResult | null> {
+  const token = process.env.QSTASH_TOKEN;
+  const workflowBaseUrl = getConfiguredWorkflowUrl();
+
+  if (!(redis && token && workflowBaseUrl)) {
+    return null;
+  }
+
+  const brandIdentityId = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const jobId = createBrandAnalysisJobId();
+  const brandName = name?.trim() || "Untitled Brand Voice";
+
+  const hasAnyBrandIdentity = await db.query.brandSettings.findFirst({
+    where: eq(brandSettings.organizationId, organizationId),
+    columns: { id: true },
+  });
+
+  const [brandIdentity] = await db
+    .insert(brandSettings)
+    .values({
+      id: brandIdentityId,
+      organizationId,
+      name: brandName,
+      isDefault: !hasAnyBrandIdentity,
+      websiteUrl,
+    })
+    .returning({ id: brandSettings.id });
+
+  if (!brandIdentity) {
+    throw new Error("Failed to create brand identity");
+  }
+
+  try {
+    const job = await createBrandAnalysisJob(redis, {
+      id: jobId,
+      organizationId,
+      brandIdentityId: brandIdentity.id,
+      status: "queued",
+      step: null,
+      currentStep: 0,
+      totalSteps: 3,
+      workflowRunId: null,
+      error: null,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+    });
+
+    const client = new WorkflowClient({ token });
+    const result = await client.trigger({
+      url: `${workflowBaseUrl}/api/workflows/brand-analysis`,
+      body: {
+        organizationId,
+        url: websiteUrl,
+        voiceId: brandIdentity.id,
+        jobId,
+      },
+    });
+
+    await updateBrandAnalysisJob(redis, jobId, {
+      workflowRunId: result.workflowRunId,
+    });
+
+    return { jobId: job.id, brandIdentityId: brandIdentity.id };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to trigger workflow";
+
+    await setBrandAnalysisJobStatus(redis, jobId, "failed", {
+      step: null,
+      currentStep: 0,
+      totalSteps: 3,
+      error: message,
+    });
+
+    await db
+      .delete(brandSettings)
+      .where(
+        and(
+          eq(brandSettings.id, brandIdentity.id),
+          eq(brandSettings.organizationId, organizationId)
+        )
+      );
+
+    throw error;
+  }
+}

--- a/apps/dashboard/src/lib/orpc/routers/brand.ts
+++ b/apps/dashboard/src/lib/orpc/routers/brand.ts
@@ -931,7 +931,6 @@ export const brandRouter = {
           headers: context.headers,
           organizationId: input.organizationId,
         });
-        await assertActiveSubscription(input.organizationId);
 
         const { success: withinLimit } = await ratelimit.importTweets.limit(
           input.organizationId

--- a/apps/dashboard/src/lib/orpc/routers/social-accounts.ts
+++ b/apps/dashboard/src/lib/orpc/routers/social-accounts.ts
@@ -4,7 +4,6 @@ import { and, eq } from "drizzle-orm";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
-import { assertActiveSubscription } from "@/lib/billing/subscription";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import { redis } from "@/lib/redis";
 import { organizationIdSchema } from "@/schemas/auth/organization";
@@ -117,7 +116,6 @@ export const socialAccountsRouter = {
           organizationId: input.organizationId,
           user: context.user,
         });
-        await assertActiveSubscription(input.organizationId);
 
         const clientId = process.env.TWITTER_CLIENT_ID;
         if (!clientId) {

--- a/apps/dashboard/src/schemas/onboarding/workspace.ts
+++ b/apps/dashboard/src/schemas/onboarding/workspace.ts
@@ -1,0 +1,18 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+import {
+  organizationNameSchema,
+  organizationSlugSchema,
+} from "@/schemas/organization";
+
+export const onboardingWorkspaceSchema = z.object({
+  name: organizationNameSchema,
+  slug: organizationSlugSchema,
+  websiteUrl: z
+    .string()
+    .url("Please enter a valid URL (e.g., https://example.com)"),
+});
+
+export type OnboardingWorkspaceInput = z.infer<
+  typeof onboardingWorkspaceSchema
+>;


### PR DESCRIPTION
## Summary
- Replace the auto-org-on-signup + pricing-only onboarding with a 3-step guided flow: workspace → socials → pricing. New users invest in their setup (name, website, X account, tweet import) before hitting the paywall.
- Strip the `auth.api.createOrganization` block from Better Auth's `user.create.after` hook — orgs are now created from the workspace step instead of silently on signup.
- Drop the `assertActiveSubscription` gate from `twitter.beginAuth` and `brand.references.importTweets` so onboarding can connect X and pull tweets pre-payment. All other subscription gates (post creation, schedule creation, content generation, etc.) are unchanged.
- Existing paid users and any legacy "Personal" orgs short-circuit the new flow via the existing `hasPaidSubscriptionHistory` check.

## Flow
1. `/onboarding/workspace` — org name + slug + website. On submit: `authClient.organization.create` → `setActive` → `triggerOnboardingBrandAnalysis` (creates `brandSettings` row + queues QStash brand-analysis workflow). The existing `organization.create.after` hook still seeds skills + creates the Autumn customer.
2. `/onboarding/socials` — connect X via existing OAuth (callback returns to `/onboarding/socials`), optional tweet import into `brandReferences` via existing `useImportTweets` hook. Skip link goes straight to pricing.
3. `/onboarding/pricing` — thin RSC wrapper around the existing `PricingClient`.
4. Root `/onboarding` redirects to the right step based on DB state (no org → workspace; org but no `brandSettings` → workspace; otherwise → socials).

## Notable touches
- `lib/brand-analysis.ts` — replicates the apps/api brand-analysis trigger so the dashboard can queue scraping without an HTTP hop.
- Slug field uses zod's `.slugify()` so dots, tabs, and spaces get stripped as you type.
- `OnboardingAccountMenu` moved into the shared onboarding layout (was duplicated in `PricingClient`).
- The in-dashboard onboarding checklist (`organizations.onboardingCompleted`) is left alone — it now starts shorter for new users (brand done, just GitHub + schedule remaining). Can be retired in a follow-up.

## Test plan
- [ ] Fresh signup with a new email → no org row in DB; user lands on `/onboarding/workspace`
- [ ] Submit name + website → org + member rows created, `brandSettings` row exists with `websiteUrl`, QStash workflow triggered, redirect to `/onboarding/socials`
- [ ] Connect X → OAuth round-trip completes, `connectedSocialAccounts` row created, return to `/onboarding/socials`
- [ ] Click "Import recent tweets" → `brandReferences` rows inserted; rate limit still applies
- [ ] Pick plan → Autumn checkout, success → `/{slug}` (returning to `/` short-circuits to dashboard)
- [ ] Refresh on `/onboarding/socials` mid-flow → stays on socials step
- [ ] Existing paid user logs in → bypasses entire new flow
- [ ] `bun run build` passes