### PR TITLE
feat(dashboard): add search and filters to logs page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
@@ -20,6 +20,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
+import { useDebouncedCallback } from "@tanstack/react-pacer";
 import { useQuery } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
 import {
@@ -73,18 +74,15 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     setSearchInput(search);
   }, [search]);
 
-  useEffect(() => {
-    if (searchInput === search) {
-      return;
-    }
-    const id = window.setTimeout(() => {
-      setSearch(searchInput);
+  const commitSearch = useDebouncedCallback(
+    (value: string) => {
+      setSearch(value);
       if (page !== 1) {
         setPage(1);
       }
-    }, SEARCH_DEBOUNCE_MS);
-    return () => window.clearTimeout(id);
-  }, [searchInput]);
+    },
+    { wait: SEARCH_DEBOUNCE_MS }
+  );
 
   const has30DayRetention = customer
     ? check({ featureId: FEATURES.LOG_RETENTION_30_DAYS }).allowed
@@ -163,7 +161,10 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             <Input
               aria-label="Search logs"
               className="pl-8"
-              onChange={(e) => setSearchInput(e.target.value)}
+              onChange={(e) => {
+                setSearchInput(e.target.value);
+                commitSearch(e.target.value);
+              }}
               placeholder="Search by title or error message"
               type="search"
               value={searchInput}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
@@ -28,7 +28,7 @@ import {
   parseAsStringLiteral,
   useQueryState,
 } from "nuqs";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { FEATURES } from "@/constants/features";
@@ -44,6 +44,8 @@ import { getSourceLabel, getStatusLabel } from "@/utils/logs";
 import { columns } from "./columns";
 import { DataTable } from "./data-table";
 import { LogsPageSkeleton } from "./skeleton";
+
+const SEARCH_DEBOUNCE_MS = 150;
 
 interface PageClientProps {
   organizationSlug: string;
@@ -65,6 +67,24 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     "status",
     parseAsStringLiteral(STATUS_VALUES).withDefault("all")
   );
