### PR TITLE
Add telemetry tracing to AI workflow generation

### DIFF
--- a/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts
+++ b/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@notra/ai/jobs/brand-analysis";
 import { getBaseUrl } from "@notra/ai/qstash/triggers";
 import { redis } from "@notra/ai/utils/redis";
+import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
 import { db } from "@notra/db/drizzle";
 import { brandSettings } from "@notra/db/schema";
 import { assertPublicHttpUrl } from "@notra/utils/url";
@@ -279,6 +280,13 @@ Extract the following information:
 4. audience: A description of their target audience (1-2 sentences)
 5. language: The primary language of the website content. Must be one of: ${SUPPORTED_LANGUAGES.join(", ")}`,
               system: `You are a brand analyst expert. Your job is to analyze website content and extract key brand identity information. Be thorough but concise. Focus on understanding the company's essence, values, and how they communicate.`,
+              experimental_telemetry: buildExperimentalTelemetry({
+                feature: "brand_analysis",
+                jobId,
+                organizationId,
+                routeName: "/api/workflows/brand-analysis",
+                voiceId,
+              }),
             });
 
             return { success: true, brandInfo: output as BrandInfo };

--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -285,6 +285,20 @@ export const { POST } = serve<EventWorkflowPayload>(
             sourceMetadata,
             autoPublish: trigger.autoPublish,
             resolveContext: getGitHubToolRepositoryContextByIntegrationId,
+            telemetryMetadata: {
+              contentType: trigger.outputType,
+              eventAction,
+              eventType,
+              feature: "content_generation",
+              generationMode: "event",
+              organizationId: trigger.organizationId,
+              repositoryId: repository.id,
+              routeName: "/api/workflows/event",
+              triggerId: trigger.id,
+              triggerName: trigger.name,
+              triggerSourceType: "github_webhook",
+              voiceId: brand?.id,
+            },
           });
         }
       );

--- a/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
+++ b/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
@@ -405,6 +405,18 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
               resolveContext: getGitHubToolRepositoryContextByIntegrationId,
               resolveLinearContext: getLinearToolContextByIntegrationId,
               log,
+              telemetryMetadata: {
+                contentType,
+                feature: "content_generation",
+                generationMode: "manual",
+                jobId,
+                organizationId,
+                routeName: "/api/workflows/on-demand-content",
+                runId,
+                source,
+                triggerId: "manual_on_demand",
+                voiceId: brand?.id,
+              },
             });
           } finally {
             log.emit();

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -406,6 +406,17 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
               resolveContext: getGitHubToolRepositoryContextByIntegrationId,
               resolveLinearContext: getLinearToolContextByIntegrationId,
               log,
+              telemetryMetadata: {
+                contentType: trigger.outputType,
+                feature: "content_generation",
+                generationMode: creationMode,
+                organizationId: trigger.organizationId,
+                routeName: "/api/workflows/schedule",
+                triggerId,
+                triggerName: trigger.name,
+                triggerSourceType: trigger.sourceType,
+                voiceId: brand?.id,
+              },
             });
           } finally {
             log.emit();

--- a/apps/dashboard/src/lib/workflows/event/handlers/index.ts
+++ b/apps/dashboard/src/lib/workflows/event/handlers/index.ts
@@ -49,6 +49,7 @@ export async function generateEventBasedContent(
       sourceMetadata: ctx.sourceMetadata,
       autoPublish: ctx.autoPublish,
       resolveContext: ctx.resolveContext,
+      telemetryMetadata: ctx.telemetryMetadata,
     };
 
     const result = await generateFn(agentOptions);

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/blog-post.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/blog-post.ts
@@ -25,6 +25,7 @@ export async function handleBlogPost(
       resolveContext: ctx.resolveContext,
       resolveLinearContext: ctx.resolveLinearContext,
       log: ctx.log,
+      telemetryMetadata: ctx.telemetryMetadata,
     });
 
     return { status: "ok", postId, title, posts, usage };

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/changelog.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/changelog.ts
@@ -25,6 +25,7 @@ export async function handleChangelog(
       resolveContext: ctx.resolveContext,
       resolveLinearContext: ctx.resolveLinearContext,
       log: ctx.log,
+      telemetryMetadata: ctx.telemetryMetadata,
     });
 
     return { status: "ok", postId, title, posts, usage };

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/linkedin.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/linkedin.ts
@@ -25,6 +25,7 @@ export async function handleLinkedIn(
       resolveContext: ctx.resolveContext,
       resolveLinearContext: ctx.resolveLinearContext,
       log: ctx.log,
+      telemetryMetadata: ctx.telemetryMetadata,
     });
 
     return { status: "ok", postId, title, posts, usage };

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/twitter.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/twitter.ts
@@ -25,6 +25,7 @@ export async function handleTwitter(
       resolveContext: ctx.resolveContext,
       resolveLinearContext: ctx.resolveLinearContext,
       log: ctx.log,
+      telemetryMetadata: ctx.telemetryMetadata,
     });
 
     return { status: "ok", postId, title, posts, usage };

