### PR TITLE
fix(dashboard): allow editing owner/repo after repo rename

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
@@ -164,12 +164,15 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           autoPublish: trigger.autoPublish,
         });
       } catch (error) {
+        const errorWithCode = error as Error & { code?: string };
         if (
-          error instanceof Error &&
-          error.message ===
-            "Cannot update enabled schedule: one or more integrations not found"
+          errorWithCode?.code === "INTEGRATION_NOT_FOUND" ||
+          (error instanceof Error &&
+            error.message.includes("integrations have been deleted"))
         ) {
-          const integrationError = new Error(error.message) as Error & {
+          const integrationError = new Error(
+            error instanceof Error ? error.message : "Integration not found"
+          ) as Error & {
             code?: string;
           };
           integrationError.code = "INTEGRATION_NOT_FOUND";

--- a/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
@@ -42,8 +42,11 @@ export function EditIntegrationDialog({
   onOpenChange: controlledOnOpenChange,
   trigger,
 }: EditIntegrationDialogProps) {
+  const firstRepository = integration.repositories[0];
   const primaryRepository =
-    integration.repositories.length === 1 ? integration.repositories[0] : null;
+    integration.repositories.length === 1 && firstRepository
+      ? firstRepository
+      : null;
   const [internalOpen, setInternalOpen] = useState(false);
   const open = controlledOpen ?? internalOpen;
   const setOpen = controlledOnOpenChange ?? setInternalOpen;
@@ -51,12 +54,25 @@ export function EditIntegrationDialog({
 
   const mutation = useMutation({
     mutationFn: async (values: EditGitHubIntegrationFormValues) => {
+      const trimmedOwner = values.owner.trim();
+      const trimmedRepo = values.repo.trim();
+      const ownerChanged =
+        primaryRepository !== null && trimmedOwner !== primaryRepository.owner;
+      const repoChanged =
+        primaryRepository !== null && trimmedRepo !== primaryRepository.repo;
+
       return dashboardOrpc.integrations.update.call({
         organizationId,
         integrationId: integration.id,
         displayName: values.displayName,
         enabled: values.enabled,
-        ...(primaryRepository ? { branch: values.branch?.trim() || null } : {}),
+        ...(primaryRepository
+          ? {
+              ...(ownerChanged ? { owner: trimmedOwner } : {}),
+              ...(repoChanged ? { repo: trimmedRepo } : {}),
+              branch: values.branch?.trim() || null,
+            }
+          : {}),
       });
     },
     onSuccess: () => {
@@ -83,6 +99,8 @@ export function EditIntegrationDialog({
     defaultValues: {
       displayName: integration.displayName,
       enabled: integration.enabled,
+      owner: primaryRepository?.owner ?? "",
+      repo: primaryRepository?.repo ?? "",
       branch: primaryRepository?.defaultBranch ?? "",
     },
     onSubmit: ({ value }) => {
@@ -168,20 +186,85 @@ export function EditIntegrationDialog({
               </form.Field>
 
               {primaryRepository ? (
-                <form.Field name="branch">
-                  {(field) => (
-                    <Field>
-                      <FieldLabel>Default Branch</FieldLabel>
-                      <Input
-                        disabled={mutation.isPending}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        placeholder="main"
-                        value={field.state.value ?? ""}
-                      />
-                    </Field>
-                  )}
-                </form.Field>
+                <>
+                  <div className="grid grid-cols-2 gap-3">
+                    <form.Field
+                      name="owner"
+                      validators={{
+                        onChange: editGitHubIntegrationFormSchema.shape.owner,
+                      }}
+                    >
+                      {(field) => (
+                        <Field>
+                          <FieldLabel>Owner</FieldLabel>
+                          <Input
+                            disabled={mutation.isPending}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            placeholder="owner"
+                            value={field.state.value}
+                          />
+                          {field.state.meta.errors.length > 0 ? (
+                            <p className="mt-1 text-destructive text-sm">
+                              {typeof field.state.meta.errors[0] === "string"
+                                ? field.state.meta.errors[0]
+                                : ((
+                                    field.state.meta.errors[0] as {
+                                      message?: string;
+                                    }
+                                  )?.message ?? "Invalid value")}
+                            </p>
+                          ) : null}
+                        </Field>
+                      )}
+                    </form.Field>
+                    <form.Field
+                      name="repo"
+                      validators={{
+                        onChange: editGitHubIntegrationFormSchema.shape.repo,
+                      }}
+                    >
+                      {(field) => (
+                        <Field>
+                          <FieldLabel>Repository</FieldLabel>
+                          <Input
+                            disabled={mutation.isPending}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            placeholder="repo"
+                            value={field.state.value}
+                          />
+                          {field.state.meta.errors.length > 0 ? (
+                            <p className="mt-1 text-destructive text-sm">
+                              {typeof field.state.meta.errors[0] === "string"
+                                ? field.state.meta.errors[0]
+                                : ((
+                                    field.state.meta.errors[0] as {
+                                      message?: string;
+                                    }
+                                  )?.message ?? "Invalid value")}
+                            </p>
+                          ) : null}
+                        </Field>
+                      )}
+                    </form.Field>
+                  </div>
+
+                  <form.Field name="branch">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel>Default Branch</FieldLabel>
+                        <Input
+                          disabled={mutation.isPending}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          placeholder="main"
+                          value={field.state.value ?? ""}
+                        />
+                      </Field>
+                    )}
+                  </form.Field>
+                </>
               ) : null}
             </div>
             <ResponsiveDialogFooter>

--- a/apps/dashboard/src/lib/orpc/routers/integrations.ts
+++ b/apps/dashboard/src/lib/orpc/routers/integrations.ts
@@ -12,6 +12,7 @@ import {
   createGitHubIntegration,
   deleteGitHubIntegration,
   deleteRepository,
+  findConflictingRepositoryInOrganization,
   GitHubBranchNotFoundError,
   generateWebhookSecretForRepository,
   getGitHubIntegrationById,
@@ -23,6 +24,7 @@ import {
   updateGitHubIntegration,
   updateGitHubIntegrationToken,
   updateRepository,
+  validateRepositoryAccess,
   validateRepositoryBranchExists,
 } from "@/lib/services/github-integration";
 import { getIntegrationsByOrganization } from "@/lib/services/integrations";
@@ -340,10 +342,56 @@ export const integrationsRouter = {
         input.integrationId
       );
 
+      const repository = integration.repositories[0];
       const normalizedBranch =
         input.branch !== undefined ? input.branch || null : undefined;
+      const ownerChanged =
+        input.owner !== undefined &&
+        repository !== undefined &&
+        input.owner !== repository.owner;
+      const repoChanged =
+        input.repo !== undefined &&
+        repository !== undefined &&
+        input.repo !== repository.repo;
+      const isRenaming = ownerChanged || repoChanged;
+      const effectiveOwner = input.owner ?? repository?.owner ?? "";
+      const effectiveRepo = input.repo ?? repository?.repo ?? "";
 
       try {
+        if (isRenaming) {
+          if (!repository) {
+            throw notFound("Repository not found");
+          }
+
+          const conflictingRepo = await findConflictingRepositoryInOrganization(
+            input.organizationId,
+            effectiveOwner,
+            effectiveRepo,
+            input.integrationId
+          );
+
+          if (conflictingRepo) {
+            throw conflict("Repository already connected");
+          }
+
+          try {
+            await validateRepositoryAccess({
+              owner: effectiveOwner,
+              repo: effectiveRepo,
+              encryptedToken: integration.encryptedToken,
+            });
+          } catch (_error) {
+            throw badRequest(
+              "Unable to access repository. It may be private and require a Personal Access Token, or the name is incorrect."
+            );
+          }
+
+          await updateGitHubIntegration(input.integrationId, {
+            owner: effectiveOwner,
+            repo: effectiveRepo,
+          });
+        }
+
         if (input.token !== undefined) {
           await updateGitHubIntegrationToken(input.integrationId, input.token);
         }
@@ -355,16 +403,14 @@ export const integrationsRouter = {
             );
           }
 
-          const repository = integration.repositories[0];
-
           if (!repository) {
             throw notFound("Repository not found");
           }
 
           if (normalizedBranch) {
             await validateRepositoryBranchExists({
-              owner: repository.owner,
-              repo: repository.repo,
+              owner: effectiveOwner,
+              repo: effectiveRepo,
               branch: normalizedBranch,
               token: input.token,
               encryptedToken: integration.encryptedToken,

--- a/apps/dashboard/src/lib/orpc/routers/integrations.ts
+++ b/apps/dashboard/src/lib/orpc/routers/integrations.ts
@@ -14,6 +14,7 @@ import {
   deleteRepository,
   findConflictingRepositoryInOrganization,
   GitHubBranchNotFoundError,
+  GitHubRepositoryNotFoundError,
   generateWebhookSecretForRepository,
   getGitHubIntegrationById,
   getOutputById,
@@ -265,6 +266,12 @@ function mapKnownIntegrationError(error: unknown): never {
     throw badRequest(error.message);
   }
 
+  if (error instanceof GitHubRepositoryNotFoundError) {
+    throw badRequest(
+      "Unable to access repository. It may be private and require a Personal Access Token, or the name is incorrect."
+    );
+  }
+
   if (error instanceof Error) {
     throw badRequest(error.message);
   }
@@ -359,10 +366,6 @@ export const integrationsRouter = {
 
       try {
         if (isRenaming) {
-          if (!repository) {
-            throw notFound("Repository not found");
-          }
-
           const conflictingRepo = await findConflictingRepositoryInOrganization(
             input.organizationId,
             effectiveOwner,
@@ -374,17 +377,12 @@ export const integrationsRouter = {
             throw conflict("Repository already connected");
           }
 
-          try {
-            await validateRepositoryAccess({
-              owner: effectiveOwner,
-              repo: effectiveRepo,
-              encryptedToken: integration.encryptedToken,
-            });
-          } catch (_error) {
-            throw badRequest(
-              "Unable to access repository. It may be private and require a Personal Access Token, or the name is incorrect."
-            );
-          }
+          await validateRepositoryAccess({
+            owner: effectiveOwner,
+            repo: effectiveRepo,
+            token: input.token,
+            encryptedToken: integration.encryptedToken,
+          });
 
           await updateGitHubIntegration(input.integrationId, {
             owner: effectiveOwner,

--- a/apps/dashboard/src/lib/services/github-integration.ts
+++ b/apps/dashboard/src/lib/services/github-integration.ts
@@ -114,6 +114,43 @@ async function findRepositoryInOrganization(
   return existing ?? null;
 }
 
+export async function findConflictingRepositoryInOrganization(
+  organizationId: string,
+  owner: string,
+  repo: string,
+  excludeIntegrationId: string
+) {
+  const existing = await findRepositoryInOrganization(
+    organizationId,
+    owner,
+    repo
+  );
+
+  if (!existing || existing.id === excludeIntegrationId) {
+    return null;
+  }
+
+  return existing;
+}
+
+export async function validateRepositoryAccess(params: {
+  owner: string;
+  repo: string;
+  encryptedToken: string | null;
+}) {
+  const { owner, repo, encryptedToken } = params;
+  const token = encryptedToken ? decryptToken(encryptedToken) : undefined;
+  const octokit = createOctokit(token);
+
+  await octokit.request("GET /repos/{owner}/{repo}", {
+    owner,
+    repo,
+    headers: {
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+}
+
 export async function validateUserOrgAccess(
   userId: string,
   organizationId: string
@@ -418,7 +455,12 @@ export async function toggleGitHubIntegration(
 
 export async function updateGitHubIntegration(
   integrationId: string,
-  data: { enabled?: boolean; displayName?: string }
+  data: {
+    enabled?: boolean;
+    displayName?: string;
+    owner?: string;
+    repo?: string;
+  }
 ) {
   const [updated] = await db
     .update(githubIntegrations)

--- a/apps/dashboard/src/lib/services/github-integration.ts
+++ b/apps/dashboard/src/lib/services/github-integration.ts
@@ -133,22 +133,42 @@ export async function findConflictingRepositoryInOrganization(
   return existing;
 }
 
+export class GitHubRepositoryNotFoundError extends Error {
+  constructor(owner: string, repo: string) {
+    super(`Repository ${owner}/${repo} not found or inaccessible`);
+    this.name = "GitHubRepositoryNotFoundError";
+  }
+}
+
 export async function validateRepositoryAccess(params: {
   owner: string;
   repo: string;
+  token?: string;
   encryptedToken: string | null;
 }) {
-  const { owner, repo, encryptedToken } = params;
-  const token = encryptedToken ? decryptToken(encryptedToken) : undefined;
-  const octokit = createOctokit(token);
+  const { owner, repo, token, encryptedToken } = params;
+  const resolvedToken =
+    token?.trim() ||
+    (encryptedToken ? decryptToken(encryptedToken) : undefined);
+  const octokit = createOctokit(resolvedToken);
 
-  await octokit.request("GET /repos/{owner}/{repo}", {
-    owner,
-    repo,
-    headers: {
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
+  try {
+    await octokit.request("GET /repos/{owner}/{repo}", {
+      owner,
+      repo,
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch (error) {
+    const status = (error as ErrorWithStatus).status;
+
+    if (status === 404) {
+      throw new GitHubRepositoryNotFoundError(owner, repo);
+    }
+
+    throw error;
+  }
 }
 
 export async function validateUserOrgAccess(

--- a/apps/dashboard/src/schemas/integrations.ts
+++ b/apps/dashboard/src/schemas/integrations.ts
@@ -146,10 +146,18 @@ export const outputIdParamSchema = z.object({
 });
 export type OutputIdParam = z.infer<typeof outputIdParamSchema>;
 
+const repoIdentifierSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => !value.includes("/"), "Cannot contain '/'");
+
 export const updateIntegrationBodySchema = z
   .object({
     enabled: z.boolean().optional(),
     displayName: z.string().trim().min(1).optional(),
+    owner: repoIdentifierSchema.optional(),
+    repo: repoIdentifierSchema.optional(),
     branch: z.string().trim().min(1).nullable().optional(),
     token: githubPersonalAccessTokenSchema.optional(),
   })
@@ -157,6 +165,8 @@ export const updateIntegrationBodySchema = z
     (value) =>
       value.enabled !== undefined ||
       value.displayName !== undefined ||
+      value.owner !== undefined ||
+      value.repo !== undefined ||
       value.branch !== undefined ||
       value.token !== undefined,
     {
@@ -168,6 +178,8 @@ export type UpdateIntegrationBody = z.infer<typeof updateIntegrationBodySchema>;
 export const editGitHubIntegrationFormSchema = z.object({
   displayName: z.string().min(1, "Display name is required"),
   enabled: z.boolean(),
+  owner: z.string().trim().min(1, "Owner is required"),
+  repo: z.string().trim().min(1, "Repository name is required"),
   branch: z.string().optional().nullable(),
 });
 export type EditGitHubIntegrationFormValues = z.infer<


### PR DESCRIPTION
### Description
Closes #313.

GitHub integrations stored `owner` / `repo` as immutable strings, so when a repo got renamed on GitHub, Notra was stuck:
- The `EditIntegrationDialog` had no way to reconcile the new name (only `displayName`, `enabled`, `branch` were editable).
- The schedule list's `INTEGRATION_NOT_FOUND` handler matched the wrong error string and silently fell through to a generic toast.

This PR:
1. Adds `owner` / `repo` inputs to the integration edit dialog. On save it validates the new pair against GitHub (using the existing token if any) and rejects collisions with another integration in the same org.
2. Fixes the schedule-list error handler to match by error code (and by the actual server message substring), so users now see the helpful "edit the schedule and select a different integration" toast when a referenced integration is gone.

### Screenshot/Recording (if applicable)
N/A — straightforward form additions, no visual redesign.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did — disclosed: written with Claude Code

</details>