### PR TITLE
feat: add skills api routes

### DIFF
--- a/apps/api/src/constants/skills.ts
+++ b/apps/api/src/constants/skills.ts
@@ -1,0 +1,11 @@
+export const SKILL_NAME_MAX_LENGTH = 64;
+export const SKILL_DESCRIPTION_MAX_LENGTH = 1000;
+export const SKILL_CONTENT_MAX_LENGTH = 200_000;
+
+export const SKILL_NAME_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+export const ORGANIZATION_SCOPED_API_KEY_ERROR =
+  "Forbidden: API key must be scoped to an organization";
+export const SKILL_NOT_FOUND_ERROR = "Skill not found";
+export const SYSTEM_SKILL_RENAME_ERROR = "System skills cannot be renamed";
+export const SYSTEM_SKILL_DELETE_ERROR = "System skills cannot be deleted";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import { integrationsRoutes } from "./routes/integrations";
 import { legacyRedirectRoutes } from "./routes/legacy-redirects";
 import { postsRoutes } from "./routes/posts";
 import { schedulesRoutes } from "./routes/schedules";
+import { skillsRoutes } from "./routes/skills";
 import { assertRequiredEnv } from "./utils/env";
 
 const FRAMER_PLUGIN_ID = "8d4wmwtko6960jsu3ojmalvqm";
@@ -122,6 +123,7 @@ app.route("/v1", brandIdentitiesRoutes);
 app.route("/v1", integrationsRoutes);
 app.route("/v1", schedulesRoutes);
 app.route("/v1", chatsRoutes);
