### PR TITLE
fix(realtime): authorize channels per-org in /api/realtime

### DIFF
--- a/apps/dashboard/src/app/api/realtime/route.ts
+++ b/apps/dashboard/src/app/api/realtime/route.ts
@@ -1,23 +1,28 @@
 import { realtime } from "@notra/ai/realtime";
 import { handle } from "@upstash/realtime";
 import { getServerSession } from "@/lib/auth/session";
+import { authorizeRealtimeChannels } from "@/lib/realtime/channel-acl";
 
 const handler = realtime
   ? handle({
       realtime,
-      middleware: async ({ request }) => {
-        const { session } = await getServerSession({
+      middleware: async ({ request, channels }) => {
+        const { session, user } = await getServerSession({
           headers: request.headers,
         });
 
-        if (!session) {
+        if (!(session && user)) {
           return new Response(JSON.stringify({ error: "Unauthorized" }), {
             status: 401,
             headers: { "Content-Type": "application/json" },
           });
         }
 
-        return undefined;
+        return authorizeRealtimeChannels({
+          headers: request.headers,
+          channels,
+          user,
+        });
       },
     })
   : null;

--- a/apps/dashboard/src/lib/realtime/channel-acl.ts
+++ b/apps/dashboard/src/lib/realtime/channel-acl.ts
@@ -1,0 +1,76 @@
+import { assertOrganizationAccess } from "@/lib/auth/organization";
+import type { User } from "@/types/auth/organization";
+import type { ParsedChatChannel } from "@/types/realtime/channel";
+
+const CHAT_CHANNEL_PREFIX = "chat";
+const CHAT_CHANNEL_SEGMENT_COUNT = 4;
+const FORBIDDEN_CHANNEL_CHARS = /[*?\s]/;
+
+function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function parseChatChannel(channel: string): ParsedChatChannel | null {
+  if (!channel || FORBIDDEN_CHANNEL_CHARS.test(channel)) {
+    return null;
+  }
+
+  const parts = channel.split(":");
+  if (parts.length !== CHAT_CHANNEL_SEGMENT_COUNT) {
+    return null;
+  }
+
+  const [prefix, organizationId, chatId, streamId] = parts;
+  if (prefix !== CHAT_CHANNEL_PREFIX) {
+    return null;
+  }
+  if (!(organizationId && chatId && streamId)) {
+    return null;
+  }
+
+  return { organizationId, chatId, streamId };
+}
+
+export async function authorizeRealtimeChannels({
+  headers,
+  channels,
+  user,
+}: {
+  headers: Headers;
+  channels: string[];
+  user: User;
+}): Promise<Response | undefined> {
+  if (channels.length === 0) {
+    return jsonResponse(400, { error: "No channels requested" });
+  }
+
+  const authorizedOrganizationIds = new Set<string>();
+
+  for (const channel of channels) {
+    const parsed = parseChatChannel(channel);
+    if (!parsed) {
+      return jsonResponse(403, { error: "Forbidden channel" });
+    }
+
+    if (authorizedOrganizationIds.has(parsed.organizationId)) {
+      continue;
+    }
+
+    try {
+      await assertOrganizationAccess({
+        headers,
+        organizationId: parsed.organizationId,
+        user,
+      });
+    } catch {
+      return jsonResponse(403, { error: "Forbidden channel" });
+    }
+
+    authorizedOrganizationIds.add(parsed.organizationId);
+  }
+
+  return undefined;
+}

--- a/apps/dashboard/src/types/realtime/channel.ts
+++ b/apps/dashboard/src/types/realtime/channel.ts
@@ -1,0 +1,5 @@
+export interface ParsedChatChannel {
+  organizationId: string;
+  chatId: string;
+  streamId: string;
+}


### PR DESCRIPTION
## Summary
- Cross-tenant read on `/api/realtime`: the `handle({ realtime, middleware })` middleware destructured only `{ request }`, ignored `channels`, and returned `undefined` after a session check. Any authenticated user could `EventSource` `chat:<otherOrgId>:<chatId>:<streamId>` and receive another tenant's AI stream chunks plus `xrange` history replay.
- New `authorizeRealtimeChannels` helper fail-closes by default: rejects wildcard chars (`*`, `?`, whitespace), enforces the exact `chat:<orgId>:<chatId>:<streamId>` shape, and runs `assertOrganizationAccess` on every requested channel (memoized per-org per-request).
- Middleware now requires `session && user`, then delegates to the helper. 401 for unauth, 403 for forbidden channels, 400 when no channels are requested.

## Test plan
- [ ] Unit: with two orgs A and B, member-of-A subscribing to `chat:<orgB>:*:*` returns 403.
- [ ] Unit: member-of-A subscribing to `chat:<orgA>:<chatId>:<streamId>` succeeds.
- [ ] Unit: channels containing `*`, `?`, whitespace, wrong segment count, or non-`chat` prefix all return 403.
- [ ] Unit: empty `channels` array returns 400.
- [ ] Manual: existing in-app chat streaming still works end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down `/api/realtime` so users can only subscribe to channels in their own org. Middleware now validates `channels` and enforces org membership for `chat:<orgId>:<chatId>:<streamId>`.

- **Bug Fixes**
  - Added `authorizeRealtimeChannels`: fail-closed, rejects `*`, `?`, whitespace, and non-`chat:<orgId>:<chatId>:<streamId>` formats; checks org access per channel.
  - Updated `@upstash/realtime` middleware to require `session` and `user`, then delegate to the helper; keeps `@notra/ai/realtime` integration.
  - Returns 401 when unauthenticated, 403 for invalid/forbidden channels, and 400 when no channels are requested.
  - Introduced `ParsedChatChannel` type for parsed channel segments.

<sup>Written for commit 17d3e02353c755f24d1b198ab6ac2b0cb16e5754. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

