### PR TITLE
fix: hide post generation job existence

### DIFF
--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -728,12 +728,8 @@ postsRoutes.openapi(getPostGenerationRoute, async (c) => {
   const { jobId } = c.req.valid("param");
   const job = await getContentGenerationJob(redis, jobId);
 
-  if (!job) {
+  if (!job || job.organizationId !== orgId) {
     return c.json({ error: "Generation job not found" }, 404);
-  }
-
-  if (job.organizationId !== orgId) {
-    return c.json({ error: "Forbidden: organization access denied" }, 403);
   }
 
   const events = await listContentGenerationJobEvents(redis, jobId);


### PR DESCRIPTION
## Summary
- return the same not-found response for missing and cross-organization post generation jobs
- avoid revealing whether a generation job ID exists outside the caller's organization

## Verification
- bun run check-types --filter=api

Linear: NOT-29

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 404 for both missing and cross-organization post generation jobs, replacing the previous 403 to avoid leaking job existence. Aligns with Linear NOT-29 by hiding generation job IDs across organizations.

<sup>Written for commit 8d0fe5b56a9d04ab16bed7b18b3f4dc6398992c1. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

