### PR TITLE
feat(content): paginate /content list with nuqs-backed page state

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
@@ -12,7 +12,15 @@ import type { ContentType } from "@notra/ai/schemas/content";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { Button } from "@notra/ui/components/ui/button";
 import { ButtonGroup } from "@notra/ui/components/ui/button-group";
-import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@notra/ui/components/ui/pagination";
 import {
   Table,
   TableBody,
@@ -26,8 +34,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
+import { cn } from "@notra/ui/lib/utils";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { parseAsInteger, useQueryState } from "nuqs";
+import { useMemo, useState } from "react";
 import {
   ContentCard,
   getContentTypeLabel,
@@ -41,6 +51,7 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { useActiveGenerations } from "@/lib/hooks/use-active-generations";
 import { useLocalStorage } from "@/lib/utils/local-storage";
 import type { Post, PostStatus } from "@/schemas/content";
+import { getPageNumbers } from "@/utils/content-preview";
 import { usePosts } from "../../../../lib/hooks/use-posts";
 import { ContentPageSkeleton } from "./skeleton";
 
@@ -123,51 +134,28 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     false | "asc" | "desc"
   >(false);
 
-  const { data, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    usePosts(organizationId);
-  const { data: activeGenerations } = useActiveGenerations(organizationId);
-
-  const loadMoreRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 0.1 }
-    );
-
-    const currentRef = loadMoreRef.current;
-    if (currentRef) {
-      observer.observe(currentRef);
-    }
-
-    return () => {
-      if (currentRef) {
-        observer.unobserve(currentRef);
-      }
-    };
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const allPosts = useMemo(
-    () => data?.pages.flatMap((page) => page.posts) ?? [],
-    [data?.pages]
+  const [page, setPage] = useQueryState(
+    "page",
+    parseAsInteger.withDefault(1).withOptions({ clearOnDefault: true })
   );
 
-  const groupedPosts = useMemo(() => groupPostsByDate(allPosts), [allPosts]);
+  const { data, isPending } = usePosts(organizationId, page);
+  const { data: activeGenerations } = useActiveGenerations(organizationId);
+
+  const posts = useMemo(() => data?.posts ?? [], [data?.posts]);
+  const totalPages = data?.pagination.totalPages ?? 1;
+
+  const groupedPosts = useMemo(() => groupPostsByDate(posts), [posts]);
 
   const previewsByPostId = useMemo(() => {
     const map = new Map<string, string>();
-    for (const post of allPosts) {
+    for (const post of posts) {
       map.set(post.id, getPreview(post.markdown));
     }
     return map;
-  }, [allPosts]);
+  }, [posts]);
 
   const sortedPosts = useMemo(() => {
-    const posts = viewMode === "table" ? allPosts : [];
     if (viewMode !== "table" || posts.length === 0) {
       return posts;
     }
@@ -187,7 +175,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
       });
     }
     return posts;
