### PR TITLE
Polish dashboard navigation, empty states, and sidebar copy

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
@@ -416,7 +416,7 @@ function SchedulesSection({
           </p>
         </div>
         {slug && (
-          <Link href={`/${slug}/automation/schedule`}>
+          <Link href={`/${slug}/automation/schedules`}>
             <Button size="sm" variant="outline">
               View All
               <HugeiconsIcon
@@ -461,7 +461,7 @@ function SchedulesSection({
             <div className="px-4 py-2 text-center">
               <Link
                 className="text-muted-foreground text-xs hover:underline"
-                href={`/${slug}/automation/schedule`}
+                href={`/${slug}/automation/schedules`}
               >
                 +{schedules.length - 5} more schedules
               </Link>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx
@@ -10,7 +10,6 @@ import {
   TableRow,
 } from "@notra/ui/components/ui/table";
 import {
-  type ColumnDef,
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
@@ -18,16 +17,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useState } from "react";
-
-interface DataTableProps<TData> {
-  // biome-ignore lint/suspicious/noExplicitAny: TanStack Table columns have varying value types
-  columns: ColumnDef<TData, any>[];
-  data: TData[];
-  page: number;
-  totalPages: number;
-  onPageChange: (page: number) => void;
-  isLoading?: boolean;
-}
+import type { DataTableProps } from "@/types/logs/data-table";
 
 export function DataTable<TData>({
   columns,
@@ -36,6 +26,7 @@ export function DataTable<TData>({
   totalPages,
   onPageChange,
   isLoading,
+  emptyState,
 }: DataTableProps<TData>) {
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -102,39 +93,63 @@ export function DataTable<TData>({
             {!(isLoading || table.getRowModel().rows?.length) && (
               <TableRow>
                 <TableCell
-                  className="h-24 text-center"
+                  className="h-32 text-center"
                   colSpan={columns.length}
                 >
-                  No results.
+                  {emptyState ? (
+                    <div className="flex flex-col items-center justify-center gap-2 py-2">
+                      <p className="font-medium text-sm">{emptyState.title}</p>
+                      {emptyState.description && (
+                        <p className="text-muted-foreground text-sm">
+                          {emptyState.description}
+                        </p>
+                      )}
+                      {emptyState.actionLabel && emptyState.onActionClick && (
+                        <Button
+                          className="mt-2"
+                          onClick={emptyState.onActionClick}
+                          size="sm"
+                          type="button"
+                          variant="outline"
+                        >
+                          {emptyState.actionLabel}
+                        </Button>
+                      )}
+                    </div>
+                  ) : (
+                    "No results."
+                  )}
                 </TableCell>
               </TableRow>
             )}
           </TableBody>
         </Table>
       </div>
-      <div className="flex items-center justify-between py-4">
-        <span className="text-muted-foreground text-sm">
-          Page {page} of {totalPages}
-        </span>
-        <div className="flex items-center space-x-2">
-          <Button
-            disabled={page <= 1}
-            onClick={() => onPageChange(page - 1)}
-            size="sm"
-            variant="outline"
-          >
-            Previous
-          </Button>
-          <Button
-            disabled={page >= totalPages}
-            onClick={() => onPageChange(page + 1)}
-            size="sm"
-            variant="outline"
-          >
-            Next
-          </Button>
+      {(totalPages > 1 || data.length > 0) && (
+        <div className="flex items-center justify-between py-4">
+          <span className="text-muted-foreground text-sm">
+            Page {page} of {totalPages}
+          </span>
+          <div className="flex items-center space-x-2">
+            <Button
+              disabled={page <= 1}
+              onClick={() => onPageChange(page - 1)}
+              size="sm"
+              variant="outline"
+            >
+              Previous
+            </Button>
+            <Button
+              disabled={page >= totalPages}
+              onClick={() => onPageChange(page + 1)}
+              size="sm"
+              variant="outline"
+            >
+              Next
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
@@ -240,9 +240,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                     onActionClick: resetFilters,
                   }
                 : {
-                    title: "No webhook events yet",
+                    title: "No logs yet",
                     description:
-                      "Events will appear here after connected integrations deliver activity.",
+                      "Activity from your integrations and automations will show up here.",
                   }
             }
             onPageChange={setPage}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
@@ -231,6 +231,20 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           <DataTable
             columns={columns}
             data={data?.logs ?? []}
+            emptyState={
+              filtersActive
+                ? {
+                    title: "No logs match your filters",
+                    description: "Try a different search, source, or status.",
+                    actionLabel: "Reset filters",
+                    onActionClick: resetFilters,
+                  }
+                : {
+                    title: "No webhook events yet",
+                    description:
+                      "Events will appear here after connected integrations deliver activity.",
+                  }
+            }
             onPageChange={setPage}
             page={page}
             totalPages={data?.pagination.totalPages ?? 1}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
@@ -105,7 +105,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     return (
       <EmptyState
         className="p-6"
-        description="Check back later or start a new post from the content page."
+        description="You have no new posts today. Create one now or review your existing drafts on the content page."
         title="No content created today"
       />
     );

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -51,7 +51,10 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
       setIsSubmitting(true);
 
       try {
-        const websiteUrl = normalizeWebsite(value.websiteUrl);
+        const trimmedWebsite = value.websiteUrl.trim();
+        const websiteUrl = trimmedWebsite
+          ? normalizeWebsite(trimmedWebsite)
+          : undefined;
         const parsed = onboardingWorkspaceSchema.safeParse({
           name: value.name,
           slug: value.slug,
@@ -94,21 +97,22 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
           await setLastVisitedOrganization(data.slug);
         }
 
-        const brandAnalysisPromise = triggerOnboardingBrandAnalysis({
-          organizationId,
-          websiteUrl: parsed.data.websiteUrl,
-          name: parsed.data.name,
-        });
-
-        brandAnalysisPromise.catch((error) => {
-          console.error("[Onboarding] Background brand analysis failed", {
+        if (parsed.data.websiteUrl) {
+          const brandAnalysisPromise = triggerOnboardingBrandAnalysis({
             organizationId,
-            error,
+            websiteUrl: parsed.data.websiteUrl,
+            name: parsed.data.name,
           });
-        });
+
+          brandAnalysisPromise.catch((error) => {
+            console.error("[Onboarding] Background brand analysis failed", {
+              organizationId,
+              error,
+            });
+          });
+        }
 
         window.location.assign("/onboarding/socials");
-        // Keep button in submitting state during navigation
         return;
       } catch (err) {
         toast.error(
@@ -131,8 +135,8 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
         </h1>
         <p className="text-muted-foreground text-sm">
           {isResuming
-            ? "Your workspace is ready — enter your website so we can finish learning your brand voice."
-            : "We'll use your website to learn your brand voice while you set up the rest."}
+            ? "Your workspace is ready. Add a website if you want us to learn your brand voice automatically."
+            : "Add a website and we'll learn your brand voice while you set up the rest. You can always add it later."}
         </p>
       </div>
 
@@ -227,9 +231,9 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
           validators={{
             onChange: ({ value }) => {
               if (!value || value.trim() === "") {
-                return "Website is required";
+                return;
               }
-              const candidate = normalizeWebsite(value);
+              const candidate = normalizeWebsite(value.trim());
               return onboardingWorkspaceSchema.shape.websiteUrl.safeParse(
                 candidate
               ).error?.issues[0]?.message;
@@ -239,7 +243,10 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
           {(field) => (
             <div className="grid gap-2">
               <Label htmlFor="website">
-                Website <span className="text-destructive">*</span>
+                Website{" "}
+                <span className="text-muted-foreground text-xs">
+                  (optional)
+                </span>
               </Label>
               <div
                 className={`flex w-full flex-row items-center rounded-md border transition-colors focus-within:border-ring focus-within:ring-ring/50 ${field.state.meta.errors.length > 0 ? "border-destructive" : "border-border"}`}

--- a/apps/dashboard/src/components/billing/credit-balance-button.tsx
+++ b/apps/dashboard/src/components/billing/credit-balance-button.tsx
@@ -5,6 +5,11 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@notra/ui/components/ui/button";
 import { DropdownMenuItem } from "@notra/ui/components/ui/dropdown-menu";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@notra/ui/components/ui/tooltip";
 import { cn } from "@notra/ui/lib/utils";
 import { useState } from "react";
 import { CreditTopupModal } from "@/components/billing/credit-topup-modal";
@@ -25,15 +30,23 @@ export function CreditBalanceButton({ className }: { className?: string }) {
 
   return (
     <>
-      <Button
-        className={cn("gap-1.5 tabular-nums", className)}
-        onClick={() => setOpen(true)}
-        size="sm"
-        variant="outline"
-      >
-        <HugeiconsIcon icon={Wallet01Icon} size={16} />
-        {balance !== null ? formatDollars(balance) : "-"}
-      </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              aria-label="Available credits"
+              className={cn("gap-1.5 tabular-nums", className)}
+              onClick={() => setOpen(true)}
+              size="sm"
+              variant="outline"
+            >
+              <HugeiconsIcon icon={Wallet01Icon} size={16} />
+              {balance !== null ? formatDollars(balance) : "-"}
+            </Button>
+          }
+        />
+        <TooltipContent>Available credits</TooltipContent>
+      </Tooltip>
       <CreditTopupModal onOpenChange={setOpen} open={open} />
     </>
   );

--- a/apps/dashboard/src/components/billing/credit-balance-button.tsx
+++ b/apps/dashboard/src/components/billing/credit-balance-button.tsx
@@ -34,7 +34,11 @@ export function CreditBalanceButton({ className }: { className?: string }) {
         <TooltipTrigger
           render={
             <Button
-              aria-label="Available credits"
+              aria-label={
+                balance !== null
+                  ? `Available credits: ${formatDollars(balance)}`
+                  : "Available credits"
+              }
               className={cn("gap-1.5 tabular-nums", className)}
               onClick={() => setOpen(true)}
               size="sm"

--- a/apps/dashboard/src/components/command-palette/registry.ts
+++ b/apps/dashboard/src/components/command-palette/registry.ts
@@ -63,7 +63,7 @@ export const COMMAND_ROUTES: CommandRoute[] = [
     keywords: ["cron", "recurring", "automation", "calendar"],
     icon: Calendar03Icon,
     section: "Automation",
-    path: (slug) => `/${slug}/automation/schedule`,
+    path: (slug) => `/${slug}/automation/schedules`,
   },
   {
     id: "automation-events",

--- a/apps/dashboard/src/components/content/content-card.tsx
+++ b/apps/dashboard/src/components/content/content-card.tsx
@@ -140,7 +140,9 @@ const ContentCard = memo(function ContentCard({
       )}
     >
       <div className="flex items-start justify-between gap-4 py-1.5 pr-2 pl-2">
-        <p className="min-w-0 truncate font-medium text-lg">{title}</p>
+        <p className="line-clamp-2 min-w-0 font-medium text-lg leading-snug">
+          {title}
+        </p>
         <div className="flex shrink-0 items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -185,10 +187,10 @@ const ContentCard = memo(function ContentCard({
           </DropdownMenu>
         </div>
       </div>
-      <div className="flex-1 rounded-[0.75rem] border border-border/80 bg-background px-4 py-3">
+      <div className="flex-1 rounded-md bg-background/60 px-3 py-2.5">
         <p className="line-clamp-3 text-muted-foreground text-sm">{preview}</p>
       </div>
-      <div className="flex items-center gap-2 px-2 py-1.5">
+      <div className="flex items-center gap-2 px-2 py-2">
         <Badge
           className="capitalize"
           variant={status === "published" ? "default" : "outline"}

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -914,11 +914,18 @@ export function CreateContentDialog({
                         <Label htmlFor={field.name}>Integrations</Label>
                         {isLoadingRepos && <Skeleton className="h-10 w-full" />}
                         {!isLoadingRepos && integrationOptions.length === 0 && (
-                          <div className="flex items-center gap-2 rounded-md border border-dashed p-3">
-                            <span className="flex-1 text-muted-foreground text-xs">
-                              No integrations connected.
-                            </span>
+                          <div className="flex items-start justify-between gap-3 rounded-md border border-dashed p-4">
+                            <div className="flex-1 space-y-1">
+                              <p className="font-medium text-sm">
+                                No integrations connected
+                              </p>
+                              <p className="text-muted-foreground text-xs">
+                                Connect GitHub or Linear so Notra can pull
+                                recent activity for this content.
+                              </p>
+                            </div>
                             <AddRepositoryButton
+                              label="Connect"
                               onAdd={handleOpenAddRepositoryFlow}
                             />
                           </div>
@@ -1283,7 +1290,14 @@ export function CreateContentDialog({
             {/* ── Footer ── */}
             <div className="shrink-0 rounded-b-xl border-t bg-muted/50 p-4">
               {step === "configure" && (
-                <div className="flex items-center justify-end">
+                <div className="flex items-center justify-between gap-3">
+                  {repositoryIds.length === 0 ? (
+                    <p className="text-muted-foreground text-xs">
+                      Select or add an integration to continue.
+                    </p>
+                  ) : (
+                    <span />
+                  )}
                   <Button
                     disabled={repositoryIds.length === 0}
                     onClick={handleContinue}

--- a/apps/dashboard/src/components/dashboard/content-activity-card.tsx
+++ b/apps/dashboard/src/components/dashboard/content-activity-card.tsx
@@ -49,7 +49,7 @@ export const ContentActivityCard = () => {
   }
 
   return (
-    <div className="w-fit rounded-lg border border-border/80 bg-background px-4 py-3">
+    <div className="w-full overflow-x-auto rounded-lg border border-border/80 bg-background px-4 py-3">
       {data?.graph?.activity ? (
         <ContributionGraph
           blockMargin={3}
@@ -106,6 +106,7 @@ export const ContentActivityCard = () => {
             <ContributionGraphTotalCount>
               {({ totalCount }) => (
                 <span className="text-muted-foreground text-sm">
+                  This year:{" "}
                   <span className="font-semibold text-foreground">
                     {totalCount.toLocaleString()}
                   </span>{" "}

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -52,6 +52,10 @@ const NON_ORG_PATHS: string[] = [];
 const SEGMENT_CONFIG: Record<string, { label?: string; href?: null }> = {
   billing: { label: "Billing & Usage" },
   automation: { href: null },
+  brand: { href: null },
+  "api-keys": { label: "API Keys" },
+  identity: { label: "Identity & References" },
+  schedules: { label: "Schedules" },
 };
 
 export function SiteHeader() {

--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -70,7 +70,7 @@ const navMainItems: NavMainItem[] = [
     category: "workspace",
   },
   {
-    link: "/automation/schedule",
+    link: "/automation/schedules",
     icon: Calendar03Icon,
     label: "Schedules",
     category: "automation",
@@ -191,9 +191,10 @@ export function NavMain() {
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton
-                className="cursor-help border border-sidebar-border/60"
+                aria-label="Open command palette"
+                className="cursor-pointer border border-sidebar-border/60"
                 onClick={() => setCommandPaletteOpen(true)}
-                tooltip="Search"
+                tooltip="Open command palette"
               >
                 <HugeiconsIcon icon={SearchIcon} />
                 <span>Search</span>

--- a/apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx
@@ -17,7 +17,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { useOnboardingStatus } from "@/lib/hooks/use-onboarding";
 
-const STORAGE_KEY = "onboarding-collapsed";
+const STORAGE_KEY_BASE = "onboarding-collapsed";
 const MORPH_TRANSITION = { duration: 0.28, ease: [0.22, 1, 0.36, 1] } as const;
 
 export function SidebarOnboarding() {
@@ -31,17 +31,29 @@ export function SidebarOnboarding() {
   });
   const [collapsed, setCollapsed] = useState(false);
 
+  const storageKey = orgId ? `${STORAGE_KEY_BASE}:${orgId}` : STORAGE_KEY_BASE;
+
   useEffect(() => {
-    setCollapsed(localStorage.getItem(STORAGE_KEY) === "true");
-  }, []);
+    const stored = localStorage.getItem(storageKey);
+    if (stored !== null) {
+      setCollapsed(stored === "true");
+      return;
+    }
+    if (!data) {
+      return;
+    }
+    const hasCompletedStep =
+      data.hasBrandIdentity || data.hasIntegration || data.hasSchedule;
+    setCollapsed(hasCompletedStep);
+  }, [storageKey, data]);
 
   const toggleCollapsed = useCallback(() => {
     setCollapsed((prev) => {
       const next = !prev;
-      localStorage.setItem(STORAGE_KEY, String(next));
+      localStorage.setItem(storageKey, String(next));
       return next;
     });
-  }, []);
+  }, [storageKey]);
 
   const hasActiveSubscription = customer?.subscriptions.some(
     (subscription) => !subscription.addOn && subscription.status === "active"
@@ -68,7 +80,7 @@ export function SidebarOnboarding() {
     },
     {
       label: "Create a schedule",
-      href: `/${slug}/automation/schedule`,
+      href: `/${slug}/automation/schedules`,
       completed: data.hasSchedule,
     },
   ];
@@ -134,7 +146,10 @@ export function SidebarOnboarding() {
               key="expanded"
               transition={MORPH_TRANSITION}
             >
-              <OnboardingChecklist onClose={toggleCollapsed}>
+              <OnboardingChecklist
+                className="bg-sidebar-accent/40 py-2 ring-0"
+                onClose={toggleCollapsed}
+              >
                 <OnboardingChecklistHeader>
                   <motion.div
                     layoutId="onboarding-title"

--- a/apps/dashboard/src/components/integrations/add-repository-button.tsx
+++ b/apps/dashboard/src/components/integrations/add-repository-button.tsx
@@ -5,7 +5,10 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@notra/ui/components/ui/button";
 import type { AddRepositoryButtonProps } from "@/types/integrations";
 
-export function AddRepositoryButton({ onAdd }: AddRepositoryButtonProps) {
+export function AddRepositoryButton({
+  onAdd,
+  label = "Add",
+}: AddRepositoryButtonProps) {
   return (
     <Button
       className="h-6 shrink-0 gap-1 rounded px-2 text-xs"
@@ -14,7 +17,7 @@ export function AddRepositoryButton({ onAdd }: AddRepositoryButtonProps) {
       type="button"
     >
       <HugeiconsIcon className="size-3" icon={Add01Icon} />
-      Add
+      {label}
     </Button>
   );
 }

--- a/apps/dashboard/src/schemas/onboarding/workspace.ts
+++ b/apps/dashboard/src/schemas/onboarding/workspace.ts
@@ -64,7 +64,8 @@ export const onboardingWorkspaceSchema = z.object({
     .refine(isValidPublicWebsiteUrl, {
       message:
         "Please enter a valid public website URL (e.g., https://example.com)",
-    }),
+    })
+    .optional(),
 });
 
 export type OnboardingWorkspaceInput = z.infer<

--- a/apps/dashboard/src/types/integrations.ts
+++ b/apps/dashboard/src/types/integrations.ts
@@ -138,6 +138,7 @@ export interface WebhookSetupDialogProps {
 
 export interface AddRepositoryButtonProps {
   onAdd?: () => void;
+  label?: string;
 }
 
 export interface CreateLinearIntegrationParams {

--- a/apps/dashboard/src/types/logs/data-table.ts
+++ b/apps/dashboard/src/types/logs/data-table.ts
@@ -1,0 +1,19 @@
+import type { ColumnDef } from "@tanstack/react-table";
+
+export interface DataTableEmptyState {
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  onActionClick?: () => void;
+}
+
+export interface DataTableProps<TData> {
+  // biome-ignore lint/suspicious/noExplicitAny: TanStack Table columns have varying value types
+  columns: ColumnDef<TData, any>[];
+  data: TData[];
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  isLoading?: boolean;
+  emptyState?: DataTableEmptyState;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -338,7 +338,7 @@
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.79", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-K0U09FPDO1kmLPjRLXFcNSvmnKHJBMARCb8r3Ulw7wU6/+Zh9djWcFDiPPNsklg6yAezcdLTcYPszgWJJ6iOTA=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.111", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-gzdRuEH9Mqeuu8zG6j4of3EH3fFJUI0UIubyeaA8gep6KzhCJF7uaTfagSE7x2vLAf381g/NrxsXhhH7Hon9iA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.112", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@2.0.106", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ=="],
 

--- a/dashboard-ui-audit-action-plan.md
+++ b/dashboard-ui-audit-action-plan.md
@@ -1,0 +1,644 @@
+# Notra Dashboard UI Audit Action Plan
+
+Date: 2026-05-06  
+Scope: manual dashboard walkthrough in browser tab `http://localhost:3000/erf/logs`, plus source-code reference pass for the dashboard app.
+
+## Evidence reviewed
+
+- Live UI walkthrough: Home, Content, Create Content dialog, Chat, Logs, and sidebar navigation.
+- Browser console: 3 errors / warnings observed.
+- Source references under `apps/dashboard/src`.
+- Screenshots captured during audit are in agent attachments, including:
+  - `att/notra-afte_n4vsqas5.png` — Home
+  - `att/notra-cont_hmi486do.png` — Content
+  - `att/notra-crea_nys82u0j.png` — Create Content dialog
+  - `att/notra-logs_gy5nohvv.png` — Logs
+
+---
+
+## Priority 0 — fix broken or misleading navigation
+
+### 1. Schedules route uses the wrong path in multiple places
+
+**Impact**  
+Users clicking **Schedules** can be routed to a non-existent path or get a stale/incorrect navigation experience. The app has a route for `automation/schedules`, but navigation references `automation/schedule`.
+
+**Observed/code evidence**
+
+- Existing route file:
+  - `apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page.tsx`
+- No route file exists for:
+  - `apps/dashboard/src/app/(dashboard)/[slug]/automation/schedule/page.tsx`
+- Broken references:
+  - `apps/dashboard/src/components/dashboard/nav-main.tsx:73` — `link: "/automation/schedule"`
+  - `apps/dashboard/src/components/command-palette/registry.ts:66` — `path: (slug) => `/${slug}/automation/schedule``
+  - `apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx:71` — `href: `/${slug}/automation/schedule``
+  - `apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx:419` and `:464` — links to `/${slug}/automation/schedule`
+
+**Action steps**
+
+1. Replace every `/automation/schedule` reference with `/automation/schedules`.
+2. Add a redirect from the old singular route to the plural route if existing users may have bookmarked it.
+   - Best place: Next middleware/proxy or a route-level `redirect()` shim if preferred.
+3. Add a route smoke test or Playwright assertion:
+   - Click **Schedules** in sidebar.
+   - Assert URL is `/{slug}/automation/schedules`.
+   - Assert page heading is `Schedules`.
+4. Re-test command palette navigation for **Schedules**.
+5. Re-test onboarding checklist item **Create a schedule**.
+
+**Suggested patch pattern**
+
+```ts
+// apps/dashboard/src/components/dashboard/nav-main.tsx
+{
+  link: "/automation/schedules",
+  icon: Calendar03Icon,
+  label: "Schedules",
+  category: "automation",
+}
+```
+
+```ts
+// apps/dashboard/src/components/command-palette/registry.ts
+path: (slug) => `/${slug}/automation/schedules`,
+```
+
+```ts
+// apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx
+href: `/${slug}/automation/schedules`,
+```
+
+---
+
+### 2. Chat route changes the entire sidebar model abruptly
+
+**Impact**  
+Clicking **Chat** shifts the user from the normal app navigation into a chat-only sidebar with **Back**, **New chat**, **Recents**, and **Settings**. It feels like switching products rather than moving to another dashboard section.
+
+**Code references**
+
+- `apps/dashboard/src/components/dashboard/app-sidebar.tsx:56-59`
+  - `isChatRoute` marks chat as a subpage.
+- `apps/dashboard/src/components/dashboard/app-sidebar.tsx:86-106`
+  - Back button only appears for settings/chat subpages.
+- `apps/dashboard/src/components/dashboard/app-sidebar.tsx:123-137`
+  - Chat replaces the main nav with `ChatHistoryNav` and `NavSecondary`.
+
+**Action steps**
+
+1. Decide whether Chat is a top-level dashboard section or a sub-product.
+2. If top-level section:
+   - Remove `isChatRoute` from `isSubpage`.
+   - Keep `NavMain` visible on chat routes.
+   - Render chat history as secondary content inside the Chat page, not as the whole sidebar.
+3. If sub-product:
+   - Make the transition explicit with a heading like `Chat workspace`.
+   - Keep a persistent, clearly labeled `Back to dashboard` button.
+   - Consider preserving the org selector and key global nav items.
+4. Add a keyboard and screen-reader check for the back behavior.
+
+**Recommended direction**  
+Treat Chat as a top-level dashboard section unless chat history genuinely needs the whole sidebar. The current replacement pattern costs orientation.
+
+---
+
+## Priority 1 — fix blocked flows and unclear disabled states
+
+### 3. Create Content disabled Continue button does not explain why it is disabled
+
+**Impact**  
+The user sees a filled-out form and a disabled **Continue** button. The reason is only inferable: no integrations selected/connected. This is a common conversion-killer.
+
+**Code references**
+
+- `apps/dashboard/src/components/content/create-content-dialog.tsx:911-989`
+  - Integrations form field.
+- `apps/dashboard/src/components/content/create-content-dialog.tsx:916-925`
+  - Empty integration state: `No integrations connected.` + Add button.
+- `apps/dashboard/src/components/content/create-content-dialog.tsx:1283-1295`
+  - Footer with disabled `Continue`.
+- `apps/dashboard/src/components/content/create-content-dialog.tsx:1288`
+  - `disabled={repositoryIds.length === 0}`
+
+**Action steps**
+
+1. Add explicit disabled-state help text in the footer when `repositoryIds.length === 0`.
+2. Make the Integrations empty state more explanatory and action-oriented.
+3. Keep the `Continue` button disabled, but pair it with the requirement.
+4. Ensure the message changes after an integration is selected.
+
+**Suggested UI text**
+
+- Empty state: `Connect at least one integration so Notra has activity data to generate from.`
+- Footer hint: `Select or add an integration to continue.`
+
+**Suggested patch pattern**
+
+```tsx
+// apps/dashboard/src/components/content/create-content-dialog.tsx
+{step === "configure" && (
+  <div className="flex items-center justify-between gap-3">
+    {repositoryIds.length === 0 ? (
+      <p className="text-muted-foreground text-xs">
+        Select or add an integration to continue.
+      </p>
+    ) : (
+      <span />
+    )}
+    <Button
+      disabled={repositoryIds.length === 0}
+      onClick={handleContinue}
+      type="button"
+    >
+      Continue
+    </Button>
+  </div>
+)}
+```
+
+---
+
+### 4. Integrations empty state in Create Content is too weak for a required step
+
+**Impact**  
+The dialog depends on integrations, but the empty state is a terse dashed box. It does not explain what integrations unlock or which integrations are supported.
+
+**Code references**
+
+- `apps/dashboard/src/components/content/create-content-dialog.tsx:916-925`
+
+**Action steps**
+
+1. Replace the single-line text with a two-line empty state.
+2. Use the full width to explain the requirement.
+3. Make the CTA label specific: `Connect integration` or `Connect GitHub/Linear` instead of just `Add`.
+4. If only GitHub/Linear are valid sources for generation, say that explicitly.
+
+**Suggested copy**
+
+```tsx
+<p className="font-medium text-sm">No integrations connected</p>
+<p className="text-muted-foreground text-xs">
+  Connect GitHub or Linear so Notra can pull recent activity for this content.
+</p>
+```
+
+---
+
+## Priority 1 — improve empty states and data clarity
+
+### 5. Home empty state conflicts with yearly activity summary
+
+**Impact**  
+Home says **No content created today**, while the activity graph below shows total posts. This can be technically correct, but it reads as contradictory without time-range context.
+
+**Code references**
+
+- `apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx:105-110`
+  - EmptyState copy: `No content created today`.
+- `apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx:121-143`
+  - Today’s Content and Content Activity sections are adjacent.
+- `apps/dashboard/src/components/dashboard/content-activity-card.tsx:106-120`
+  - Footer summary: `posts (drafts / published)`.
+
+**Action steps**
+
+1. Make the empty state explicitly scoped to today.
+2. Make the graph footer explicitly scoped to year/all-time, depending on what the API returns.
+3. Consider using `This year:` before the graph summary.
+
+**Suggested copy changes**
+
+```tsx
+// apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
+<EmptyState
+  className="p-6"
+  description="You have no new posts today. Create one now or review your existing drafts below."
+  title="No content created today"
+/>
+```
+
+```tsx
+// apps/dashboard/src/components/dashboard/content-activity-card.tsx
+<span className="text-muted-foreground text-sm">
+  This year: ...
+</span>
+```
+
+---
+
+### 6. Logs empty state looks unfinished
+
+**Impact**  
+The Logs page shows a large table with a single `No results.` row. It does not explain whether there are no webhook events yet, filters removed the results, or logs are unavailable due retention.
+
+**Code references**
+
+- `apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx:117-126`
+  - `filtersActive` and `resetFilters` already exist.
+- `apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx:231-237`
+  - `DataTable` receives only table data and pagination.
+- `apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx:102-110`
+  - Empty state: `No results.`
+- `apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx:115-137`
+  - Pagination always renders.
+
+**Action steps**
+
+1. Pass an explicit `emptyState` prop to `DataTable`.
+2. Use different copy for no logs vs filtered-out logs.
+3. Hide pagination when `totalPages <= 1` and there are no rows.
+4. Keep a reset button near the empty state when filters are active.
+
+**Suggested patch pattern**
+
+```tsx
+// apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+<DataTable
+  columns={columns}
+  data={data?.logs ?? []}
+  emptyState={
+    filtersActive
+      ? {
+          title: "No logs match your filters",
+          description: "Try a different search, source, or status.",
+          actionLabel: "Reset filters",
+          onActionClick: resetFilters,
+        }
+      : {
+          title: "No webhook events yet",
+          description: "Events will appear here after connected integrations deliver activity.",
+        }
+  }
+  onPageChange={setPage}
+  page={page}
+  totalPages={data?.pagination.totalPages ?? 1}
+/>
+```
+
+```tsx
+// apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx
+interface DataTableProps<TData> {
+  columns: ColumnDef<TData, any>[];
+  data: TData[];
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  isLoading?: boolean;
+  emptyState?: {
+    title: string;
+    description?: string;
+    actionLabel?: string;
+    onActionClick?: () => void;
+  };
+}
+```
+
+---
+
+### 7. Logs pagination should not render as usable controls when there is only one page
+
+**Impact**  
+`Page 1 of 1`, `Previous`, and `Next` appear even when there are no results. This adds disabled UI noise.
+
+**Code references**
+
+- `apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx:115-137`
+
+**Action steps**
+
+1. Hide pagination when `totalPages <= 1` and `data.length === 0`.
+2. Optionally hide previous/next buttons when `totalPages <= 1` even with rows.
+3. If pagination remains, use stronger disabled styling.
+
+**Suggested patch**
+
+```tsx
+const showPagination = totalPages > 1 || data.length > 0;
+
+{showPagination ? (
+  <div className="flex items-center justify-between py-4">
+    ...
+  </div>
+) : null}
+```
+
+---
+
+## Priority 2 — polish content cards and dashboard density
+
+### 8. Content card titles truncate too aggressively
+
+**Impact**  
+Cards show titles like `One-Click Approval for AI Dr...` even when the grid has room to provide more context. This makes cards harder to distinguish.
+
+**Code references**
+
+- `apps/dashboard/src/components/content/content-card.tsx:142-144`
+  - Title uses `truncate`.
+- `apps/dashboard/src/components/content/content-card.tsx:188-190`
+  - Preview uses `line-clamp-3`.
+
+**Action steps**
+
+1. Replace single-line title truncation with two-line clamping.
+2. Rebalance preview height if needed.
+3. Keep card height consistent across grid/list views.
+
+**Suggested patch**
+
+```tsx
+// apps/dashboard/src/components/content/content-card.tsx
+<p className="min-w-0 line-clamp-2 font-medium text-lg leading-snug">
+  {title}
+</p>
+```
+
+---
+
+### 9. Content card preview area feels heavier than metadata
+
+**Impact**  
+The dark inset preview dominates the card while the status/type metadata feels cramped. The card hierarchy is slightly off.
+
+**Code references**
+
+- `apps/dashboard/src/components/content/content-card.tsx:133-206`
+
+**Action steps**
+
+1. Reduce preview inset contrast.
+2. Consider making the whole card background lighter and the preview unboxed.
+3. Increase vertical spacing around badges.
+4. Confirm hover/focus state still clearly communicates clickability.
+
+**Suggested class changes to test**
+
+```tsx
+// Current
+"flex-1 rounded-[0.75rem] border border-border/80 bg-background px-4 py-3"
+
+// Try
+"flex-1 rounded-md bg-background/60 px-3 py-2.5"
+```
+
+---
+
+### 10. Dashboard activity graph width can feel arbitrary
+
+**Impact**  
+The graph uses `w-fit`, so the card width is content-driven and can look visually detached from the rest of the page grid.
+
+**Code references**
+
+- `apps/dashboard/src/components/dashboard/content-activity-card.tsx:52`
+  - `className="w-fit ..."`
+- `apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx:135-143`
+
+**Action steps**
+
+1. Test replacing `w-fit` with `w-full overflow-x-auto`.
+2. Keep the graph scrollable horizontally on narrow screens.
+3. Align the card width with the Today’s Content section.
+
+**Suggested patch**
+
+```tsx
+<div className="w-full overflow-x-auto rounded-lg border border-border/80 bg-background px-4 py-3">
+```
+
+---
+
+## Priority 2 — sidebar and onboarding polish
+
+### 11. Getting Started card is visually heavy and persistent
+
+**Impact**  
+The onboarding checklist competes with primary navigation on every page until dismissed/collapsed. It looks like a floating card inside the sidebar rather than a secondary helper.
+
+**Code references**
+
+- `apps/dashboard/src/components/dashboard/app-sidebar.tsx:149-153`
+  - Sidebar bottom stack: trial expired, onboarding, upgrade, secondary nav.
+- `apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx:79-172`
+  - Full checklist rendering.
+- `apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx:20`
+  - Collapse state stored globally as `onboarding-collapsed`.
+
+**Action steps**
+
+1. Default to collapsed after first completed step, not only after manual collapse.
+2. Scope collapsed state per organization instead of global localStorage key.
+3. Reduce expanded visual weight: smaller header, less padding, no card-like shadow/border if present in the UI component.
+4. Move to a dashboard home card if it remains too intrusive in the sidebar.
+
+**Suggested storage change**
+
+```ts
+const storageKey = orgId ? `onboarding-collapsed:${orgId}` : STORAGE_KEY;
+```
+
+---
+
+### 12. Search button looks like an input but uses cursor-help
+
+**Impact**  
+The sidebar Search control looks like a search input, but it opens the command palette. `cursor-help` is misleading.
+
+**Code references**
+
+- `apps/dashboard/src/components/dashboard/nav-main.tsx:192-204`
+- `apps/dashboard/src/components/dashboard/nav-main.tsx:194`
+  - `className="cursor-help ..."`
+
+**Action steps**
+
+1. Replace `cursor-help` with `cursor-pointer`.
+2. Consider label `Search or jump to...` if space allows.
+3. Ensure `aria-label`/tooltip says `Open command palette` rather than just `Search`.
+
+**Suggested patch**
+
+```tsx
+<SidebarMenuButton
+  className="cursor-pointer border border-sidebar-border/60"
+  onClick={() => setCommandPaletteOpen(true)}
+  tooltip="Open command palette"
+>
+```
+
+---
+
+## Priority 2 — header clarity
+
+### 13. Credit balance button lacks semantic clarity
+
+**Impact**  
+A wallet icon plus `$11.91` is visually clean but ambiguous. Users cannot tell if it means credits, balance, monthly spend, or budget.
+
+**Code references**
+
+- `apps/dashboard/src/components/dashboard/header.tsx:40-42`
+  - Imports credit balance components.
+- `apps/dashboard/src/components/dashboard/header.tsx:201-203`
+  - `CreditBalanceButton` in header.
+- Likely implementation file:
+  - `apps/dashboard/src/components/billing/credit-balance-button.tsx`
+
+**Action steps**
+
+1. Add tooltip copy: `Credit balance` or `Available credits`.
+2. If the value is money, label as `Credits: $11.91` in expanded contexts.
+3. For mobile menu, keep the same label so the meaning is consistent.
+
+---
+
+### 14. Breadcrumb labels are generated from URL segments and can be too generic
+
+**Impact**  
+The header breadcrumb is mostly mechanical. For pages like integrations, settings, or nested content detail pages, generated labels can be less helpful than explicit route metadata.
+
+**Code references**
+
+- `apps/dashboard/src/components/dashboard/header.tsx:52-55`
+  - `SEGMENT_CONFIG` only customizes `billing` and `automation`.
+- `apps/dashboard/src/components/dashboard/header.tsx:135-184`
+  - Breadcrumb generation from segments.
+
+**Action steps**
+
+1. Extend `SEGMENT_CONFIG` for high-traffic segments:
+   - `api-keys` → `API Keys`
+   - `brand` → non-clickable group or `Brand`
+   - `identity` → `Identity & References`
+   - `schedules` → `Schedules`
+2. Avoid showing purely structural segments when they do not help orientation.
+3. For detail pages, use fetched entity names where available.
+
+---
+
+## Priority 3 — accessibility and micro-interactions
+
+### 15. Icon-only controls need stronger accessible names and hover/focus consistency
+
+**Impact**  
+The UI relies on icon recognition: sidebar toggle, card kebab menus, grid/list view toggle, info icon, modal close, and header more menu. Some have `sr-only` or `aria-label`; this should be audited consistently.
+
+**Code references**
+
+- `apps/dashboard/src/components/content/content-card.tsx:145-155`
+  - Card menu trigger has `sr-only` text.
+- `apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx:134-148`
+  - Logs info tooltip trigger.
+- `apps/dashboard/src/components/dashboard/header.tsx:227-239`
+  - Mobile menu has `aria-label="More actions"`.
+- Create Content dialog close is likely provided by `ResponsiveDialogContent` internals; verify accessible label in `@notra/ui`.
+
+**Action steps**
+
+1. Tab through all icon-only controls.
+2. Confirm visible focus ring on every control.
+3. Confirm accessible names with browser accessibility tree.
+4. Add `aria-label` where only tooltip/sr-only text is missing.
+5. Ensure tooltip-only information is not required to complete a task.
+
+---
+
+### 16. Disabled buttons need reason text when they block a flow
+
+**Impact**  
+Disabled states are acceptable for obvious cases, but not when the user must infer missing requirements.
+
+**Code references**
+
+- `apps/dashboard/src/components/content/create-content-dialog.tsx:1288`
+  - Continue disabled by missing repository IDs.
+- `apps/dashboard/src/components/content/create-content-dialog.tsx:1307-1311`
+  - Create content disabled during pending/loading/no event selection.
+- `apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx:120-134`
+  - Previous/Next disabled at boundaries.
+
+**Action steps**
+
+1. Add inline reason text for blocked primary actions.
+2. For pagination, hide unavailable controls when they add no value.
+3. For selection-dependent actions, show `Select at least one event to create content`.
+
+---
+
+## Priority 3 — technical console cleanup
+
+### 17. Consent banner fetch errors are present in console
+
+**Observed console errors**
+
+```text
+Error fetching consent banner information: Error: Failed to fetch consent banner info: undefined
+```
+
+**Impact**  
+This is noisy and can hide real regressions. It may also indicate a broken consent/privacy integration.
+
+**Action steps**
+
+1. Identify the consent manager integration path.
+   - Likely related: `apps/dashboard/src/lib/consent-manager/theme.ts`
+2. Reproduce on local dashboard load.
+3. Check network request URL and response status.
+4. Add graceful fallback if consent config is unavailable.
+5. Prevent duplicate logging of the same error.
+
+---
+
+### 18. CSP blocks an inline GitHub assets script
+
+**Observed console error**
+
+```text
+Executing inline script violates the following Content Security Policy directive 'script-src github.githubassets.com'.
+```
+
+**Impact**  
+This may be benign if it is from an embedded GitHub context, but it should be understood. CSP errors in production erode confidence and can indicate integration breakage.
+
+**Action steps**
+
+1. Determine which page/action triggers GitHub asset loading.
+2. Confirm whether this is from GitHub OAuth, GitHub repository previews, or an embedded asset.
+3. Avoid adding `unsafe-inline` unless absolutely necessary.
+4. Prefer nonce/hash-based CSP only if the inline script is controlled and required.
+5. If the script is third-party and non-critical, suppress the embed or isolate it.
+
+---
+
+## Suggested implementation order
+
+1. Fix `/automation/schedule` → `/automation/schedules` references.
+2. Improve Create Content disabled reason and integration empty state.
+3. Upgrade Logs empty state and hide no-op pagination.
+4. Clarify Home empty state vs yearly activity summary.
+5. Reduce sidebar onboarding weight and fix command-palette search affordance.
+6. Polish content cards: two-line titles, lighter preview region.
+7. Add accessibility pass for icon-only controls and disabled states.
+8. Clean console errors.
+
+---
+
+## Verification checklist
+
+Use this after implementation:
+
+- [ ] Sidebar **Schedules** opens `/{slug}/automation/schedules` and shows the Schedules page.
+- [ ] Command palette **Schedules** opens the same route.
+- [ ] Onboarding **Create a schedule** opens the same route.
+- [ ] Create Content dialog explains why **Continue** is disabled when no integration is selected.
+- [ ] Create Content dialog empty integrations state clearly explains what to connect and why.
+- [ ] Logs page with no logs shows a descriptive empty state, not just `No results.`
+- [ ] Logs pagination is hidden or visually minimized when only one page exists.
+- [ ] Home copy distinguishes today’s content from yearly/all-time activity.
+- [ ] Content card titles can wrap to two lines without breaking card layout.
+- [ ] Sidebar Search uses pointer cursor and command-palette-specific labeling.
+- [ ] Credit balance has tooltip/label explaining what the value means.
+- [ ] Browser console is free of consent/CSP errors during normal dashboard navigation.
+- [ ] Keyboard tab order and focus rings work for sidebar, header, content cards, dialogs, filters, and pagination.


### PR DESCRIPTION
## Summary
- Fixed dashboard navigation to use the plural schedules route across the sidebar, command palette, onboarding checklist, and GitHub integration links.
- Improved empty states in Logs, Create Content, and Home so the UI explains what is missing and what to do next.
- Refined dashboard chrome and content cards with clearer labels, better spacing, and more consistent navigation semantics.
- Scoped onboarding collapse state per organization and softened the onboarding card styling.
- Added a reusable logs table empty-state API and a label override for the repository add button.

## Testing
- Not run (no test execution requested).
- Reviewed route references to confirm `automation/schedules` is used consistently.
- Reviewed the updated logs table and empty-state props for the filtered and unfiltered cases.
- Reviewed the updated onboarding storage key logic to ensure it is org-scoped.
- Reviewed the updated button and tooltip copy for accessibility and clarity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished dashboard navigation and empty states to reduce confusion and guide users better. Made the onboarding website optional and only run brand analysis when a website is provided.

- **Bug Fixes**
  - Replaced every schedules link with `/{slug}/automation/schedules` in the sidebar, command palette, onboarding, and GitHub integration views.

- **New Features**
  - Logs: Reusable table empty state with actions; clearer copy (“No logs yet — activity from your integrations and automations will show up here”); filtered views offer “Reset filters”; hides pagination when not needed; extracted `DataTable` prop types to `apps/dashboard/src/types/logs/data-table.ts`.
  - Create Content: Clearer “No integrations connected” state with a “Connect” CTA; footer hint explains why Continue is disabled until an integration is selected (`AddRepositoryButton` now supports a `label` prop).
  - Onboarding: Website field is optional; trims input and only runs brand analysis when provided. Updated copy and validation.
  - Sidebar/Header: Onboarding collapse is org-scoped with a smart default based on progress; sidebar search has proper aria/tooltip (“Open command palette”); credit balance shows an “Available credits” tooltip and sets an aria-label with the formatted amount (falls back while loading); breadcrumbs add labels for Schedules, API Keys, Identity & References, and Brand.
  - Content & Home: Card titles are two-line clamped with lighter previews; activity graph uses full width and shows “This year” totals; updated today’s content empty-state copy.
  - Docs: Added `dashboard-ui-audit-action-plan.md` to track follow-ups.

<sup>Written for commit 84e5bc990fbecf1164db900a5e00b78b4be953d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