--- a/apps/dashboard/src/lib/workflows/schedule/types.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/types.ts
@@ -7,6 +7,7 @@ import type {
   ResolveIntegrationContext,
   ResolveLinearIntegrationContext,
 } from "@notra/ai/types/agents";
+import type { TccMetadata } from "@notra/ai/types/tcc";
 import type { GitHubSelectionFilters } from "@notra/ai/types/tools";
 import type { PostSourceMetadata } from "@notra/db/schema";
 import type { PostSummary } from "@/types/posts";
@@ -45,6 +46,7 @@ export interface ContentGenerationContext {
   resolveContext: ResolveIntegrationContext;
   resolveLinearContext?: ResolveLinearIntegrationContext;
   log?: AILogTarget;
+  telemetryMetadata?: TccMetadata;
 }
 
 export type ContentGenerationResult =

--- a/apps/dashboard/src/types/workflows/workflows.ts
+++ b/apps/dashboard/src/types/workflows/workflows.ts
@@ -3,6 +3,7 @@ import type {
   AgentTokenUsage,
   ResolveIntegrationContext,
 } from "@notra/ai/types/agents";
+import type { TccMetadata } from "@notra/ai/types/tcc";
 import type { PostSourceMetadata } from "@notra/db/schema";
 import type { PostSummary } from "@/types/posts";
 
@@ -73,6 +74,7 @@ export interface EventGenerationContext {
   sourceMetadata: PostSourceMetadata;
   autoPublish?: boolean;
   resolveContext: ResolveIntegrationContext;
+  telemetryMetadata?: TccMetadata;
 }
 
 export type EventGenerationResult =

--- a/apps/web/src/app/subprocessors/page.tsx
+++ b/apps/web/src/app/subprocessors/page.tsx
@@ -6,7 +6,7 @@ const title = "Subprocessors";
 const description =
   "Current subprocessors Notra uses to provide hosting, analytics, authentication, billing, email, AI, and integrations.";
 const url = `${SITE_URL}/subprocessors`;
-const currentAsOf = "May 11, 2026";
+const currentAsOf = "May 12, 2026";
 
 const subprocessors = [
   {
@@ -44,6 +44,12 @@ const subprocessors = [
     purpose: "AI model access for content generation",
     location: "United States",
     website: "https://vercel.com/ai-gateway",
+  },
+  {
+    name: "The Context Company",
+    purpose: "AI observability, tracing, and generation monitoring",
+    location: "United States",
+    website: "https://www.thecontext.company",
   },
   {
     name: "Autumn",

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -31,10 +31,12 @@ import type {
 } from "@notra/ai/types/post-tools";
 import type { PostSummary } from "@notra/ai/types/posts";
 import type { BaseTonePromptInput } from "@notra/ai/types/prompts";
+import type { TccMetadata } from "@notra/ai/types/tcc";
 import type {
   CommitWindow,
   GitHubSelectionFilters,
 } from "@notra/ai/types/tools";
+import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
 import type { PostSourceMetadata } from "@notra/db/schema";
 import { stepCountIs, ToolLoopAgent } from "ai";
 
@@ -61,6 +63,7 @@ export interface BackgroundGenOptions {
   resolveContext: ResolveIntegrationContext;
   resolveLinearContext?: ResolveLinearIntegrationContext;
   log?: AILogTarget;
+  telemetryMetadata?: TccMetadata;
   includeSearchBrandReferencesTool?: boolean;
 }
 
@@ -128,6 +131,7 @@ export async function runBackgroundGen(
     resolveContext,
     resolveLinearContext,
     log,
+    telemetryMetadata,
     includeSearchBrandReferencesTool,
   } = options;
 
@@ -225,6 +229,7 @@ export async function runBackgroundGen(
     },
     instructions,
     stopWhen: stepCountIs(35),
+    experimental_telemetry: buildExperimentalTelemetry(telemetryMetadata),
   });
 
   const result = await agent.generate({ prompt });

--- a/packages/ai/src/agents/blog-post.ts
+++ b/packages/ai/src/agents/blog-post.ts
@@ -25,5 +25,6 @@ export async function generateBlogPost(
     resolveContext: options.resolveContext,
     resolveLinearContext: options.resolveLinearContext,
     log: options.log,
+    telemetryMetadata: options.telemetryMetadata,
   });
 }

--- a/packages/ai/src/agents/changelog.ts
+++ b/packages/ai/src/agents/changelog.ts
@@ -25,5 +25,6 @@ export async function generateChangelog(
     resolveContext: options.resolveContext,
     resolveLinearContext: options.resolveLinearContext,
     log: options.log,
+    telemetryMetadata: options.telemetryMetadata,
   });
 }

--- a/packages/ai/src/agents/chat.ts
+++ b/packages/ai/src/agents/chat.ts
@@ -4,6 +4,7 @@ import { createMarkdownTools } from "@notra/ai/tools/edit-markdown";
 import { exampleTool } from "@notra/ai/tools/example";
 import { getSkillByName, listAvailableSkills } from "@notra/ai/tools/skills";
 import type { ChatAgentContext } from "@notra/ai/types/agents";
