### PR TITLE
fix(integrations): authorize Linear OAuth state per-org

### DIFF
--- a/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
@@ -17,7 +17,13 @@ export async function GET(request: NextRequest) {
     });
 
     if (!parsed.success) {
-      return NextResponse.redirect(`${baseUrl}/?error=invalid_request`);
+      const missingOrganization = parsed.error.issues.some(
+        (issue) => issue.path[0] === "organizationId"
+      );
+      const errorParam = missingOrganization
+        ? "missing_organization"
+        : "invalid_request";
+      return NextResponse.redirect(`${baseUrl}/?error=${errorParam}`);
     }
 
     const { organizationId, callbackPath } = parsed.data;

--- a/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
     });
 
     if (!parsed.success) {
-      return NextResponse.redirect(`${baseUrl}/?error=missing_organization`);
+      return NextResponse.redirect(`${baseUrl}/?error=invalid_request`);
     }
 
     const { organizationId, callbackPath } = parsed.data;

--- a/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
@@ -1,6 +1,9 @@
 import { redis } from "@notra/ai/utils/redis";
+import { ORPCError } from "@orpc/server";
 import { type NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "@/lib/auth/session";
+import { assertOrganizationAccess } from "@/lib/auth/organization";
+import { linearOAuthErrorParam } from "@/lib/integrations/linear/oauth-errors";
+import { linearAuthorizeQuerySchema } from "@/schemas/linear";
 
 export async function GET(request: NextRequest) {
   const baseUrl =
@@ -8,16 +11,31 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const organizationId = searchParams.get("organizationId");
-    const callbackPath = searchParams.get("callbackPath") ?? "/";
+    const parsed = linearAuthorizeQuerySchema.safeParse({
+      organizationId: searchParams.get("organizationId") ?? undefined,
+      callbackPath: searchParams.get("callbackPath") ?? undefined,
+    });
 
-    if (!organizationId) {
+    if (!parsed.success) {
       return NextResponse.redirect(`${baseUrl}/?error=missing_organization`);
     }
 
-    const { session } = await getServerSession({ headers: request.headers });
-    if (!session?.userId) {
-      return NextResponse.redirect(`${baseUrl}/?error=not_authenticated`);
+    const { organizationId, callbackPath } = parsed.data;
+
+    let userId: string;
+    try {
+      const access = await assertOrganizationAccess({
+        headers: request.headers,
+        organizationId,
+      });
+      userId = access.user.id;
+    } catch (error) {
+      if (error instanceof ORPCError) {
+        return NextResponse.redirect(
+          `${baseUrl}/?error=${linearOAuthErrorParam(error.status)}`
+        );
+      }
+      throw error;
     }
 
     const clientId = process.env.LINEAR_CLIENT_ID;
@@ -32,7 +50,7 @@ export async function GET(request: NextRequest) {
       `linear_oauth:${state}`,
       JSON.stringify({
         organizationId,
-        userId: session.userId,
+        userId,
         callbackPath,
       }),
       { ex: 600 }

--- a/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
@@ -40,8 +40,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(`${baseUrl}/?error=expired_state`);
     }
 
-    await redis.del(`linear_oauth:${state}`);
-
     const oauthState: LinearOAuthState =
       typeof raw === "string" ? JSON.parse(raw) : raw;
 
@@ -63,6 +61,8 @@ export async function GET(request: NextRequest) {
       }
       throw error;
     }
+
+    await redis.del(`linear_oauth:${state}`);
 
     const clientId = process.env.LINEAR_CLIENT_ID;
     const clientSecret = process.env.LINEAR_CLIENT_SECRET;

--- a/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
@@ -3,7 +3,11 @@ import {
   getLinearIntegrationsByOrganization,
 } from "@notra/ai/integrations/linear";
 import { redis } from "@notra/ai/utils/redis";
+import { ORPCError } from "@orpc/server";
 import { type NextRequest, NextResponse } from "next/server";
+import { assertOrganizationAccess } from "@/lib/auth/organization";
+import { getServerSession } from "@/lib/auth/session";
+import { linearOAuthErrorParam } from "@/lib/integrations/linear/oauth-errors";
 import type {
   LinearOAuthState,
   LinearOrganizationResponse,
@@ -40,6 +44,25 @@ export async function GET(request: NextRequest) {
 
     const oauthState: LinearOAuthState =
       typeof raw === "string" ? JSON.parse(raw) : raw;
+
+    const { session } = await getServerSession({ headers: request.headers });
+    if (!session?.userId || session.userId !== oauthState.userId) {
+      return NextResponse.redirect(`${baseUrl}/?error=session_mismatch`);
+    }
+
+    try {
+      await assertOrganizationAccess({
+        headers: request.headers,
+        organizationId: oauthState.organizationId,
+      });
+    } catch (error) {
+      if (error instanceof ORPCError) {
+        return NextResponse.redirect(
+          `${baseUrl}/?error=${linearOAuthErrorParam(error.status, "forbidden")}`
+        );
+      }
+      throw error;
+    }
 
     const clientId = process.env.LINEAR_CLIENT_ID;
     const clientSecret = process.env.LINEAR_CLIENT_SECRET;

--- a/apps/dashboard/src/lib/integrations/linear/oauth-errors.ts
+++ b/apps/dashboard/src/lib/integrations/linear/oauth-errors.ts
@@ -1,0 +1,11 @@
+const LINEAR_OAUTH_ERROR_BY_STATUS = new Map<number, string>([
+  [401, "not_authenticated"],
+  [403, "forbidden"],
+]);
+
+export function linearOAuthErrorParam(
+  status: number,
+  fallback = "linear_auth_failed"
+): string {
+  return LINEAR_OAUTH_ERROR_BY_STATUS.get(status) ?? fallback;
+}

--- a/apps/dashboard/src/schemas/linear.ts
+++ b/apps/dashboard/src/schemas/linear.ts
@@ -41,3 +41,9 @@ export const linearIntegrationIdParamSchema = z.object({
 export type LinearIntegrationIdParam = z.infer<
   typeof linearIntegrationIdParamSchema
 >;
+
+export const linearAuthorizeQuerySchema = z.object({
+  organizationId: z.string().min(1, "Organization ID is required"),
+  callbackPath: z.string().min(1).default("/"),
+});
+export type LinearAuthorizeQuery = z.infer<typeof linearAuthorizeQuerySchema>;


### PR DESCRIPTION
## Summary
- `/api/integrations/linear/authorize` accepted an arbitrary `organizationId` query param and stored it in Redis state alongside `session.userId` without ever calling `assertOrganizationAccess`. A logged-in victim following an attacker's link would seed Redis state for the attacker's org; if the victim consented on Linear's screen, the callback would mint an integration in the attacker's tenant containing the victim's Linear access token. The CLI `sessions/[sessionId]/authorize` handler already follows the correct pattern.
- `/api/integrations/linear/callback` never verified that the redeeming session matched `oauthState.userId`, so a leaked or replayed state UUID inside the 10-minute TTL could be redeemed by a different identity.
- Cross-tenant integration plant was previously prevented only by the membership re-check inside `createLinearIntegration` — a brittle, single line of defense per the threat model in `CLAUDE.md` ("every per-org route MUST go through assertOrganizationAccess").

## Changes
- `authorize/route.ts`: validate query with new `linearAuthorizeQuerySchema`, call `assertOrganizationAccess` before generating state, translate `ORPCError` into a redirect with `not_authenticated` / `forbidden` / `linear_auth_failed` via a shared status -> param map.
- `callback/route.ts`: after parsing state, require `session.userId === oauthState.userId` (returns `?error=session_mismatch`), then re-run `assertOrganizationAccess` against `oauthState.organizationId`.
- `schemas/linear.ts`: add `linearAuthorizeQuerySchema`.
- `lib/integrations/linear/oauth-errors.ts`: shared `linearOAuthErrorParam(status, fallback)` helper used by both routes.

## Test plan
- [ ] Logged-in user following `/api/integrations/linear/authorize?organizationId=<their-org>&callbackPath=/...` still completes the OAuth round-trip and lands back on `callbackPath` with `linearConnected=true`.
- [ ] Logged-in user passing an org they don't belong to is redirected to `/?error=forbidden` and never sees Linear's consent screen.
- [ ] Anonymous request to authorize redirects to `/?error=not_authenticated`.
- [ ] Missing/blank `organizationId` redirects to `/?error=missing_organization`.
- [ ] Manually expiring the user out of the org between authorize and callback causes the callback to redirect to `/?error=forbidden` instead of creating the integration.
- [ ] Hitting the callback with a state token while logged in as a different user redirects to `/?error=session_mismatch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down the Linear OAuth flow to enforce per-organization authorization and session-bound state. Prevents cross-tenant token planting, state replay, and accidental state loss.

- **Bug Fixes**
  - `authorize`: validate `organizationId` and `callbackPath` with `linearAuthorizeQuerySchema`; on parse error return `?error=missing_organization` (absent org) or `?error=invalid_request`; call `assertOrganizationAccess` to derive `userId` before minting state; on `ORPCError`, redirect via `linearOAuthErrorParam`.
  - `callback`: require `session.userId` to match state `userId` (`?error=session_mismatch`); re-run `assertOrganizationAccess` for the stored org and map errors via `linearOAuthErrorParam` (fallback `forbidden`); delete Redis state only after both checks pass.
  - Added `linearOAuthErrorParam` helper and `linearAuthorizeQuerySchema`.

<sup>Written for commit 1e22b3b36c3ab018ebc23ab8d6b2381db4f02a9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

