### PR TITLE
Add skipped status for no-op content generation

### DIFF
--- a/apps/api/src/schemas/content.ts
+++ b/apps/api/src/schemas/content.ts
@@ -636,6 +636,7 @@ const contentGenerationStatusSchema = z.enum([
   "running",
   "completed",
   "failed",
+  "skipped",
 ]);
 
 const contentGenerationLookbackWindowSchema = z.enum(LOOKBACK_WINDOWS);
@@ -805,6 +806,7 @@ const contentGenerationJobEventSchema = z.object({
     "post_created",
     "completed",
     "failed",
+    "skipped",
   ]),
   message: z.string(),
   createdAt: z.string(),

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/columns.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/columns.tsx
@@ -56,6 +56,7 @@ function StatusBadge({ status }: { status: StatusWithCode }) {
     success: "default",
     failed: "destructive",
     pending: "secondary",
+    skipped: "secondary",
   };
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/notifications/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/notifications/page.tsx
@@ -19,6 +19,7 @@ interface PageProps {
 interface NotificationSettings {
   scheduledContentCreation: boolean;
   scheduledContentFailed: boolean;
+  scheduledContentSkipped: boolean;
   marketingEmails: boolean;
 }
 
@@ -148,6 +149,25 @@ export default function NotificationsSettingsPage({ params }: PageProps) {
                   id="scheduled-content-failed"
                   onCheckedChange={(checked) =>
                     updateSettings({ scheduledContentFailed: checked })
+                  }
+                />
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <div className="space-y-0.5">
+                  <Label htmlFor="scheduled-content-skipped">
+                    Scheduled content skips
+                  </Label>
+                  <p className="text-muted-foreground text-xs">
+                    Receive an email when scheduled content generation is
+                    skipped
+                  </p>
+                </div>
+                <Switch
+                  checked={settings?.scheduledContentSkipped ?? false}
+                  disabled={!isOwner || isUpdating}
+                  id="scheduled-content-skipped"
+                  onCheckedChange={(checked) =>
+                    updateSettings({ scheduledContentSkipped: checked })
                   }
                 />
               </div>

--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -28,6 +28,7 @@ import { checkLogRetention } from "@/lib/billing/check-log-retention";
 import {
   trackScheduledContentCreated,
   trackScheduledContentFailed,
+  trackScheduledContentSkipped,
 } from "@/lib/databuddy";
 import { sendScheduledContentCreatedEmail } from "@/lib/email/send";
 import {
@@ -410,6 +411,84 @@ export const { POST } = serve<EventWorkflowPayload>(
         return;
       }
 
+      if (contentResult.status === "skipped") {
+        await context.run("track-generation-end-skipped", async () => {
+          await completeActiveGeneration(trigger.organizationId, {
+            runId,
+            triggerId,
+            outputType: trigger.outputType,
+            triggerName: trigger.name.trim() || `${eventType} event`,
+            status: "skipped",
+            reason: contentResult.reason,
+            completedAt: new Date().toISOString(),
+          });
+        });
+
+        const autumnClient = autumn;
+        if (aiCreditReservation.reserved && autumnClient) {
+          await context.run("refund-ai-credit-skipped", async () => {
+            try {
+              await autumnClient.track({
+                customerId: trigger.organizationId,
+                featureId: FEATURES.AI_CREDITS,
+                value: 0,
+                properties: {
+                  source: "workflow_event",
+                  output_type: trigger.outputType,
+                  trigger_name: trigger.name.trim() || `${eventType} event`,
+                  trigger_id: triggerId,
+                  run_id: runId,
+                  event_type: eventType,
+                  refund_reason: "skipped",
+                },
+              });
+            } catch (error) {
+              console.error("[Event] Failed to refund AI credit:", error);
+            }
+          });
+        }
+
+        await context.run("log-generation-skipped", async () => {
+          await appendWebhookLog({
+            organizationId: trigger.organizationId,
+            integrationId: triggerId,
+            integrationType: "events",
+            title: `Event "${trigger.name.trim() || eventType}" skipped content generation`,
+            status: "skipped",
+            statusCode: null,
+            errorMessage: contentResult.reason,
+            retentionDays: logRetentionDays,
+          });
+        });
+
+        await context.run("track-content-skipped", async () => {
+          try {
+            await trackScheduledContentSkipped({
+              triggerId: trigger.id,
+              organizationId: trigger.organizationId,
+              outputType: trigger.outputType,
+              creationMode: "automatic",
+              reason: contentResult.reason,
+              lookbackWindow,
+              repositoryCount: 1,
+              source: "event",
+            });
+          } catch (trackingError) {
+            console.warn("[Event] Failed to track content generation skip", {
+              triggerId,
+              organizationId: trigger.organizationId,
+              error: trackingError,
+            });
+          }
+        });
+
+        console.log(
+          `[Event] Content generation skipped for trigger ${triggerId}: ${contentResult.reason}`
+        );
+        await context.cancel();
+        return;
+      }
+
       const createdPosts = contentResult.posts;
 
       if (createdPosts.length === 0) {
@@ -503,14 +582,11 @@ export const { POST } = serve<EventWorkflowPayload>(
       });
 
       const autumnClientSuccess = autumn;
-      if (
-        aiCreditReservation.reserved &&
-        autumnClientSuccess &&
-        contentResult.usage
-      ) {
+      const contentUsage = contentResult.usage;
+      if (aiCreditReservation.reserved && autumnClientSuccess && contentUsage) {
         await context.run("track-ai-credit-usage", async () => {
           const costCents = calculateTokenCostCents(
-            contentResult.usage!,
+            contentUsage,
             "anthropic/claude-haiku-4.5",
             aiCreditReservation.useMarkup
           );

--- a/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
+++ b/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
@@ -25,6 +25,7 @@ import { createRequestLogger } from "evlog";
 import {
   trackScheduledContentCreated,
   trackScheduledContentFailed,
+  trackScheduledContentSkipped,
 } from "@/lib/databuddy";
 import { completeActiveGeneration } from "@/lib/generations/tracking";
 import { appendWebhookLog } from "@/lib/webhooks/logging";
@@ -49,7 +50,7 @@ import type {
 
 async function setTrackedJobStatus(
   jobId: string | undefined,
-  status: "running" | "completed" | "failed",
+  status: "running" | "completed" | "failed" | "skipped",
   updates?: { postId?: string | null; error?: string | null }
 ) {
   if (!(jobId && redis)) {
@@ -70,7 +71,8 @@ async function appendTrackedJobEvent(
     | "generating_content"
     | "post_created"
     | "completed"
-    | "failed",
+    | "failed"
+    | "skipped",
   message: string,
   metadata?: Record<string, unknown> | null
 ) {
@@ -410,17 +412,93 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
         }
       );
 
+      if (contentResult.status === "skipped") {
+        await context.run("complete-skipped", async () => {
+          await completeActiveGeneration(organizationId, {
+            runId,
+            triggerId: "manual_on_demand",
+            outputType: contentType,
+            triggerName: contentType,
+            status: "skipped",
+            reason: contentResult.reason,
+            completedAt: new Date().toISOString(),
+            source,
+          });
+          await setTrackedJobStatus(jobId, "skipped", {
+            error: contentResult.reason,
+          });
+          await appendTrackedJobEvent(jobId, "skipped", contentResult.reason);
+        });
+
+        await context.run("log-generation-skipped", async () => {
+          await appendWebhookLog({
+            organizationId,
+            integrationId: "manual_on_demand",
+            integrationType: "manual",
+            title: `On-demand generation skipped for ${contentType.replaceAll("_", " ")}`,
+            status: "skipped",
+            statusCode: null,
+            errorMessage: contentResult.reason,
+          });
+        });
+
+        await context.run("refund-skipped", async () => {
+          await refundReservedAiCredit(organizationId, aiCreditReserved, {
+            source: "manual",
+            output_type: contentType,
+            trigger_id: "manual_on_demand",
+            trigger_name: contentType,
+            refund_reason: "skipped",
+            run_id: runId,
+          });
+        });
+
+        await context.run("track-content-skipped", async () => {
+          try {
+            await trackScheduledContentSkipped({
+              triggerId: "manual_on_demand",
+              organizationId,
+              outputType: contentType,
+              creationMode: "manual",
+              reason: contentResult.reason,
+              lookbackWindow,
+              repositoryCount: repositories.length,
+              source: "on_demand",
+            });
+          } catch (trackingError) {
+            console.error("[OnDemandContent] Failed to track generation skip", {
+              organizationId,
+              contentType,
+              error: trackingError,
+            });
+          }
+        });
+
+        console.log(
+          `[OnDemandContent] Generation skipped: ${contentResult.reason}`,
+          {
+            organizationId,
+            contentType,
+          }
+        );
+
+        await context.cancel();
+        return;
+      }
+
       if (
         contentResult.status === "rate_limited" ||
         contentResult.status === "unsupported_output_type" ||
         contentResult.status === "generation_failed"
       ) {
-        const reason =
-          contentResult.status === "rate_limited"
-            ? "GitHub API rate limit reached"
-            : contentResult.status === "unsupported_output_type"
-              ? `Unsupported content type: ${contentResult.outputType}`
-              : contentResult.reason;
+        let reason: string;
+        if (contentResult.status === "rate_limited") {
+          reason = "GitHub API rate limit reached";
+        } else if (contentResult.status === "unsupported_output_type") {
+          reason = `Unsupported content type: ${contentResult.outputType}`;
+        } else {
+          reason = contentResult.reason;
+        }
 
         await context.run("complete-failed", async () => {
           await completeActiveGeneration(organizationId, {
@@ -604,10 +682,11 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
       });
 
       const autumnClient = autumn;
-      if (aiCreditReserved && autumnClient && contentResult.usage) {
+      const contentUsage = contentResult.usage;
+      if (aiCreditReserved && autumnClient && contentUsage) {
         await context.run("track-ai-credit-usage", async () => {
           const costCents = calculateTokenCostCents(
-            contentResult.usage!,
+            contentUsage,
             "anthropic/claude-haiku-4.5",
             aiCreditMarkup
           );

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -31,6 +31,7 @@ import { GITHUB_RATE_LIMIT_RETRY_DELAY } from "@/constants/workflows";
 import {
   trackScheduledContentCreated,
   trackScheduledContentFailed,
+  trackScheduledContentSkipped,
 } from "@/lib/databuddy";
 import {
   sendScheduledContentCreatedEmail,
@@ -696,6 +697,94 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
         return;
       }
 
+      if (contentResult.status === "skipped") {
+        const autumnClient = autumn;
+        if (aiCreditReservation.reserved && autumnClient) {
+          await context.run(
+            "refund-ai-credit-after-generation-skip",
+            async () => {
+              try {
+                await autumnClient.track({
+                  customerId: trigger.organizationId,
+                  featureId: FEATURES.AI_CREDITS,
+                  value: 0,
+                  properties: {
+                    source: "workflow_schedule",
+                    output_type: trigger.outputType,
+                    trigger_name: trigger.name.trim() || trigger.outputType,
+                    trigger_id: triggerId,
+                    run_id: runId,
+                    refund_reason: "skipped",
+                  },
+                });
+              } catch (error) {
+                console.error(
+                  "[Schedule] Failed to refund AI credit after generation skip",
+                  {
+                    triggerId,
+                    organizationId: trigger.organizationId,
+                    reason: contentResult.reason,
+                    error,
+                  }
+                );
+              }
+            }
+          );
+        }
+
+        console.log(
+          `[Schedule] Content generation skipped for trigger ${triggerId}: ${contentResult.reason}`
+        );
+
+        await context.run("track-generation-end-skipped", async () => {
+          await completeActiveGeneration(trigger.organizationId, {
+            runId,
+            triggerId,
+            outputType: trigger.outputType,
+            triggerName: trigger.name.trim() || trigger.outputType,
+            status: "skipped",
+            reason: contentResult.reason,
+            completedAt: new Date().toISOString(),
+          });
+        });
+
+        await context.run("log-generation-skipped", async () => {
+          await appendWebhookLog({
+            organizationId: trigger.organizationId,
+            integrationId: triggerId,
+            integrationType: manual ? "manual" : "schedule",
+            title: `Schedule "${trigger.name.trim() || trigger.outputType}" skipped content generation`,
+            status: "skipped",
+            statusCode: null,
+            errorMessage: contentResult.reason,
+          });
+        });
+
+        await context.run("track-content-skipped", async () => {
+          try {
+            await trackScheduledContentSkipped({
+              triggerId: trigger.id,
+              organizationId: trigger.organizationId,
+              outputType: trigger.outputType,
+              creationMode,
+              reason: contentResult.reason,
+              lookbackWindow,
+              repositoryCount: repositories.length,
+              source: "schedule",
+            });
+          } catch (trackingError) {
+            console.warn("[Schedule] Failed to track generation skip", {
+              triggerId,
+              organizationId: trigger.organizationId,
+              error: trackingError,
+            });
+          }
+        });
+
+        await context.cancel();
+        return;
+      }
+
       const createdPosts = contentResult.posts;
 
       if (createdPosts.length === 0) {
@@ -877,14 +966,11 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
       }
 
       const autumnClientSuccess = autumn;
-      if (
-        aiCreditReservation.reserved &&
-        autumnClientSuccess &&
-        contentResult.usage
-      ) {
+      const contentUsage = contentResult.usage;
+      if (aiCreditReservation.reserved && autumnClientSuccess && contentUsage) {
         await context.run("track-ai-credit-usage", async () => {
           const costCents = calculateTokenCostCents(
-            contentResult.usage!,
+            contentUsage,
             "anthropic/claude-haiku-4.5",
             aiCreditReservation.useMarkup
           );

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -36,6 +36,7 @@ import {
 import {
   sendScheduledContentCreatedEmail,
   sendScheduledContentFailedEmail,
+  sendScheduledContentSkippedEmail,
 } from "@/lib/email/send";
 import {
   addActiveGeneration,
@@ -780,6 +781,83 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
             });
           }
         });
+
+        const skippedNotificationData = await context.run<{
+          enabled: boolean;
+          ownerEmails: string[];
+          organizationName: string;
+          organizationSlug: string;
+        }>("fetch-skipped-notification-data", async () => {
+          const notificationSettings =
+            await db.query.organizationNotificationSettings.findFirst({
+              where: eq(
+                organizationNotificationSettings.organizationId,
+                trigger.organizationId
+              ),
+            });
+
+          if (!notificationSettings?.scheduledContentSkipped) {
+            return {
+              enabled: false,
+              ownerEmails: [],
+              organizationName: "",
+              organizationSlug: "",
+            };
+          }
+
+          const org = await db.query.organizations.findFirst({
+            where: eq(organizations.id, trigger.organizationId),
+            columns: { name: true, slug: true },
+          });
+
+          const ownerMemberships = await db.query.members.findMany({
+            where: and(
+              eq(members.organizationId, trigger.organizationId),
+              eq(members.role, "owner")
+            ),
+            with: { users: { columns: { email: true } } },
+          });
+
+          return {
+            enabled: true,
+            ownerEmails: ownerMemberships.map((m) => m.users.email),
+            organizationName: org?.name ?? "Your organization",
+            organizationSlug: org?.slug ?? "",
+          };
+        });
+
+        if (
+          skippedNotificationData.enabled &&
+          skippedNotificationData.ownerEmails.length > 0
+        ) {
+          await context.run("send-skipped-notification-emails", async () => {
+            const resend = getResend();
+            if (!resend) {
+              return;
+            }
+
+            const scheduleName = trigger.name.trim() || trigger.outputType;
+
+            await Promise.allSettled(
+              skippedNotificationData.ownerEmails.map((email) =>
+                sendScheduledContentSkippedEmail(resend, {
+                  recipientEmail: email,
+                  organizationName: skippedNotificationData.organizationName,
+                  organizationSlug: skippedNotificationData.organizationSlug,
+                  scheduleName,
+                  reason: contentResult.reason,
+                }).then((result) => {
+                  if (result.error) {
+                    console.warn(
+                      `[Schedule] Failed to send skipped notification to ${email}:`,
+                      result.error
+                    );
+                  }
+                })
+              )
+            );
+          });
+        }
 
         await context.cancel();
         return;

--- a/apps/dashboard/src/constants/logs.ts
+++ b/apps/dashboard/src/constants/logs.ts
@@ -18,6 +18,7 @@ export const STATUS_VALUES = [
   "success",
   "failed",
   "pending",
+  "skipped",
 ] as const satisfies readonly LogStatusFilter[];
 
 export const SOURCE_LABELS: Record<LogSourceFilter, string> = {
@@ -35,4 +36,5 @@ export const STATUS_LABELS: Record<LogStatusFilter, string> = {
   success: "Success",
   failed: "Failed",
   pending: "Pending",
+  skipped: "Skipped",
 };

--- a/apps/dashboard/src/lib/databuddy.ts
+++ b/apps/dashboard/src/lib/databuddy.ts
@@ -2,12 +2,15 @@ import { Databuddy } from "@databuddy/sdk/node";
 import type {
   ContentCreatedTrackingEvent,
   ContentFailedTrackingEvent,
+  ContentSkippedTrackingEvent,
 } from "@notra/content-generation/databuddy";
 import {
   buildContentCreatedDatabuddyProperties,
   buildContentFailedDatabuddyProperties,
+  buildContentSkippedDatabuddyProperties,
   CONTENT_CREATED_DATABUDDY_EVENT,
   CONTENT_FAILED_DATABUDDY_EVENT,
+  CONTENT_SKIPPED_DATABUDDY_EVENT,
 } from "@notra/content-generation/databuddy";
 
 const apiKey = process.env.DATABUDDY_API_KEY;
@@ -93,6 +96,37 @@ export async function trackScheduledContentFailed(
   } catch (error) {
     if (isDevelopment) {
       console.warn("[Databuddy] scheduled_content_failed error", {
+        triggerId: event.triggerId,
+        error,
+      });
+    }
+  }
+}
+
+export async function trackScheduledContentSkipped(
+  event: ContentSkippedTrackingEvent
+): Promise<void> {
+  if (!databuddy) {
+    return;
+  }
+
+  try {
+    const result = await databuddy.track({
+      name: CONTENT_SKIPPED_DATABUDDY_EVENT,
+      namespace: "workflows",
+      source: event.source ?? "schedule",
+      properties: buildContentSkippedDatabuddyProperties(event),
+    });
+
+    if (!result.success && isDevelopment) {
+      console.warn("[Databuddy] scheduled_content_skipped failed", {
+        triggerId: event.triggerId,
+        error: result.error,
+      });
+    }
+  } catch (error) {
+    if (isDevelopment) {
+      console.warn("[Databuddy] scheduled_content_skipped error", {
         triggerId: event.triggerId,
         error,
       });

--- a/apps/dashboard/src/lib/email/send.ts
+++ b/apps/dashboard/src/lib/email/send.ts
@@ -4,6 +4,7 @@ import { InviteUserEmail } from "@notra/email/emails/invite";
 import { ResetPasswordEmail } from "@notra/email/emails/reset";
 import { ScheduledContentCreatedEmail } from "@notra/email/emails/schedule-content-created";
 import { ScheduledContentFailedEmail } from "@notra/email/emails/schedule-content-failed";
+import { ScheduledContentSkippedEmail } from "@notra/email/emails/schedule-content-skipped";
 import { VerifyUserEmail } from "@notra/email/emails/verify";
 import { WelcomeEmail } from "@notra/email/emails/welcome";
 import { EMAIL_CONFIG } from "@notra/email/utils/config";
@@ -15,6 +16,7 @@ import type {
   SendInviteEmailProps,
   SendScheduledContentCreatedEmailProps,
   SendScheduledContentFailedEmailProps,
+  SendScheduledContentSkippedEmailProps,
 } from "@/types/email/send";
 
 // --- Retry & Idempotency ---
@@ -259,6 +261,40 @@ export async function sendScheduledContentFailedEmail(
       tags: [{ name: "category", value: "schedule-content-failed" }],
     },
     `notra:schedule-content-failed:${recipientEmail}:${scheduleName}:${Date.now()}`
+  );
+}
+
+export async function sendScheduledContentSkippedEmail(
+  resend: Resend,
+  {
+    recipientEmail,
+    organizationName,
+    scheduleName,
+    reason,
+    organizationSlug,
+    subject,
+  }: SendScheduledContentSkippedEmailProps
+) {
+  const settingsLink = `${process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com"}/${organizationSlug}/schedules`;
+
+  return sendWithRetry(
+    resend,
+    {
+      from: EMAIL_CONFIG.from,
+      replyTo: EMAIL_CONFIG.replyTo,
+      to: recipientEmail,
+      subject:
+        subject ?? `Your ${scheduleName} schedule skipped content generation`,
+      react: ScheduledContentSkippedEmail({
+        organizationName,
+        organizationSlug,
+        scheduleName,
+        reason,
+        settingsLink,
+      }),
+      tags: [{ name: "category", value: "schedule-content-skipped" }],
+    },
+    `notra:schedule-content-skipped:${recipientEmail}:${scheduleName}:${Date.now()}`
   );
 }
 

--- a/apps/dashboard/src/lib/hooks/use-active-generations.ts
+++ b/apps/dashboard/src/lib/hooks/use-active-generations.ts
@@ -75,6 +75,14 @@ export function useActiveGenerations(organizationId: string) {
           toast.success(
             result.title ? `"${result.title}" generated` : "Content generated"
           );
+        } else if (result.status === "skipped") {
+          toast.info("Content generation skipped", {
+            action: {
+              label: "View logs",
+              onClick: () => router.push(logsPath),
+            },
+            description: result.reason ?? "No meaningful content was found.",
+          });
         } else {
           toast.error("Content generation failed", {
             action: {

--- a/apps/dashboard/src/lib/orpc/routers/notifications.ts
+++ b/apps/dashboard/src/lib/orpc/routers/notifications.ts
@@ -41,6 +41,7 @@ export const notificationsRouter = {
         settings: settings ?? {
           scheduledContentCreation: false,
           scheduledContentFailed: false,
+          scheduledContentSkipped: false,
           marketingEmails: true,
         },
       };
@@ -73,6 +74,10 @@ export const notificationsRouter = {
         updates.scheduledContentFailed = input.scheduledContentFailed;
       }
 
+      if (input.scheduledContentSkipped !== undefined) {
+        updates.scheduledContentSkipped = input.scheduledContentSkipped;
+      }
+
       if (input.marketingEmails !== undefined) {
         updates.marketingEmails = input.marketingEmails;
       }
@@ -84,6 +89,7 @@ export const notificationsRouter = {
           organizationId: input.organizationId,
           scheduledContentCreation: input.scheduledContentCreation ?? false,
           scheduledContentFailed: input.scheduledContentFailed ?? false,
+          scheduledContentSkipped: input.scheduledContentSkipped ?? false,
           marketingEmails: input.marketingEmails ?? true,
         })
         .onConflictDoUpdate({

--- a/apps/dashboard/src/lib/workflows/event/handlers/index.ts
+++ b/apps/dashboard/src/lib/workflows/event/handlers/index.ts
@@ -1,3 +1,4 @@
+import { ContentGenerationSkippedError } from "@notra/ai/agents/background-gen";
 import { generateBlogPost } from "@notra/ai/agents/blog-post";
 import { generateChangelog } from "@notra/ai/agents/changelog";
 import { generateLinkedInPost } from "@notra/ai/agents/linkedin";
@@ -60,6 +61,13 @@ export async function generateEventBasedContent(
       usage: result.usage,
     };
   } catch (error) {
+    if (error instanceof ContentGenerationSkippedError) {
+      return {
+        status: "skipped",
+        reason: error.message,
+      };
+    }
+
     return {
       status: "generation_failed",
       reason: error instanceof Error ? error.message : String(error),

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/blog-post.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/blog-post.ts
@@ -1,3 +1,4 @@
+import { ContentGenerationSkippedError } from "@notra/ai/agents/background-gen";
 import { generateBlogPost } from "@notra/ai/agents/blog-post";
 import { isGitHubRateLimitError } from "@notra/ai/tools/github";
 import type {
@@ -28,6 +29,13 @@ export async function handleBlogPost(
 
     return { status: "ok", postId, title, posts, usage };
   } catch (error) {
+    if (error instanceof ContentGenerationSkippedError) {
+      return {
+        status: "skipped",
+        reason: error.message,
+      };
+    }
+
     if (isGitHubRateLimitError(error)) {
       return {
         status: "rate_limited",

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/changelog.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/changelog.ts
@@ -1,3 +1,4 @@
+import { ContentGenerationSkippedError } from "@notra/ai/agents/background-gen";
 import { generateChangelog } from "@notra/ai/agents/changelog";
 import { isGitHubRateLimitError } from "@notra/ai/tools/github";
 import type {
@@ -28,6 +29,13 @@ export async function handleChangelog(
 
     return { status: "ok", postId, title, posts, usage };
   } catch (error) {
+    if (error instanceof ContentGenerationSkippedError) {
+      return {
+        status: "skipped",
+        reason: error.message,
+      };
+    }
+
     if (isGitHubRateLimitError(error)) {
       return {
         status: "rate_limited",

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/linkedin.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/linkedin.ts
@@ -1,3 +1,4 @@
+import { ContentGenerationSkippedError } from "@notra/ai/agents/background-gen";
 import { generateLinkedInPost } from "@notra/ai/agents/linkedin";
 import { isGitHubRateLimitError } from "@notra/ai/tools/github";
 import type {
@@ -28,6 +29,13 @@ export async function handleLinkedIn(
 
     return { status: "ok", postId, title, posts, usage };
   } catch (error) {
+    if (error instanceof ContentGenerationSkippedError) {
+      return {
+        status: "skipped",
+        reason: error.message,
+      };
+    }
+
     if (isGitHubRateLimitError(error)) {
       return {
         status: "rate_limited",

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/twitter.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/twitter.ts
@@ -1,3 +1,4 @@
+import { ContentGenerationSkippedError } from "@notra/ai/agents/background-gen";
 import { generateTwitterPost } from "@notra/ai/agents/twitter";
 import { isGitHubRateLimitError } from "@notra/ai/tools/github";
 import type {
@@ -28,6 +29,13 @@ export async function handleTwitter(
 
     return { status: "ok", postId, title, posts, usage };
   } catch (error) {
+    if (error instanceof ContentGenerationSkippedError) {
+      return {
+        status: "skipped",
+        reason: error.message,
+      };
+    }
+
     if (isGitHubRateLimitError(error)) {
       return {
         status: "rate_limited",

--- a/apps/dashboard/src/lib/workflows/schedule/types.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/types.ts
@@ -55,6 +55,7 @@ export type ContentGenerationResult =
       posts: PostSummary[];
       usage?: AgentTokenUsage;
     }
+  | { status: "skipped"; reason: string }
   | { status: "rate_limited"; retryAfterSeconds?: number }
   | { status: "generation_failed"; reason: string }
   | { status: "unsupported_output_type"; outputType: string };

--- a/apps/dashboard/src/schemas/api-params.ts
+++ b/apps/dashboard/src/schemas/api-params.ts
@@ -20,6 +20,7 @@ export const webhookLogStatusFilterSchema = z.enum([
   "success",
   "failed",
   "pending",
+  "skipped",
 ]);
 
 export const webhookLogsQuerySchema = z.object({

--- a/apps/dashboard/src/schemas/notification-settings.ts
+++ b/apps/dashboard/src/schemas/notification-settings.ts
@@ -4,6 +4,7 @@ import * as z from "zod";
 export const updateNotificationSettingsSchema = z.object({
   scheduledContentCreation: z.boolean().optional(),
   scheduledContentFailed: z.boolean().optional(),
+  scheduledContentSkipped: z.boolean().optional(),
   marketingEmails: z.boolean().optional(),
 });
 

--- a/apps/dashboard/src/types/email/send.ts
+++ b/apps/dashboard/src/types/email/send.ts
@@ -35,6 +35,15 @@ export interface SendScheduledContentFailedEmailProps {
   subject?: string;
 }
 
+export interface SendScheduledContentSkippedEmailProps {
+  recipientEmail: string;
+  organizationName: string;
+  organizationSlug: string;
+  scheduleName: string;
+  reason: string;
+  subject?: string;
+}
+
 export interface ScheduledCreatedContentItem {
   title: string;
   contentLink: string;

--- a/apps/dashboard/src/types/generations/tracking.ts
+++ b/apps/dashboard/src/types/generations/tracking.ts
@@ -12,7 +12,7 @@ export interface GenerationResult {
   triggerId: string;
   outputType: string;
   triggerName: string;
-  status: "success" | "failed";
+  status: "success" | "failed" | "skipped";
   title?: string;
   reason?: string;
   completedAt: string;

--- a/apps/dashboard/src/types/webhooks/webhooks.ts
+++ b/apps/dashboard/src/types/webhooks/webhooks.ts
@@ -15,12 +15,13 @@ export type WebhookHandler = (
   context: WebhookContext
 ) => Response | Promise<Response>;
 
-export type WebhookLogStatus = "success" | "failed" | "pending";
+export type WebhookLogStatus = "success" | "failed" | "pending" | "skipped";
 
 export type StatusWithCode =
   | { label: "pending"; code: number | null }
   | { label: "success"; code: number }
-  | { label: "failed"; code: number };
+  | { label: "failed"; code: number }
+  | { label: "skipped"; code: number | null };
 
 export type LogDirection = "incoming" | "outgoing";
 
@@ -82,7 +83,7 @@ export interface WebhookLogInput {
   integrationId: string;
   integrationType: IntegrationType;
   title: string;
-  status: "success" | "failed" | "pending";
+  status: WebhookLogStatus;
   statusCode: number | null;
   referenceId?: string | null;
   errorMessage?: string | null;

--- a/apps/dashboard/src/types/workflows/workflows.ts
+++ b/apps/dashboard/src/types/workflows/workflows.ts
@@ -83,6 +83,7 @@ export type EventGenerationResult =
       posts: PostSummary[];
       usage?: AgentTokenUsage;
     }
+  | { status: "skipped"; reason: string }
   | { status: "generation_failed"; reason: string }
   | { status: "unsupported_output_type"; outputType: string };
 

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -12,6 +12,7 @@ import { buildLinearDataTools } from "@notra/ai/tools/linear";
 import {
   createCreatePostTool,
   createFailTool,
+  createSkipTool,
   createUpdatePostTool,
   createViewPostTool,
 } from "@notra/ai/tools/post";
@@ -70,6 +71,13 @@ export interface BackgroundGenResult {
   usage?: AgentTokenUsage;
 }
 
+export class ContentGenerationSkippedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContentGenerationSkippedError";
+  }
+}
+
 function buildDispatcherInstructions(options: {
   contentLabel: string;
   contentType: string;
@@ -91,7 +99,7 @@ Do these steps in order:
 
 5. Before finalizing, scan the skill list again for supporting skills (for example, a "humanizer" skill for polishing AI-sounding output, or any org-specific skill whose description applies). Load any that apply via getSkillByName and apply their guidance to your near-final draft.
 
-6. When the content is finalized, call createPost. If you cannot produce meaningful output, call fail with a concise reason. Do not return the content as plain text.
+6. When the content is finalized, call createPost. If source lookup succeeds but there is no meaningful source material, call skip with a concise reason. Use skip for expected no-op cases such as no commits, no PRs, no releases, no Linear issues, or only low-signal/internal changes in the requested lookback window. Use fail only for actual errors, impossible requests, invalid inputs, or tool/API failures. Do not return the content as plain text.
 
 ## Output rules (hard)
 - NEVER use em dashes (—) or en dashes (–) anywhere in the post content, title, recommendations, or any text you emit. Use commas, periods, semicolons, parentheses, or a hyphen (-). If a loaded skill's examples contain em/en dashes, ignore that part of the style and substitute safe punctuation.
@@ -212,6 +220,7 @@ export async function runBackgroundGen(
       createPost: createCreatePostTool(postToolsConfig, postToolsResult),
       updatePost: createUpdatePostTool(postToolsConfig, postToolsResult),
       viewPost: createViewPostTool(postToolsConfig),
+      skip: createSkipTool(postToolsResult),
       fail: createFailTool(postToolsResult),
     },
     instructions,
@@ -219,6 +228,10 @@ export async function runBackgroundGen(
   });
 
   const result = await agent.generate({ prompt });
+
+  if (postToolsResult.skipReason) {
+    throw new ContentGenerationSkippedError(postToolsResult.skipReason);
+  }
 
   if (postToolsResult.failReason) {
     throw new Error(postToolsResult.failReason);

--- a/packages/ai/src/prompts/_shared/index.ts
+++ b/packages/ai/src/prompts/_shared/index.ts
@@ -42,5 +42,5 @@ export const brandIdentityRule = dedent`
 `;
 
 export const failGuidance = dedent`
-  If no meaningful data is available from any connected source (no commits, no PRs, no releases in the lookback window), do NOT call createPost. Call the fail tool instead with a concise reason explaining why no post could be generated.
+  If no meaningful data is available from any connected source (no commits, no PRs, no releases in the lookback window), do NOT call createPost. Call the skip tool instead with a concise reason explaining why no post should be generated. Reserve fail for actual errors, rate limits, invalid inputs, or impossible requests.
 `;

--- a/packages/ai/src/prompts/changelog/shared.ts
+++ b/packages/ai/src/prompts/changelog/shared.ts
@@ -75,7 +75,7 @@ export function buildChangelogPrompt(options: ChangelogPromptOptions): string {
     - Only call createPost after the content is finalized and you have at least one meaningful, audience-relevant change worth publishing. Do not return the content as text.
     - If you need to revise after creating, call viewPost to review and updatePost to make changes.
     - ${failGuidance}
-    - If data exists but every candidate change is filtered out as low-signal, internal-only, maintenance-only, or otherwise not worth mentioning to <target-audience>, do NOT call createPost. Call the fail tool instead. The reason for filtering matters more than reaching a minimum count.
+    - If data exists but every candidate change is filtered out as low-signal, internal-only, maintenance-only, or otherwise not worth mentioning to <target-audience>, do NOT call createPost. Call the skip tool instead. The reason for filtering matters more than reaching a minimum count.
     </rules>
 
     <examples>
@@ -137,7 +137,7 @@ export function buildChangelogPrompt(options: ChangelogPromptOptions): string {
     - Format PR entries as:
       - **[Descriptive Title]** [#\${number}](https://github.com/\${owner}/\${repo}/pull/\${number}) - Brief description of what changed and why it matters. (Author: [@\${author}](https://github.com/\${author}/))
 
-    If a change reads as a maintenance update, an internal change, or a new package added or updated, omit it from the changelog completely. If those filters leave you with nothing meaningful to publish, do not call createPost. Call fail instead with a concise reason.
+    If a change reads as a maintenance update, an internal change, or a new package added or updated, omit it from the changelog completely. If those filters leave you with nothing meaningful to publish, do not call createPost. Call skip instead with a concise reason.
 
     ${recommendationsGuidance}
 

--- a/packages/ai/src/tools/post.ts
+++ b/packages/ai/src/tools/post.ts
@@ -382,7 +382,7 @@ export function createFailTool(result: PostToolsResult): Tool {
       toolName: "fail",
       intro: "Signals that you cannot complete the task and provides a reason.",
       whenToUse:
-        "When you determine that you cannot generate meaningful content, for example if there are no changes, no data available, or the request is impossible to fulfill.",
+        "When an actual error, invalid input, tool/API failure, or impossible request prevents generation. Do not use this for expected no-op cases with no meaningful source material; use skip instead.",
       usageNotes:
         "Provide a concise 1-2 sentence reason explaining why you cannot complete the task. This reason will be shown to the user.",
     }),
@@ -397,6 +397,32 @@ export function createFailTool(result: PostToolsResult): Tool {
     execute: async ({ reason }) => {
       result.failReason = reason;
       return { status: "failed", reason };
+    },
+  });
+}
+
+export function createSkipTool(result: PostToolsResult): Tool {
+  return tool({
+    description: toolDescription({
+      toolName: "skip",
+      intro:
+        "Signals that generation should be skipped because there is no meaningful source material.",
+      whenToUse:
+        "When source lookup succeeds but there are no commits, pull requests, releases, Linear issues, or other meaningful changes worth turning into content.",
+      usageNotes:
+        "Use this instead of fail for expected no-op cases. Provide a concise 1-2 sentence reason that can be shown in workflow logs.",
+    }),
+    inputSchema: z.object({
+      reason: z
+        .string()
+        .max(300)
+        .describe(
+          "A concise 1-2 sentence explanation of why generation was skipped"
+        ),
+    }),
+    execute: async ({ reason }) => {
+      result.skipReason = reason;
+      return { status: "skipped", reason };
     },
   });
 }

--- a/packages/ai/src/types/post-tools.ts
+++ b/packages/ai/src/types/post-tools.ts
@@ -15,4 +15,5 @@ export interface PostToolsResult {
   title?: string;
   posts?: PostSummary[];
   failReason?: string;
+  skipReason?: string;
 }

--- a/packages/content-generation/src/databuddy.ts
+++ b/packages/content-generation/src/databuddy.ts
@@ -1,5 +1,6 @@
 export const CONTENT_CREATED_DATABUDDY_EVENT = "scheduled_content_created";
 export const CONTENT_FAILED_DATABUDDY_EVENT = "scheduled_content_failed";
+export const CONTENT_SKIPPED_DATABUDDY_EVENT = "scheduled_content_skipped";
 
 export type ContentCreationMode = "automatic" | "manual";
 export type DatabuddyWorkflowSource = "schedule" | "event" | "on_demand";
@@ -24,6 +25,12 @@ export interface ContentFailedTrackingEvent extends BaseContentTrackingEvent {
   repositoryCount?: number;
 }
 
+export interface ContentSkippedTrackingEvent extends BaseContentTrackingEvent {
+  reason: string;
+  lookbackWindow?: string;
+  repositoryCount?: number;
+}
+
 export function buildContentCreatedDatabuddyProperties(
   event: ContentCreatedTrackingEvent
 ) {
@@ -40,6 +47,20 @@ export function buildContentCreatedDatabuddyProperties(
 
 export function buildContentFailedDatabuddyProperties(
   event: ContentFailedTrackingEvent
+) {
+  return {
+    trigger_id: event.triggerId,
+    organization_id: event.organizationId,
+    output_type: event.outputType,
+    creation_mode: event.creationMode,
+    reason: event.reason,
+    lookback_window: event.lookbackWindow,
+    repository_count: event.repositoryCount,
+  };
+}
+
+export function buildContentSkippedDatabuddyProperties(
+  event: ContentSkippedTrackingEvent
 ) {
   return {
     trigger_id: event.triggerId,

--- a/packages/content-generation/src/jobs.ts
+++ b/packages/content-generation/src/jobs.ts
@@ -140,7 +140,7 @@ export async function setContentGenerationJobStatus(
   return updateContentGenerationJob(redis, jobId, {
     ...updates,
     status,
-    ...(status === "completed" || status === "failed"
+    ...(status === "completed" || status === "failed" || status === "skipped"
       ? { completedAt: new Date().toISOString() }
       : {}),
   });

--- a/packages/content-generation/src/schemas.ts
+++ b/packages/content-generation/src/schemas.ts
@@ -132,6 +132,7 @@ export const contentGenerationJobStatusSchema = z.enum([
   "running",
   "completed",
   "failed",
+  "skipped",
 ]);
 
 export const contentGenerationJobEventSchema = z.object({
@@ -146,6 +147,7 @@ export const contentGenerationJobEventSchema = z.object({
     "post_created",
     "completed",
     "failed",
+    "skipped",
   ]),
   message: z.string(),
   createdAt: z.string(),

--- a/packages/db/migrations/0035_fine_nitro.sql
+++ b/packages/db/migrations/0035_fine_nitro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organization_notification_settings" ADD COLUMN "scheduled_content_skipped" boolean DEFAULT false NOT NULL;

--- a/packages/db/migrations/meta/0035_snapshot.json
+++ b/packages/db/migrations/meta/0035_snapshot.json
@@ -1,0 +1,2564 @@
+{
+  "id": "43a3d1af-ee5d-400d-a52c-6bb79050253a",
+  "prevId": "0c17ef95-dd04-4367-9aeb-8769c952dfb8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_references": {
+      "name": "brand_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_document_id": {
+          "name": "supermemory_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_memory_id": {
+          "name": "supermemory_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_synced_at": {
+          "name": "supermemory_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_last_sync_error": {
+          "name": "supermemory_last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to": {
+          "name": "applicable_to",
+          "type": "applicable_platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['all']::applicable_platform[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandReferences_brandSettingsId_idx": {
+          "name": "brandReferences_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_references_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_references_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_references",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_settings": {
+      "name": "brand_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_description": {
+          "name": "company_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone_profile": {
+          "name": "tone_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_tone": {
+          "name": "custom_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'English'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSettings_org_name_uidx": {
+          "name": "brandSettings_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_org_default_uidx": {
+          "name": "brandSettings_org_default_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brand_settings\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_organizationId_idx": {
+          "name": "brandSettings_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_settings_organization_id_organizations_id_fk": {
+          "name": "brand_settings_organization_id_organizations_id_fk",
+          "tableFrom": "brand_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_attachments": {
+      "name": "chat_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatAttachments_organizationId_createdAt_idx": {
+          "name": "chatAttachments_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatAttachments_userId_idx": {
+          "name": "chatAttachments_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_attachments_organization_id_organizations_id_fk": {
+          "name": "chat_attachments_organization_id_organizations_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_attachments_user_id_users_id_fk": {
+          "name": "chat_attachments_user_id_users_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_attachments_key_unique": {
+          "name": "chat_attachments_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_source": {
+          "name": "external_channel_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_id": {
+          "name": "external_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatSessions_organizationId_idx": {
+          "name": "chatSessions_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_organizationId_deletedAt_idx": {
+          "name": "chatSessions_organizationId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_org_externalChannel_uidx": {
+          "name": "chatSessions_org_externalChannel_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_sessions\".\"external_channel_source\" IN ('discord', 'slack') AND \"chat_sessions\".\"external_channel_id\" IS NOT NULL AND \"chat_sessions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_sessions_organization_id_organizations_id_fk": {
+          "name": "chat_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_social_accounts": {
+      "name": "connected_social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectedSocialAccounts_organizationId_idx": {
+          "name": "connectedSocialAccounts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connectedSocialAccounts_org_provider_account_uidx": {
+          "name": "connectedSocialAccounts_org_provider_account_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connected_social_accounts_organization_id_organizations_id_fk": {
+          "name": "connected_social_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "connected_social_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_trigger_lookback_windows": {
+      "name": "content_trigger_lookback_windows",
+      "schema": "",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "lookback_window",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk": {
+          "name": "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk",
+          "tableFrom": "content_trigger_lookback_windows",
+          "tableTo": "content_triggers",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_triggers": {
+      "name": "content_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Schedule'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_config": {
+          "name": "output_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_hash": {
+          "name": "dedupe_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_publish": {
+          "name": "auto_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentTriggers_organizationId_idx": {
+          "name": "contentTriggers_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contentTriggers_organization_dedupe_uidx": {
+          "name": "contentTriggers_organization_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_triggers_organization_id_organizations_id_fk": {
+          "name": "content_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "content_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_enabled": {
+          "name": "repository_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubIntegrations_organizationId_idx": {
+          "name": "githubIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_createdByUserId_idx": {
+          "name": "githubIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_organization_owner_repo_uidx": {
+          "name": "githubIntegrations_organization_owner_repo_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_organization_id_organizations_id_fk": {
+          "name": "github_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_created_by_user_id_users_id_fk": {
+          "name": "github_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitations_organizationId_idx": {
+          "name": "invitations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_integrations": {
+      "name": "linear_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_id": {
+          "name": "linear_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_name": {
+          "name": "linear_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linearIntegrations_organizationId_idx": {
+          "name": "linearIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_createdByUserId_idx": {
+          "name": "linearIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_no_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_no_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"linear_integrations\".\"linear_team_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_integrations_organization_id_organizations_id_fk": {
+          "name": "linear_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_integrations_created_by_user_id_users_id_fk": {
+          "name": "linear_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_organizationId_idx": {
+          "name": "members_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_userId_idx": {
+          "name": "members_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_notification_settings": {
+      "name": "organization_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_content_creation": {
+          "name": "scheduled_content_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_content_failed": {
+          "name": "scheduled_content_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scheduled_content_skipped": {
+          "name": "scheduled_content_skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orgNotificationSettings_organizationId_uidx": {
+          "name": "orgNotificationSettings_organizationId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_settings_organization_id_organizations_id_fk": {
+          "name": "organization_notification_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_dismissed": {
+          "name": "onboarding_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "organizations_slug_uidx": {
+          "name": "organizations_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_org_slug_uidx": {
+          "name": "posts_org_slug_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_org_createdAt_id_idx": {
+          "name": "posts_org_createdAt_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_organization_id_organizations_id_fk": {
+          "name": "posts_organization_id_organizations_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_outputs": {
+      "name": "repository_outputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositoryOutputs_repositoryId_idx": {
+          "name": "repositoryOutputs_repositoryId_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositoryOutputs_repository_outputType_uidx": {
+          "name": "repositoryOutputs_repository_outputType_uidx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "output_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_outputs_repository_id_github_integrations_id_fk": {
+          "name": "repository_outputs_repository_id_github_integrations_id_fk",
+          "tableFrom": "repository_outputs",
+          "tableTo": "github_integrations",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skills_organizationId_idx": {
+          "name": "skills_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skills_org_name_uidx": {
+          "name": "skills_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_organization_id_organizations_id_fk": {
+          "name": "skills_organization_id_organizations_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_personal_data": {
+          "name": "hide_personal_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_agent_stats": {
+          "name": "show_agent_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.applicable_platform": {
+      "name": "applicable_platform",
+      "schema": "public",
+      "values": [
+        "all",
+        "twitter",
+        "linkedin",
+        "blog"
+      ]
+    },
+    "public.lookback_window": {
+      "name": "lookback_window",
+      "schema": "public",
+      "values": [
+        "current_day",
+        "yesterday",
+        "last_7_days",
+        "last_14_days",
+        "last_30_days"
+      ]
+    },
+    "public.post_status": {
+      "name": "post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.reference_type": {
+      "name": "reference_type",
+      "schema": "public",
+      "values": [
+        "twitter_post",
+        "linkedin_post",
+        "blog_post",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1777782870926,
       "tag": "0034_absurd_donald_blake",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1778358496565,
+      "tag": "0035_fine_nitro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -487,6 +487,9 @@ export const organizationNotificationSettings = pgTable(
     scheduledContentFailed: boolean("scheduled_content_failed")
       .default(true)
       .notNull(),
+    scheduledContentSkipped: boolean("scheduled_content_skipped")
+      .default(false)
+      .notNull(),
     marketingEmails: boolean("marketing_emails").default(true).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at")

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -7,6 +7,7 @@
     "./emails/reset": "./src/emails/reset.tsx",
     "./emails/schedule-content-created": "./src/emails/schedule-content-created.tsx",
     "./emails/schedule-content-failed": "./src/emails/schedule-content-failed.tsx",
+    "./emails/schedule-content-skipped": "./src/emails/schedule-content-skipped.tsx",
     "./emails/verify": "./src/emails/verify.tsx",
     "./emails/welcome": "./src/emails/welcome.tsx",
     "./types/feedback": "./src/types/feedback.ts",

--- a/packages/email/src/emails/schedule-content-skipped.tsx
+++ b/packages/email/src/emails/schedule-content-skipped.tsx
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+import { EmailButton } from "../components/button";
+import { EmailFooter } from "../components/footer";
+import { EMAIL_CONFIG } from "../utils/config";
+
+interface ScheduledContentSkippedEmailProps {
+  organizationName: string;
+  scheduleName: string;
+  reason: string;
+  settingsLink: string;
+  organizationSlug: string;
+}
+
+export const ScheduledContentSkippedEmail = ({
+  organizationName = "Acme Inc",
+  scheduleName = "Weekly Product Updates",
+  reason = "No meaningful changes were found in the lookback window.",
+  organizationSlug = "acme",
+  settingsLink = `https://app.usenotra.com/${organizationSlug}/automation/schedules`,
+}: ScheduledContentSkippedEmailProps) => {
+  const logoUrl = EMAIL_CONFIG.getLogoUrl();
+
+  return (
+    <Html>
+      <Head />
+      <Preview>Your scheduled content generation was skipped</Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white px-2 font-sans">
+          <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
+            <Section className="mt-[32px]">
+              <Img
+                alt="Notra Logo"
+                className="mx-auto"
+                height="40"
+                src={logoUrl}
+                width="40"
+              />
+            </Section>
+
+            <Heading className="my-6 text-center font-medium text-2xl text-black">
+              Scheduled content generation was skipped
+            </Heading>
+
+            <Text className="text-center text-[#737373] text-base leading-relaxed">
+              Your <strong>{scheduleName}</strong> schedule in{" "}
+              <strong>{organizationName}</strong> ran successfully, but did not
+              create content.
+            </Text>
+
+            <Section className="mt-8">
+              <Text className="m-0 text-[#666666] text-[12px] uppercase tracking-wide">
+                Reason:
+              </Text>
+              <Text className="mt-2 mb-0 text-[14px] text-black leading-[22px]">
+                {reason}
+              </Text>
+            </Section>
+
+            <Section className="my-8 text-center">
+              <EmailButton href={settingsLink}>View Schedule</EmailButton>
+            </Section>
+
+            <Text className="text-[14px] text-black leading-[24px]">
+              If the button does not work, copy and paste this URL into your
+              browser: <Link href={settingsLink}>{settingsLink}</Link>
+            </Text>
+
+            <Section className="mt-8">
+              <Text className="m-0 text-center text-[#666666] text-[12px] uppercase tracking-wide">
+                If you don't want to receive these emails, you can click{" "}
+                <Link
+                  href={`${EMAIL_CONFIG.getAppUrl()}/${organizationSlug}/settings/notifications`}
+                >
+                  here
+                </Link>{" "}
+                to update your notification settings.
+              </Text>
+            </Section>
+
+            <EmailFooter />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};


### PR DESCRIPTION
## Summary
- Adds a `skipped` content-generation status across API schemas, job tracking, webhook logs, and dashboard UI.
- Introduces a new `skip` tool in the AI post tooling so agents can intentionally exit when source material is present but not meaningful enough to publish.
- Updates schedule, on-demand, and event workflows to handle skipped runs by completing tracking, logging the skip, and refunding reserved AI credit where applicable.
- Surfaces skipped runs in the dashboard with a dedicated toast, log badge, and Databuddy tracking event.

## Testing
- Not run (not requested).
- Verified code paths were updated for `skipped` handling in workflow handlers, job status updates, and dashboard types/schemas.
- Verified the new skip flow is wired through AI prompts and tooling instead of treating no-op cases as failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new skipped status for no-op content generation, route no-source cases through a dedicated skip tool, and ensure runs are tracked as skipped (not failed), credits are refunded, and users get clear feedback and optional email notifications.

- **New Features**
  - Added "skipped" to content-generation status enums, job events, webhook logs, and filters.
  - Introduced a skip tool in `@notra/ai` plus `ContentGenerationSkippedError`; prompts now prefer skip for expected no-op cases.
  - Updated schedule, on-demand, and event workflows to complete tracking, log skipped runs, emit Databuddy `scheduled_content_skipped`, and refund reserved credits.
  - Dashboard: new toast for skipped runs, status badge, and log label.
  - Added org notification setting and email for skipped schedules: toggle in Notifications, send `ScheduledContentSkippedEmail` from `@notra/email`.

- **Migration**
  - If you consume statuses or webhook logs, allow "skipped" alongside "success", "failed", and "pending".
  - Run DB migration adding `organization_notification_settings.scheduled_content_skipped` (defaults to false).

<sup>Written for commit 1afcc15051595909d545bfb68ba846065d8668ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

