### PR TITLE
Add hotkeys for create actions and rename call-to-action labels

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "@notra/ui/components/ui/dropdown-menu";
 import { Field, FieldLabel } from "@notra/ui/components/ui/field";
 import { Input } from "@notra/ui/components/ui/input";
+import { Kbd } from "@notra/ui/components/ui/kbd";
 import {
   Select,
   SelectContent,
@@ -62,6 +63,7 @@ import {
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
 import { useForm } from "@tanstack/react-form";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   KeyResponseData,
@@ -262,6 +264,11 @@ export default function ApiKeysPage() {
   const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deletingKey, setDeletingKey] = useState<ApiKeyListItem | null>(null);
+
+  useHotkey("C", () => setDialogOpen(true), {
+    enabled: !(dialogOpen || editDialogOpen || !!deletingKey),
+  });
+
   const [createdSortOrder, setCreatedSortOrder] = useState<
     false | "asc" | "desc"
   >(false);
@@ -476,7 +483,10 @@ export default function ApiKeysPage() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <Button onClick={() => setDialogOpen(true)}>Create API Key</Button>
+            <Button className="gap-1.5" onClick={() => setDialogOpen(true)}>
+              Create API Key
+              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+            </Button>
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -16,12 +16,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@notra/ui/components/ui/card";
+import { Kbd } from "@notra/ui/components/ui/kbd";
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from "@notra/ui/components/ui/tabs";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -103,6 +105,18 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const [activeTab, setActiveTab] = useQueryState(
     "view",
     parseAsStringLiteral(TAB_VALUES).withDefault("identity")
+  );
+
+  useHotkey(
+    "C",
+    () => {
+      if (activeTab === "identity") {
+        setAddIdentityOpen(true);
+      } else {
+        setAddReferenceOpen(true);
+      }
+    },
+    { enabled: !(addIdentityOpen || addReferenceOpen) }
   );
 
   const selectedVoice =
@@ -375,14 +389,24 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             </p>
           </div>
           {activeTab === "identity" ? (
-            <Button onClick={() => setAddIdentityOpen(true)} size="sm">
+            <Button
+              className="gap-1.5"
+              onClick={() => setAddIdentityOpen(true)}
+              size="sm"
+            >
               <HugeiconsIcon className="size-4" icon={Add01Icon} />
-              Add Identity
+              Create Identity
+              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
             </Button>
           ) : (
-            <Button onClick={() => setAddReferenceOpen(true)} size="sm">
+            <Button
+              className="gap-1.5"
+              onClick={() => setAddReferenceOpen(true)}
+              size="sm"
+            >
               <HugeiconsIcon className="size-4" icon={Add01Icon} />
-              Add Reference
+              Create Reference
+              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
             </Button>
           )}
         </div>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -26,9 +26,11 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@notra/ui/components/ui/input-group";
+import { Kbd } from "@notra/ui/components/ui/kbd";
 import { Separator } from "@notra/ui/components/ui/separator";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { Textarea } from "@notra/ui/components/ui/textarea";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2Icon } from "lucide-react";
 import Link from "next/link";
@@ -50,6 +52,9 @@ export default function PageClient({ slug }: PageClientProps) {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [quickstartUrl, setQuickstartUrl] = useState("");
+
+  useHotkey("C", () => setDialogOpen(true), { enabled: !dialogOpen });
+
   const [form, setForm] = useState({
     name: "",
     description: "",
@@ -157,9 +162,10 @@ export default function PageClient({ slug }: PageClientProps) {
               Reusable instructions your agents load when generating content.
             </p>
           </div>
-          <Button onClick={() => setDialogOpen(true)}>
+          <Button className="gap-1.5" onClick={() => setDialogOpen(true)}>
             <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
-            New Skill
+            Create Skill
+            <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
           </Button>
         </div>
 

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -37,6 +37,7 @@ import {
   ComboboxList,
   useComboboxAnchor,
 } from "@notra/ui/components/ui/combobox";
+import { Kbd } from "@notra/ui/components/ui/kbd";
 import { Label } from "@notra/ui/components/ui/label";
 import {
   Pagination,
@@ -58,6 +59,7 @@ import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { Switch } from "@notra/ui/components/ui/switch";
 import { cn } from "@notra/ui/lib/utils";
 import { useForm } from "@tanstack/react-form";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useStore } from "@tanstack/react-store";
 import { useParams, useRouter } from "next/navigation";
@@ -128,6 +130,17 @@ export function CreateContentDialog({
   const { slug } = useParams<{ slug: string }>();
   const router = useRouter();
   const [open, setOpen] = useState(false);
+
+  useHotkey(
+    "C",
+    () => {
+      if (organizationId) {
+        setOpen(true);
+      }
+    },
+    { enabled: !open }
+  );
+
   const [addRepoOpen, setAddRepoOpen] = useState(false);
   const [addRepoMode, setAddRepoMode] = useState<
     "integration" | "repository" | null
@@ -774,9 +787,10 @@ export function CreateContentDialog({
       <ResponsiveDialog onOpenChange={handleOpenChange} open={open}>
         <ResponsiveDialogTrigger
           render={
-            <Button disabled={!organizationId} size="sm">
+            <Button className="gap-1.5" disabled={!organizationId} size="sm">
               <HugeiconsIcon className="size-4" icon={Add01Icon} />
               Create Content
+              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
             </Button>
           }
         />

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -71,7 +71,7 @@ export function SiteHeader() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [mobileFeedbackOpen, setMobileFeedbackOpen] = useState(false);
 
-  function triggerBookCall() {
+  function triggerScheduleDemo() {
     const btn = document.querySelector<HTMLButtonElement>(
       '[data-cal-namespace="15min"]'
     );
@@ -120,8 +120,8 @@ export function SiteHeader() {
     })();
   }, []);
 
-  useHotkey("C", () => {
-    triggerBookCall();
+  useHotkey("D", () => {
+    triggerScheduleDemo();
   });
 
   useHotkey("F", () => {
@@ -224,8 +224,8 @@ export function SiteHeader() {
               variant="outline"
             >
               <HugeiconsIcon icon={Calendar03Icon} size={16} />
-              Book a Call
-              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+              Schedule a Demo
+              <Kbd className="ml-1 hidden sm:inline-flex">D</Kbd>
             </Button>
           </div>
           <DropdownMenu onOpenChange={setMobileMenuOpen} open={mobileMenuOpen}>
@@ -257,11 +257,11 @@ export function SiteHeader() {
                 className="cursor-pointer"
                 onClick={() => {
                   setMobileMenuOpen(false);
-                  triggerBookCall();
+                  triggerScheduleDemo();
                 }}
               >
                 <HugeiconsIcon icon={Calendar03Icon} />
-                Book a Call
+                Schedule a Demo
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>


### PR DESCRIPTION
## Summary
- Added `C` hotkeys to open create flows across API keys, skills, content, and brand identity/reference screens.
- Updated button labels to use consistent "Create" language and display the shortcut hint with `Kbd`.
- Renamed the dashboard header CTA from "Book a Call" to "Schedule a Demo" and moved its hotkey to `D`.

## Testing
- Not run.
- Reviewed the affected create-action entry points for matching button labels and hotkey handlers.
- Verified hotkey guards only enable shortcuts when the related dialog or modal is not already open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard shortcuts to speed up create actions and standardizes "Create" labels with visible shortcut hints. Also renames the dashboard header CTA to "Schedule a Demo" and moves its shortcut to D.

- **New Features**
  - Press C to open create flows on API Keys, Skills, Brand Identity/Reference (active tab), and Content dialog. Implemented with `@tanstack/react-hotkeys` and guarded so it only fires when relevant dialogs are closed.
  - Updated buttons to “Create …” and show the C shortcut using `@notra/ui/components/ui/kbd`.
  - Dashboard header CTA changed to “Schedule a Demo” with the D shortcut (works in desktop and mobile menu).

<sup>Written for commit 669da1dc2b0307c40ea07472b2bd8ff520cc657f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

