### PR TITLE
feat(web): add Article and FAQ JSON-LD to blog posts

### DIFF
--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -4,6 +4,11 @@ import { notFound } from "next/navigation";
 import { ChangelogHtmlArticle } from "@/components/changelog-html-article";
 import { NotraMark } from "@/components/notra-mark";
 import { formatBlogDate, getNotraBlogPostBySlug } from "@/utils/blog";
+import {
+  buildBlogArticleJsonLd,
+  buildBlogFaqJsonLd,
+  serializeJsonLd,
+} from "@/utils/blog-jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";
 import type { BlogEntryPageProps } from "~types/blog";
@@ -53,8 +58,26 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
     notFound();
   }
 
+  const url = `${SITE_URL}/blog/${slug}`;
+  const imageUrl = `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`;
+  const articleJsonLd = buildBlogArticleJsonLd({ post, url, imageUrl });
+  const faqJsonLd = buildBlogFaqJsonLd(post);
+
   return (
     <>
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD payload is server-built and script-close-escaped
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(articleJsonLd) }}
+        type="application/ld+json"
+      />
+      {faqJsonLd ? (
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD payload is server-built and script-close-escaped
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqJsonLd) }}
+          type="application/ld+json"
+        />
+      ) : null}
+
       <Link
         className="mb-6 inline-flex items-center gap-1 font-sans text-foreground/50 text-sm transition-colors hover:text-foreground"
         href="/blog"