+import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
 import { stepCountIs, ToolLoopAgent } from "ai";
 
 export async function createChatAgent(
@@ -11,7 +12,13 @@ export async function createChatAgent(
   instruction: string
 ) {
   const { organizationId } = context;
-  const decision = await routeMessage(instruction, false, context.log);
+  const decision = await routeMessage(
+    instruction,
+    false,
+    context.log,
+    false,
+    context.telemetryMetadata
+  );
   const model = selectModel(decision);
 
   const modelWithMemory = createModel(
@@ -86,5 +93,8 @@ Triggers: the user wants the document changed (rewrite, shorten, tone change, cl
     }
 ${selectionContext}`,
     stopWhen: stepCountIs(15),
+    experimental_telemetry: buildExperimentalTelemetry(
+      context.telemetryMetadata
+    ),
   });
 }

--- a/packages/ai/src/agents/linkedin.ts
+++ b/packages/ai/src/agents/linkedin.ts
@@ -25,5 +25,6 @@ export async function generateLinkedInPost(
     resolveContext: options.resolveContext,
     resolveLinearContext: options.resolveLinearContext,
     log: options.log,
+    telemetryMetadata: options.telemetryMetadata,
   });
 }

--- a/packages/ai/src/agents/twitter.ts
+++ b/packages/ai/src/agents/twitter.ts
@@ -25,6 +25,7 @@ export async function generateTwitterPost(
     resolveContext: options.resolveContext,
     resolveLinearContext: options.resolveLinearContext,
     log: options.log,
+    telemetryMetadata: options.telemetryMetadata,
     includeSearchBrandReferencesTool: true,
   });
 }

--- a/packages/ai/src/types/agents.ts
+++ b/packages/ai/src/types/agents.ts
@@ -9,6 +9,7 @@ import type {
   LinkedInTonePromptInput,
   TwitterTonePromptInput,
 } from "./prompts";
+import type { TccMetadata } from "./tcc";
 import type {
   CommitWindow,
   GitHubSelectionFilters,
@@ -76,6 +77,7 @@ export interface ChangelogAgentOptions {
   resolveContext: ResolveIntegrationContext;
   resolveLinearContext?: ResolveLinearIntegrationContext;
   log?: AILogTarget;
+  telemetryMetadata?: TccMetadata;
 }
 
 export interface LinkedInAgentResult {
@@ -105,6 +107,7 @@ export interface LinkedInAgentOptions {
   resolveContext: ResolveIntegrationContext;
   resolveLinearContext?: ResolveLinearIntegrationContext;
   log?: AILogTarget;
+  telemetryMetadata?: TccMetadata;
 }
 
 export interface TwitterAgentResult {
@@ -134,6 +137,7 @@ export interface TwitterAgentOptions {
   resolveContext: ResolveIntegrationContext;
   resolveLinearContext?: ResolveLinearIntegrationContext;
   log?: AILogTarget;
+  telemetryMetadata?: TccMetadata;
 }
 
 export interface BlogPostAgentResult {
@@ -163,6 +167,7 @@ export interface BlogPostAgentOptions {
   resolveContext: ResolveIntegrationContext;
   resolveLinearContext?: ResolveLinearIntegrationContext;
   log?: AILogTarget;
+  telemetryMetadata?: TccMetadata;
 }
 
 export interface ChatAgentContext {
@@ -172,4 +177,5 @@ export interface ChatAgentContext {
   onMarkdownUpdate: (markdown: string) => void;
   brandContext?: string;
   log?: AILogTarget;
+  telemetryMetadata?: TccMetadata;
 }


### PR DESCRIPTION
## Summary
- Thread telemetry metadata through dashboard workflow routes into AI generation calls for scheduled, manual, and event-driven content.
- Add experimental telemetry to background generation and chat agents using shared TCC metadata helpers.
- Extend agent and workflow types to carry telemetry context end to end.
- Update the Subprocessors page to reflect The Context Company and refresh the “current as of” date.

## Testing
- Not run
- Verified the diff updates telemetry plumbing across dashboard routes, workflow handlers, and AI agent entrypoints.
- Verified the Subprocessors page content change includes the new vendor entry and updated date.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end telemetry tracing for workflow-generated content by threading TCC metadata from dashboard routes into agents and attaching `experimental_telemetry` to model runs. Also update the Subprocessors page to include The Context Company.

- **New Features**
  - Threaded `telemetryMetadata` from workflow routes (event, schedule, on-demand) into agents with fields like content type, generation mode, org/repo IDs, trigger info, route name, and `voiceId`.
  - Added telemetry to brand analysis and background/chat agents using `buildExperimentalTelemetry`, which is passed as `experimental_telemetry` to model calls.
  - Updated agent and workflow types (`ChatAgentContext`, blog/changelog/LinkedIn/Twitter options, scheduler/event contexts) to carry `telemetryMetadata` end to end.
  - Subprocessors page now lists The Context Company and updates the “current as of” date.

<sup>Written for commit 1d8833765ce8c6285cde284ac2a5062f579679e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

