### PR TITLE
Validate brand reference ownership

### DIFF
--- a/packages/ai/src/tools/brand-references.ts
+++ b/packages/ai/src/tools/brand-references.ts
@@ -2,11 +2,11 @@ import type { BrandReferencesConfig } from "@notra/ai/types/brand-references";
 import { serializeBrandReference } from "@notra/ai/utils/brand-references";
 import { toolDescription } from "@notra/ai/utils/description";
 import { db } from "@notra/db/drizzle";
+import { brandReferences, brandSettings } from "@notra/db/schema";
 import {
   getBrandReferenceIdFromSearchResult,
   searchBrandReferenceMemories,
 } from "@notra/db/utils/supermemory";
-import { brandReferences, brandSettings } from "@notra/db/schema";
 import { type Tool, tool } from "ai";
 import { and, desc, eq } from "drizzle-orm";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing

--- a/packages/ai/src/tools/brand-references.ts
+++ b/packages/ai/src/tools/brand-references.ts
@@ -6,8 +6,9 @@ import {
   getBrandReferenceIdFromSearchResult,
   searchBrandReferenceMemories,
 } from "@notra/db/utils/supermemory";
+import { brandReferences, brandSettings } from "@notra/db/schema";
 import { type Tool, tool } from "ai";
-import { sql } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 import { getAICachedTools } from "./tool-cache";
@@ -18,11 +19,22 @@ type BrandReferenceRecord = Awaited<
 
 async function resolveSettingsId(config: BrandReferencesConfig) {
   if (config.voiceId) {
-    return config.voiceId;
+    const voice = await db.query.brandSettings.findFirst({
+      where: and(
+        eq(brandSettings.id, config.voiceId),
+        eq(brandSettings.organizationId, config.organizationId)
+      ),
+      columns: { id: true },
+    });
+
+    return voice?.id;
   }
 
   const defaultVoice = await db.query.brandSettings.findFirst({
-    where: sql`organization_id = ${config.organizationId} and is_default = true`,
+    where: and(
+      eq(brandSettings.organizationId, config.organizationId),
+      eq(brandSettings.isDefault, true)
+    ),
     columns: { id: true },
   });
 
@@ -37,8 +49,8 @@ async function getFilteredReferences(config: BrandReferencesConfig) {
   }
 
   const refs = await db.query.brandReferences.findMany({
-    where: sql`brand_settings_id = ${settingsId}`,
-    orderBy: [sql`created_at desc`],
+    where: eq(brandReferences.brandSettingsId, settingsId),
+    orderBy: [desc(brandReferences.createdAt)],
   });
 
   const agentType = config.agentType;


### PR DESCRIPTION
## Summary
- verify a supplied brand identity belongs to the current organization before loading brand references
- use typed Drizzle predicates for brand settings and reference lookups
- return no references for missing or cross-org brand identity ids

## Test
- bun --filter @notra/ai check-types

Closes NOT-26

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate brand identity ownership before loading brand references, ensuring references resolve only within the current organization. Replaces raw SQL with typed `drizzle-orm` predicates for safer, consistent queries. Closes NOT-26.

- **Bug Fixes**
  - Verify `brandSettings` belongs to `organizationId` when resolving `voiceId`; return no references if missing or cross-org.
  - Fetch `brandReferences` by the resolved settings id and order by `createdAt` desc.

- **Refactors**
  - Use `and`, `eq`, `desc` from `drizzle-orm` with `@notra/db/schema` in `packages/ai/src/tools/brand-references.ts`.

<sup>Written for commit 02f78c2f7b3d80771e8cdf7e5c6f1ab8d5e70e15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