--- a/apps/web/src/utils/blog-jsonld.ts
+++ b/apps/web/src/utils/blog-jsonld.ts
@@ -13,10 +13,17 @@ import {
 import { SITE_URL } from "@/utils/urls";
 import type { BlogFaqEntry, BlogJsonLdInput, NotraBlogPost } from "~types/blog";
 
+interface BlogHeading {
+  level: number;
+  text: string;
+  index: number;
+  endIndex: number;
+}
+
 function decodeHtmlEntities(value: string) {
   return value.replace(
     HTML_ENTITY_REGEX,
-    (_, entity: string) => HTML_ENTITY_MAP[entity] ?? ""
+    (match, entity: string) => HTML_ENTITY_MAP[entity] ?? match
   );
 }
 
@@ -26,27 +33,47 @@ function stripHtml(value: string) {
     .trim();
 }
 
-function extractHeadings(html: string) {
-  const headings: { level: number; text: string; index: number }[] = [];
-  BLOG_HEADING_REGEX.lastIndex = 0;
+function extractHeadings(html: string): BlogHeading[] {
+  const headings: BlogHeading[] = [];
 
-  let match = BLOG_HEADING_REGEX.exec(html);
-  while (match !== null) {
-    const [, levelGroup, contentGroup] = match;
-    if (levelGroup && contentGroup !== undefined) {
-      const text = stripHtml(contentGroup);
-      if (text.length > 0) {
-        headings.push({
-          level: Number(levelGroup),
-          text,
-          index: match.index,
-        });
-      }
+  for (const match of html.matchAll(BLOG_HEADING_REGEX)) {
+    const [fullMatch, levelGroup, contentGroup] = match;
+    if (!(levelGroup && contentGroup !== undefined && fullMatch)) {
+      continue;
     }
-    match = BLOG_HEADING_REGEX.exec(html);
+
+    const text = stripHtml(contentGroup);
+    if (text.length === 0) {
+      continue;
+    }
+
+    const startIndex = match.index ?? 0;
+    headings.push({
+      level: Number(levelGroup),
+      text,
+      index: startIndex,
+      endIndex: startIndex + fullMatch.length,
+    });
   }
 
   return headings;
+}
+
+function extractParagraphs(html: string) {
+  const paragraphs: string[] = [];
+
+  for (const match of html.matchAll(BLOG_PARAGRAPH_REGEX)) {
+    const content = match[1];
+    if (content === undefined) {
+      continue;
+    }
+    const stripped = stripHtml(content);
+    if (stripped.length > 0) {
+      paragraphs.push(stripped);
+    }
+  }
+
+  return paragraphs;
 }
 
 export function extractBlogFaqEntries(html: string): BlogFaqEntry[] {
@@ -65,57 +92,30 @@ export function extractBlogFaqEntries(html: string): BlogFaqEntry[] {
     return [];
   }
 
-  const nextH2 = headings
-    .slice(faqHeadingIndex + 1)
-    .find((heading) => heading.level === 2);
-
-  const sectionStart = faqHeading.index;
-  const sectionEnd = nextH2?.index ?? html.length;
-  const section = html.slice(sectionStart, sectionEnd);
+  const sectionHeadings = headings.slice(faqHeadingIndex + 1);
+  const sectionEnd =
+    sectionHeadings.find((heading) => heading.level === 2)?.index ??
+    html.length;
 
   const entries: BlogFaqEntry[] = [];
-  BLOG_HEADING_REGEX.lastIndex = 0;
 
-  let questionMatch = BLOG_HEADING_REGEX.exec(section);
-  while (questionMatch !== null) {
-    const [fullMatch, levelGroup, contentGroup] = questionMatch;
-    if (!(levelGroup && contentGroup !== undefined && fullMatch)) {
-      questionMatch = BLOG_HEADING_REGEX.exec(section);
+  for (let i = 0; i < sectionHeadings.length; i += 1) {
+    const heading = sectionHeadings[i];
+    if (!heading || heading.level !== 3 || heading.index >= sectionEnd) {
       continue;
     }
 
-    if (Number(levelGroup) !== 3) {
-      questionMatch = BLOG_HEADING_REGEX.exec(section);
-      continue;
+    const nextHeading = sectionHeadings[i + 1];
+    const answerEnd = Math.min(nextHeading?.index ?? sectionEnd, sectionEnd);
+    const answerSlice = html.slice(heading.endIndex, answerEnd);
+    const answerParts = extractParagraphs(answerSlice);
+
+    if (heading.text.length > 0 && answerParts.length > 0) {
+      entries.push({
+        question: heading.text,
+        answer: answerParts.join(" "),
+      });
     }
-
-    const question = stripHtml(contentGroup);
-    const answerStart = questionMatch.index + fullMatch.length;
-    BLOG_HEADING_REGEX.lastIndex = answerStart;
-    const nextHeading = BLOG_HEADING_REGEX.exec(section);
-    const nextHeadingIndex = nextHeading?.index ?? section.length;
-
-    const answerSlice = section.slice(answerStart, nextHeadingIndex);
-    BLOG_PARAGRAPH_REGEX.lastIndex = 0;
-    const answerParts: string[] = [];
-    let paragraphMatch = BLOG_PARAGRAPH_REGEX.exec(answerSlice);
-    while (paragraphMatch !== null) {
-      const paragraphContent = paragraphMatch[1];
-      if (paragraphContent !== undefined) {
-        const paragraph = stripHtml(paragraphContent);
-        if (paragraph.length > 0) {
-          answerParts.push(paragraph);
-        }
-      }
-      paragraphMatch = BLOG_PARAGRAPH_REGEX.exec(answerSlice);
-    }
-
-    if (question.length > 0 && answerParts.length > 0) {
-      entries.push({ question, answer: answerParts.join(" ") });
-    }
-
-    BLOG_HEADING_REGEX.lastIndex = nextHeadingIndex;
-    questionMatch = BLOG_HEADING_REGEX.exec(section);
   }
 
   return entries;

--- a/apps/web/src/utils/blog-jsonld.ts
+++ b/apps/web/src/utils/blog-jsonld.ts
@@ -1,0 +1,199 @@
+import {
+  BLOG_FAQ_HEADING_REGEX,
+  BLOG_HEADING_REGEX,
+  BLOG_NUMBERED_HEADING_PREFIX_REGEX,
+  BLOG_PARAGRAPH_REGEX,
+  BLOG_TAG_REGEX,
+  BLOG_WHITESPACE_REGEX,
+  HTML_ENTITY_MAP,
+  HTML_ENTITY_REGEX,
+  JSON_LD_SCRIPT_CLOSE_REGEX,
+  NOTRA_LOGO_PATH,
+} from "@/utils/constants";
+import { SITE_URL } from "@/utils/urls";
+import type { BlogFaqEntry, BlogJsonLdInput, NotraBlogPost } from "~types/blog";
+
+function decodeHtmlEntities(value: string) {
+  return value.replace(
+    HTML_ENTITY_REGEX,
+    (_, entity: string) => HTML_ENTITY_MAP[entity] ?? ""
+  );
+}
+
+function stripHtml(value: string) {
+  return decodeHtmlEntities(value.replace(BLOG_TAG_REGEX, ""))
+    .replace(BLOG_WHITESPACE_REGEX, " ")
+    .trim();
+}
+
+function extractHeadings(html: string) {
+  const headings: { level: number; text: string; index: number }[] = [];
+  BLOG_HEADING_REGEX.lastIndex = 0;
+
+  let match = BLOG_HEADING_REGEX.exec(html);
+  while (match !== null) {
+    const [, levelGroup, contentGroup] = match;
+    if (levelGroup && contentGroup !== undefined) {
+      const text = stripHtml(contentGroup);
+      if (text.length > 0) {
+        headings.push({
+          level: Number(levelGroup),
+          text,
+          index: match.index,
+        });
+      }
+    }
+    match = BLOG_HEADING_REGEX.exec(html);
+  }
+
+  return headings;
+}
+
+export function extractBlogFaqEntries(html: string): BlogFaqEntry[] {
+  const headings = extractHeadings(html);
+  const faqHeadingIndex = headings.findIndex(
+    (heading) =>
+      heading.level === 2 && BLOG_FAQ_HEADING_REGEX.test(heading.text)
+  );
+
+  if (faqHeadingIndex === -1) {
+    return [];
+  }
+
+  const faqHeading = headings[faqHeadingIndex];
+  if (!faqHeading) {
+    return [];
+  }
+
+  const nextH2 = headings
+    .slice(faqHeadingIndex + 1)
+    .find((heading) => heading.level === 2);
+
+  const sectionStart = faqHeading.index;
+  const sectionEnd = nextH2?.index ?? html.length;
+  const section = html.slice(sectionStart, sectionEnd);
+
+  const entries: BlogFaqEntry[] = [];
+  BLOG_HEADING_REGEX.lastIndex = 0;
+
+  let questionMatch = BLOG_HEADING_REGEX.exec(section);
+  while (questionMatch !== null) {
+    const [fullMatch, levelGroup, contentGroup] = questionMatch;
+    if (!(levelGroup && contentGroup !== undefined && fullMatch)) {
+      questionMatch = BLOG_HEADING_REGEX.exec(section);
+      continue;
+    }
+
+    if (Number(levelGroup) !== 3) {
+      questionMatch = BLOG_HEADING_REGEX.exec(section);
+      continue;
+    }
+
+    const question = stripHtml(contentGroup);
+    const answerStart = questionMatch.index + fullMatch.length;
+    BLOG_HEADING_REGEX.lastIndex = answerStart;
+    const nextHeading = BLOG_HEADING_REGEX.exec(section);
+    const nextHeadingIndex = nextHeading?.index ?? section.length;
+
+    const answerSlice = section.slice(answerStart, nextHeadingIndex);
+    BLOG_PARAGRAPH_REGEX.lastIndex = 0;
+    const answerParts: string[] = [];
+    let paragraphMatch = BLOG_PARAGRAPH_REGEX.exec(answerSlice);
+    while (paragraphMatch !== null) {
+      const paragraphContent = paragraphMatch[1];
+      if (paragraphContent !== undefined) {
+        const paragraph = stripHtml(paragraphContent);
+        if (paragraph.length > 0) {
+          answerParts.push(paragraph);
+        }
+      }
+      paragraphMatch = BLOG_PARAGRAPH_REGEX.exec(answerSlice);
+    }
+
+    if (question.length > 0 && answerParts.length > 0) {
+      entries.push({ question, answer: answerParts.join(" ") });
+    }
+
+    BLOG_HEADING_REGEX.lastIndex = nextHeadingIndex;
+    questionMatch = BLOG_HEADING_REGEX.exec(section);
+  }
+
+  return entries;
+}
+
+export function extractBlogAboutEntities(html: string) {
+  return extractHeadings(html)
+    .filter(
+      (heading) =>
+        heading.level === 2 && !BLOG_FAQ_HEADING_REGEX.test(heading.text)
+    )
+    .map((heading) =>
+      heading.text.replace(BLOG_NUMBERED_HEADING_PREFIX_REGEX, "")
+    )
+    .filter((text, index, list) => list.indexOf(text) === index);
+}
+
+export function buildBlogArticleJsonLd({
+  post,
+  url,
+  imageUrl,
+}: BlogJsonLdInput) {
+  const aboutEntities = extractBlogAboutEntities(post.content);
+  const publisher = {
+    "@type": "Organization",
+    name: "Notra",
+    url: SITE_URL,
+    logo: {
+      "@type": "ImageObject",
+      url: `${SITE_URL}${NOTRA_LOGO_PATH}`,
+    },
+  } as const;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.excerpt,
+    image: imageUrl,
+    datePublished: post.createdAt,
+    dateModified: post.updatedAt,
+    author: publisher,
+    publisher,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+    url,
+    inLanguage: "en-US",
+    keywords: aboutEntities.length > 0 ? aboutEntities.join(", ") : undefined,
+    about:
+      aboutEntities.length > 0
+        ? aboutEntities.map((name) => ({ "@type": "Thing", name }))
+        : undefined,
+  };
+}
+
+export function buildBlogFaqJsonLd(post: NotraBlogPost) {
+  const entries = extractBlogFaqEntries(post.content);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: entries.map((entry) => ({
+      "@type": "Question",
+      name: entry.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: entry.answer,
+      },
+    })),
+  };
+}
+
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value).replace(JSON_LD_SCRIPT_CLOSE_REGEX, "<\\/$1");
+}

--- a/apps/web/src/utils/constants.ts
+++ b/apps/web/src/utils/constants.ts
@@ -11,6 +11,27 @@ export const SOCIAL_LINKS = {
   discord: "/discord",
 } as const;
 
+export const NOTRA_LOGO_PATH = "/notra-mark.svg";
+
+export const BLOG_HEADING_REGEX = /<h([2-3])[^>]*>([\s\S]*?)<\/h\1>/gi;
+export const BLOG_PARAGRAPH_REGEX = /<p[^>]*>([\s\S]*?)<\/p>/gi;
+export const BLOG_TAG_REGEX = /<[^>]+>/g;
+export const BLOG_WHITESPACE_REGEX = /\s+/g;
+export const BLOG_FAQ_HEADING_REGEX =
+  /^(frequently asked questions|faqs?|q\s*&\s*a)$/i;
+export const BLOG_NUMBERED_HEADING_PREFIX_REGEX = /^\d+\.\s*/;
+export const JSON_LD_SCRIPT_CLOSE_REGEX = /<\/(script)/gi;
+export const HTML_ENTITY_REGEX = /&(amp|lt|gt|quot|#39|nbsp);/g;
+
+export const HTML_ENTITY_MAP: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  "#39": "'",
+  nbsp: " ",
+};
+
 export const PRICING_PLANS = {
   basic: {
     name: "Basic",

--- a/apps/web/types/blog.ts
+++ b/apps/web/types/blog.ts
@@ -42,3 +42,14 @@ interface BlogHtmlArticleProps {
 export interface BlogEntryPageProps {
   params: Promise<{ slug: string }>;
 }
+
+export interface BlogFaqEntry {
+  question: string;
+  answer: string;
+}
+
+export interface BlogJsonLdInput {
+  post: NotraBlogPost;
+  url: string;
+  imageUrl: string;
+}


### PR DESCRIPTION
## Summary
- Emits `BlogPosting` JSON-LD on every `/blog/[slug]` page with `author`, `publisher`, `datePublished`, `dateModified`, `mainEntityOfPage`, and `about: Thing[]` derived from H2 headings.
- When a post contains a "Frequently asked questions" (or `FAQ`/`Q&A`) section, also emits `FAQPage` JSON-LD with `Question`/`acceptedAnswer` pairs parsed from the H3/p structure.
- Constants (regex literals, entity map, logo path) live in `src/utils/constants.ts`; types in `types/blog.ts`.

Why: AI engines (Perplexity, Gemini) and search engines preferentially extract structured data. Personabox-style schema closes the biggest AEO gap on /blog.

## Test plan
- [x] `bun run build` passes (typecheck included)
- [x] Parser sanity-checked against the live AI tools post: 6 `about` entities + 5 FAQ entries extracted cleanly
- [ ] After deploy, validate one post with Google Rich Results Test
- [ ] Confirm FAQ rich result eligibility for the AI tools post