### PR TITLE
feat: fade chat suggestions while typing

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -398,6 +398,7 @@ function StandaloneChatPageClient({
   >({});
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const chatInputRef = useRef<ChatInputHandle | null>(null);
+  const [isInputEmpty, setIsInputEmpty] = useState(true);
 
   const handleSuggestionSelect = useCallback((text: string) => {
     chatInputRef.current?.setText(text);
@@ -1836,6 +1837,7 @@ function StandaloneChatPageClient({
               model={selectedModel}
               onAddContext={handleAddContext}
               onClearError={handleClearError}
+              onEmptyChange={setIsInputEmpty}
               onModelChange={handleModelChange}
               onRemoveContext={handleRemoveContext}
               onSend={handleSend}
@@ -1851,6 +1853,7 @@ function StandaloneChatPageClient({
           </div>
           <ChatSuggestions
             disabled={isLoading}
+            hidden={!isInputEmpty}
             onSelect={handleSuggestionSelect}
           />
         </div>

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -307,6 +307,7 @@ interface ChatInputAdvancedProps {
   connectedTop?: boolean;
   queuedMessages?: QueuedMessage[];
   onUpdateQueued?: (id: string, text: string) => void;
+  onEmptyChange?: (isEmpty: boolean) => void;
   ref?: Ref<ChatInputHandle>;
 }
 
@@ -346,6 +347,7 @@ export function ChatInputAdvanced({
   thinkingLevel = "medium",
   onThinkingLevelChange,
   connectedTop = false,
+  onEmptyChange,
   ref,
 }: ChatInputAdvancedProps) {
   const currentModel =
@@ -566,6 +568,12 @@ export function ChatInputAdvanced({
       }
     };
   }, [cleanupChatUpload]);
+
+  const onEmptyChangeRef = useRef(onEmptyChange);
+  onEmptyChangeRef.current = onEmptyChange;
+  useEffect(() => {
+    onEmptyChangeRef.current?.(isEmpty);
+  }, [isEmpty]);
 
   useEffect(() => {
     function onDragEnter(event: DragEvent) {

--- a/apps/dashboard/src/components/chat/chat-suggestions.tsx
+++ b/apps/dashboard/src/components/chat/chat-suggestions.tsx
@@ -31,11 +31,26 @@ const SUGGESTIONS: Suggestion[] = [
   },
 ];
 
-export function ChatSuggestions({ onSelect, disabled }: ChatSuggestionsProps) {
+export function ChatSuggestions({
+  onSelect,
+  disabled,
+  hidden = false,
+}: ChatSuggestionsProps) {
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <ul className="w-full divide-y divide-border border-y">
+    <motion.ul
+      animate={
+        shouldReduceMotion
+          ? undefined
+          : { opacity: hidden ? 0 : 1, y: hidden ? -2 : 0 }
+      }
+      aria-hidden={hidden}
+      className="w-full divide-y divide-border border-y"
+      initial={false}
+      style={{ pointerEvents: hidden ? "none" : undefined }}
+      transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+    >
       {SUGGESTIONS.map((suggestion, index) => (
         <motion.li
           animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
@@ -49,8 +64,9 @@ export function ChatSuggestions({ onSelect, disabled }: ChatSuggestionsProps) {
         >
           <button
             className="group flex w-full cursor-pointer items-center gap-[1rem] px-[0.25rem] py-[0.75rem] text-left transition-colors duration-200 hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
-            disabled={disabled}
+            disabled={disabled || hidden}
             onClick={() => onSelect(suggestion.prompt)}
+            tabIndex={hidden ? -1 : undefined}
             type="button"
           >
             <span className="flex min-w-0 flex-1 flex-col gap-[0.125rem]">
@@ -68,6 +84,6 @@ export function ChatSuggestions({ onSelect, disabled }: ChatSuggestionsProps) {
           </button>
         </motion.li>
       ))}
-    </ul>
+    </motion.ul>
   );
 }

--- a/apps/dashboard/src/types/components/chat-suggestions.ts
+++ b/apps/dashboard/src/types/components/chat-suggestions.ts
@@ -6,4 +6,5 @@ export interface Suggestion {
 export interface ChatSuggestionsProps {
   onSelect: (prompt: string) => void;
   disabled?: boolean;
+  hidden?: boolean;
 }


### PR DESCRIPTION
### Description
:D 

### Screenshot/Recording (if applicable)
https://github.com/user-attachments/assets/14451d66-d9a5-4fb0-b74f-19773a47cde4

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fade out chat suggestions while typing and bring them back when the input is empty. Improves focus and accessibility by reducing visual noise.

- **New Features**
  - Added `hidden` prop to `ChatSuggestions` with fade/slide animation and `aria-hidden`.
  - Disabled clicks and focus when hidden (`pointer-events: none`, `tabIndex=-1`).
  - Respects reduced motion settings.
  - Tracked input emptiness in the page via `isInputEmpty`.
  - Added `onEmptyChange` callback to `ChatInputAdvanced` to sync input state and toggle suggestions.

<sup>Written for commit 098cd2b144a2f1db24741f9f2c65965400a192fa. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/343?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