+app.route("/v1", skillsRoutes);
 app.route("/", chatWorkflowRoutes);
 
 app.openAPIRegistry.registerComponent("securitySchemes", "BearerAuth", {
@@ -161,6 +163,11 @@ app.doc31("/openapi.json", (_c) => ({
       name: "Chats",
       description:
         "Manage chat sessions. Organization is inferred from the API key (identity.externalId).",
+    },
+    {
+      name: "Skills",
+      description:
+        "Manage reusable writing skills. Organization is inferred from the API key (identity.externalId).",
     },
   ],
 }));

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -1,0 +1,305 @@
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { skills } from "@notra/db/schema";
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import {
+  ORGANIZATION_SCOPED_API_KEY_ERROR,
+  SKILL_NOT_FOUND_ERROR,
+  SYSTEM_SKILL_DELETE_ERROR,
+  SYSTEM_SKILL_RENAME_ERROR,
+} from "../constants/skills";
+import {
+  createSkillRequestSchema,
+  createSkillResponseSchema,
+  deleteSkillResponseSchema,
+  listSkillsResponseSchema,
+  patchSkillRequestSchema,
+  patchSkillResponseSchema,
+  skillParamsSchema,
+  skillResponseSchema,
+} from "../schemas/skills";
+import { errorResponse } from "../utils/openapi-responses";
+import { isPgUniqueViolation } from "../utils/pg-errors";
+import {
+  getScopedOrganizationId,
+  serializeSkill,
+  serializeSkillSummary,
+} from "../utils/skills";
+
+export const skillsRoutes = new OpenAPIHono();
+
+const listSkillsRoute = createRoute({
+  method: "get",
+  path: "/skills",
+  tags: ["Skills"],
+  operationId: "listSkills",
+  summary: "List skills",
+  responses: {
+    200: {
+      description: "Skills fetched successfully",
+      content: { "application/json": { schema: listSkillsResponseSchema } },
+    },
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    503: errorResponse("Authentication service unavailable"),
+  },
+});
+
+const getSkillRoute = createRoute({
+  method: "get",
+  path: "/skills/{name}",
+  tags: ["Skills"],
+  operationId: "getSkill",
+  summary: "Get a single skill",
+  request: { params: skillParamsSchema },
+  responses: {
+    200: {
+      description: "Skill fetched successfully",
+      content: { "application/json": { schema: skillResponseSchema } },
+    },
+    400: errorResponse("Invalid path params"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse(SKILL_NOT_FOUND_ERROR),
+    503: errorResponse("Authentication service unavailable"),
+  },
+});
+
+const createSkillRoute = createRoute({
+  method: "post",
+  path: "/skills",
+  tags: ["Skills"],
+  operationId: "createSkill",
+  summary: "Create a skill",
+  request: {
+    body: {
+      content: { "application/json": { schema: createSkillRequestSchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Skill created successfully",
+      content: { "application/json": { schema: createSkillResponseSchema } },
+    },
+    400: errorResponse("Invalid request body"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    409: errorResponse("Skill name already exists"),
+    503: errorResponse("Authentication service unavailable"),
+  },
+});
+
+const patchSkillRoute = createRoute({
+  method: "patch",
+  path: "/skills/{name}",
+  tags: ["Skills"],
+  operationId: "patchSkill",
+  summary: "Update a skill",
+  request: {
+    params: skillParamsSchema,
+    body: {
+      content: { "application/json": { schema: patchSkillRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Skill updated successfully",
+      content: { "application/json": { schema: patchSkillResponseSchema } },
+    },
+    400: errorResponse("Invalid path params or request body"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse(SKILL_NOT_FOUND_ERROR),
+    409: errorResponse("Skill name already exists"),
+    503: errorResponse("Authentication service unavailable"),
+  },
+});
+
+const deleteSkillRoute = createRoute({
+  method: "delete",
+  path: "/skills/{name}",
+  tags: ["Skills"],
+  operationId: "deleteSkill",
+  summary: "Delete a skill",
+  request: { params: skillParamsSchema },
+  responses: {
+    200: {
+      description: "Skill deleted successfully",
+      content: { "application/json": { schema: deleteSkillResponseSchema } },
+    },
+    400: errorResponse("Invalid path params"),
+    401: errorResponse("Missing or invalid API key"),
+    403: errorResponse("Forbidden"),
+    404: errorResponse(SKILL_NOT_FOUND_ERROR),
+    503: errorResponse("Authentication service unavailable"),
+  },
+});
+
+skillsRoutes.openapi(listSkillsRoute, async (c) => {
+  const organizationId = getScopedOrganizationId(c);
+  if (!organizationId) {
+    return c.json({ error: ORGANIZATION_SCOPED_API_KEY_ERROR }, 403);
+  }
+
+  const rows = await c
+    .get("db")
+    .select({
+      id: skills.id,
+      name: skills.name,
+      description: skills.description,
+      isSystem: skills.isSystem,
+      updatedAt: skills.updatedAt,
+    })
+    .from(skills)
+    .where(eq(skills.organizationId, organizationId));
+
+  return c.json({ skills: rows.map(serializeSkillSummary) }, 200);
+});
+
+skillsRoutes.openapi(getSkillRoute, async (c) => {
+  const organizationId = getScopedOrganizationId(c);
+  if (!organizationId) {
+    return c.json({ error: ORGANIZATION_SCOPED_API_KEY_ERROR }, 403);
+  }
+
+  const { name } = c.req.valid("param");
+  const skill = await c.get("db").query.skills.findFirst({
+    where: and(
+      eq(skills.organizationId, organizationId),
+      eq(skills.name, name)
+    ),
+  });
+
+  if (!skill) {
+    return c.json({ error: SKILL_NOT_FOUND_ERROR }, 404);
+  }
+
+  return c.json({ skill: serializeSkill(skill) }, 200);
+});
+
+skillsRoutes.openapi(createSkillRoute, async (c) => {
+  const organizationId = getScopedOrganizationId(c);
+  if (!organizationId) {
+    return c.json({ error: ORGANIZATION_SCOPED_API_KEY_ERROR }, 403);
+  }
+
+  const body = c.req.valid("json");
+
+  try {
+    const [created] = await c
+      .get("db")
+      .insert(skills)
+      .values({
+        id: nanoid(),
+        organizationId,
+        name: body.name,
+        description: body.description,
+        content: body.content,
+        isSystem: false,
+      })
+      .returning();
+
+    if (!created) {
+      throw new Error("Failed to create skill");
+    }
+
+    return c.json({ skill: serializeSkill(created) }, 201);
+  } catch (error) {
+    if (isPgUniqueViolation(error)) {
+      return c.json(
+        { error: `A skill named "${body.name}" already exists` },
+        409
+      );
+    }
+    throw error;
+  }
+});
+
+skillsRoutes.openapi(patchSkillRoute, async (c) => {
+  const organizationId = getScopedOrganizationId(c);
+  if (!organizationId) {
+    return c.json({ error: ORGANIZATION_SCOPED_API_KEY_ERROR }, 403);
+  }
+
+  const { name } = c.req.valid("param");
+  const body = c.req.valid("json");
+  const existing = await c.get("db").query.skills.findFirst({
+    where: and(
+      eq(skills.organizationId, organizationId),
+      eq(skills.name, name)
+    ),
+    columns: { id: true, isSystem: true },
+  });
+
+  if (!existing) {
+    return c.json({ error: SKILL_NOT_FOUND_ERROR }, 404);
+  }
+
+  const nextName = body.name ?? name;
+  if (existing.isSystem && nextName !== name) {
+    return c.json({ error: SYSTEM_SKILL_RENAME_ERROR }, 403);
+  }
+
+  try {
+    const [updated] = await c
+      .get("db")
+      .update(skills)
+      .set({
+        name: nextName,
+        description: body.description,
+        content: body.content,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(skills.organizationId, organizationId), eq(skills.name, name))
+      )
+      .returning();
+
+    if (!updated) {
+      return c.json({ error: SKILL_NOT_FOUND_ERROR }, 404);
+    }
+
+    return c.json({ skill: serializeSkill(updated) }, 200);
+  } catch (error) {
+    if (isPgUniqueViolation(error)) {
+      return c.json(
+        { error: `A skill named "${nextName}" already exists` },
+        409
+      );
+    }
+    throw error;
+  }
+});
+
+skillsRoutes.openapi(deleteSkillRoute, async (c) => {
+  const organizationId = getScopedOrganizationId(c);
+  if (!organizationId) {
+    return c.json({ error: ORGANIZATION_SCOPED_API_KEY_ERROR }, 403);
+  }
+
+  const { name } = c.req.valid("param");
+  const existing = await c.get("db").query.skills.findFirst({
+    where: and(
+      eq(skills.organizationId, organizationId),
+      eq(skills.name, name)
+    ),
+    columns: { id: true, isSystem: true },
+  });
+
+  if (!existing) {
+    return c.json({ error: SKILL_NOT_FOUND_ERROR }, 404);
+  }
+
+  if (existing.isSystem) {
+    return c.json({ error: SYSTEM_SKILL_DELETE_ERROR }, 403);
+  }
+
+  await c
+    .get("db")
+    .delete(skills)
+    .where(
+      and(eq(skills.organizationId, organizationId), eq(skills.name, name))
+    );
+
+  return c.json({ success: true as const }, 200);
+});

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -1,6 +1,6 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { skills } from "@notra/db/schema";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import {
   ORGANIZATION_SCOPED_API_KEY_ERROR,
@@ -151,7 +151,8 @@ skillsRoutes.openapi(listSkillsRoute, async (c) => {
       updatedAt: skills.updatedAt,
     })
     .from(skills)
-    .where(eq(skills.organizationId, organizationId));
+    .where(eq(skills.organizationId, organizationId))
+    .orderBy(asc(skills.name));
 
   return c.json({ skills: rows.map(serializeSkillSummary) }, 200);
 });

--- a/apps/api/src/schemas/skills.ts
+++ b/apps/api/src/schemas/skills.ts
@@ -1,0 +1,115 @@
+import { z } from "@hono/zod-openapi";
+import {
+  SKILL_CONTENT_MAX_LENGTH,
+  SKILL_DESCRIPTION_MAX_LENGTH,
+  SKILL_NAME_MAX_LENGTH,
+  SKILL_NAME_REGEX,
+} from "../constants/skills";
+
+const skillNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Name is required")
+  .max(
+    SKILL_NAME_MAX_LENGTH,
+    `Name must be ${SKILL_NAME_MAX_LENGTH} characters or fewer`
+  )
+  .regex(
+    SKILL_NAME_REGEX,
+    "Name must be lowercase, start and end with a letter or digit, and contain only letters, digits, and hyphens"
+  )
+  .openapi({
+    description: "Skill name. Lowercase letters, digits, and hyphens only.",
+    example: "humanizer",
+  });
+
+const skillDescriptionSchema = z
+  .string()
+  .trim()
+  .min(1, "Description is required")
+  .max(
+    SKILL_DESCRIPTION_MAX_LENGTH,
+    `Description must be ${SKILL_DESCRIPTION_MAX_LENGTH} characters or fewer`
+  )
+  .openapi({
+    description: "Short description of when the skill should be used.",
+    example: "Polish near-final drafts so they sound natural and specific.",
+  });
+
+const skillContentSchema = z
+  .string()
+  .min(1, "Content is required")
+  .max(SKILL_CONTENT_MAX_LENGTH, "Content is too large")
+  .openapi({
+    description: "Full skill instructions, typically Markdown.",
+  });
+
+export const skillParamsSchema = z.object({
+  name: skillNameSchema,
+});
+
+export const createSkillRequestSchema = z
+  .object({
+    name: skillNameSchema,
+    description: skillDescriptionSchema,
+    content: skillContentSchema,
+  })
+  .openapi("CreateSkillRequest");
+
+export const patchSkillRequestSchema = z
+  .object({
+    name: skillNameSchema.optional(),
+    description: skillDescriptionSchema.optional(),
+    content: skillContentSchema.optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one field is required",
+  })
+  .openapi("PatchSkillRequest");
+
+const skillSummarySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    isSystem: z.boolean(),
+    updatedAt: z.string(),
+  })
+  .openapi("SkillSummary");
+
+const skillSchema = skillSummarySchema
+  .extend({
+    content: z.string(),
+    createdAt: z.string(),
+  })
+  .openapi("Skill");
+
+export const listSkillsResponseSchema = z
+  .object({
+    skills: z.array(skillSummarySchema),
+  })
+  .openapi("ListSkillsResponse");
+
+export const skillResponseSchema = z
+  .object({
+    skill: skillSchema,
+  })
+  .openapi("SkillResponse");
+
+export const createSkillResponseSchema = z
+  .object({
+    skill: skillSchema,
+  })
+  .openapi("CreateSkillResponse");
+
+export const patchSkillResponseSchema = z
+  .object({
+    skill: skillSchema,
+  })
+  .openapi("PatchSkillResponse");
+
+export const deleteSkillResponseSchema = z
+  .object({
+    success: z.literal(true),
+  })
+  .openapi("DeleteSkillResponse");

--- a/apps/api/src/types/skills.ts
+++ b/apps/api/src/types/skills.ts
@@ -1,0 +1,23 @@
+export interface SkillTimestamps {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SkillUpdatedAt {
+  updatedAt: Date;
+}
+
+export type SerializedSkill<T extends SkillTimestamps> = Omit<
+  T,
+  "createdAt" | "updatedAt"
+> & {
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SerializedSkillSummary<T extends SkillUpdatedAt> = Omit<
+  T,
+  "updatedAt"
+> & {
+  updatedAt: string;
+};

--- a/apps/api/src/utils/skills.ts
+++ b/apps/api/src/utils/skills.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+import type {
+  SerializedSkill,
+  SerializedSkillSummary,
+  SkillTimestamps,
+  SkillUpdatedAt,
+} from "../types/skills";
+import { getOrganizationId } from "./auth";
+
+export function getScopedOrganizationId(c: Context) {
+  const organizationId = getOrganizationId(c);
+  if (!organizationId) {
+    return null;
+  }
+  return organizationId;
+}
+
+export function serializeSkill<T extends SkillTimestamps>(
+  skill: T
+): SerializedSkill<T> {
+  return {
+    ...skill,
+    createdAt: skill.createdAt.toISOString(),
+    updatedAt: skill.updatedAt.toISOString(),
+  };
+}
+
+export function serializeSkillSummary<T extends SkillUpdatedAt>(
+  skill: T
+): SerializedSkillSummary<T> {
+  return {
+    ...skill,
+    updatedAt: skill.updatedAt.toISOString(),
+  };
+}

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -207,6 +207,17 @@
                 ]
               },
               {
+                "group": "Skills",
+                "expanded": true,
+                "pages": [
+                  "GET /v1/skills",
+                  "POST /v1/skills",
+                  "GET /v1/skills/{name}",
+                  "PATCH /v1/skills/{name}",
+                  "DELETE /v1/skills/{name}"
+                ]
+              },
+              {
                 "group": "Chats",
                 "expanded": true,
                 "pages": [


### PR DESCRIPTION
### Description
Adds first-class skills management endpoints to the public API app, scoped by the organization from the API key. The new `/v1/skills` routes support listing, reading, creating, updating, renaming, and deleting skills, with OpenAPI schemas plus route helpers split across `constants`, `types`, and `utils`.

Import-from-URL support is intentionally not included for now.

### Screenshot/Recording (if applicable)
Not applicable. API-only change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds organization-scoped Skills API under `/v1/skills` to manage reusable writing skills with list, read, create, update/rename, and delete endpoints. Includes OpenAPI docs, validation, conflict handling, protections for system skills, and docs pages in the API reference.

- **New Features**
  - Endpoints: GET `/skills`, GET `/skills/{name}`, POST, PATCH, DELETE; list is sorted by name.
  - Organization inferred from API key; missing org scope returns 403.
  - Validation for name/description/content; 409 on duplicate names; 403 if renaming/deleting system skills.
  - OpenAPI schemas and “Skills” tag added; responses use ISO timestamps; routes mounted under `/v1`; API reference pages added under “Skills” in `apps/docs`.

<sup>Written for commit f3b9d050b04fd13ea244b5d773bdf770321b09ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

