### PR TITLE
fix: clarify integration context for chat

### DIFF
--- a/packages/ai/src/orchestration/standalone-tool-registry.ts
+++ b/packages/ai/src/orchestration/standalone-tool-registry.ts
@@ -198,23 +198,31 @@ function getLinearTeamList(integrations: ValidatedIntegration[]): string {
 export function getRepoContextFromIntegrations(
   integrations: ValidatedIntegration[]
 ): RepoContext[] {
-  return Array.from(
-    new Set(
-      integrations
-        .filter((integration) => integration.type === "github")
-        .map((integration) => integration.id)
-    )
-  ).map((integrationId) => ({ integrationId }));
+  return integrations.flatMap((integration) => {
+    if (integration.type !== "github") {
+      return [];
+    }
+
+    return integration.repositories.map((repository) => ({
+      integrationId: integration.id,
+      owner: repository.owner,
+      repo: repository.repo,
+    }));
+  });
 }
 
 export function getLinearContextFromIntegrations(
   integrations: ValidatedIntegration[]
 ): LinearContext[] {
-  return Array.from(
-    new Set(
-      integrations
-        .filter((integration) => integration.type === "linear")
-        .map((integration) => integration.id)
-    )
-  ).map((integrationId) => ({ integrationId }));
+  return integrations.flatMap((integration) => {
+    if (integration.type !== "linear") {
+      return [];
+    }
+
+    return {
+      integrationId: integration.id,
+      teamName: integration.linearTeamName ?? undefined,
+      displayName: integration.displayName,
+    };
+  });
 }

--- a/packages/ai/src/prompts/standalone-chat.ts
+++ b/packages/ai/src/prompts/standalone-chat.ts
@@ -16,14 +16,19 @@ export function getStandaloneChatPrompt(params: StandaloneChatPromptParams) {
     ? `\n\n## Available Capabilities\n${toolDescriptions.map((d) => `- ${d}`).join("\n")}`
     : "";
 
+  const integrationResolutionSection =
+    hasGitHubEnabled || hasLinearEnabled
+      ? "\n\n## Integration Context Resolution\nBefore using GitHub or Linear tools, check whether the user's request clearly names or implies exactly one available integration from the prompt, attached context, or current conversation. Match against repository owner/name for GitHub and team/display name for Linear.\n- If exactly one integration clearly matches, use that integrationId.\n- If multiple integrations could match, ask the user which integration or repository/team they want before calling tools.\n- If no integration clearly matches but the request needs GitHub or Linear data, ask the user for the missing integration/context before calling tools or creating content.\n- Do not guess a default integration for PR, commit, release, issue, project, or social-content generation requests."
+      : "";
+
   const githubSection =
     hasGitHubEnabled && repoContext?.length
-      ? `\n\n## GitHub Repositories\nSource of truth identifiers for repository context:\n${repoContext.map((c) => `- integrationId: ${c.integrationId}`).join("\n")}\n\nWhen working with GitHub data, always call GitHub tools using integrationId. Do not pass owner, repo, or defaultBranch values in tool calls.`
+      ? `\n\n## GitHub Repositories\nSource of truth identifiers for repository context:\n${repoContext.map((c) => `- ${formatRepoContext(c)}`).join("\n")}\n\nWhen working with GitHub data, always call GitHub tools using integrationId. Do not pass owner, repo, or defaultBranch values in tool calls.`
       : "";
 
   const linearSection =
     hasLinearEnabled && linearContext?.length
-      ? `\n\n## Linear Integration\nSource of truth identifiers for Linear context:\n${linearContext.map((c) => `- integrationId: ${c.integrationId}`).join("\n")}\n\nWhen working with Linear data, call Linear tools (getLinearIssues, getLinearProjects, getLinearCycles) using integrationId.`
+      ? `\n\n## Linear Integration\nSource of truth identifiers for Linear context:\n${linearContext.map((c) => `- ${formatLinearContext(c)}`).join("\n")}\n\nWhen working with Linear data, call Linear tools (getLinearIssues, getLinearProjects, getLinearCycles) using integrationId.`
       : "";
 
   const { formatted: currentDate, timezone: resolvedTimezone } =
@@ -69,6 +74,26 @@ export function getStandaloneChatPrompt(params: StandaloneChatPromptParams) {
     - Never use em dashes or en dashes in content. Use hyphens or rewrite the sentence.
     - When creating posts, always use the matching create tool instead of only outputting content as text.
     - When you create a post, tell the user the post title and that it was saved as a draft.
-    ${capabilitiesSection}${githubSection}${linearSection}
+    ${capabilitiesSection}${integrationResolutionSection}${githubSection}${linearSection}
   `;
+}
+
+function formatRepoContext(
+  context: NonNullable<StandaloneChatPromptParams["repoContext"]>[number]
+) {
+  const repository =
+    context.owner && context.repo
+      ? `repository: ${context.owner}/${context.repo}; `
+      : "";
+  return `${repository}integrationId: ${context.integrationId}`;
+}
+
+function formatLinearContext(
+  context: NonNullable<StandaloneChatPromptParams["linearContext"]>[number]
+) {
+  const team = context.teamName ? `team: ${context.teamName}; ` : "";
+  const displayName = context.displayName
+    ? `displayName: ${context.displayName}; `
+    : "";
+  return `${team}${displayName}integrationId: ${context.integrationId}`;
 }

--- a/packages/ai/src/types/orchestration.ts
+++ b/packages/ai/src/types/orchestration.ts
@@ -90,10 +90,14 @@ export interface ToolSet {
 
 export interface RepoContext {
   integrationId: string;
+  owner?: string;
+  repo?: string;
 }
 
 export interface LinearContext {
   integrationId: string;
+  teamName?: string;
+  displayName?: string;
 }
 
 export interface OrchestrateInput {

--- a/packages/ai/src/types/prompts.ts
+++ b/packages/ai/src/types/prompts.ts
@@ -38,9 +38,13 @@ export interface ContentEditorChatPromptParams {
 export interface StandaloneChatPromptParams {
   repoContext?: Array<{
     integrationId: string;
+    owner?: string;
+    repo?: string;
   }>;
   linearContext?: Array<{
     integrationId: string;
+    teamName?: string;
+    displayName?: string;
   }>;
   toolDescriptions?: string[];
   hasGitHubEnabled: boolean;


### PR DESCRIPTION
### Description
Clarifies the standalone chat system prompt so GitHub and Linear tool use only proceeds when the user request clearly maps to one available repository or team. If the context is missing or ambiguous, chat now asks for the integration/context instead of guessing a default.

Also includes repository and Linear team names in standalone chat prompt context so the model can match user wording to the correct integrationId.

Fixes NOT-61.

### Screenshot/Recording (if applicable)
Not applicable. Prompt/context-only change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies standalone chat integration context so GitHub/Linear tools run only when a single repo or team is clearly identified; otherwise chat asks the user. Adds repo and team names to prompt context to improve matching and prevent wrong defaults. Fixes NOT-61.

- **Bug Fixes**
  - Adds Integration Context Resolution rules to the prompt: use one clear match, otherwise ask; never guess defaults for PRs, commits, releases, issues, projects, or social posts.
  - GitHub context now includes owner/repo with `integrationId`; Linear context includes team/display name for better matching.
  - Registry returns per-repository GitHub entries and enriched Linear entries; extended types in `RepoContext`, `LinearContext`, and `StandaloneChatPromptParams`.

<sup>Written for commit efab55c310bfc3508f05841088cb2e0c31ab1309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