-  }, [allPosts, viewMode, createdSortOrder, updatedSortOrder]);
+  }, [posts, viewMode, createdSortOrder, updatedSortOrder]);
 
   function getSortIcon(isSorted: false | "asc" | "desc") {
     if (isSorted === "asc") {
@@ -255,7 +243,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         </div>
         {isPending && <ContentPageSkeleton />}
         {!isPending &&
-          allPosts.length === 0 &&
+          posts.length === 0 &&
           !(activeGenerations && activeGenerations.length > 0) && (
             <EmptyState
               className="p-8"
@@ -264,7 +252,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             />
           )}
         {!isPending &&
-          (allPosts.length > 0 ||
+          (posts.length > 0 ||
             (activeGenerations && activeGenerations.length > 0)) &&
           viewMode === "grid" &&
           (() => {
@@ -273,10 +261,11 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
               activeGenerations && activeGenerations.length > 0;
             const entries = Array.from(groupedPosts.entries());
             const todayExists = entries.some(([key]) => key === todayKey);
+            const showActiveGensOnThisPage = hasActiveGens && page === 1;
 
             return (
               <>
-                {hasActiveGens && !todayExists && (
+                {showActiveGensOnThisPage && !todayExists && (
                   <section className="space-y-4" key="today-generating">
                     <h2 className="font-semibold text-lg">
                       {formatDateHeading(todayKey)}
@@ -292,13 +281,13 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                     </div>
                   </section>
                 )}
-                {entries.map(([dateKey, posts]) => (
+                {entries.map(([dateKey, datePosts]) => (
                   <section className="space-y-4" key={dateKey}>
                     <h2 className="font-semibold text-lg">
                       {formatDateHeading(dateKey)}
                     </h2>
                     <div className="grid gap-3 sm:gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                      {hasActiveGens &&
+                      {showActiveGensOnThisPage &&
                         dateKey === todayKey &&
                         activeGenerations.map((gen) => (
                           <ContentSkeletonCard
@@ -307,7 +296,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                             source={gen.source}
                           />
                         ))}
-                      {posts.map((post) => (
+                      {datePosts.map((post) => (
                         <ContentCard
                           contentType={post.contentType as ContentType}
                           href={`/${organizationSlug}/content/${post.id}`}
@@ -325,7 +314,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
               </>
             );
           })()}
-        {!isPending && allPosts.length > 0 && viewMode === "table" && (
+        {!isPending && posts.length > 0 && viewMode === "table" && (
           <div className="overflow-x-auto rounded-lg border">
             <Table>
               <TableHeader>
@@ -426,13 +415,51 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             </Table>
           </div>
         )}
-        <div className="h-10" ref={loadMoreRef}>
-          {isFetchingNextPage && (
-            <div className="flex items-center justify-center">
-              <Skeleton className="size-6 rounded-full" />
-            </div>
-          )}
-        </div>
+        {!isPending && totalPages > 1 && (
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  className={cn(page === 1 && "pointer-events-none opacity-50")}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setPage(Math.max(1, page - 1));
+                  }}
+                />
+              </PaginationItem>
+              {getPageNumbers(page, totalPages).map((pageNumber, i) =>
+                pageNumber === "ellipsis" ? (
+                  <PaginationItem key={`ellipsis-${i}`}>
+                    <PaginationEllipsis />
+                  </PaginationItem>
+                ) : (
+                  <PaginationItem key={pageNumber}>
+                    <PaginationLink
+                      isActive={pageNumber === page}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setPage(pageNumber);
+                      }}
+                    >
+                      {pageNumber}
+                    </PaginationLink>
+                  </PaginationItem>
+                )
+              )}
+              <PaginationItem>
+                <PaginationNext
+                  className={cn(
+                    page === totalPages && "pointer-events-none opacity-50"
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setPage(Math.min(totalPages, page + 1));
+                  }}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        )}
       </div>
     </PageContainer>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
@@ -134,10 +134,11 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     false | "asc" | "desc"
   >(false);
 
-  const [page, setPage] = useQueryState(
+  const [rawPage, setPage] = useQueryState(
     "page",
     parseAsInteger.withDefault(1).withOptions({ clearOnDefault: true })
   );
+  const page = Math.max(1, rawPage);
 
   const { data, isPending } = usePosts(organizationId, page);
   const { data: activeGenerations } = useActiveGenerations(organizationId);

--- a/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
@@ -50,7 +50,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const greeting = getGreeting(new Date());
   const userName = session?.user?.name?.trim();
   const greetingText = userName ? `${greeting}, ${userName}!` : `${greeting}!`;
-  const posts = data?.pages.flatMap((page) => page.posts) ?? [];
+  const posts = data?.posts ?? [];
   const visibleGenerations = activeGenerations?.slice(0, 3) ?? [];
   const hasActiveGenerations = visibleGenerations.length > 0;
   const maxPreviewPosts = Math.max(0, 3 - visibleGenerations.length);

--- a/apps/dashboard/src/lib/hooks/use-posts.ts
+++ b/apps/dashboard/src/lib/hooks/use-posts.ts
@@ -1,49 +1,31 @@
 "use client";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { PostsResponse } from "@/schemas/content";
 import { dashboardOrpc } from "../orpc/query";
 
-const DEFAULT_LIMIT = 12;
+const DEFAULT_PAGE_SIZE = 12;
 
-export function usePosts(organizationId: string) {
-  return useInfiniteQuery<PostsResponse>({
-    queryKey: dashboardOrpc.content.list.queryKey({
-      input: { organizationId, limit: DEFAULT_LIMIT },
+export function usePosts(organizationId: string, page: number) {
+  return useQuery<PostsResponse>({
+    ...dashboardOrpc.content.list.queryOptions({
+      input: { organizationId, page, pageSize: DEFAULT_PAGE_SIZE },
     }),
-    queryFn: ({ pageParam }) => {
-      const cursor = pageParam as string | null;
-
-      return dashboardOrpc.content.list.call({
-        organizationId,
-        limit: DEFAULT_LIMIT,
-        cursor: cursor ?? undefined,
-      });
-    },
-    initialPageParam: null as string | null,
-    getNextPageParam: (lastPage) => lastPage.nextCursor,
     enabled: !!organizationId,
     meta: { errorMessage: "Failed to load content" },
   });
 }
 
 export function useTodayPosts(organizationId: string) {
-  return useInfiniteQuery<PostsResponse>({
-    queryKey: dashboardOrpc.content.list.queryKey({
-      input: { organizationId, limit: DEFAULT_LIMIT, date: "today" },
-    }),
-    queryFn: ({ pageParam }) => {
-      const cursor = pageParam as string | null;
-
-      return dashboardOrpc.content.list.call({
+  return useQuery<PostsResponse>({
+    ...dashboardOrpc.content.list.queryOptions({
+      input: {
         organizationId,
-        limit: DEFAULT_LIMIT,
+        page: 1,
+        pageSize: DEFAULT_PAGE_SIZE,
         date: "today",
-        cursor: cursor ?? undefined,
-      });
-    },
-    initialPageParam: null as string | null,
-    getNextPageParam: (lastPage) => lastPage.nextCursor,
+      },
+    }),
     enabled: !!organizationId,
     meta: { errorMessage: "Failed to load today's content" },
   });

--- a/apps/dashboard/src/lib/orpc/routers/content.ts
+++ b/apps/dashboard/src/lib/orpc/routers/content.ts
@@ -16,17 +16,7 @@ import { db } from "@notra/db/drizzle";
 import { githubIntegrations, posts } from "@notra/db/schema";
 import type { CheckResponse } from "autumn-js";
 import { eachDayOfInterval, endOfYear, format, startOfYear } from "date-fns";
-import {
-  and,
-  desc,
-  eq,
-  gte,
-  type InferSelectModel,
-  inArray,
-  lt,
-  lte,
-  or,
-} from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, lt, lte } from "drizzle-orm";
 import { marked } from "marked";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
@@ -77,13 +67,6 @@ const previewRequestSchema = z.object({
   includeReleases: z.boolean().default(true),
   linearIntegrationIds: z.array(z.string().min(1)).optional(),
 });
-
-type PostRecord = InferSelectModel<typeof posts>;
-
-interface CursorData {
-  createdAt: string;
-  id: string;
-}
 
 function serializePost(post: {
   content: string;
@@ -204,20 +187,6 @@ export interface RepositoryPreviewFailure {
   repo: string | null;
   repositoryId: string;
   stage: PreviewFailureStage;
-}
-
-function encodeCursor(createdAt: Date, id: string): string {
-  const data: CursorData = { createdAt: createdAt.toISOString(), id };
-  return Buffer.from(JSON.stringify(data)).toString("base64url");
-}
-
-function decodeCursor(cursor: string): CursorData | null {
-  try {
-    const decoded = Buffer.from(cursor, "base64url").toString("utf-8");
-    return JSON.parse(decoded) as CursorData;
-  } catch {
-    return null;
-  }
 }
 
 function getDateRange(dateParam: string | null) {
@@ -504,51 +473,30 @@ export const contentRouter = {
         );
       }
 
-      let results: PostRecord[];
+      const whereClause = and(...baseFilters);
+      const offset = (input.page - 1) * input.pageSize;
 
-      if (input.cursor) {
-        const cursorData = decodeCursor(input.cursor);
-
-        if (!cursorData) {
-          throw badRequest("Invalid cursor");
-        }
-
-        const cursorDate = new Date(cursorData.createdAt);
-
-        if (Number.isNaN(cursorDate.getTime())) {
-          throw badRequest("Invalid cursor");
-        }
-
-        results = await db.query.posts.findMany({
-          where: and(
-            ...baseFilters,
-            or(
-              lt(posts.createdAt, cursorDate),
-              and(eq(posts.createdAt, cursorDate), lt(posts.id, cursorData.id))
-            )
-          ),
+      const [items, totalCountResult] = await Promise.all([
+        db.query.posts.findMany({
+          where: whereClause,
           orderBy: [desc(posts.createdAt), desc(posts.id)],
-          limit: input.limit + 1,
-        });
-      } else {
-        results = await db.query.posts.findMany({
-          where: and(...baseFilters),
-          orderBy: [desc(posts.createdAt), desc(posts.id)],
-          limit: input.limit + 1,
-        });
-      }
+          limit: input.pageSize,
+          offset,
+        }),
+        db.select({ value: count() }).from(posts).where(whereClause),
+      ]);
 
-      const hasMore = results.length > input.limit;
-      const items = hasMore ? results.slice(0, input.limit) : results;
-      const lastItem = items.at(-1);
-      const nextCursor =
-        hasMore && lastItem
-          ? encodeCursor(lastItem.createdAt, lastItem.id)
-          : null;
+      const totalCount = totalCountResult[0]?.value ?? 0;
+      const totalPages = Math.max(1, Math.ceil(totalCount / input.pageSize));
 
       return {
         posts: items.map(serializePost),
-        nextCursor,
+        pagination: {
+          page: input.page,
+          pageSize: input.pageSize,
+          totalCount,
+          totalPages,
+        },
       };
     }),
   get: baseProcedure

--- a/apps/dashboard/src/schemas/api-params.ts
+++ b/apps/dashboard/src/schemas/api-params.ts
@@ -43,8 +43,8 @@ export const webhookLogsQuerySchema = z.object({
 });
 
 export const contentListQuerySchema = z.object({
-  cursor: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(100).default(12),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(12),
   date: z.string().optional(),
 });
 

--- a/apps/dashboard/src/schemas/content.ts
+++ b/apps/dashboard/src/schemas/content.ts
@@ -73,9 +73,18 @@ export const postSchema = z.object({
 
 export type Post = z.infer<typeof postSchema>;
 
+export const postsPaginationSchema = z.object({
+  page: z.number().int().min(1),
+  pageSize: z.number().int().min(1),
+  totalCount: z.number().int().min(0),
+  totalPages: z.number().int().min(1),
+});
+
+export type PostsPagination = z.infer<typeof postsPaginationSchema>;
+
 export const postsResponseSchema = z.object({
   posts: z.array(postSchema),
-  nextCursor: z.string().nullable(),
+  pagination: postsPaginationSchema,
 });
 
 export type PostsResponse = z.infer<typeof postsResponseSchema>;


### PR DESCRIPTION
### Description
Replaces the infinite-scroll on `/content` with the same `Pagination` component used in the on-demand content creation dialog. Page state is stored in the `?page=` URL param via `nuqs`.

- `contentListQuerySchema` now takes `page`/`pageSize` instead of `cursor`/`limit`.
- `postsResponseSchema` returns `pagination: { page, pageSize, totalCount, totalPages }`.
- `content.list` uses an offset query plus a parallel `count()` for `totalPages`.
- `usePosts` / `useTodayPosts` switched from `useInfiniteQuery` to `useQuery`.
- Active-generation skeletons only render on page 1.

### Screenshot/Recording (if applicable)
N/A

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced infinite scroll on /content with page-based pagination. Page state lives in the `?page=` URL via `nuqs`, and the UI uses the shared `Pagination` component.

- **New Features**
  - Pagination controls with previous/next and page numbers; active-generation skeletons only on page 1.
  - Query uses `@tanstack/react-query` `useQuery` for stable page loads and URL-driven navigation.
  - Clamp `?page=` to 1 or greater to prevent invalid page values.

- **Migration**
  - `contentListQuerySchema`: `page`/`pageSize` replace `cursor`/`limit`.
  - `postsResponseSchema`: returns `pagination { page, pageSize, totalCount, totalPages }` instead of `nextCursor`; update callers (e.g., switch `useInfiniteQuery` to `useQuery`).

<sup>Written for commit 412861543507b5f0bd1ebc304359205dfd268a30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

