### PR TITLE
fix(web): SEO fixes across robots, sitemap, headings, and structured data

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,19 +1,12 @@
 import path from "node:path";
 import { createMDX } from "fumadocs-mdx/next";
 import type { NextConfig } from "next";
+import { SHOWCASE_COMPANIES } from "./src/utils/showcase";
 import { HOMEPAGE_LINK_HEADER } from "./src/utils/urls";
 
-const SHOWCASE_COMPANY_SLUGS = [
-  "autumn",
-  "better-auth",
-  "cal-com",
-  "databuddy",
-  "langfuse",
-  "marble",
-  "neon",
-  "openclaw",
-  "unkey",
-];
+const SHOWCASE_COMPANY_SLUGS = SHOWCASE_COMPANIES.map(
+  (company) => company.slug
+);
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -87,17 +80,6 @@ const nextConfig: NextConfig = {
         destination: "/blog/markdown",
       },
       {
-        source: "/blog/markdown",
-        destination: "/blog/markdown",
-        has: [
-          {
-            type: "header",
-            key: "accept",
-            value: ".*text/markdown.*",
-          },
-        ],
-      },
-      {
         source: "/blog/:slug",
         destination: "/blog/:slug/markdown",
         has: [
@@ -124,34 +106,12 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        source: "/changelog/notra",
-        destination: "/changelog/notra/markdown",
-        has: [
-          {
-            type: "header",
-            key: "accept",
-            value: ".*text/markdown.*",
-          },
-        ],
-      },
-      {
-        source: "/changelog/notra/:slug",
-        destination: "/changelog/notra/:slug/markdown",
-        has: [
-          {
-            type: "header",
-            key: "accept",
-            value: ".*text/markdown.*",
-          },
-        ],
-      },
-      {
         source: "/changelog.md",
         destination: "/changelog/markdown",
       },
       {
-        source: "/changelog/markdown",
-        destination: "/changelog/markdown",
+        source: "/changelog/notra",
+        destination: "/changelog/notra/markdown",
         has: [
           {
             type: "header",
@@ -165,8 +125,8 @@ const nextConfig: NextConfig = {
         destination: "/changelog/notra/markdown",
       },
       {
-        source: "/changelog/notra/markdown",
-        destination: "/changelog/notra/markdown",
+        source: "/changelog/notra/:slug",
+        destination: "/changelog/notra/:slug/markdown",
         has: [
           {
             type: "header",
@@ -178,28 +138,6 @@ const nextConfig: NextConfig = {
       {
         source: "/changelog/notra/:slug.md",
         destination: "/changelog/notra/:slug/markdown",
-      },
-      {
-        source: "/changelog/notra/:slug/markdown",
-        destination: "/changelog/notra/:slug/markdown",
-        has: [
-          {
-            type: "header",
-            key: "accept",
-            value: ".*text/markdown.*",
-          },
-        ],
-      },
-      {
-        source: "/changelog/:name/markdown",
-        destination: "/changelog/:name/markdown",
-        has: [
-          {
-            type: "header",
-            key: "accept",
-            value: ".*text/markdown.*",
-          },
-        ],
       },
       {
         source: "/changelog/:name",
@@ -215,17 +153,6 @@ const nextConfig: NextConfig = {
       {
         source: "/changelog/:name.md",
         destination: "/changelog/:name/markdown",
-      },
-      {
-        source: "/changelog/:name/:slug/markdown",
-        destination: "/changelog/:name/:slug/markdown",
-        has: [
-          {
-            type: "header",
-            key: "accept",
-            value: ".*text/markdown.*",
-          },
-        ],
       },
       {
         source: "/changelog/:name/:slug",

--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -6,8 +6,8 @@ import { formatBlogDate, getNotraBlogPostBySlug } from "@/utils/blog";
 import {
   buildBlogArticleJsonLd,
   buildBlogFaqJsonLd,
-  serializeJsonLd,
 } from "@/utils/blog-jsonld";
+import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";
 import type { BlogEntryPageProps } from "~types/blog";
@@ -61,12 +61,22 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
   const imageUrl = `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`;
   const articleJsonLd = buildBlogArticleJsonLd({ post, url, imageUrl });
   const faqJsonLd = buildBlogFaqJsonLd(post);
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Blog", url: `${SITE_URL}/blog` },
+    { name: post.title, url },
+  ]);
 
   return (
     <>
       <script
         // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD payload is server-built and script-close-escaped
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(articleJsonLd) }}
+        type="application/ld+json"
+      />
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD payload is server-built and script-close-escaped
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
         type="application/ld+json"
       />
       {faqJsonLd ? (

--- a/apps/web/src/app/(changelog)/changelog/[name]/[slug]/page.tsx
+++ b/apps/web/src/app/(changelog)/changelog/[name]/[slug]/page.tsx
@@ -6,6 +6,11 @@ import { getMDXComponents } from "@/../mdx-components";
 import { NotraMark } from "@/components/notra-mark";
 import { TableOfContents } from "@/components/table-of-contents";
 import { formatChangelogDate } from "@/utils/changelog";
+import {
+  buildArticleJsonLd,
+  buildBreadcrumbJsonLd,
+  serializeJsonLd,
+} from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import {
   getShowcaseCompany,
@@ -50,6 +55,7 @@ export async function generateMetadata({
       url,
       type: "article",
       publishedTime: entry.date,
+      modifiedTime: entry.date,
       siteName: "Notra",
       images: [DEFAULT_SOCIAL_IMAGE],
     },
@@ -78,9 +84,34 @@ export default async function ShowcaseEntryPage({
   }
 
   const MDX = entry.body;
+  const url = `${SITE_URL}/changelog/${name}/${slug}`;
+  const articleJsonLd = buildArticleJsonLd({
+    url,
+    title: entry.title,
+    description: entry.description,
+    imageUrl: `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`,
+    datePublished: entry.date,
+    authorName: company.name,
+  });
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Changelog", url: `${SITE_URL}/changelog` },
+    { name: company.name, url: `${SITE_URL}/changelog/${name}` },
+    { name: entry.title, url },
+  ]);
 
   return (
     <div className="w-full max-w-[760px] self-center">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(articleJsonLd) }}
+        type="application/ld+json"
+      />
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
       <Link
         className="mb-6 inline-flex items-center gap-1 font-sans text-foreground/50 text-sm transition-colors hover:text-foreground"
         href={`/changelog/${name}`}

--- a/apps/web/src/app/(changelog)/changelog/notra/[slug]/page.tsx
+++ b/apps/web/src/app/(changelog)/changelog/notra/[slug]/page.tsx
@@ -7,6 +7,11 @@ import {
   formatChangelogDate,
   getNotraChangelogPostBySlug,
 } from "@/utils/changelog";
+import {
+  buildArticleJsonLd,
+  buildBreadcrumbJsonLd,
+  serializeJsonLd,
+} from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";
 import type { ChangelogEntryPageProps } from "~types/changelog";
@@ -58,8 +63,34 @@ export default async function ChangelogEntryPage({
     notFound();
   }
 
+  const url = `${SITE_URL}/changelog/notra/${slug}`;
+  const articleJsonLd = buildArticleJsonLd({
+    url,
+    title: post.title,
+    description: post.excerpt,
+    imageUrl: `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`,
+    datePublished: post.createdAt,
+    dateModified: post.updatedAt,
+  });
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Changelog", url: `${SITE_URL}/changelog` },
+    { name: "Notra", url: `${SITE_URL}/changelog/notra` },
+    { name: post.title, url },
+  ]);
+
   return (
     <>
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(articleJsonLd) }}
+        type="application/ld+json"
+      />
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
       <Link
         className="mb-6 inline-flex items-center gap-1 font-sans text-foreground/50 text-sm transition-colors hover:text-foreground"
         href="/changelog/notra"

--- a/apps/web/src/app/contributors/loading.tsx
+++ b/apps/web/src/app/contributors/loading.tsx
@@ -6,7 +6,7 @@ export default function Loading() {
       <section className="flex w-full items-center justify-center px-6 py-12 md:px-24 md:py-16">
         <div className="flex w-full max-w-[586px] flex-col items-center gap-4">
           <h1 className="text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
-            Contributors & <span className="text-primary">community</span>
+            Contributors & <span className="text-primary">Community</span>
           </h1>
           <p className="text-center font-normal font-sans text-base text-muted-foreground leading-7">
             Meet the developers who build Notra. Browse open issues, check in on

--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -1,0 +1,255 @@
+import type { Metadata } from "next";
+import dynamic from "next/dynamic";
+import { ActivityFeed } from "@/components/activity-feed";
+import BrandVoicePreview from "@/components/brand-voice-preview";
+import ReferencesPreview from "@/components/references-preview";
+import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
+import { SITE_URL } from "@/utils/urls";
+
+const CTASection = dynamic(() => import("@/components/cta-section"));
+const IntegrationOrbit = dynamic(
+  () => import("@/components/integration-orbit")
+);
+
+const title = "Features";
+const description =
+  "See how Notra turns shipped engineering work into changelogs, launch posts, and social updates that match your brand voice.";
+const url = `${SITE_URL}/features`;
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: url },
+  openGraph: {
+    title,
+    description,
+    url,
+    type: "website",
+    siteName: "Notra",
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE.url],
+    site: TWITTER_HANDLE,
+    creator: TWITTER_HANDLE,
+  },
+};
+
+const CORE_FEATURES = [
+  {
+    title: "One timeline of everything you shipped",
+    description:
+      "PRs, issues, and decisions from GitHub, Linear, and Slack land in one place, so nothing worth writing about slips through.",
+    visual: "activity",
+  },
+  {
+    title: "Drafts that don't sound like AI",
+    description:
+      "Notra learns your brand voice from your real posts and tweets. Every draft reads like your best writer wrote it.",
+    visual: "brandVoice",
+  },
+  {
+    title: "Set up in under a minute",
+    description:
+      "One click connects GitHub, Linear, and Slack. No pipelines, no prompts to engineer, no Zapier spaghetti.",
+    visual: "integrations",
+  },
+  {
+    title: "Train it on your best writing",
+    description:
+      "Drop in your tweets, launch posts, or blog snippets. Notra matches tone, cadence, and vocabulary. Yours, not ChatGPT's.",
+    visual: "references",
+  },
+] as const;
+
+const PUBLISHING_WORKFLOWS = [
+  {
+    title: "Auto-generate changelogs",
+    description:
+      "Every merged PR becomes a changelog entry. Kill the “what did we ship this week?” meeting.",
+  },
+  {
+    title: "Draft launch posts from features",
+    description:
+      "Ship a feature, get a first-draft announcement waiting for you. Review, polish, publish.",
+  },
+  {
+    title: "Social updates on autopilot",
+    description:
+      "Milestones and releases become short posts for X and LinkedIn. Stay visible without context-switching.",
+  },
+] as const;
+
+const featuresJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  itemListElement: CORE_FEATURES.map((feature, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    name: feature.title,
+    description: feature.description,
+  })),
+};
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: SITE_URL,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Features",
+      item: url,
+    },
+  ],
+};
+
+function FeatureVisual({
+  kind,
+}: {
+  kind: (typeof CORE_FEATURES)[number]["visual"];
+}) {
+  if (kind === "activity") {
+    return (
+      <div className="relative flex w-full items-end justify-center overflow-hidden rounded-lg pt-4">
+        <ActivityFeed />
+        <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-8 bg-linear-to-t from-background to-transparent" />
+      </div>
+    );
+  }
+
+  if (kind === "brandVoice") {
+    return (
+      <div className="w-full pt-2">
+        <BrandVoicePreview />
+      </div>
+    );
+  }
+
+  if (kind === "integrations") {
+    return (
+      <div className="relative flex h-50 w-full items-center justify-center overflow-hidden rounded-lg sm:h-62.5 md:h-75">
+        <IntegrationOrbit className="h-full w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full pt-2">
+      <ReferencesPreview />
+    </div>
+  );
+}
+
+export default function FeaturesPage() {
+  return (
+    <div className="flex w-full flex-col items-center justify-start overflow-hidden border-border/70 border-b pt-20 sm:pt-24 md:pt-28 lg:pt-32">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(featuresJsonLd) }}
+        type="application/ld+json"
+      />
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
+
+      <section className="flex w-full items-center justify-center px-6 py-12 md:px-24 md:py-16">
+        <div className="flex w-full max-w-[586px] flex-col items-center gap-4">
+          <h1 className="text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
+            Every shipped feature, <span className="text-primary">told</span>
+          </h1>
+          <p className="text-center font-normal font-sans text-base text-muted-foreground leading-7">
+            Notra watches GitHub, Linear, and Slack, then drafts changelogs,
+            launch posts, and social updates in your brand voice.
+          </p>
+        </div>
+      </section>
+
+      <section className="flex w-full flex-col items-center justify-center border-border border-t">
+        <div className="flex items-center justify-center gap-6 self-stretch border-border border-b px-6 py-12 md:px-24 md:py-16">
+          <div className="flex w-full max-w-[586px] flex-col items-center justify-start gap-4">
+            <h2 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
+              Built around how your team{" "}
+              <span className="text-primary">actually ships</span>
+            </h2>
+            <p className="self-stretch text-center font-normal font-sans text-base text-muted-foreground leading-7">
+              No new dashboards to babysit. Notra fits the workflow you already
+              have.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid w-full grid-cols-1 border-border border-b md:grid-cols-2">
+          {CORE_FEATURES.map((feature, index) => {
+            const isLastRowEven = index >= CORE_FEATURES.length - 2;
+            const isLeftColumn = index % 2 === 0;
+            return (
+              <div
+                className={`flex flex-col items-start justify-start gap-4 p-4 sm:gap-6 sm:p-6 md:p-8 lg:p-12 ${isLeftColumn ? "md:border-border md:border-r" : ""} ${isLastRowEven ? "" : "border-border border-b"}`}
+                key={feature.title}
+              >
+                <div className="flex flex-col gap-2">
+                  <h3 className="font-sans font-semibold text-foreground text-lg leading-tight sm:text-xl">
+                    {feature.title}
+                  </h3>
+                  <p className="font-normal font-sans text-muted-foreground text-sm leading-relaxed md:text-base">
+                    {feature.description}
+                  </p>
+                </div>
+                <FeatureVisual kind={feature.visual} />
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="flex w-full flex-col items-center justify-center">
+        <div className="flex items-center justify-center gap-6 self-stretch border-border border-b px-6 py-12 md:px-24 md:py-16">
+          <div className="flex w-full max-w-[586px] flex-col items-center justify-start gap-4">
+            <h2 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
+              Publishing workflows that{" "}
+              <span className="text-primary">run themselves</span>
+            </h2>
+            <p className="self-stretch text-center font-normal font-sans text-base text-muted-foreground leading-7">
+              Pick the surfaces you care about. Notra keeps them filled.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid w-full grid-cols-1 border-border border-b md:grid-cols-3">
+          {PUBLISHING_WORKFLOWS.map((workflow, index) => {
+            const isLast = index === PUBLISHING_WORKFLOWS.length - 1;
+            return (
+              <div
+                className={`flex flex-col items-start justify-start gap-3 p-6 sm:p-8 lg:p-10 ${isLast ? "" : "border-border border-b md:border-r md:border-b-0"}`}
+                key={workflow.title}
+              >
+                <h3 className="font-sans font-semibold text-foreground text-lg leading-tight sm:text-xl">
+                  {workflow.title}
+                </h3>
+                <p className="font-normal font-sans text-muted-foreground text-sm leading-relaxed md:text-base">
+                  {workflow.description}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="w-full">
+        <CTASection />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { ActivityFeed } from "@/components/activity-feed";
 import BrandVoicePreview from "@/components/brand-voice-preview";
 import ReferencesPreview from "@/components/references-preview";
+import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";
 
@@ -94,24 +95,10 @@ const featuresJsonLd = {
   })),
 };
 
-const breadcrumbJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  itemListElement: [
-    {
-      "@type": "ListItem",
-      position: 1,
-      name: "Home",
-      item: SITE_URL,
-    },
-    {
-      "@type": "ListItem",
-      position: 2,
-      name: "Features",
-      item: url,
-    },
-  ],
-};
+const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+  { name: "Home", url: SITE_URL },
+  { name: "Features", url },
+]);
 
 function FeatureVisual({
   kind,
@@ -155,34 +142,22 @@ export default function FeaturesPage() {
     <div className="flex w-full flex-col items-center justify-start overflow-hidden border-border/70 border-b pt-20 sm:pt-24 md:pt-28 lg:pt-32">
       <script
         // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(featuresJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(featuresJsonLd) }}
         type="application/ld+json"
       />
       <script
         // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
         type="application/ld+json"
       />
 
-      <section className="flex w-full items-center justify-center px-6 py-12 md:px-24 md:py-16">
-        <div className="flex w-full max-w-[586px] flex-col items-center gap-4">
-          <h1 className="text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
-            Every shipped feature, <span className="text-primary">told</span>
-          </h1>
-          <p className="text-center font-normal font-sans text-base text-muted-foreground leading-7">
-            Notra watches GitHub, Linear, and Slack, then drafts changelogs,
-            launch posts, and social updates in your brand voice.
-          </p>
-        </div>
-      </section>
-
-      <section className="flex w-full flex-col items-center justify-center border-border border-t">
+      <section className="flex w-full flex-col items-center justify-center">
         <div className="flex items-center justify-center gap-6 self-stretch border-border border-b px-6 py-12 md:px-24 md:py-16">
           <div className="flex w-full max-w-[586px] flex-col items-center justify-start gap-4">
-            <h2 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
+            <h1 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
               Built around how your team{" "}
               <span className="text-primary">actually ships</span>
-            </h2>
+            </h1>
             <p className="self-stretch text-center font-normal font-sans text-base text-muted-foreground leading-7">
               No new dashboards to babysit. Notra fits the workflow you already
               have.

--- a/apps/web/src/app/manifest.json
+++ b/apps/web/src/app/manifest.json
@@ -1,12 +1,27 @@
 {
   "name": "Notra",
   "short_name": "Notra",
+  "description": "Notra turns shipped work into changelogs, launch posts, and social updates in your voice.",
+  "start_url": "/",
+  "scope": "/",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/web-app-manifest-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
       "purpose": "maskable"
+    },
+    {
+      "src": "/web-app-manifest-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/web-app-manifest-512x512.png",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -118,10 +118,10 @@ export default function LandingPage() {
         >
           <div className="flex items-center justify-center gap-6 self-stretch border-border border-b px-4 py-8 sm:px-6 sm:py-12 md:px-24 md:py-16">
             <div className="flex w-full max-w-146.5 flex-col items-center justify-start gap-3 sm:gap-4">
-              <div className="w-full max-w-[29.53rem] text-balance text-center font-sans font-semibold text-foreground text-xl leading-tight tracking-tight sm:text-2xl md:text-3xl md:leading-15 lg:text-5xl">
+              <h2 className="w-full max-w-[29.53rem] text-balance text-center font-sans font-semibold text-foreground text-xl leading-tight tracking-tight sm:text-2xl md:text-3xl md:leading-15 lg:text-5xl">
                 Fast-moving teams trust Notra to{" "}
                 <span className="text-primary">tell their story</span>
-              </div>
+              </h2>
               <div className="self-stretch text-balance text-center font-normal font-sans text-muted-foreground text-sm leading-6 sm:text-base sm:leading-7">
                 Startups use Notra to turn every shipped feature{" "}
                 <br className="hidden sm:block" />
@@ -190,10 +190,10 @@ export default function LandingPage() {
         >
           <div className="flex items-center justify-center gap-6 self-stretch border-border border-b px-6 py-12 md:px-24 md:py-16">
             <div className="flex w-full max-w-[586px] flex-col items-center justify-start gap-4">
-              <div className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
+              <h2 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
                 Your team ships. Notra{" "}
                 <span className="text-primary">tells the story</span>
-              </div>
+              </h2>
               <div className="self-stretch text-center font-normal font-sans text-base text-muted-foreground leading-7">
                 Notra quietly watches GitHub, Linear, and Slack, then drafts
                 <br />
@@ -285,8 +285,8 @@ export default function LandingPage() {
             <div className="flex items-center justify-center gap-6 self-stretch px-6 py-12 md:px-24 md:py-16">
               <div className="flex w-full max-w-[586px] flex-col items-center justify-start gap-4">
                 <h2 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
-                  Pricing that scales with{" "}
-                  <span className="text-primary">what you ship</span>
+                  Pricing that grows with{" "}
+                  <span className="text-primary">your team</span>
                 </h2>
 
                 <div className="self-stretch text-center font-normal font-sans text-base text-muted-foreground leading-7">

--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
+import type { OfferLike } from "~types/jsonld";
 import PricingComparisonTable from "../../components/pricing-comparison-table";
 import { PricingCards } from "../../components/pricing-section";
+import { PRICING_PLANS } from "../../utils/constants";
+import {
+  buildBreadcrumbJsonLd,
+  buildProductJsonLd,
+  serializeJsonLd,
+} from "../../utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "../../utils/metadata";
 import { SITE_URL } from "../../utils/urls";
 
@@ -8,6 +15,40 @@ const title = "Pricing";
 const description =
   "Choose the right Notra plan for your team. Compare features across Basic, Pro, and Enterprise tiers.";
 const url = `${SITE_URL}/pricing`;
+
+const offers: OfferLike[] = Object.values(PRICING_PLANS).map((plan) => {
+  if (plan.pricing.monthly === null) {
+    return {
+      "@type": "Offer",
+      name: `${plan.name} plan`,
+      url,
+      availability: "https://schema.org/InStock",
+      category: plan.name,
+    };
+  }
+
+  return {
+    "@type": "Offer",
+    name: `${plan.name} plan`,
+    price: String(plan.pricing.monthly),
+    priceCurrency: "USD",
+    url,
+    availability: "https://schema.org/InStock",
+    category: plan.name,
+  };
+});
+
+const productJsonLd = buildProductJsonLd({
+  name: "Notra",
+  description,
+  url,
+  offers,
+});
+
+const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+  { name: "Home", url: SITE_URL },
+  { name: "Pricing", url },
+]);
 
 export const metadata: Metadata = {
   title,
@@ -36,6 +77,16 @@ export const metadata: Metadata = {
 export default function PricingPage() {
   return (
     <div className="flex w-full flex-col items-center justify-start overflow-hidden border-border/70 border-b pt-20 sm:pt-24 md:pt-28 lg:pt-32">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(productJsonLd) }}
+        type="application/ld+json"
+      />
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
       <div className="flex w-full flex-col items-center justify-center gap-2">
         <div className="flex items-center justify-center gap-6 self-stretch px-6 py-12 md:px-24 md:py-16">
           <div className="flex w-full max-w-[586px] flex-col items-center justify-start gap-4">

--- a/apps/web/src/app/robots.txt/route.ts
+++ b/apps/web/src/app/robots.txt/route.ts
@@ -4,6 +4,7 @@ const ROBOTS_TXT = `User-agent: *
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 Disallow: /.well-known/
+Disallow: /_next/
 
 Sitemap: ${SITE_URL}/sitemap.xml
 `;

--- a/apps/web/src/app/robots.txt/route.ts
+++ b/apps/web/src/app/robots.txt/route.ts
@@ -4,7 +4,6 @@ const ROBOTS_TXT = `User-agent: *
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 Disallow: /.well-known/
-Disallow: /_next/
 
 Sitemap: ${SITE_URL}/sitemap.xml
 `;

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -5,6 +5,8 @@ import { listNotraChangelogPosts } from "@/utils/changelog";
 import { SITE_URL } from "@/utils/urls";
 import { getShowcaseEntrySlug, SHOWCASE_COMPANIES } from "../utils/showcase";
 
+const STATIC_PAGE_LAST_MODIFIED = new Date("2026-04-24");
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const showcaseEntries = SHOWCASE_COMPANIES.flatMap((company) =>
     changelog
@@ -27,46 +29,79 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     lastModified: new Date(post.updatedAt),
   }));
 
+  const latestNotraChangelog = notraChangelogEntries.reduce<Date>(
+    (latest, entry) =>
+      entry.lastModified > latest ? entry.lastModified : latest,
+    STATIC_PAGE_LAST_MODIFIED
+  );
+
+  const latestBlog = notraBlogEntries.reduce<Date>(
+    (latest, entry) =>
+      entry.lastModified > latest ? entry.lastModified : latest,
+    STATIC_PAGE_LAST_MODIFIED
+  );
+
+  const latestShowcaseByCompany = new Map<string, Date>();
+  for (const company of SHOWCASE_COMPANIES) {
+    const latest = changelog
+      .filter((entry) => entry.info.path.startsWith(`${company.slug}/`))
+      .reduce<Date>((acc, entry) => {
+        const entryDate = new Date(entry.date);
+        return entryDate > acc ? entryDate : acc;
+      }, STATIC_PAGE_LAST_MODIFIED);
+    latestShowcaseByCompany.set(company.slug, latest);
+  }
+
+  const latestShowcaseAny = [...latestShowcaseByCompany.values()].reduce<Date>(
+    (latest, date) => (date > latest ? date : latest),
+    STATIC_PAGE_LAST_MODIFIED
+  );
+
   return [
     {
       url: SITE_URL,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
+    },
+    {
+      url: `${SITE_URL}/features`,
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
       url: `${SITE_URL}/pricing`,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
       url: `${SITE_URL}/contributors`,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
       url: `${SITE_URL}/privacy`,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
       url: `${SITE_URL}/terms`,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
       url: `${SITE_URL}/legal`,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
       url: `${SITE_URL}/blog`,
-      lastModified: new Date(),
+      lastModified: latestBlog,
     },
     {
       url: `${SITE_URL}/changelog`,
-      lastModified: new Date(),
+      lastModified: latestShowcaseAny,
     },
     {
       url: `${SITE_URL}/changelog/notra`,
-      lastModified: new Date(),
+      lastModified: latestNotraChangelog,
     },
     ...SHOWCASE_COMPANIES.map((company) => ({
       url: `${SITE_URL}/changelog/${company.slug}`,
-      lastModified: new Date(),
+      lastModified:
+        latestShowcaseByCompany.get(company.slug) ?? STATIC_PAGE_LAST_MODIFIED,
     })),
     ...showcaseEntries,
     ...notraChangelogEntries,

--- a/apps/web/src/components/cta-section.tsx
+++ b/apps/web/src/components/cta-section.tsx
@@ -10,10 +10,10 @@ export default function CTASection() {
 
         <div className="relative z-20 flex w-full max-w-[586px] flex-col items-center justify-start gap-6 overflow-hidden rounded-lg px-6 py-5 md:py-8">
           <div className="flex flex-col items-start justify-start gap-3 self-stretch">
-            <div className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[56px]">
+            <h2 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[56px]">
               Stop letting great work{" "}
               <span className="text-primary">go unannounced</span>
-            </div>
+            </h2>
             <div className="self-stretch text-center font-medium font-sans text-base text-muted-foreground leading-7">
               Your team ships every week. Let Notra turn it into
               <br />

--- a/apps/web/src/components/documentation-section.tsx
+++ b/apps/web/src/components/documentation-section.tsx
@@ -15,7 +15,9 @@ function ChangelogCard() {
             checklist.
           </p>
 
-          <h3>Configurable lookback windows for scheduled changelogs</h3>
+          <p className="font-semibold">
+            Configurable lookback windows for scheduled changelogs
+          </p>
           <p>
             Schedules now support five predefined time ranges (current day,
             yesterday, last 7/14/30 days) instead of hardcoded 7-day windows.
@@ -24,7 +26,9 @@ function ChangelogCard() {
             produced each post.
           </p>
 
-          <h3>Full table support in the rich-text editor</h3>
+          <p className="font-semibold">
+            Full table support in the rich-text editor
+          </p>
           <p>
             The Lexical editor can now insert, edit, and manipulate tables with
             a /table slash command and floating action menu. Markdown
@@ -33,7 +37,7 @@ function ChangelogCard() {
             load.
           </p>
 
-          <h3>Database-backed onboarding checklist</h3>
+          <p className="font-semibold">Database-backed onboarding checklist</p>
           <p>
             A collapsible checklist in the sidebar footer tracks brand identity,
             integration, and schedule setup. Progress is synced across all
@@ -41,7 +45,9 @@ function ChangelogCard() {
             persists via localStorage to reduce visual noise.
           </p>
 
-          <h3>Modular tone-specific changelog prompts</h3>
+          <p className="font-semibold">
+            Modular tone-specific changelog prompts
+          </p>
           <p>
             Changelog generation moved from a shared base prompt to
             self-contained, one-file-per-tone templates. This simplifies backend
@@ -49,7 +55,9 @@ function ChangelogCard() {
             profile resolution through Zod schemas.
           </p>
 
-          <h3>Point-in-time source metadata on generated content</h3>
+          <p className="font-semibold">
+            Point-in-time source metadata on generated content
+          </p>
           <p>
             Each post now stores a JSONB snapshot of its trigger, repositories,
             and lookback window. The content detail page displays this metadata
@@ -80,7 +88,9 @@ function BlogCard() {
             how it sounds.
           </p>
 
-          <h2>Generate what you actually want to ship</h2>
+          <p className="font-semibold">
+            Generate what you actually want to ship
+          </p>
           <p>
             For the first two months, Notra worked like this: set up a trigger,
             the AI looks at everything since last time, drafts appear. Fine if
@@ -94,7 +104,7 @@ function BlogCard() {
             releases on or off. Pick a time window. Scope to specific repos.
           </p>
 
-          <h2>Your voice, not a generic one</h2>
+          <p className="font-semibold">Your voice, not a generic one</p>
           <p>
             The other gap we kept hearing: content that looked good but sounded
             like nobody. Teams would edit our drafts because the tone felt off.
@@ -198,10 +208,10 @@ export default function DocumentationSection() {
     <div className="flex w-full flex-col items-center justify-center shadow-[inset_0_-1px_0_var(--border)]">
       <div className="flex items-center justify-center gap-6 self-stretch px-6 py-12 shadow-[inset_0_-1px_0_var(--border)] md:px-24 md:py-16">
         <div className="flex w-full max-w-[586px] flex-col items-center justify-start gap-4">
-          <div className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
+          <h2 className="self-stretch text-balance text-center font-sans font-semibold text-3xl text-foreground leading-tight tracking-tight md:text-5xl md:leading-[60px]">
             From shipped code to{" "}
             <span className="text-primary">published post, same day</span>
-          </div>
+          </h2>
           <div className="self-stretch text-center font-normal font-sans text-base text-muted-foreground leading-7">
             Notra follows your actual workflow, picks out what's worth
             announcing,

--- a/apps/web/src/components/faq-section.tsx
+++ b/apps/web/src/components/faq-section.tsx
@@ -8,6 +8,7 @@ import {
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
 import { useState } from "react";
+import { serializeJsonLd } from "@/utils/jsonld";
 import type { FAQItem } from "~types/faq";
 
 const faqData: FAQItem[] = [
@@ -71,8 +72,8 @@ export default function FAQSection() {
   return (
     <div className="flex w-full items-start justify-center">
       <script
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-rendered JSON-LD
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: SSR'd JSON-LD payload, escaped via serializeJsonLd
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqJsonLd) }}
         type="application/ld+json"
       />
       <div className="flex flex-1 flex-col items-start justify-start gap-6 px-4 py-16 md:px-12 md:py-20 lg:flex-row lg:gap-12">

--- a/apps/web/src/components/faq-section.tsx
+++ b/apps/web/src/components/faq-section.tsx
@@ -8,11 +8,7 @@ import {
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
 import { useState } from "react";
-
-interface FAQItem {
-  question: string;
-  answer: string;
-}
+import type { FAQItem } from "~types/faq";
 
 const faqData: FAQItem[] = [
   {
@@ -52,6 +48,19 @@ const faqData: FAQItem[] = [
   },
 ];
 
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqData.map((item) => ({
+    "@type": "Question",
+    name: item.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.answer,
+    },
+  })),
+};
+
 export default function FAQSection() {
   const [openItem, setOpenItem] = useState<string | null>(null);
 
@@ -61,14 +70,19 @@ export default function FAQSection() {
 
   return (
     <div className="flex w-full items-start justify-center">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-rendered JSON-LD
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        type="application/ld+json"
+      />
       <div className="flex flex-1 flex-col items-start justify-start gap-6 px-4 py-16 md:px-12 md:py-20 lg:flex-row lg:gap-12">
         <div className="flex w-full flex-col items-start justify-center gap-4 lg:flex-1 lg:py-5">
-          <div className="flex w-full flex-col justify-center text-balance font-sans font-semibold text-4xl text-foreground leading-tight tracking-tight md:leading-[44px]">
+          <h2 className="flex w-full flex-col justify-center text-balance font-sans font-semibold text-4xl text-foreground leading-tight tracking-tight md:leading-[44px]">
             Frequently{" "}
             <span className="whitespace-nowrap text-primary">
               Asked Questions
             </span>
-          </div>
+          </h2>
           <div className="w-full font-normal font-sans text-base text-muted-foreground leading-7">
             Common questions about how Notra
             <br className="hidden md:block" /> turns your team's work into
@@ -89,9 +103,9 @@ export default function FAQSection() {
                   open={isOpen}
                 >
                   <CollapsibleTrigger className="flex w-full items-center justify-between gap-5 px-5 py-[18px] text-left transition-colors duration-200 hover:bg-foreground/2">
-                    <div className="flex-1 font-medium font-sans text-base text-foreground leading-6">
+                    <h3 className="flex-1 font-medium font-sans text-base text-foreground leading-6">
                       {item.question}
-                    </div>
+                    </h3>
                     <div className="flex items-center justify-center">
                       <HugeiconsIcon
                         className={`size-5 text-foreground/60 transition-transform duration-300 ease-in-out ${

--- a/apps/web/src/components/footer-section.tsx
+++ b/apps/web/src/components/footer-section.tsx
@@ -41,6 +41,7 @@ export default function FooterSection() {
               aria-label="Visit Notra on X"
               className={buttonVariants({ size: "icon", variant: "ghost" })}
               href={SOCIAL_LINKS.x}
+              rel="noopener noreferrer"
               target="_blank"
             >
               <XTwitter className="size-5" />
@@ -49,6 +50,7 @@ export default function FooterSection() {
               aria-label="Visit Notra on LinkedIn"
               className={buttonVariants({ size: "icon", variant: "ghost" })}
               href={SOCIAL_LINKS.linkedin}
+              rel="noopener noreferrer"
               target="_blank"
             >
               <Linkedin className="size-5" />
@@ -57,6 +59,7 @@ export default function FooterSection() {
               aria-label="Visit Notra on GitHub"
               className={buttonVariants({ size: "icon", variant: "ghost" })}
               href={SOCIAL_LINKS.github}
+              rel="noopener noreferrer"
               target="_blank"
             >
               <Github className="size-5" />
@@ -65,6 +68,7 @@ export default function FooterSection() {
               aria-label="Visit Notra on Discord"
               className={buttonVariants({ size: "icon", variant: "ghost" })}
               href={SOCIAL_LINKS.discord}
+              rel="noopener noreferrer"
               target="_blank"
             >
               <Discord className="size-5" />

--- a/apps/web/src/utils/blog-jsonld.ts
+++ b/apps/web/src/utils/blog-jsonld.ts
@@ -7,7 +7,6 @@ import {
   BLOG_WHITESPACE_REGEX,
   HTML_ENTITY_MAP,
   HTML_ENTITY_REGEX,
-  JSON_LD_SCRIPT_CLOSE_REGEX,
   NOTRA_LOGO_PATH,
 } from "@/utils/constants";
 import { SITE_URL } from "@/utils/urls";
@@ -192,8 +191,4 @@ export function buildBlogFaqJsonLd(post: NotraBlogPost) {
       },
     })),
   };
-}
-
-export function serializeJsonLd(value: unknown) {
-  return JSON.stringify(value).replace(JSON_LD_SCRIPT_CLOSE_REGEX, "<\\/$1");
 }

--- a/apps/web/src/utils/blog.ts
+++ b/apps/web/src/utils/blog.ts
@@ -9,7 +9,7 @@ import type { BlogTimelineItem, NotraBlogPost } from "~types/blog";
 const BLOG_CONTENT_TYPE = "blog_post";
 const BLOG_STATUS = "published";
 const DEFAULT_POST_LIMIT = 100;
-const FALLBACK_EXCERPT = "Insights, guides, and stories from the Notra team.";
+const FALLBACK_EXCERPT_MAX_LENGTH = 160;
 const BLOCK_SEPARATOR_REGEX = /\n\s*\n/;
 
 function getNotraBlogConfig() {
@@ -58,7 +58,7 @@ function stripMarkdownFormatting(value: string) {
     .trim();
 }
 
-function getPostExcerpt(markdown: string) {
+function getPostExcerpt(markdown: string, fallbackTitle: string) {
   const blocks = markdown
     .split(BLOCK_SEPARATOR_REGEX)
     .map((block) => block.trim())
@@ -71,11 +71,16 @@ function getPostExcerpt(markdown: string) {
 
     const excerpt = stripMarkdownFormatting(block);
     if (excerpt.length > 0) {
-      return excerpt;
+      return excerpt.slice(0, FALLBACK_EXCERPT_MAX_LENGTH);
     }
   }
 
-  return FALLBACK_EXCERPT;
+  const stripped = stripMarkdownFormatting(markdown);
+  if (stripped.length > 0) {
+    return stripped.slice(0, FALLBACK_EXCERPT_MAX_LENGTH);
+  }
+
+  return `${fallbackTitle} on the Notra blog.`;
 }
 
 function slugifySegment(value: string) {
@@ -106,7 +111,7 @@ function normalizePost(post: NotraApiPost): NotraBlogPost {
     createdAt: post.createdAt,
     updatedAt: post.updatedAt,
     slug,
-    excerpt: getPostExcerpt(post.markdown),
+    excerpt: getPostExcerpt(post.markdown, post.title),
   };
 }
 

--- a/apps/web/src/utils/jsonld.ts
+++ b/apps/web/src/utils/jsonld.ts
@@ -1,0 +1,88 @@
+import { JSON_LD_SCRIPT_CLOSE_REGEX, NOTRA_LOGO_PATH } from "@/utils/constants";
+import { SITE_URL } from "@/utils/urls";
+import type {
+  ArticleJsonLdInput,
+  BreadcrumbItem,
+  ProductJsonLdInput,
+} from "~types/jsonld";
+
+const NOTRA_PUBLISHER = {
+  "@type": "Organization",
+  name: "Notra",
+  url: SITE_URL,
+  logo: {
+    "@type": "ImageObject",
+    url: `${SITE_URL}${NOTRA_LOGO_PATH}`,
+  },
+} as const;
+
+export function buildBreadcrumbJsonLd(items: BreadcrumbItem[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+export function buildArticleJsonLd({
+  url,
+  title,
+  description,
+  imageUrl,
+  datePublished,
+  dateModified,
+  authorName,
+  type = "Article",
+}: ArticleJsonLdInput) {
+  return {
+    "@context": "https://schema.org",
+    "@type": type,
+    headline: title,
+    description,
+    image: imageUrl,
+    datePublished,
+    dateModified: dateModified ?? datePublished,
+    author: authorName
+      ? {
+          "@type": "Organization",
+          name: authorName,
+        }
+      : NOTRA_PUBLISHER,
+    publisher: NOTRA_PUBLISHER,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+    url,
+    inLanguage: "en-US",
+  };
+}
+
+export function buildProductJsonLd({
+  name,
+  description,
+  url,
+  offers,
+}: ProductJsonLdInput) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name,
+    description,
+    url,
+    brand: {
+      "@type": "Brand",
+      name: "Notra",
+    },
+    offers,
+  };
+}
+
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value).replace(JSON_LD_SCRIPT_CLOSE_REGEX, "<\\/$1");
+}

--- a/apps/web/src/utils/navigation.ts
+++ b/apps/web/src/utils/navigation.ts
@@ -1,6 +1,6 @@
 export const MARKETING_NAV_LINKS = [
   {
-    href: "/#features",
+    href: "/features",
     label: "Features",
   },
   {
@@ -21,19 +21,19 @@ export const FOOTER_TOOL_LINKS = [
   {
     href: "https://www.framer.com/marketplace/plugins/notra/",
     label: "Framer",
-    rel: "noreferrer",
+    rel: "noopener noreferrer",
     target: "_blank",
   },
   {
     href: "https://www.raycast.com/dominikdev/notra",
     label: "Raycast",
-    rel: "noreferrer",
+    rel: "noopener noreferrer",
     target: "_blank",
   },
   {
     href: "https://docs.usenotra.com/integrations/mcp",
     label: "MCP Server",
-    rel: "noreferrer",
+    rel: "noopener noreferrer",
     target: "_blank",
   },
 ] as const;
@@ -42,20 +42,20 @@ export const FOOTER_INTEGRATION_LINKS = [
   {
     href: "https://github.com",
     label: "GitHub",
-    rel: "noreferrer",
+    rel: "noopener noreferrer",
     target: "_blank",
   },
   {
     href: "https://linear.app",
     label: "Linear",
-    rel: "noreferrer",
+    rel: "noopener noreferrer",
     target: "_blank",
   },
 ] as const;
 
 export const FOOTER_PRODUCT_LINKS = [
   {
-    href: "/#features",
+    href: "/features",
     label: "Features",
   },
   {
@@ -67,8 +67,12 @@ export const FOOTER_PRODUCT_LINKS = [
     label: "Blog",
   },
   {
-    href: "/changelog",
+    href: "/changelog/notra",
     label: "Changelog",
+  },
+  {
+    href: "/changelog",
+    label: "Examples",
   },
   {
     href: "/contributors",
@@ -77,7 +81,7 @@ export const FOOTER_PRODUCT_LINKS = [
   {
     href: "https://docs.usenotra.com",
     label: "Docs",
-    rel: "noreferrer",
+    rel: "noopener noreferrer",
     target: "_blank",
   },
 ] as const;

--- a/apps/web/types/faq.ts
+++ b/apps/web/types/faq.ts
@@ -1,0 +1,4 @@
+export interface FAQItem {
+  question: string;
+  answer: string;
+}

--- a/apps/web/types/jsonld.ts
+++ b/apps/web/types/jsonld.ts
@@ -1,0 +1,33 @@
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export interface ArticleJsonLdInput {
+  url: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+  datePublished: string;
+  dateModified?: string;
+  authorName?: string;
+  type?: "Article" | "BlogPosting" | "TechArticle" | "NewsArticle";
+}
+
+export interface OfferLike {
+  "@type": "Offer" | "AggregateOffer";
+  name?: string;
+  price?: string;
+  priceCurrency?: string;
+  priceSpecification?: unknown;
+  url?: string;
+  availability?: string;
+  category?: string;
+}
+
+export interface ProductJsonLdInput {
+  name: string;
+  description: string;
+  url: string;
+  offers: OfferLike | OfferLike[];
+}


### PR DESCRIPTION
### Description
SEO fixes across `apps/web` from the audit:

**Critical**
- `robots.txt`: stop disallowing `/_next/` so Googlebot can fetch hashed JS/CSS chunks
- `sitemap.ts`: use a stable `lastModified` for static pages; derive hub dates from the latest underlying content (no more "everything changed today" on every fetch)
- New `/features` HTML page — `features.md` and `llms.txt` advertised it but only the markdown route existed

**On-page**
- Landing page section "headlines" were `<div>`s — now real `<h2>`s on landing, CTA, FAQ, documentation
- Documentation cards mixed `<h2>` and `<h3>` out of order — downgraded to styled paragraphs
- FAQ accordion triggers are now `<h3>` for indexability
- Differentiated the homepage pricing H2 from the `/pricing` H1

**Structured data**
- New shared `utils/jsonld.ts` with `buildArticleJsonLd`, `buildBreadcrumbJsonLd`, `buildProductJsonLd`, `serializeJsonLd`
- `/pricing`: `Product` + `Offer` per plan + `BreadcrumbList`
- `/changelog/notra/[slug]` and `/changelog/[name]/[slug]`: `Article` + `BreadcrumbList`
- `/blog/[slug]`: added `BreadcrumbList`
- Homepage `FAQSection` now emits `FAQPage` JSON-LD inline

**Polish**
- Footer social and tool links: `rel="noopener noreferrer"` with `target="_blank"` (CLAUDE.md rule)
- `manifest.json`: add `start_url`, `description`, both `any` and `maskable` icons
- `next.config.ts`: derive showcase redirect slugs from `SHOWCASE_COMPANIES` (was a stale 9-of-22 list); drop vestigial self-rewrites
- Footer/nav: link Features to `/features`, point footer "Changelog" to `/changelog/notra`, expose `/changelog` as "Examples"
- Match contributors loading copy to the rendered page
- Better blog excerpt fallback so meta descriptions aren't all the same string

Empty placeholder route directories (`/1`, `/2`, `/3`, `/compare`, `/og`, `/og/blog`, `/og/brand-voice`) were also removed.

### Screenshot/Recording (if applicable)
N/A — content/SEO changes; no visible UI redesign beyond a new `/features` page.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally (`bun x ultracite check` clean on touched files; one pre-existing warning in an untouched markdown route)
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious (only `biome-ignore` for JSON-LD `dangerouslySetInnerHTML`)
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did — disclosed: Claude Code

</details>