### PR TITLE
Add post persistence and editable chat previews

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -28,11 +28,7 @@ import {
 } from "@notra/ui/components/ui/collapsible";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  DefaultChatTransport,
-  isToolUIPart,
-  lastAssistantMessageIsCompleteWithApprovalResponses,
-} from "ai";
+import { DefaultChatTransport, isToolUIPart } from "ai";
 import { motion } from "motion/react";
 import { nanoid } from "nanoid";
 import dynamic from "next/dynamic";
@@ -79,6 +75,7 @@ import {
   writeStoredChatPreferences,
 } from "@/utils/chat-preferences";
 import { formatLongDate, getGreeting } from "@/utils/dashboard-greeting";
+import { getOutputTypeLabel } from "@/utils/output-types";
 
 const BlogChangelogPreview = dynamic(
   () =>
@@ -238,6 +235,82 @@ function isTerminalToolState(state: string): boolean {
   );
 }
 
+function hasSendableParts(message: ChatUIMessage): boolean {
+  return Array.isArray(message.parts) && message.parts.length > 0;
+}
+
+function normalizeToolApprovalsForSend(
+  messages: ChatUIMessage[]
+): ChatUIMessage[] {
+  return messages.map((message) => {
+    if (!Array.isArray(message.parts)) {
+      return message;
+    }
+
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (
+        isToolUIPart(part) &&
+        part.state === "approval-responded" &&
+        part.approval.approved === false
+      ) {
+        changed = true;
+        return {
+          ...part,
+          approval: {
+            ...part.approval,
+            approved: false,
+          },
+          state: "output-denied" as const,
+        } as ChatUIMessage["parts"][number];
+      }
+
+      return part;
+    });
+
+    return changed ? { ...message, parts } : message;
+  }) as ChatUIMessage[];
+}
+
+function getSendableMessages(messages: ChatUIMessage[]): ChatUIMessage[] {
+  return normalizeToolApprovalsForSend(messages).filter(hasSendableParts);
+}
+
+function shouldContinueAfterApprovalResponse({
+  messages,
+}: {
+  messages: ChatUIMessage[];
+}): boolean {
+  const message = messages.at(-1);
+
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+
+  const lastStepStartIndex = message.parts.reduce((lastIndex, part, index) => {
+    return part.type === "step-start" ? index : lastIndex;
+  }, -1);
+
+  const toolParts = message.parts
+    .slice(lastStepStartIndex + 1)
+    .filter(isToolUIPart);
+
+  const approvalResponses = toolParts.filter(
+    (part) => part.state === "approval-responded"
+  );
+
+  return (
+    approvalResponses.length > 0 &&
+    approvalResponses.every((part) => part.approval.approved) &&
+    toolParts.every(
+      (part) =>
+        part.state === "output-available" ||
+        part.state === "output-error" ||
+        part.state === "approval-responded"
+    )
+  );
+}
+
 function ChatImageAttachment({
   url,
   filename,
@@ -346,7 +419,7 @@ function StandaloneChatPageClient({
         prepareSendMessagesRequest: ({ id, messages }) => ({
           body: {
             chatId: id,
-            messages,
+            messages: getSendableMessages(messages),
             context: hasCustomizedContextRef.current
               ? contextRef.current
               : undefined,
@@ -471,7 +544,7 @@ function StandaloneChatPageClient({
     resume: Boolean(initialChatId && pendingMessageId),
     experimental_throttle: 90,
     transport,
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+    sendAutomaticallyWhen: shouldContinueAfterApprovalResponse,
     onFinish: handleFinish,
     onError: handleChatError,
   });
@@ -1047,6 +1120,10 @@ function StandaloneChatPageClient({
 
   const dispatchMessage = useCallback(
     async (text: string, attachments: ChatAttachment[] = []) => {
+      if (text.trim().length === 0 && attachments.length === 0) {
+        return;
+      }
+
       const isFirstMessage = !initialChatId && !hasUpdatedUrlRef.current;
       if (messagesRef.current.length === 0) {
         triggerFirstMessageTransition();
@@ -1388,14 +1465,6 @@ function StandaloneChatPageClient({
 
   const handleClearError = useCallback(() => setChatError(null), []);
 
-  const contentAuthor = useMemo(
-    () => ({
-      name: organization?.name ?? "Your Name",
-      avatar: organization?.logo ?? undefined,
-    }),
-    [organization?.name, organization?.logo]
-  );
-
   function renderPart(
     part: { type: string; [key: string]: unknown },
     messageId: string,
@@ -1495,7 +1564,7 @@ function StandaloneChatPageClient({
         toolCallId: string;
         input?: { title?: string; markdown?: string };
         output?: { postId?: string; status?: string };
-        approval?: { id: string };
+        approval?: { id: string; approved?: boolean; reason?: string };
       };
       const toolName = toolPart.type.replace("tool-", "");
 
@@ -1529,8 +1598,20 @@ function StandaloneChatPageClient({
           return null;
         }
 
+        if (toolPart.approval?.reason === "discard") {
+          return null;
+        }
+
         const previewState: "draft" | "finished" =
-          toolPart.state === "output-available" ? "finished" : "draft";
+          toolPart.state === "output-available" ||
+          toolPart.approval?.reason === "manual-draft" ||
+          toolPart.approval?.reason === "manual-published"
+            ? "finished"
+            : "draft";
+        const persistedStatus: "draft" | "published" =
+          toolPart.approval?.reason === "manual-published"
+            ? "published"
+            : "draft";
 
         const approvalId = toolPart.approval?.id;
         const handleApprove = approvalId
@@ -1545,17 +1626,66 @@ function StandaloneChatPageClient({
               addToolApprovalResponse({
                 id: approvalId,
                 approved: false,
+                reason: "discard",
               })
+          : undefined;
+        const handlePersist = approvalId
+          ? async (
+              status: "draft" | "published",
+              payload: { title: string; markdown: string }
+            ) => {
+              const response = await fetch(
+                `/api/organizations/${organizationId}/chat/posts`,
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    ...payload,
+                    contentType,
+                    status,
+                  }),
+                }
+              );
+              if (!response.ok) {
+                throw new Error("Failed to save post");
+              }
+              await addToolApprovalResponse({
+                id: approvalId,
+                approved: false,
+                reason:
+                  status === "published" ? "manual-published" : "manual-draft",
+              });
+              queryClient.invalidateQueries({
+                queryKey: ["chat-sessions", organizationId],
+              });
+            }
+          : undefined;
+        const handleRegenerate = approvalId
+          ? (
+              instructions: string,
+              payload: { title: string; markdown: string }
+            ) => {
+              addToolApprovalResponse({
+                id: approvalId,
+                approved: false,
+                reason: "discard",
+              });
+              sendMessage({
+                text: `Regenerate the ${getOutputTypeLabel(contentType)} with these changes: ${instructions}\n\nCurrent title: ${payload.title}\n\nCurrent draft:\n${payload.markdown}`,
+              });
+            }
           : undefined;
 
         if (contentType === "twitter_post") {
           return (
             <TwitterPreview
-              author={contentAuthor}
               key={toolPart.toolCallId}
               markdown={markdown}
               onApprove={handleApprove}
               onDeny={handleDeny}
+              onPersist={handlePersist}
+              onRegenerate={handleRegenerate}
+              persistedStatus={persistedStatus}
               state={previewState}
               title={title}
             />
@@ -1565,11 +1695,13 @@ function StandaloneChatPageClient({
         if (contentType === "linkedin_post") {
           return (
             <LinkedInPreview
-              author={contentAuthor}
               key={toolPart.toolCallId}
               markdown={markdown}
               onApprove={handleApprove}
               onDeny={handleDeny}
+              onPersist={handlePersist}
+              onRegenerate={handleRegenerate}
+              persistedStatus={persistedStatus}
               state={previewState}
               title={title}
             />
@@ -1583,6 +1715,9 @@ function StandaloneChatPageClient({
             markdown={markdown}
             onApprove={handleApprove}
             onDeny={handleDeny}
+            onPersist={handlePersist}
+            onRegenerate={handleRegenerate}
+            persistedStatus={persistedStatus}
             state={previewState}
             title={title}
           />

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -253,7 +253,7 @@ function normalizeToolApprovalsForSend(
         isToolUIPart(part) &&
         part.state === "approval-responded" &&
         part.approval.approved === false &&
-        part.approval.reason === "discard"
+        (part.approval.reason === "discard" || part.approval.reason == null)
       ) {
         changed = true;
         return {
@@ -1650,12 +1650,21 @@ function StandaloneChatPageClient({
               if (!response.ok) {
                 throw new Error("Failed to save post");
               }
-              await addToolApprovalResponse({
-                id: approvalId,
-                approved: false,
-                reason:
-                  status === "published" ? "manual-published" : "manual-draft",
-              });
+              try {
+                await addToolApprovalResponse({
+                  id: approvalId,
+                  approved: false,
+                  reason:
+                    status === "published"
+                      ? "manual-published"
+                      : "manual-draft",
+                });
+              } catch (error) {
+                console.error(
+                  "[Chat] Failed to mark persisted post approval:",
+                  error
+                );
+              }
               queryClient.invalidateQueries({
                 queryKey: ["chat-sessions", organizationId],
               });

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -252,7 +252,8 @@ function normalizeToolApprovalsForSend(
       if (
         isToolUIPart(part) &&
         part.state === "approval-responded" &&
-        part.approval.approved === false
+        part.approval.approved === false &&
+        part.approval.reason === "discard"
       ) {
         changed = true;
         return {
@@ -1661,11 +1662,11 @@ function StandaloneChatPageClient({
             }
           : undefined;
         const handleRegenerate = approvalId
-          ? (
+          ? async (
               instructions: string,
               payload: { title: string; markdown: string }
             ) => {
-              addToolApprovalResponse({
+              await addToolApprovalResponse({
                 id: approvalId,
                 approved: false,
                 reason: "discard",

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/posts/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/posts/route.ts
@@ -1,0 +1,60 @@
+import { contentTypeSchema } from "@notra/ai/schemas/content";
+import { supportsPostSlug } from "@notra/ai/schemas/post";
+import { sanitizeMarkdownHtml } from "@notra/ai/utils/sanitize";
+import { db } from "@notra/db/drizzle";
+import { posts } from "@notra/db/schema";
+import { marked } from "marked";
+import { nanoid } from "nanoid";
+import { NextResponse } from "next/server";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing.
+import * as z from "zod";
+import { assertOrganizationAccess } from "@/lib/auth/organization";
+
+const createChatPostSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+  slug: z.string().trim().min(1).nullable().optional(),
+  markdown: z.string().trim().min(1),
+  contentType: contentTypeSchema,
+  status: z.enum(["draft", "published"]),
+});
+
+interface RouteContext {
+  params: Promise<{ organizationId: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteContext) {
+  const { organizationId } = await params;
+
+  await assertOrganizationAccess({
+    headers: request.headers,
+    organizationId,
+  });
+
+  const parsed = createChatPostSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid post payload", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { title, contentType, markdown, status } = parsed.data;
+  const slug =
+    supportsPostSlug(contentType) && parsed.data.slug ? parsed.data.slug : null;
+  const content = sanitizeMarkdownHtml(await marked.parse(markdown));
+  const id = nanoid();
+
+  await db.insert(posts).values({
+    id,
+    organizationId,
+    title,
+    slug,
+    content,
+    markdown,
+    contentType,
+    status,
+    sourceMetadata: null,
+  });
+
+  return NextResponse.json({ postId: id, status });
+}

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/posts/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/posts/route.ts
@@ -30,7 +30,9 @@ export async function POST(request: Request, { params }: RouteContext) {
     organizationId,
   });
 
-  const parsed = createChatPostSchema.safeParse(await request.json());
+  const parsed = createChatPostSchema.safeParse(
+    await request.json().catch(() => null)
+  );
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Invalid post payload", details: parsed.error.issues },

--- a/apps/dashboard/src/components/ai/blog-changelog-preview.tsx
+++ b/apps/dashboard/src/components/ai/blog-changelog-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  ArrowReloadHorizontalIcon,
   ArrowRight01Icon,
   Cancel01Icon,
   CheckmarkSquare01Icon,
@@ -8,7 +9,6 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CHAT_PREVIEW_SAVE_TIMEOUT_MS } from "@notra/ai/constants/chat";
 import type { ContentType } from "@notra/ai/schemas/content";
-import { MessageResponse } from "@notra/ui/components/ai-elements/message";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { Button } from "@notra/ui/components/ui/button";
 import {
@@ -16,13 +16,27 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@notra/ui/components/ui/tabs";
 import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { BrailleLoader } from "@/components/braille-loader";
+import { LexicalEditor } from "@/components/content/editor/lexical-editor";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 
 type IncomingState = "draft" | "finished";
 type EffectiveState = "draft" | "loading" | "finished";
-type UserAction = "none" | "saving" | "save-failed";
+type UserAction =
+  | "none"
+  | "saving"
+  | "publishing"
+  | "generating"
+  | "save-failed";
 
 interface BlogChangelogPreviewProps {
   state: IncomingState;
@@ -32,8 +46,17 @@ interface BlogChangelogPreviewProps {
     ContentType,
     "blog_post" | "changelog" | "investor_update"
   >;
+  persistedStatus?: "draft" | "published";
   onApprove?: () => void;
   onDeny?: () => void;
+  onPersist?: (
+    status: "draft" | "published",
+    payload: { title: string; markdown: string }
+  ) => Promise<void>;
+  onRegenerate?: (
+    instructions: string,
+    payload: { title: string; markdown: string }
+  ) => void;
 }
 
 export function BlogChangelogPreview({
@@ -41,16 +64,28 @@ export function BlogChangelogPreview({
   title,
   markdown,
   contentType,
+  persistedStatus = "draft",
   onApprove,
   onDeny,
+  onPersist,
+  onRegenerate,
 }: BlogChangelogPreviewProps) {
   const [userAction, setUserAction] = useState<UserAction>("none");
+  const [draftTitle, setDraftTitle] = useState(title);
+  const [draftMarkdown, setDraftMarkdown] = useState(markdown);
+  const [regenerateOpen, setRegenerateOpen] = useState(false);
+  const [regenerateInstructions, setRegenerateInstructions] = useState("");
+  const [isOpen, setIsOpen] = useState(incomingState !== "finished");
 
   const effectiveState: EffectiveState = (() => {
     if (incomingState === "finished") {
       return "finished";
     }
-    if (userAction === "saving") {
+    if (
+      userAction === "saving" ||
+      userAction === "publishing" ||
+      userAction === "generating"
+    ) {
       return "loading";
     }
     if (userAction === "save-failed") {
@@ -69,23 +104,66 @@ export function BlogChangelogPreview({
     return () => window.clearTimeout(timer);
   }, [userAction]);
 
-  const handleApprove = useCallback(() => {
+  const handleApprove = useCallback(async () => {
     setUserAction("saving");
-    onApprove?.();
-  }, [onApprove]);
+    setIsOpen(false);
+    const toastId = toast.loading("Saving draft...");
+    try {
+      if (onPersist) {
+        await onPersist("draft", {
+          title: draftTitle,
+          markdown: draftMarkdown,
+        });
+      } else {
+        onApprove?.();
+      }
+      toast.success("Saved as draft", { id: toastId });
+    } catch {
+      setUserAction("save-failed");
+      toast.error("Failed to save draft", { id: toastId });
+    }
+  }, [draftMarkdown, draftTitle, onApprove, onPersist]);
+
+  const handlePublish = useCallback(async () => {
+    setUserAction("publishing");
+    setIsOpen(false);
+    const toastId = toast.loading("Publishing post...");
+    try {
+      await onPersist?.("published", {
+        title: draftTitle,
+        markdown: draftMarkdown,
+      });
+      toast.success("Post published", { id: toastId });
+    } catch {
+      setUserAction("save-failed");
+      toast.error("Failed to publish post", { id: toastId });
+    }
+  }, [draftMarkdown, draftTitle, onPersist]);
 
   const handleDeny = useCallback(() => {
     onDeny?.();
+    toast("Canceled");
   }, [onDeny]);
 
+  const handleRegenerate = useCallback(() => {
+    const instructions = regenerateInstructions.trim();
+    if (!instructions) {
+      setRegenerateOpen(true);
+      return;
+    }
+    setUserAction("generating");
+    toast("Generating post...");
+    onRegenerate?.(instructions, {
+      title: draftTitle,
+      markdown: draftMarkdown,
+    });
+  }, [draftMarkdown, draftTitle, onRegenerate, regenerateInstructions]);
+
   const isFinished = effectiveState === "finished";
-  const showDraftBadge = isFinished && userAction !== "save-failed";
+  const showStatusBadge = isFinished && userAction !== "save-failed";
 
   return (
-    <Collapsible
-      defaultOpen={!isFinished}
-      key={isFinished ? "collapsed" : "open"}
-    >
+    <Collapsible onOpenChange={setIsOpen} open={isOpen}>
       <div className="ml-px max-w-xl">
         <div className="rounded-lg border border-border bg-muted/80">
           <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 [&[data-panel-open]>svg]:rotate-90">
@@ -94,12 +172,12 @@ export function BlogChangelogPreview({
               icon={ArrowRight01Icon}
             />
             <span className="min-w-0 truncate text-left font-medium text-sm">
-              {title}
+              {draftTitle}
             </span>
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              {showDraftBadge && (
+              {showStatusBadge && (
                 <Badge className="text-[0.625rem]" variant="outline">
-                  draft
+                  {persistedStatus}
                 </Badge>
               )}
               <Badge
@@ -113,27 +191,95 @@ export function BlogChangelogPreview({
           </CollapsibleTrigger>
 
           <CollapsibleContent>
-            <div className="mx-2 mb-2">
-              <div className="max-h-[24rem] overflow-y-auto rounded-lg border border-border/80 bg-background px-4 py-3">
-                <MessageResponse className="text-sm leading-relaxed [&_ol]:pl-5 [&_ul]:pl-5 [&_ul]:marker:text-muted-foreground">
-                  {markdown}
-                </MessageResponse>
-              </div>
+            <div className="mx-2 mb-2 space-y-2">
+              {!isFinished && (
+                <input
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onChange={(event) => setDraftTitle(event.target.value)}
+                  value={draftTitle}
+                />
+              )}
+              <Tabs defaultValue="markdown">
+                <TabsList variant="line">
+                  <TabsTrigger value="markdown">Markdown</TabsTrigger>
+                  <TabsTrigger value="preview">Preview</TabsTrigger>
+                </TabsList>
+                <TabsContent className="mt-2" value="markdown">
+                  <textarea
+                    className="min-h-72 w-full resize-y rounded-md border border-border bg-background px-3 py-2 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onChange={(event) => setDraftMarkdown(event.target.value)}
+                    readOnly={isFinished}
+                    value={draftMarkdown}
+                  />
+                </TabsContent>
+                <TabsContent className="mt-2" value="preview">
+                  <div className="max-h-[24rem] overflow-y-auto rounded-lg border border-border/80 bg-background px-4 py-3">
+                    <LexicalEditor
+                      editable={!isFinished}
+                      initialMarkdown={draftMarkdown}
+                      onChange={setDraftMarkdown}
+                      onSelectionChange={() => null}
+                    />
+                  </div>
+                </TabsContent>
+              </Tabs>
+              {regenerateOpen && !isFinished && (
+                <input
+                  autoFocus
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onChange={(event) =>
+                    setRegenerateInstructions(event.target.value)
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      handleRegenerate();
+                    }
+                  }}
+                  placeholder="What should change?"
+                  value={regenerateInstructions}
+                />
+              )}
             </div>
           </CollapsibleContent>
 
-          {!isFinished && (
-            <div className="flex items-center justify-end gap-2 px-3 pb-2">
+          {!isFinished && isOpen && (
+            <div className="flex items-center gap-2 px-3 pb-2">
+              {userAction === "generating" && (
+                <div className="mr-auto flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+                  <BrailleLoader className="text-sm" variant="shimmer" />
+                  <span className="truncate">Generating post...</span>
+                </div>
+              )}
               {effectiveState === "draft" && (
-                <Button onClick={handleDeny} size="sm" variant="ghost">
-                  <HugeiconsIcon className="size-4" icon={Cancel01Icon} />
-                  Discard
-                </Button>
+                <div className="mr-auto flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+                  <BrailleLoader className="text-sm" variant="shimmer" />
+                  <span className="truncate">Waiting for response</span>
+                </div>
+              )}
+              {effectiveState === "draft" && (
+                <>
+                  <Button
+                    onClick={() => setRegenerateOpen((open) => !open)}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    <HugeiconsIcon
+                      className="size-4"
+                      icon={ArrowReloadHorizontalIcon}
+                    />
+                    Regenerate
+                  </Button>
+                  <Button onClick={handleDeny} size="sm" variant="ghost">
+                    <HugeiconsIcon className="size-4" icon={Cancel01Icon} />
+                    Discard
+                  </Button>
+                </>
               )}
               <Button
                 disabled={effectiveState === "loading"}
                 onClick={handleApprove}
                 size="sm"
+                variant="secondary"
               >
                 {effectiveState === "loading" ? (
                   <>
@@ -148,6 +294,20 @@ export function BlogChangelogPreview({
                     />
                     Save as draft
                   </>
+                )}
+              </Button>
+              <Button
+                disabled={effectiveState === "loading"}
+                onClick={handlePublish}
+                size="sm"
+              >
+                {effectiveState === "loading" && userAction === "publishing" ? (
+                  <>
+                    <Loader2Icon className="size-4 animate-spin" />
+                    Publishing
+                  </>
+                ) : (
+                  "Publish"
                 )}
               </Button>
             </div>

--- a/apps/dashboard/src/components/ai/blog-changelog-preview.tsx
+++ b/apps/dashboard/src/components/ai/blog-changelog-preview.tsx
@@ -77,6 +77,14 @@ export function BlogChangelogPreview({
   const [regenerateInstructions, setRegenerateInstructions] = useState("");
   const [isOpen, setIsOpen] = useState(incomingState !== "finished");
 
+  useEffect(() => {
+    setDraftTitle(title);
+  }, [title]);
+
+  useEffect(() => {
+    setDraftMarkdown(markdown);
+  }, [markdown]);
+
   const effectiveState: EffectiveState = (() => {
     if (incomingState === "finished") {
       return "finished";
@@ -95,7 +103,11 @@ export function BlogChangelogPreview({
   })();
 
   useEffect(() => {
-    if (userAction !== "saving") {
+    if (
+      userAction !== "saving" &&
+      userAction !== "publishing" &&
+      userAction !== "generating"
+    ) {
       return;
     }
     const timer = window.setTimeout(() => {
@@ -129,10 +141,16 @@ export function BlogChangelogPreview({
     setIsOpen(false);
     const toastId = toast.loading("Publishing post...");
     try {
-      await onPersist?.("published", {
+      if (!onPersist) {
+        setUserAction("save-failed");
+        toast.error("Publish is not available", { id: toastId });
+        return;
+      }
+      await onPersist("published", {
         title: draftTitle,
         markdown: draftMarkdown,
       });
+      setUserAction("none");
       toast.success("Post published", { id: toastId });
     } catch {
       setUserAction("save-failed");

--- a/apps/dashboard/src/components/ai/linkedin-preview.tsx
+++ b/apps/dashboard/src/components/ai/linkedin-preview.tsx
@@ -1,16 +1,13 @@
 "use client";
 
 import {
+  ArrowReloadHorizontalIcon,
   ArrowRight01Icon,
   Cancel01Icon,
   CheckmarkSquare01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import {
-  CHAT_LINKEDIN_PREVIEW_TRUNCATION_LIMIT,
-  CHAT_PREVIEW_SAVE_TIMEOUT_MS,
-} from "@notra/ai/constants/chat";
-import { LinkedInPostPreview } from "@notra/ui/components/ai-elements/linkedin-post-preview";
+import { CHAT_PREVIEW_SAVE_TIMEOUT_MS } from "@notra/ai/constants/chat";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { Button } from "@notra/ui/components/ui/button";
 import {
@@ -18,43 +15,71 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@notra/ui/components/ui/tabs";
 import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { BrailleLoader } from "@/components/braille-loader";
+import { LinkedInPost } from "@/components/linkedin-post";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 
 type IncomingState = "draft" | "finished";
 type EffectiveState = "draft" | "loading" | "finished";
-type UserAction = "none" | "saving" | "save-failed";
-
-interface LinkedInPreviewAuthor {
-  name: string;
-  avatar?: string;
-}
+type UserAction =
+  | "none"
+  | "saving"
+  | "publishing"
+  | "generating"
+  | "save-failed";
 
 interface LinkedInPreviewProps {
   state: IncomingState;
   title: string;
   markdown: string;
-  author?: LinkedInPreviewAuthor;
+  persistedStatus?: "draft" | "published";
   onApprove?: () => void;
   onDeny?: () => void;
+  onPersist?: (
+    status: "draft" | "published",
+    payload: { title: string; markdown: string }
+  ) => Promise<void>;
+  onRegenerate?: (
+    instructions: string,
+    payload: { title: string; markdown: string }
+  ) => void;
 }
 
 export function LinkedInPreview({
   state: incomingState,
   title,
   markdown,
-  author,
+  persistedStatus = "draft",
   onApprove,
   onDeny,
+  onPersist,
+  onRegenerate,
 }: LinkedInPreviewProps) {
   const [userAction, setUserAction] = useState<UserAction>("none");
+  const [draftTitle, setDraftTitle] = useState(title);
+  const [draftMarkdown, setDraftMarkdown] = useState(markdown);
+  const [regenerateOpen, setRegenerateOpen] = useState(false);
+  const [regenerateInstructions, setRegenerateInstructions] = useState("");
+  const [isOpen, setIsOpen] = useState(incomingState !== "finished");
 
   const effectiveState: EffectiveState = (() => {
     if (incomingState === "finished") {
       return "finished";
     }
-    if (userAction === "saving") {
+    if (
+      userAction === "saving" ||
+      userAction === "publishing" ||
+      userAction === "generating"
+    ) {
       return "loading";
     }
     if (userAction === "save-failed") {
@@ -73,23 +98,66 @@ export function LinkedInPreview({
     return () => window.clearTimeout(timer);
   }, [userAction]);
 
-  const handleApprove = useCallback(() => {
+  const handleApprove = useCallback(async () => {
     setUserAction("saving");
-    onApprove?.();
-  }, [onApprove]);
+    setIsOpen(false);
+    const toastId = toast.loading("Saving draft...");
+    try {
+      if (onPersist) {
+        await onPersist("draft", {
+          title: draftTitle,
+          markdown: draftMarkdown,
+        });
+      } else {
+        onApprove?.();
+      }
+      toast.success("Saved as draft", { id: toastId });
+    } catch {
+      setUserAction("save-failed");
+      toast.error("Failed to save draft", { id: toastId });
+    }
+  }, [draftMarkdown, draftTitle, onApprove, onPersist]);
+
+  const handlePublish = useCallback(async () => {
+    setUserAction("publishing");
+    setIsOpen(false);
+    const toastId = toast.loading("Publishing post...");
+    try {
+      await onPersist?.("published", {
+        title: draftTitle,
+        markdown: draftMarkdown,
+      });
+      toast.success("Post published", { id: toastId });
+    } catch {
+      setUserAction("save-failed");
+      toast.error("Failed to publish post", { id: toastId });
+    }
+  }, [draftMarkdown, draftTitle, onPersist]);
 
   const handleDeny = useCallback(() => {
     onDeny?.();
+    toast("Canceled");
   }, [onDeny]);
 
+  const handleRegenerate = useCallback(() => {
+    const instructions = regenerateInstructions.trim();
+    if (!instructions) {
+      setRegenerateOpen(true);
+      return;
+    }
+    setUserAction("generating");
+    toast("Generating post...");
+    onRegenerate?.(instructions, {
+      title: draftTitle,
+      markdown: draftMarkdown,
+    });
+  }, [draftMarkdown, draftTitle, onRegenerate, regenerateInstructions]);
+
   const isFinished = effectiveState === "finished";
-  const showDraftBadge = isFinished && userAction !== "save-failed";
+  const showStatusBadge = isFinished && userAction !== "save-failed";
 
   return (
-    <Collapsible
-      defaultOpen={!isFinished}
-      key={isFinished ? "collapsed" : "open"}
-    >
+    <Collapsible onOpenChange={setIsOpen} open={isOpen}>
       <div className="ml-px max-w-md">
         <div className="rounded-lg border border-border bg-muted/80">
           <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 [&[data-panel-open]>svg]:rotate-90">
@@ -98,12 +166,12 @@ export function LinkedInPreview({
               icon={ArrowRight01Icon}
             />
             <span className="min-w-0 truncate text-left font-medium text-sm">
-              {title}
+              {draftTitle}
             </span>
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              {showDraftBadge && (
+              {showStatusBadge && (
                 <Badge className="text-[0.625rem]" variant="outline">
-                  draft
+                  {persistedStatus}
                 </Badge>
               )}
               <Badge
@@ -117,32 +185,100 @@ export function LinkedInPreview({
           </CollapsibleTrigger>
 
           <CollapsibleContent>
-            <div className="mx-2 mb-2">
-              <LinkedInPostPreview
-                author={{
-                  name: author?.name ?? "Your Name",
-                  avatar: author?.avatar,
-                }}
-                className="w-full"
-                content={markdown}
-                timestamp="Just now"
-                truncationLimit={CHAT_LINKEDIN_PREVIEW_TRUNCATION_LIMIT}
-              />
+            <div className="mx-2 mb-2 space-y-2">
+              {!isFinished && (
+                <input
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onChange={(event) => setDraftTitle(event.target.value)}
+                  value={draftTitle}
+                />
+              )}
+              <Tabs defaultValue="markdown">
+                <TabsList variant="line">
+                  <TabsTrigger value="markdown">Markdown</TabsTrigger>
+                  <TabsTrigger value="preview">Preview</TabsTrigger>
+                </TabsList>
+                <TabsContent className="mt-2" value="markdown">
+                  <textarea
+                    className="min-h-40 w-full resize-y rounded-md border border-border bg-background px-3 py-2 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onChange={(event) => setDraftMarkdown(event.target.value)}
+                    readOnly={isFinished}
+                    value={draftMarkdown}
+                  />
+                </TabsContent>
+                <TabsContent className="mt-2" value="preview">
+                  <LinkedInPost
+                    author={{ name: "Your Name" }}
+                    className="w-full"
+                    content={draftMarkdown}
+                    defaultExpanded
+                    onContentChange={
+                      isFinished
+                        ? undefined
+                        : (value) => setDraftMarkdown(value)
+                    }
+                    timestamp="Just now"
+                    truncate={false}
+                  />
+                </TabsContent>
+              </Tabs>
+              {regenerateOpen && !isFinished && (
+                <input
+                  autoFocus
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onChange={(event) =>
+                    setRegenerateInstructions(event.target.value)
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      handleRegenerate();
+                    }
+                  }}
+                  placeholder="What should change?"
+                  value={regenerateInstructions}
+                />
+              )}
             </div>
           </CollapsibleContent>
 
-          {!isFinished && (
-            <div className="flex items-center justify-end gap-2 px-3 pb-2">
+          {!isFinished && isOpen && (
+            <div className="flex items-center gap-2 px-3 pb-2">
+              {userAction === "generating" && (
+                <div className="mr-auto flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+                  <BrailleLoader className="text-sm" variant="shimmer" />
+                  <span className="truncate">Generating post...</span>
+                </div>
+              )}
               {effectiveState === "draft" && (
-                <Button onClick={handleDeny} size="sm" variant="ghost">
-                  <HugeiconsIcon className="size-4" icon={Cancel01Icon} />
-                  Discard
-                </Button>
+                <div className="mr-auto flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+                  <BrailleLoader className="text-sm" variant="shimmer" />
+                  <span className="truncate">Waiting for response</span>
+                </div>
+              )}
+              {effectiveState === "draft" && (
+                <>
+                  <Button
+                    onClick={() => setRegenerateOpen((open) => !open)}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    <HugeiconsIcon
+                      className="size-4"
+                      icon={ArrowReloadHorizontalIcon}
+                    />
+                    Regenerate
+                  </Button>
+                  <Button onClick={handleDeny} size="sm" variant="ghost">
+                    <HugeiconsIcon className="size-4" icon={Cancel01Icon} />
+                    Discard
+                  </Button>
+                </>
               )}
               <Button
                 disabled={effectiveState === "loading"}
                 onClick={handleApprove}
                 size="sm"
+                variant="secondary"
               >
                 {effectiveState === "loading" ? (
                   <>
@@ -157,6 +293,20 @@ export function LinkedInPreview({
                     />
                     Save as draft
                   </>
+                )}
+              </Button>
+              <Button
+                disabled={effectiveState === "loading"}
+                onClick={handlePublish}
+                size="sm"
+              >
+                {effectiveState === "loading" && userAction === "publishing" ? (
+                  <>
+                    <Loader2Icon className="size-4 animate-spin" />
+                    Publishing
+                  </>
+                ) : (
+                  "Publish"
                 )}
               </Button>
             </div>

--- a/apps/dashboard/src/components/ai/linkedin-preview.tsx
+++ b/apps/dashboard/src/components/ai/linkedin-preview.tsx
@@ -71,6 +71,14 @@ export function LinkedInPreview({
   const [regenerateInstructions, setRegenerateInstructions] = useState("");
   const [isOpen, setIsOpen] = useState(incomingState !== "finished");
 
+  useEffect(() => {
+    setDraftTitle(title);
+  }, [title]);
+
+  useEffect(() => {
+    setDraftMarkdown(markdown);
+  }, [markdown]);
+
   const effectiveState: EffectiveState = (() => {
     if (incomingState === "finished") {
       return "finished";
@@ -89,7 +97,11 @@ export function LinkedInPreview({
   })();
 
   useEffect(() => {
-    if (userAction !== "saving") {
+    if (
+      userAction !== "saving" &&
+      userAction !== "publishing" &&
+      userAction !== "generating"
+    ) {
       return;
     }
     const timer = window.setTimeout(() => {
@@ -123,10 +135,16 @@ export function LinkedInPreview({
     setIsOpen(false);
     const toastId = toast.loading("Publishing post...");
     try {
-      await onPersist?.("published", {
+      if (!onPersist) {
+        setUserAction("save-failed");
+        toast.error("Publish is not available", { id: toastId });
+        return;
+      }
+      await onPersist("published", {
         title: draftTitle,
         markdown: draftMarkdown,
       });
+      setUserAction("none");
       toast.success("Post published", { id: toastId });
     } catch {
       setUserAction("save-failed");

--- a/apps/dashboard/src/components/ai/twitter-preview.tsx
+++ b/apps/dashboard/src/components/ai/twitter-preview.tsx
@@ -71,6 +71,14 @@ export function TwitterPreview({
   const [regenerateInstructions, setRegenerateInstructions] = useState("");
   const [isOpen, setIsOpen] = useState(incomingState !== "finished");
 
+  useEffect(() => {
+    setDraftTitle(title);
+  }, [title]);
+
+  useEffect(() => {
+    setDraftMarkdown(markdown);
+  }, [markdown]);
+
   const effectiveState: EffectiveState = (() => {
     if (incomingState === "finished") {
       return "finished";
@@ -89,7 +97,11 @@ export function TwitterPreview({
   })();
 
   useEffect(() => {
-    if (userAction !== "saving") {
+    if (
+      userAction !== "saving" &&
+      userAction !== "publishing" &&
+      userAction !== "generating"
+    ) {
       return;
     }
     const timer = window.setTimeout(() => {
@@ -123,10 +135,16 @@ export function TwitterPreview({
     setIsOpen(false);
     const toastId = toast.loading("Publishing post...");
     try {
-      await onPersist?.("published", {
+      if (!onPersist) {
+        setUserAction("save-failed");
+        toast.error("Publish is not available", { id: toastId });
+        return;
+      }
+      await onPersist("published", {
         title: draftTitle,
         markdown: draftMarkdown,
       });
+      setUserAction("none");
       toast.success("Post published", { id: toastId });
     } catch {
       setUserAction("save-failed");

--- a/apps/dashboard/src/components/ai/twitter-preview.tsx
+++ b/apps/dashboard/src/components/ai/twitter-preview.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import {
+  ArrowReloadHorizontalIcon,
   ArrowRight01Icon,
   Cancel01Icon,
   CheckmarkSquare01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CHAT_PREVIEW_SAVE_TIMEOUT_MS } from "@notra/ai/constants/chat";
-import { TwitterPostPreview } from "@notra/ui/components/ai-elements/twitter-post-preview";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { Button } from "@notra/ui/components/ui/button";
 import {
@@ -15,43 +15,71 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@notra/ui/components/ui/tabs";
 import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { BrailleLoader } from "@/components/braille-loader";
+import { TwitterPost } from "@/components/twitter-post";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 
 type IncomingState = "draft" | "finished";
 type EffectiveState = "draft" | "loading" | "finished";
-type UserAction = "none" | "saving" | "save-failed";
-
-interface TwitterPreviewAuthor {
-  name: string;
-  avatar?: string;
-}
+type UserAction =
+  | "none"
+  | "saving"
+  | "publishing"
+  | "generating"
+  | "save-failed";
 
 interface TwitterPreviewProps {
   state: IncomingState;
   title: string;
   markdown: string;
-  author?: TwitterPreviewAuthor;
+  persistedStatus?: "draft" | "published";
   onApprove?: () => void;
   onDeny?: () => void;
+  onPersist?: (
+    status: "draft" | "published",
+    payload: { title: string; markdown: string }
+  ) => Promise<void>;
+  onRegenerate?: (
+    instructions: string,
+    payload: { title: string; markdown: string }
+  ) => void;
 }
 
 export function TwitterPreview({
   state: incomingState,
   title,
   markdown,
-  author,
+  persistedStatus = "draft",
   onApprove,
   onDeny,
+  onPersist,
+  onRegenerate,
 }: TwitterPreviewProps) {
   const [userAction, setUserAction] = useState<UserAction>("none");
+  const [draftTitle, setDraftTitle] = useState(title);
+  const [draftMarkdown, setDraftMarkdown] = useState(markdown);
+  const [regenerateOpen, setRegenerateOpen] = useState(false);
+  const [regenerateInstructions, setRegenerateInstructions] = useState("");
+  const [isOpen, setIsOpen] = useState(incomingState !== "finished");
 
   const effectiveState: EffectiveState = (() => {
     if (incomingState === "finished") {
       return "finished";
     }
-    if (userAction === "saving") {
+    if (
+      userAction === "saving" ||
+      userAction === "publishing" ||
+      userAction === "generating"
+    ) {
       return "loading";
     }
     if (userAction === "save-failed") {
@@ -70,23 +98,66 @@ export function TwitterPreview({
     return () => window.clearTimeout(timer);
   }, [userAction]);
 
-  const handleApprove = useCallback(() => {
+  const handleApprove = useCallback(async () => {
     setUserAction("saving");
-    onApprove?.();
-  }, [onApprove]);
+    setIsOpen(false);
+    const toastId = toast.loading("Saving draft...");
+    try {
+      if (onPersist) {
+        await onPersist("draft", {
+          title: draftTitle,
+          markdown: draftMarkdown,
+        });
+      } else {
+        onApprove?.();
+      }
+      toast.success("Saved as draft", { id: toastId });
+    } catch {
+      setUserAction("save-failed");
+      toast.error("Failed to save draft", { id: toastId });
+    }
+  }, [draftMarkdown, draftTitle, onApprove, onPersist]);
+
+  const handlePublish = useCallback(async () => {
+    setUserAction("publishing");
+    setIsOpen(false);
+    const toastId = toast.loading("Publishing post...");
+    try {
+      await onPersist?.("published", {
+        title: draftTitle,
+        markdown: draftMarkdown,
+      });
+      toast.success("Post published", { id: toastId });
+    } catch {
+      setUserAction("save-failed");
+      toast.error("Failed to publish post", { id: toastId });
+    }
+  }, [draftMarkdown, draftTitle, onPersist]);
 
   const handleDeny = useCallback(() => {
     onDeny?.();
+    toast("Canceled");
   }, [onDeny]);
 
+  const handleRegenerate = useCallback(() => {
+    const instructions = regenerateInstructions.trim();
+    if (!instructions) {
+      setRegenerateOpen(true);
+      return;
+    }
+    setUserAction("generating");
+    toast("Generating post...");
+    onRegenerate?.(instructions, {
+      title: draftTitle,
+      markdown: draftMarkdown,
+    });
+  }, [draftMarkdown, draftTitle, onRegenerate, regenerateInstructions]);
+
   const isFinished = effectiveState === "finished";
-  const showDraftBadge = isFinished && userAction !== "save-failed";
+  const showStatusBadge = isFinished && userAction !== "save-failed";
 
   return (
-    <Collapsible
-      defaultOpen={!isFinished}
-      key={isFinished ? "collapsed" : "open"}
-    >
+    <Collapsible onOpenChange={setIsOpen} open={isOpen}>
       <div className="ml-px max-w-md">
         <div className="rounded-lg border border-border bg-muted/80">
           <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 [&[data-panel-open]>svg]:rotate-90">
@@ -95,12 +166,12 @@ export function TwitterPreview({
               icon={ArrowRight01Icon}
             />
             <span className="min-w-0 truncate text-left font-medium text-sm">
-              {title}
+              {draftTitle}
             </span>
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              {showDraftBadge && (
+              {showStatusBadge && (
                 <Badge className="text-[0.625rem]" variant="outline">
-                  draft
+                  {persistedStatus}
                 </Badge>
               )}
               <Badge
@@ -114,34 +185,101 @@ export function TwitterPreview({
           </CollapsibleTrigger>
 
           <CollapsibleContent>
-            <div className="mx-2 mb-2">
-              <TwitterPostPreview
-                author={{
-                  name: author?.name ?? "Your Name",
-                  avatar: author?.avatar,
-                  handle: (author?.name ?? "yourname")
-                    .toLowerCase()
-                    .replace(/\s+/g, ""),
-                }}
-                className="w-full"
-                content={markdown}
-                timestamp="Just now"
-              />
+            <div className="mx-2 mb-2 space-y-2">
+              {!isFinished && (
+                <input
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onChange={(event) => setDraftTitle(event.target.value)}
+                  value={draftTitle}
+                />
+              )}
+              <Tabs defaultValue="markdown">
+                <TabsList variant="line">
+                  <TabsTrigger value="markdown">Markdown</TabsTrigger>
+                  <TabsTrigger value="preview">Preview</TabsTrigger>
+                </TabsList>
+                <TabsContent className="mt-2" value="markdown">
+                  <textarea
+                    className="min-h-40 w-full resize-y rounded-md border border-border bg-background px-3 py-2 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onChange={(event) => setDraftMarkdown(event.target.value)}
+                    readOnly={isFinished}
+                    value={draftMarkdown}
+                  />
+                </TabsContent>
+                <TabsContent className="mt-2" value="preview">
+                  <TwitterPost
+                    author={{
+                      name: "Your Name",
+                      handle: "yourname",
+                    }}
+                    className="w-full"
+                    content={draftMarkdown}
+                    onContentChange={
+                      isFinished
+                        ? undefined
+                        : (value) => setDraftMarkdown(value)
+                    }
+                    timestamp="Just now"
+                  />
+                </TabsContent>
+              </Tabs>
+              {regenerateOpen && !isFinished && (
+                <input
+                  autoFocus
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onChange={(event) =>
+                    setRegenerateInstructions(event.target.value)
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      handleRegenerate();
+                    }
+                  }}
+                  placeholder="What should change?"
+                  value={regenerateInstructions}
+                />
+              )}
             </div>
           </CollapsibleContent>
 
-          {!isFinished && (
-            <div className="flex items-center justify-end gap-2 px-3 pb-2">
+          {!isFinished && isOpen && (
+            <div className="flex items-center gap-2 px-3 pb-2">
+              {userAction === "generating" && (
+                <div className="mr-auto flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+                  <BrailleLoader className="text-sm" variant="shimmer" />
+                  <span className="truncate">Generating post...</span>
+                </div>
+              )}
               {effectiveState === "draft" && (
-                <Button onClick={handleDeny} size="sm" variant="ghost">
-                  <HugeiconsIcon className="size-4" icon={Cancel01Icon} />
-                  Discard
-                </Button>
+                <div className="mr-auto flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+                  <BrailleLoader className="text-sm" variant="shimmer" />
+                  <span className="truncate">Waiting for response</span>
+                </div>
+              )}
+              {effectiveState === "draft" && (
+                <>
+                  <Button
+                    onClick={() => setRegenerateOpen((open) => !open)}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    <HugeiconsIcon
+                      className="size-4"
+                      icon={ArrowReloadHorizontalIcon}
+                    />
+                    Regenerate
+                  </Button>
+                  <Button onClick={handleDeny} size="sm" variant="ghost">
+                    <HugeiconsIcon className="size-4" icon={Cancel01Icon} />
+                    Discard
+                  </Button>
+                </>
               )}
               <Button
                 disabled={effectiveState === "loading"}
                 onClick={handleApprove}
                 size="sm"
+                variant="secondary"
               >
                 {effectiveState === "loading" ? (
                   <>
@@ -156,6 +294,20 @@ export function TwitterPreview({
                     />
                     Save as draft
                   </>
+                )}
+              </Button>
+              <Button
+                disabled={effectiveState === "loading"}
+                onClick={handlePublish}
+                size="sm"
+              >
+                {effectiveState === "loading" && userAction === "publishing" ? (
+                  <>
+                    <Loader2Icon className="size-4 animate-spin" />
+                    Publishing
+                  </>
+                ) : (
+                  "Publish"
                 )}
               </Button>
             </div>

--- a/bun.lock
+++ b/bun.lock
@@ -4,13 +4,17 @@
   "workspaces": {
     "": {
       "name": "turbo",
+      "dependencies": {
+        "@ai-sdk/react": "^3.0.177",
+        "ai": "^6.0.175",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.3.2",
         "dotenv-cli": "^11.0.0",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
         "openlogs": "^0.0.1",
-        "turbo": "^2.9.6",
+        "turbo": "^2.9.9",
         "ultracite": "7.1.4",
       },
     },
@@ -344,7 +348,7 @@
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.176", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.26", "ai": "6.0.174", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-8CKMdSJDAHHUYEJSsI+HGanP/75dOYtnLWQ5WtQMvdmsA4PUVy8Hv6Bn1npoZBcTh250ESsuSptvctxFuIJrYw=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.177", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.26", "ai": "6.0.175", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-7K3bmj2ajbAkrqR7P8bByKp0w2iACGSIpahoEkeUhhZqVJO4/mxqk6Q5wcd12EaOi+5+86k2VH91BKgzCuCRaw=="],
 
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
@@ -1700,7 +1704,7 @@
 
     "aggregate-error": ["aggregate-error@4.0.1", "", { "dependencies": { "clean-stack": "^4.0.0", "indent-string": "^5.0.0" } }, "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w=="],
 
-    "ai": ["ai@6.0.174", "", { "dependencies": { "@ai-sdk/gateway": "3.0.109", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bTrfLUWHWtkjzWyCY4bmyuk4Qvmj4S4NSNsXyNSVVqkmftQNtxRj7dzUoMeQDBBwlJO6fC7m2Q/lNOPqQQfAGA=="],
+    "ai": ["ai@6.0.175", "", { "dependencies": { "@ai-sdk/gateway": "3.0.110", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -3844,8 +3848,6 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@ai-sdk-tools/cache/ai": ["ai@5.0.183", "", { "dependencies": { "@ai-sdk/gateway": "2.0.86", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-lmLFkxJ2epeUXi6QXi/9VYs1HF61vikpP8vGnGd3Erdh/syUyfZ/DC1to2AoNwytBNpICN3OGbTpwc7jfPewgg=="],
-
     "@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
 
     "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.25", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA=="],
@@ -4178,8 +4180,6 @@
 
     "@upstash/workflow/@upstash/qstash": ["@upstash/qstash@2.10.1", "", { "dependencies": { "crypto-js": ">=4.2.0", "jose": "^5.2.3", "neverthrow": "^7.0.1" } }, "sha512-LsTAPxPk0dFvhlEnRqwObRS94b8mmDHYaBlF3IaONUL+Scq6i9cZraA6936KSUVe+Vq3eNQle3CjOZkStPUFTw=="],
 
-    "ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.109", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-r6dOqThjODp1vOhGRJg2OCmyB/ZOQtGx1esZ2SDvwDX5XoX8dBqYaYjLg8MPXTzMGJSgOkJyCxWgUcZtAl16pw=="],
-
     "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -4407,14 +4407,6 @@
     "xss/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@ai-sdk-tools/cache/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.86", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-pP9F5G7C5sqZtAwquFB+g50lVS/s4Wf/ll2WSm0ODk0Iix27trVgBDpFK5CBletcQXSDlAvSQQi25nBodYLt3g=="],
-
-    "@ai-sdk-tools/cache/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
-
-    "@ai-sdk-tools/cache/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.25", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA=="],
-
-    "@ai-sdk-tools/cache/ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@ai-sdk/anthropic/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -5085,10 +5077,6 @@
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "@ai-sdk-tools/cache/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
-
-    "@ai-sdk-tools/cache/ai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@asyncapi/parser/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 


### PR DESCRIPTION
## Summary
- Added a new chat post persistence endpoint at `/api/organizations/[organizationId]/chat/posts` to save draft or published posts after access checks and markdown sanitization.
- Upgraded the blog, LinkedIn, and Twitter AI previews to support inline editing, regenerate flows, draft/publish actions, and persisted status badges.
- Updated chat send logic to filter tool approval payloads before sending and to continue automatically after approved tool responses.
- Prevented empty chat submissions and added support for discarding or persisting generated content from the preview UI.

## Testing
- Not run
- Verified the change set includes the new post API route and preview component updates.
- Reviewed the chat send/persist flow for draft, publish, regenerate, and discard paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds post persistence for generated chat content and makes blog, LinkedIn, and Twitter previews editable with regenerate, draft, and publish. Tightens approval and send logic to auto-continue after approvals, respect discards, and block empty sends.

- **New Features**
  - POST `/api/organizations/[organizationId]/chat/posts` to save drafts or published posts with org access checks, schema validation (400 on invalid), optional `slug` for types that support it, and sanitized HTML storage; returns `{ postId, status }`.
  - Editable previews (blog/changelog, LinkedIn, Twitter): inline title/content edits with Markdown/Preview tabs, regenerate with instructions, draft/publish via the new API, persisted status badges, and live sync with incoming title/markdown updates.

- **Refactors**
  - Normalizes tool approvals for send (discards become `output-denied`) and auto-continues when all approvals are done; hides discarded previews.
  - Filters sendable message parts, prevents empty submissions, marks previews finished after manual draft/publish, and invalidates `["chat-sessions", organizationId]` after saves.

<sup>Written for commit 555294e95577af22a7cc75fd57e9e275efe3ab65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