+  const [searchInput, setSearchInput] = useState(search);
+
+  useEffect(() => {
+    setSearchInput(search);
+  }, [search]);
+
+  useEffect(() => {
+    if (searchInput === search) {
+      return;
+    }
+    const id = window.setTimeout(() => {
+      setSearch(searchInput);
+      if (page !== 1) {
+        setPage(1);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [searchInput]);
 
   const has30DayRetention = customer
     ? check({ featureId: FEATURES.LOG_RETENTION_30_DAYS }).allowed
@@ -74,11 +94,11 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     : false;
   const logRetentionDays = has30DayRetention ? 30 : has14DayRetention ? 14 : 7;
 
-  useEffect(() => {
+  const resetPage = () => {
     if (page !== 1) {
       setPage(1);
     }
-  }, [search, source, status]);
+  };
 
   const { data, isPending } = useQuery<LogsResponse>({
     ...dashboardOrpc.logs.webhooks.list.queryOptions({
@@ -100,9 +120,11 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     source !== "all" || status !== "all" || search.length > 0;
 
   const resetFilters = () => {
+    setSearchInput("");
     setSearch("");
     setSource("all");
     setStatus("all");
+    resetPage();
   };
 
   return (
@@ -141,13 +163,19 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             <Input
               aria-label="Search logs"
               className="pl-8"
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search by title or error message"
               type="search"
-              value={search}
+              value={searchInput}
             />
           </div>
-          <Select onValueChange={(value) => setSource(value)} value={source}>
+          <Select
+            onValueChange={(value) => {
+              setSource(value);
+              resetPage();
+            }}
+            value={source}
+          >
             <SelectTrigger aria-label="Filter by source" className="sm:w-44">
               <SelectValue>
                 {(value: string) => getSourceLabel(value)}
@@ -161,7 +189,13 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
               ))}
             </SelectContent>
           </Select>
-          <Select onValueChange={(value) => setStatus(value)} value={status}>
+          <Select
+            onValueChange={(value) => {
+              setStatus(value);
+              resetPage();
+            }}
+            value={status}
+          >
             <SelectTrigger aria-label="Filter by status" className="sm:w-40">
               <SelectValue>
                 {(value: string) => getStatusLabel(value)}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
@@ -1,16 +1,46 @@
 "use client";
 
-import { InformationCircleIcon } from "@hugeicons/core-free-icons";
+import {
+  Cancel01Icon,
+  InformationCircleIcon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Alert, AlertDescription } from "@notra/ui/components/ui/alert";
+import { Button } from "@notra/ui/components/ui/button";
+import { Input } from "@notra/ui/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@notra/ui/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@notra/ui/components/ui/tooltip";
 import { useQuery } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
-import { parseAsInteger, useQueryState } from "nuqs";
+import {
+  parseAsInteger,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryState,
+} from "nuqs";
+import { useEffect } from "react";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { FEATURES } from "@/constants/features";
+import {
+  SOURCE_LABELS,
+  SOURCE_VALUES,
+  STATUS_LABELS,
+  STATUS_VALUES,
+} from "@/constants/logs";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { LogsResponse } from "@/types/webhooks/webhooks";
+import { getSourceLabel, getStatusLabel } from "@/utils/logs";
 import { columns } from "./columns";
 import { DataTable } from "./data-table";
 import { LogsPageSkeleton } from "./skeleton";
@@ -26,6 +56,15 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const { check, data: customer } = useCustomer();
 
   const [page, setPage] = useQueryState("page", parseAsInteger.withDefault(1));
+  const [search, setSearch] = useQueryState("q", parseAsString.withDefault(""));
+  const [source, setSource] = useQueryState(
+    "source",
+    parseAsStringLiteral(SOURCE_VALUES).withDefault("all")
+  );
+  const [status, setStatus] = useQueryState(
+    "status",
+    parseAsStringLiteral(STATUS_VALUES).withDefault("all")
+  );
 
   const has30DayRetention = customer
     ? check({ featureId: FEATURES.LOG_RETENTION_30_DAYS }).allowed
@@ -35,6 +74,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     : false;
   const logRetentionDays = has30DayRetention ? 30 : has14DayRetention ? 14 : 7;
 
+  useEffect(() => {
+    if (page !== 1) {
+      setPage(1);
+    }
+  }, [search, source, status]);
+
   const { data, isPending } = useQuery<LogsResponse>({
     ...dashboardOrpc.logs.webhooks.list.queryOptions({
       input: {
@@ -43,28 +88,107 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         integrationId: "all",
         page,
         pageSize: 10,
+        source,
+        status,
+        search,
       },
     }),
     enabled: !!organizationId,
   });
 
+  const filtersActive =
+    source !== "all" || status !== "all" || search.length > 0;
+
+  const resetFilters = () => {
+    setSearch("");
+    setSource("all");
+    setStatus("all");
+  };
+
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
         <div className="space-y-1">
-          <h1 className="font-bold text-3xl tracking-tight">Logs</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="font-bold text-3xl tracking-tight">Logs</h1>
+            <Tooltip>
+              <TooltipTrigger
+                aria-label="Log retention information"
+                className="cursor-help text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <HugeiconsIcon
+                  className="size-4"
+                  icon={InformationCircleIcon}
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                Log data is retained for {logRetentionDays} days. Older entries
+                are automatically removed.
+              </TooltipContent>
+            </Tooltip>
+          </div>
           <p className="text-muted-foreground">
             View all integration events and their delivery status
           </p>
         </div>
 
-        <Alert>
-          <HugeiconsIcon className="size-4" icon={InformationCircleIcon} />
-          <AlertDescription>
-            Log data is retained for {logRetentionDays} days. Older entries are
-            automatically removed.
-          </AlertDescription>
-        </Alert>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="relative flex-1">
+            <HugeiconsIcon
+              className="-translate-y-1/2 absolute top-1/2 left-2.5 size-4 text-muted-foreground"
+              icon={Search01Icon}
+            />
+            <Input
+              aria-label="Search logs"
+              className="pl-8"
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by title or error message"
+              type="search"
+              value={search}
+            />
+          </div>
+          <Select onValueChange={(value) => setSource(value)} value={source}>
+            <SelectTrigger aria-label="Filter by source" className="sm:w-44">
+              <SelectValue>
+                {(value: string) => getSourceLabel(value)}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {SOURCE_VALUES.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {SOURCE_LABELS[value]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select onValueChange={(value) => setStatus(value)} value={status}>
+            <SelectTrigger aria-label="Filter by status" className="sm:w-40">
+              <SelectValue>
+                {(value: string) => getStatusLabel(value)}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_VALUES.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {STATUS_LABELS[value]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {filtersActive && (
+            <Button
+              aria-label="Clear all filters"
+              className="h-8 shrink-0 gap-1.5 px-2.5 font-normal text-muted-foreground text-xs hover:bg-transparent hover:text-foreground"
+              onClick={resetFilters}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              <HugeiconsIcon className="size-3.5" icon={Cancel01Icon} />
+              Reset
+            </Button>
+          )}
+        </div>
 
         {organizationId && isPending ? (
           <LogsPageSkeleton />

--- a/apps/dashboard/src/constants/logs.ts
+++ b/apps/dashboard/src/constants/logs.ts
@@ -1,0 +1,39 @@
+import type {
+  LogSourceFilter,
+  LogStatusFilter,
+} from "@/types/webhooks/webhooks";
+
+export const SOURCE_VALUES = [
+  "all",
+  "github",
+  "linear",
+  "webhook",
+  "manual",
+  "schedule",
+  "events",
+] as const satisfies readonly LogSourceFilter[];
+
+export const STATUS_VALUES = [
+  "all",
+  "success",
+  "failed",
+  "pending",
+] as const satisfies readonly LogStatusFilter[];
+
+export const SOURCE_LABELS: Record<LogSourceFilter, string> = {
+  all: "All sources",
+  github: "GitHub",
+  linear: "Linear",
+  slack: "Slack",
+  webhook: "Webhook",
+  manual: "Manual",
+  schedule: "Schedule",
+  events: "Events",
+};
+
+export const STATUS_LABELS: Record<LogStatusFilter, string> = {
+  all: "All statuses",
+  success: "Success",
+  failed: "Failed",
+  pending: "Pending",
+};

--- a/apps/dashboard/src/constants/logs.ts
+++ b/apps/dashboard/src/constants/logs.ts
@@ -24,7 +24,6 @@ export const SOURCE_LABELS: Record<LogSourceFilter, string> = {
   all: "All sources",
   github: "GitHub",
   linear: "Linear",
-  slack: "Slack",
   webhook: "Webhook",
   manual: "Manual",
   schedule: "Schedule",

--- a/apps/dashboard/src/lib/orpc/routers/logs.ts
+++ b/apps/dashboard/src/lib/orpc/routers/logs.ts
@@ -13,12 +13,42 @@ function paginateLogs(logs: Log[], page: number, pageSize: number) {
   return logs.slice(startIndex, endIndex);
 }
 
+function filterLogs(
+  logs: Log[],
+  filters: {
+    source: z.infer<typeof webhookLogsQuerySchema.shape.source>;
+    status: z.infer<typeof webhookLogsQuerySchema.shape.status>;
+    search: string;
+  }
+) {
+  const search = filters.search.trim().toLowerCase();
+  return logs.filter((log) => {
+    if (filters.source !== "all" && log.integrationType !== filters.source) {
+      return false;
+    }
+    if (filters.status !== "all" && log.status !== filters.status) {
+      return false;
+    }
+    if (search.length > 0) {
+      const inTitle = log.title.toLowerCase().includes(search);
+      const inError = log.errorMessage?.toLowerCase().includes(search) ?? false;
+      if (!(inTitle || inError)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
 const listWebhookLogsInputSchema = z.object({
   organizationId: organizationIdSchema,
   page: webhookLogsQuerySchema.shape.page,
   pageSize: webhookLogsQuerySchema.shape.pageSize,
   integrationType: webhookLogsQuerySchema.shape.integrationType,
   integrationId: z.string().nullish(),
+  source: webhookLogsQuerySchema.shape.source,
+  status: webhookLogsQuerySchema.shape.status,
+  search: webhookLogsQuerySchema.shape.search,
 });
 
 export const logsRouter = {
@@ -38,15 +68,28 @@ export const logsRouter = {
           input.integrationId === "all" ? null : (input.integrationId ?? null)
         );
 
-        const paginatedLogs = paginateLogs(logs, input.page, input.pageSize);
+        const filteredLogs = filterLogs(logs, {
+          source: input.source,
+          status: input.status,
+          search: input.search,
+        });
+
+        const paginatedLogs = paginateLogs(
+          filteredLogs,
+          input.page,
+          input.pageSize
+        );
 
         const response: LogsResponse = {
           logs: paginatedLogs,
           pagination: {
             page: input.page,
             pageSize: input.pageSize,
-            totalCount: logs.length,
-            totalPages: Math.max(1, Math.ceil(logs.length / input.pageSize)),
+            totalCount: filteredLogs.length,
+            totalPages: Math.max(
+              1,
+              Math.ceil(filteredLogs.length / input.pageSize)
+            ),
           },
         };
 

--- a/apps/dashboard/src/schemas/api-params.ts
+++ b/apps/dashboard/src/schemas/api-params.ts
@@ -9,7 +9,6 @@ export const webhookLogSourceFilterSchema = z.enum([
   "all",
   "github",
   "linear",
-  "slack",
   "webhook",
   "manual",
   "schedule",

--- a/apps/dashboard/src/schemas/api-params.ts
+++ b/apps/dashboard/src/schemas/api-params.ts
@@ -5,6 +5,24 @@ export const triggerIdQuerySchema = z.object({
   triggerId: z.string().min(1),
 });
 
+export const webhookLogSourceFilterSchema = z.enum([
+  "all",
+  "github",
+  "linear",
+  "slack",
+  "webhook",
+  "manual",
+  "schedule",
+  "events",
+]);
+
+export const webhookLogStatusFilterSchema = z.enum([
+  "all",
+  "success",
+  "failed",
+  "pending",
+]);
+
 export const webhookLogsQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(10),
@@ -20,6 +38,9 @@ export const webhookLogsQuerySchema = z.object({
     ])
     .default("github"),
   integrationId: z.string().nullish(),
+  source: webhookLogSourceFilterSchema.default("all"),
+  status: webhookLogStatusFilterSchema.default("all"),
+  search: z.string().max(200).default(""),
 });
 
 export const contentListQuerySchema = z.object({

--- a/apps/dashboard/src/types/webhooks/webhooks.ts
+++ b/apps/dashboard/src/types/webhooks/webhooks.ts
@@ -33,6 +33,10 @@ export type IntegrationType =
   | "schedule"
   | "events";
 
+export type LogSourceFilter = "all" | IntegrationType;
+
+export type LogStatusFilter = "all" | WebhookLogStatus;
+
 export interface Log {
   id: string;
   referenceId: string | null;

--- a/apps/dashboard/src/types/webhooks/webhooks.ts
+++ b/apps/dashboard/src/types/webhooks/webhooks.ts
@@ -33,7 +33,7 @@ export type IntegrationType =
   | "schedule"
   | "events";
 
-export type LogSourceFilter = "all" | IntegrationType;
+export type LogSourceFilter = "all" | Exclude<IntegrationType, "slack">;
 
 export type LogStatusFilter = "all" | WebhookLogStatus;
 

--- a/apps/dashboard/src/utils/logs.ts
+++ b/apps/dashboard/src/utils/logs.ts
@@ -1,0 +1,16 @@
+import {
+  SOURCE_LABELS,
+  SOURCE_VALUES,
+  STATUS_LABELS,
+  STATUS_VALUES,
+} from "@/constants/logs";
+
+export function getSourceLabel(value: string) {
+  const match = SOURCE_VALUES.find((option) => option === value);
+  return match ? SOURCE_LABELS[match] : value;
+}
+
+export function getStatusLabel(value: string) {
+  const match = STATUS_VALUES.find((option) => option === value);
+  return match ? STATUS_LABELS[match] : value;
+}


### PR DESCRIPTION
### Description
Adds search and filtering to the integration activity feed (logs page) so users can browse events without diving into backend data — addresses the debugging-integrations and content-review workflows from #190.

- Search input filters by log title or error message
- Source filter (GitHub / Linear / Webhook / Manual / Schedule / Events)
- Status filter (Success / Failed / Pending)
- All filter state persists in URL query params (`q`, `source`, `status`) via nuqs and is shareable
- Page resets to 1 whenever a filter changes
- Filtering applied server-side in the orpc router so pagination stays accurate
- Retention notice moved into a tooltip on an info icon next to the page title to declutter the row

Closes #190

### Screenshot/Recording (if applicable)
_to add_

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>