### PR TITLE
chore: improve thread ux

### DIFF
--- a/apps/dashboard/knip.json
+++ b/apps/dashboard/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignore": ["src/app/.well-known/**"],
   "ignoreIssues": {
     "src/app/(dashboard)/**/constants/**/*.ts": ["exports"],
     "src/components/**/*.tsx": ["types"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@c15t/nextjs": "^2.0.4",
     "@databuddy/sdk": "^2.4.11",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@dualmark/converters": "0.5.0",
     "@dualmark/nextjs": "0.5.1",
     "@hugeicons/core-free-icons": "^4.1.1",

--- a/apps/web/src/app/threads/page.tsx
+++ b/apps/web/src/app/threads/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import ThreadBuilder from "@/components/thread-builder";
+import ThreadBuilder from "@/components/threads/thread-builder";
 import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";

--- a/apps/web/src/components/threads/inline-editable.tsx
+++ b/apps/web/src/components/threads/inline-editable.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+interface InlineEditableProps {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder: string;
+  prefix?: string;
+  className?: string;
+  ariaLabel: string;
+  maxLength: number;
+}
+
+export function InlineEditable({
+  value,
+  onChange,
+  placeholder,
+  prefix,
+  className,
+  ariaLabel,
+  maxLength,
+}: InlineEditableProps) {
+  const [editing, setEditing] = useState(false);
+  const [inputWidth, setInputWidth] = useState<number | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const display = value.trim() ? value : placeholder;
+  const isPlaceholder = !value.trim();
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  useLayoutEffect(() => {
+    if (!editing) {
+      return;
+    }
+    const measuredWidth = measureRef.current?.getBoundingClientRect().width;
+    if (measuredWidth) {
+      setInputWidth(Math.ceil(measuredWidth));
+    }
+  });
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter" || event.key === "Escape") {
+      event.preventDefault();
+      setEditing(false);
+    }
+  }
+
+  function handleEditClick(event: MouseEvent<HTMLButtonElement>) {
+    const displayWidth = event.currentTarget
+      .querySelector("[data-inline-editable-display]")
+      ?.getBoundingClientRect().width;
+    if (displayWidth) {
+      setInputWidth(Math.ceil(displayWidth));
+    }
+    setEditing(true);
+  }
+
+  if (editing) {
+    return (
+      <span
+        className={cn(
+          "relative inline-flex items-center border-transparent border-b border-dashed transition-colors focus-within:border-muted-foreground/70 hover:border-muted-foreground/70 group-hover/post:border-muted-foreground/45",
+          className,
+          isPlaceholder && "font-normal"
+        )}
+      >
+        {prefix && (
+          <span className={cn("pointer-events-none", className)}>{prefix}</span>
+        )}
+        <span
+          aria-hidden
+          className={cn(
+            "pointer-events-none invisible absolute whitespace-pre",
+            className,
+            isPlaceholder && "font-normal"
+          )}
+          ref={measureRef}
+        >
+          {display}
+        </span>
+        <input
+          aria-label={ariaLabel}
+          className={cn("min-w-4 bg-transparent outline-none", className)}
+          maxLength={maxLength}
+          onBlur={() => setEditing(false)}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          ref={inputRef}
+          style={inputWidth ? { width: inputWidth } : undefined}
+          value={value}
+        />
+      </span>
+    );
+  }
+
+  return (
+    <button
+      aria-label={ariaLabel}
+      className={cn(
+        "group/edit inline-flex max-w-full cursor-text items-center gap-1 truncate border-transparent border-b border-dashed text-left transition-colors hover:border-muted-foreground/70 hover:underline hover:decoration-foreground/40 hover:decoration-dashed hover:underline-offset-4 focus-visible:border-muted-foreground/70 focus-visible:bg-muted/70 focus-visible:outline-none group-hover/post:border-muted-foreground/45",
+        className,
+        isPlaceholder && "font-normal text-muted-foreground/60"
+      )}
+      onClick={handleEditClick}
+      type="button"
+    >
+      <span className="truncate" data-inline-editable-display>
+        {prefix}
+        {display}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/threads/sortable-thread-post.tsx
+++ b/apps/web/src/components/threads/sortable-thread-post.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  Cancel01Icon,
+  DragDropVerticalIcon,
+  Image01Icon,
+  User02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
+import { cn } from "@notra/ui/lib/utils";
+import type { KeyboardEvent, RefObject } from "react";
+import {
+  AUTHOR_HANDLE_LIMIT,
+  AUTHOR_NAME_LIMIT,
+  THREAD_POST_LIMIT,
+  type ThreadPost,
+} from "@/types/threads";
+import { InlineEditable } from "./inline-editable";
+
+const DEFAULT_AUTHOR_NAME = "Your name";
+const DEFAULT_AUTHOR_HANDLE = "yourhandle";
+
+interface SortableThreadPostProps {
+  post: ThreadPost;
+  index: number;
+  postsCount: number;
+  authorAvatar: string | null;
+  authorInitials: string;
+  authorName: string;
+  authorHandle: string;
+  previewName: string;
+  dragId: string | null;
+  dragOverId: string | null;
+  hasMultiplePosts: boolean;
+  avatarInputRef: RefObject<HTMLInputElement | null>;
+  registerTextarea: (id: string) => (el: HTMLTextAreaElement | null) => void;
+  onAuthorNameChange: (next: string) => void;
+  onAuthorHandleChange: (next: string) => void;
+  onPostChange: (id: string, content: string) => void;
+  onPostKeyDown: (
+    id: string,
+    event: KeyboardEvent<HTMLTextAreaElement>
+  ) => void;
+  onRemovePost: (id: string) => void;
+}
+
+export function SortableThreadPost({
+  post,
+  index,
+  postsCount,
+  authorAvatar,
+  authorInitials,
+  authorName,
+  authorHandle,
+  previewName,
+  dragId,
+  dragOverId,
+  hasMultiplePosts,
+  avatarInputRef,
+  registerTextarea,
+  onAuthorNameChange,
+  onAuthorHandleChange,
+  onPostChange,
+  onPostKeyDown,
+  onRemovePost,
+}: SortableThreadPostProps) {
+  const {
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: post.id });
+  const isDragging = dragId === post.id;
+  const isDropTarget =
+    dragOverId === post.id && dragId !== null && dragId !== post.id;
+  const length = post.content.length;
+  const overLimit = length > THREAD_POST_LIMIT;
+  const nearLimit = length > THREAD_POST_LIMIT - 20;
+  let counterColor = "text-muted-foreground/70";
+  if (overLimit) {
+    counterColor = "text-destructive";
+  } else if (nearLimit) {
+    counterColor = "text-amber-500";
+  }
+  const isSoloEmpty = postsCount === 1 && length === 0;
+  const showDelete = !isSoloEmpty;
+  const showConnector = index < postsCount - 1;
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <li
+      className={cn(
+        "group/post relative flex gap-3 rounded-xl p-3 transition-colors focus-within:bg-muted/50 hover:bg-muted/40",
+        isDragging && "opacity-50",
+        isDropTarget && "bg-primary/5 ring-1 ring-primary/40"
+      )}
+      data-thread-post-id={post.id}
+      key={post.id}
+      ref={setNodeRef}
+      style={style}
+    >
+      {showConnector && (
+        <div
+          aria-hidden
+          className="-translate-x-1/2 pointer-events-none absolute top-13 bottom-[-1.375rem] left-8 w-px bg-border"
+          data-thread-connector
+        />
+      )}
+
+      <button
+        aria-label="Change avatar"
+        className="group/avatar relative z-10 size-10 shrink-0 cursor-pointer rounded-full bg-background outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        onClick={() => avatarInputRef.current?.click()}
+        type="button"
+      >
+        <Avatar className="size-10" size="lg">
+          {authorAvatar && <AvatarImage alt={previewName} src={authorAvatar} />}
+          <AvatarFallback className="bg-muted text-muted-foreground text-xs">
+            {authorInitials || (
+              <HugeiconsIcon className="size-4" icon={User02Icon} />
+            )}
+          </AvatarFallback>
+        </Avatar>
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-foreground/55 text-background opacity-0 transition-opacity group-hover/avatar:opacity-100 group-focus-visible/avatar:opacity-100">
+          <HugeiconsIcon className="size-4" icon={Image01Icon} />
+        </span>
+      </button>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1 pt-1">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+          <InlineEditable
+            ariaLabel="Edit display name"
+            className="max-w-[14rem] font-sans font-semibold text-foreground text-sm leading-tight"
+            maxLength={AUTHOR_NAME_LIMIT}
+            onChange={onAuthorNameChange}
+            placeholder={DEFAULT_AUTHOR_NAME}
+            value={authorName}
+          />
+          <InlineEditable
+            ariaLabel="Edit handle"
+            className="max-w-[10rem] font-sans text-muted-foreground text-sm leading-tight"
+            maxLength={AUTHOR_HANDLE_LIMIT}
+            onChange={onAuthorHandleChange}
+            placeholder={DEFAULT_AUTHOR_HANDLE}
+            prefix="@"
+            value={authorHandle}
+          />
+        </div>
+
+        <textarea
+          className="field-sizing-content w-full resize-none whitespace-pre-wrap text-pretty rounded-sm bg-transparent font-sans text-[0.9375rem] text-foreground leading-relaxed outline-none placeholder:text-muted-foreground/80"
+          onChange={(event) => onPostChange(post.id, event.target.value)}
+          onKeyDown={(event) => onPostKeyDown(post.id, event)}
+          placeholder={
+            index === 0 ? "Write the first post…" : "Continue the thread…"
+          }
+          ref={registerTextarea(post.id)}
+          rows={1}
+          value={post.content}
+        />
+
+        <span
+          className={cn(
+            "self-end font-mono text-xs tabular-nums",
+            counterColor
+          )}
+        >
+          {length}/{THREAD_POST_LIMIT}
+        </span>
+      </div>
+
+      <div className="-right-18 absolute top-3 flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/post:opacity-100">
+        {hasMultiplePosts && (
+          <button
+            aria-label={`Drag post ${index + 1}`}
+            className="flex size-7 cursor-grab touch-none items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:cursor-grabbing"
+            ref={setActivatorNodeRef}
+            type="button"
+            {...attributes}
+            {...listeners}
+          >
+            <HugeiconsIcon className="size-4" icon={DragDropVerticalIcon} />
+          </button>
+        )}
+        {showDelete && (
+          <button
+            aria-label={`Delete post ${index + 1}`}
+            className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+            onClick={() => onRemovePost(post.id)}
+            type="button"
+          >
+            <HugeiconsIcon className="size-3.5" icon={Cancel01Icon} />
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/components/threads/thread-builder.tsx
+++ b/apps/web/src/components/threads/thread-builder.tsx
@@ -3,9 +3,8 @@
 import {
   Add01Icon,
   Cancel01Icon,
-  Edit02Icon,
+  DragDropVerticalIcon,
   Image01Icon,
-  Menu02Icon,
   User02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -32,95 +31,19 @@ import {
   THREAD_POST_LIMIT,
   type ThreadPost,
 } from "@/types/threads";
+import { InlineEditable } from "./inline-editable";
 
 const DEFAULT_AUTHOR_NAME = "Your name";
 const DEFAULT_AUTHOR_HANDLE = "yourhandle";
 const LEADING_AT_REGEX = /^@/;
 const WHITESPACE_REGEX = /\s+/;
+const THREAD_POST_SELECTOR = "[data-thread-post-id]";
 
-interface InlineEditableProps {
-  value: string;
-  onChange: (next: string) => void;
-  placeholder: string;
-  prefix?: string;
-  className?: string;
-  ariaLabel: string;
-  maxLength: number;
-}
-
-function InlineEditable({
-  value,
-  onChange,
-  placeholder,
-  prefix,
-  className,
-  ariaLabel,
-  maxLength,
-}: InlineEditableProps) {
-  const [editing, setEditing] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (editing) {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    }
-  }, [editing]);
-
-  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === "Enter" || event.key === "Escape") {
-      event.preventDefault();
-      setEditing(false);
-    }
-  }
-
-  if (editing) {
-    return (
-      <span className="inline-flex items-center">
-        {prefix && (
-          <span className={cn("pointer-events-none", className)}>{prefix}</span>
-        )}
-        <input
-          aria-label={ariaLabel}
-          className={cn(
-            "min-w-4 rounded-sm bg-background px-1 outline-none ring-2 ring-primary/60",
-            className
-          )}
-          maxLength={maxLength}
-          onBlur={() => setEditing(false)}
-          onChange={(event) => onChange(event.target.value)}
-          onKeyDown={handleKeyDown}
-          ref={inputRef}
-          size={Math.max(value.length, placeholder.length, 4)}
-          value={value}
-        />
-      </span>
-    );
-  }
-
-  const display = value.trim() ? value : placeholder;
-  const isPlaceholder = !value.trim();
-  return (
-    <button
-      aria-label={ariaLabel}
-      className={cn(
-        "group/edit inline-flex max-w-full cursor-text items-center gap-1 truncate rounded-sm px-1 text-left transition-colors hover:bg-muted/70 hover:underline hover:decoration-foreground/40 hover:decoration-dashed hover:underline-offset-4 focus-visible:bg-muted/70 focus-visible:outline-none",
-        className,
-        isPlaceholder && "font-normal text-muted-foreground/60"
-      )}
-      onClick={() => setEditing(true)}
-      type="button"
-    >
-      <span className="truncate">
-        {prefix}
-        {display}
-      </span>
-      <HugeiconsIcon
-        className="size-3 shrink-0 opacity-0 transition-opacity group-hover/edit:opacity-100 group-focus-visible/edit:opacity-100"
-        icon={Edit02Icon}
-      />
-    </button>
-  );
+function getAddPostShortcut() {
+  const isMac =
+    typeof navigator !== "undefined" &&
+    navigator.platform.toUpperCase().includes("MAC");
+  return isMac ? "⌘ + Enter" : "Ctrl + Enter";
 }
 
 export default function ThreadBuilder() {
@@ -132,6 +55,8 @@ export default function ThreadBuilder() {
   const [dragOverId, setDragOverId] = useState<string | null>(null);
 
   const avatarInputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLOListElement>(null);
+  const completedDropRef = useRef(false);
   const textareaRefs = useRef(new Map<string, HTMLTextAreaElement>());
   const focusNextRef = useRef<string | null>(null);
 
@@ -144,6 +69,7 @@ export default function ThreadBuilder() {
   }, [authorAvatar]);
 
   const trimmedName = authorName.trim();
+  const addPostShortcut = getAddPostShortcut();
   const previewName = trimmedName || DEFAULT_AUTHOR_NAME;
   const previewHandle =
     authorHandle.trim().replace(LEADING_AT_REGEX, "") || DEFAULT_AUTHOR_HANDLE;
@@ -222,30 +148,13 @@ export default function ThreadBuilder() {
   }
 
   function handleDragStart(id: string, event: DragEvent<HTMLElement>) {
+    completedDropRef.current = false;
     setDragId(id);
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("text/plain", id);
   }
 
-  function handleDragOver(id: string, event: DragEvent<HTMLLIElement>) {
-    if (!dragId) {
-      return;
-    }
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "move";
-    if (dragOverId !== id) {
-      setDragOverId(id);
-    }
-  }
-
-  function handleDrop(targetId: string, event: DragEvent<HTMLLIElement>) {
-    event.preventDefault();
-    const sourceId = dragId ?? event.dataTransfer.getData("text/plain");
-    setDragId(null);
-    setDragOverId(null);
-    if (!sourceId || sourceId === targetId) {
-      return;
-    }
+  function movePost(sourceId: string, targetId: string) {
     setPosts((current) => {
       const fromIndex = current.findIndex((post) => post.id === sourceId);
       const toIndex = current.findIndex((post) => post.id === targetId);
@@ -263,9 +172,93 @@ export default function ThreadBuilder() {
     });
   }
 
-  function handleDragEnd() {
+  function getPostIdFromY(clientY: number, list = listRef.current) {
+    if (!list) {
+      return null;
+    }
+    const items = Array.from(
+      list.querySelectorAll<HTMLElement>(THREAD_POST_SELECTOR)
+    );
+    let closestId: string | null = null;
+    let closestDistance = Number.POSITIVE_INFINITY;
+
+    for (const item of items) {
+      const rect = item.getBoundingClientRect();
+      const itemCenter = rect.top + rect.height / 2;
+      const distance = Math.abs(clientY - itemCenter);
+
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        closestId = item.dataset.threadPostId ?? null;
+      }
+    }
+
+    return closestId;
+  }
+
+  function handleDragOver(event: DragEvent<HTMLOListElement>) {
+    if (!dragId) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const targetId = getPostIdFromY(event.clientY, event.currentTarget);
+    if (targetId && dragOverId !== targetId) {
+      setDragOverId(targetId);
+    }
+  }
+
+  function handleTargetDragOver(id: string, event: DragEvent<HTMLElement>) {
+    if (!dragId) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "move";
+    if (dragOverId !== id) {
+      setDragOverId(id);
+    }
+  }
+
+  function handleTargetDrop(targetId: string, event: DragEvent<HTMLElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    const sourceId = dragId ?? event.dataTransfer.getData("text/plain");
     setDragId(null);
     setDragOverId(null);
+    if (!(sourceId && targetId) || sourceId === targetId) {
+      return;
+    }
+    completedDropRef.current = true;
+    movePost(sourceId, targetId);
+  }
+
+  function handleDrop(event: DragEvent<HTMLOListElement>) {
+    event.preventDefault();
+    const sourceId = dragId ?? event.dataTransfer.getData("text/plain");
+    const targetId = dragOverId ?? getPostIdFromY(event.clientY);
+    setDragId(null);
+    setDragOverId(null);
+    if (!(sourceId && targetId) || sourceId === targetId) {
+      return;
+    }
+    completedDropRef.current = true;
+    movePost(sourceId, targetId);
+  }
+
+  function handleDragEnd(sourceId: string, event: DragEvent<HTMLElement>) {
+    if (completedDropRef.current) {
+      completedDropRef.current = false;
+      setDragId(null);
+      setDragOverId(null);
+      return;
+    }
+    const targetId = dragOverId ?? getPostIdFromY(event.clientY);
+    setDragId(null);
+    setDragOverId(null);
+    if (targetId && sourceId !== targetId) {
+      movePost(sourceId, targetId);
+    }
   }
 
   function handlePostKeyDown(
@@ -279,7 +272,7 @@ export default function ThreadBuilder() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-2xl rounded-2xl border border-border bg-card p-3 shadow-sm sm:p-5">
+    <div className="mx-auto w-full max-w-2xl p-3 sm:p-5">
       <input
         accept="image/*"
         className="hidden"
@@ -288,12 +281,17 @@ export default function ThreadBuilder() {
         type="file"
       />
 
-      <ol className="relative flex flex-col">
-        <div
-          aria-hidden
-          className="pointer-events-none absolute top-10 bottom-10 left-7 w-px bg-border"
-        />
+      <p className="mb-5 text-center font-normal font-sans text-muted-foreground text-xs leading-5">
+        Click the name, handle, or avatar to customize the author.
+      </p>
 
+      {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: list handles native drag-and-drop targets; reorder controls remain keyboard accessible */}
+      <ol
+        className="relative flex flex-col gap-2"
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        ref={listRef}
+      >
         {posts.map((post, index) => {
           const isDragging = dragId === post.id;
           const isDropTarget =
@@ -310,19 +308,26 @@ export default function ThreadBuilder() {
           const isSoloEmpty = posts.length === 1 && length === 0;
           const showDelete = !isSoloEmpty;
           const showDrag = hasMultiplePosts;
+          const showConnector = index < posts.length - 1;
 
           return (
-            // biome-ignore lint/a11y/noNoninteractiveElementInteractions: list item acts as a drag-and-drop target; reorder is also accessible via per-item buttons
             <li
               className={cn(
-                "group/post relative flex gap-3 rounded-lg px-2 py-3 transition-colors focus-within:bg-muted/50 hover:bg-muted/40",
+                "group/post relative flex gap-3 rounded-xl p-3 transition-colors focus-within:bg-muted/50 hover:bg-muted/40",
                 isDragging && "opacity-50",
                 isDropTarget && "bg-primary/5 ring-1 ring-primary/40"
               )}
+              data-thread-post-id={post.id}
               key={post.id}
-              onDragOver={(event) => handleDragOver(post.id, event)}
-              onDrop={(event) => handleDrop(post.id, event)}
             >
+              {showConnector && (
+                <div
+                  aria-hidden
+                  className="-translate-x-1/2 pointer-events-none absolute top-13 bottom-[-1.375rem] left-8 w-px bg-border"
+                  data-thread-connector
+                />
+              )}
+
               <button
                 aria-label="Change avatar"
                 className="group/avatar relative z-10 size-10 shrink-0 cursor-pointer rounded-full bg-background outline-none focus-visible:ring-2 focus-visible:ring-primary"
@@ -344,7 +349,7 @@ export default function ThreadBuilder() {
                 </span>
               </button>
 
-              <div className="flex min-w-0 flex-1 flex-col gap-1 pt-0.5">
+              <div className="flex min-w-0 flex-1 flex-col gap-1 pt-1">
                 <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
                   <InlineEditable
                     ariaLabel="Edit display name"
@@ -389,17 +394,26 @@ export default function ThreadBuilder() {
                 </span>
               </div>
 
-              <div className="absolute top-3 right-2 flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/post:opacity-100">
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: controls rail is part of the native drag-and-drop target area */}
+              {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: controls rail catches drops released outside the card body */}
+              <div
+                className="-right-18 absolute top-3 flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/post:opacity-100"
+                onDragOver={(event) => handleTargetDragOver(post.id, event)}
+                onDrop={(event) => handleTargetDrop(post.id, event)}
+              >
                 {showDrag && (
                   <button
                     aria-label={`Drag post ${index + 1}`}
                     className="flex size-7 cursor-grab items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:cursor-grabbing"
                     draggable
-                    onDragEnd={handleDragEnd}
+                    onDragEnd={(event) => handleDragEnd(post.id, event)}
                     onDragStart={(event) => handleDragStart(post.id, event)}
                     type="button"
                   >
-                    <HugeiconsIcon className="size-4" icon={Menu02Icon} />
+                    <HugeiconsIcon
+                      className="size-4"
+                      icon={DragDropVerticalIcon}
+                    />
                   </button>
                 )}
                 {showDelete && (
@@ -418,15 +432,7 @@ export default function ThreadBuilder() {
         })}
       </ol>
 
-      <div className="mt-4 flex flex-col-reverse items-stretch gap-3 pl-13 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-0.5">
-          <p className="font-normal font-sans text-muted-foreground text-xs leading-5">
-            Click the name, handle, or avatar to customize the author.
-          </p>
-          <p className="hidden font-normal font-sans text-muted-foreground/70 text-xs leading-5 sm:block">
-            Shortcut: ⌘/Ctrl + Enter adds a post.
-          </p>
-        </div>
+      <div className="mt-8 flex flex-col-reverse items-stretch gap-3 sm:flex-col sm:items-center sm:justify-between">
         <Button
           className="sm:w-auto"
           onClick={() => addPostAfter()}
@@ -436,6 +442,10 @@ export default function ThreadBuilder() {
           <HugeiconsIcon className="size-3.5" icon={Add01Icon} />
           <span>Add post</span>
         </Button>
+        <p className="hidden font-normal font-sans text-muted-foreground/70 text-xs leading-5 sm:block">
+          <span suppressHydrationWarning>{addPostShortcut}</span> when an input
+          is focused adds a post.
+        </p>
       </div>
     </div>
   );

--- a/apps/web/src/components/threads/thread-builder.tsx
+++ b/apps/web/src/components/threads/thread-builder.tsx
@@ -1,23 +1,27 @@
 "use client";
 
 import {
-  Add01Icon,
-  Cancel01Icon,
-  DragDropVerticalIcon,
-  Image01Icon,
-  User02Icon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@notra/ui/components/ui/avatar";
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@notra/ui/components/ui/button";
-import { cn } from "@notra/ui/lib/utils";
 import {
   type ChangeEvent,
-  type DragEvent,
   type KeyboardEvent,
   useCallback,
   useEffect,
@@ -25,19 +29,13 @@ import {
   useState,
 } from "react";
 import { createEmptyPost, createSeedThread } from "@/lib/threads/posts";
-import {
-  AUTHOR_HANDLE_LIMIT,
-  AUTHOR_NAME_LIMIT,
-  THREAD_POST_LIMIT,
-  type ThreadPost,
-} from "@/types/threads";
-import { InlineEditable } from "./inline-editable";
+import type { ThreadPost } from "@/types/threads";
+import { SortableThreadPost } from "./sortable-thread-post";
 
 const DEFAULT_AUTHOR_NAME = "Your name";
 const DEFAULT_AUTHOR_HANDLE = "yourhandle";
 const LEADING_AT_REGEX = /^@/;
 const WHITESPACE_REGEX = /\s+/;
-const THREAD_POST_SELECTOR = "[data-thread-post-id]";
 
 function getAddPostShortcut() {
   const isMac =
@@ -55,10 +53,16 @@ export default function ThreadBuilder() {
   const [dragOverId, setDragOverId] = useState<string | null>(null);
 
   const avatarInputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLOListElement>(null);
-  const completedDropRef = useRef(false);
   const textareaRefs = useRef(new Map<string, HTMLTextAreaElement>());
   const focusNextRef = useRef<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
 
   useEffect(() => {
     return () => {
@@ -147,118 +151,35 @@ export default function ThreadBuilder() {
     setAuthorHandle(next.replace(LEADING_AT_REGEX, ""));
   }
 
-  function handleDragStart(id: string, event: DragEvent<HTMLElement>) {
-    completedDropRef.current = false;
-    setDragId(id);
-    event.dataTransfer.effectAllowed = "move";
-    event.dataTransfer.setData("text/plain", id);
+  function handleDragStart(event: DragStartEvent) {
+    setDragId(String(event.active.id));
   }
 
-  function movePost(sourceId: string, targetId: string) {
+  function handleDragOver(event: DragOverEvent) {
+    setDragOverId(event.over ? String(event.over.id) : null);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    setDragId(null);
+    setDragOverId(null);
+    if (!over || active.id === over.id) {
+      return;
+    }
+
     setPosts((current) => {
-      const fromIndex = current.findIndex((post) => post.id === sourceId);
-      const toIndex = current.findIndex((post) => post.id === targetId);
-      if (fromIndex === -1 || toIndex === -1) {
+      const oldIndex = current.findIndex((post) => post.id === active.id);
+      const newIndex = current.findIndex((post) => post.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) {
         return current;
       }
-      const moved = current[fromIndex];
-      if (!moved) {
-        return current;
-      }
-      const next = current.slice();
-      next.splice(fromIndex, 1);
-      next.splice(toIndex, 0, moved);
-      return next;
+      return arrayMove(current, oldIndex, newIndex);
     });
   }
 
-  function getPostIdFromY(clientY: number, list = listRef.current) {
-    if (!list) {
-      return null;
-    }
-    const items = Array.from(
-      list.querySelectorAll<HTMLElement>(THREAD_POST_SELECTOR)
-    );
-    let closestId: string | null = null;
-    let closestDistance = Number.POSITIVE_INFINITY;
-
-    for (const item of items) {
-      const rect = item.getBoundingClientRect();
-      const itemCenter = rect.top + rect.height / 2;
-      const distance = Math.abs(clientY - itemCenter);
-
-      if (distance < closestDistance) {
-        closestDistance = distance;
-        closestId = item.dataset.threadPostId ?? null;
-      }
-    }
-
-    return closestId;
-  }
-
-  function handleDragOver(event: DragEvent<HTMLOListElement>) {
-    if (!dragId) {
-      return;
-    }
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "move";
-    const targetId = getPostIdFromY(event.clientY, event.currentTarget);
-    if (targetId && dragOverId !== targetId) {
-      setDragOverId(targetId);
-    }
-  }
-
-  function handleTargetDragOver(id: string, event: DragEvent<HTMLElement>) {
-    if (!dragId) {
-      return;
-    }
-    event.preventDefault();
-    event.stopPropagation();
-    event.dataTransfer.dropEffect = "move";
-    if (dragOverId !== id) {
-      setDragOverId(id);
-    }
-  }
-
-  function handleTargetDrop(targetId: string, event: DragEvent<HTMLElement>) {
-    event.preventDefault();
-    event.stopPropagation();
-    const sourceId = dragId ?? event.dataTransfer.getData("text/plain");
+  function handleDragCancel() {
     setDragId(null);
     setDragOverId(null);
-    if (!(sourceId && targetId) || sourceId === targetId) {
-      return;
-    }
-    completedDropRef.current = true;
-    movePost(sourceId, targetId);
-  }
-
-  function handleDrop(event: DragEvent<HTMLOListElement>) {
-    event.preventDefault();
-    const sourceId = dragId ?? event.dataTransfer.getData("text/plain");
-    const targetId = dragOverId ?? getPostIdFromY(event.clientY);
-    setDragId(null);
-    setDragOverId(null);
-    if (!(sourceId && targetId) || sourceId === targetId) {
-      return;
-    }
-    completedDropRef.current = true;
-    movePost(sourceId, targetId);
-  }
-
-  function handleDragEnd(sourceId: string, event: DragEvent<HTMLElement>) {
-    if (completedDropRef.current) {
-      completedDropRef.current = false;
-      setDragId(null);
-      setDragOverId(null);
-      return;
-    }
-    const targetId = dragOverId ?? getPostIdFromY(event.clientY);
-    setDragId(null);
-    setDragOverId(null);
-    if (targetId && sourceId !== targetId) {
-      movePost(sourceId, targetId);
-    }
   }
 
   function handlePostKeyDown(
@@ -285,152 +206,45 @@ export default function ThreadBuilder() {
         Click the name, handle, or avatar to customize the author.
       </p>
 
-      {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: list handles native drag-and-drop targets; reorder controls remain keyboard accessible */}
-      <ol
-        className="relative flex flex-col gap-2"
+      <DndContext
+        collisionDetection={closestCenter}
+        onDragCancel={handleDragCancel}
+        onDragEnd={handleDragEnd}
         onDragOver={handleDragOver}
-        onDrop={handleDrop}
-        ref={listRef}
+        onDragStart={handleDragStart}
+        sensors={sensors}
       >
-        {posts.map((post, index) => {
-          const isDragging = dragId === post.id;
-          const isDropTarget =
-            dragOverId === post.id && dragId !== null && dragId !== post.id;
-          const length = post.content.length;
-          const overLimit = length > THREAD_POST_LIMIT;
-          const nearLimit = length > THREAD_POST_LIMIT - 20;
-          let counterColor = "text-muted-foreground/70";
-          if (overLimit) {
-            counterColor = "text-destructive";
-          } else if (nearLimit) {
-            counterColor = "text-amber-500";
-          }
-          const isSoloEmpty = posts.length === 1 && length === 0;
-          const showDelete = !isSoloEmpty;
-          const showDrag = hasMultiplePosts;
-          const showConnector = index < posts.length - 1;
-
-          return (
-            <li
-              className={cn(
-                "group/post relative flex gap-3 rounded-xl p-3 transition-colors focus-within:bg-muted/50 hover:bg-muted/40",
-                isDragging && "opacity-50",
-                isDropTarget && "bg-primary/5 ring-1 ring-primary/40"
-              )}
-              data-thread-post-id={post.id}
-              key={post.id}
-            >
-              {showConnector && (
-                <div
-                  aria-hidden
-                  className="-translate-x-1/2 pointer-events-none absolute top-13 bottom-[-1.375rem] left-8 w-px bg-border"
-                  data-thread-connector
-                />
-              )}
-
-              <button
-                aria-label="Change avatar"
-                className="group/avatar relative z-10 size-10 shrink-0 cursor-pointer rounded-full bg-background outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                onClick={() => avatarInputRef.current?.click()}
-                type="button"
-              >
-                <Avatar className="size-10" size="lg">
-                  {authorAvatar && (
-                    <AvatarImage alt={previewName} src={authorAvatar} />
-                  )}
-                  <AvatarFallback className="bg-muted text-muted-foreground text-xs">
-                    {avatarInitials || (
-                      <HugeiconsIcon className="size-4" icon={User02Icon} />
-                    )}
-                  </AvatarFallback>
-                </Avatar>
-                <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-foreground/55 text-background opacity-0 transition-opacity group-hover/avatar:opacity-100 group-focus-visible/avatar:opacity-100">
-                  <HugeiconsIcon className="size-4" icon={Image01Icon} />
-                </span>
-              </button>
-
-              <div className="flex min-w-0 flex-1 flex-col gap-1 pt-1">
-                <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
-                  <InlineEditable
-                    ariaLabel="Edit display name"
-                    className="max-w-[14rem] font-sans font-semibold text-foreground text-sm leading-tight"
-                    maxLength={AUTHOR_NAME_LIMIT}
-                    onChange={setAuthorName}
-                    placeholder={DEFAULT_AUTHOR_NAME}
-                    value={authorName}
-                  />
-                  <InlineEditable
-                    ariaLabel="Edit handle"
-                    className="max-w-[10rem] font-sans text-muted-foreground text-sm leading-tight"
-                    maxLength={AUTHOR_HANDLE_LIMIT}
-                    onChange={handleHandleChange}
-                    placeholder={DEFAULT_AUTHOR_HANDLE}
-                    prefix="@"
-                    value={authorHandle}
-                  />
-                </div>
-
-                <textarea
-                  className="field-sizing-content w-full resize-none whitespace-pre-wrap text-pretty rounded-sm bg-transparent font-sans text-[0.9375rem] text-foreground leading-relaxed outline-none placeholder:text-muted-foreground/80"
-                  onChange={(event) => updatePost(post.id, event.target.value)}
-                  onKeyDown={(event) => handlePostKeyDown(post.id, event)}
-                  placeholder={
-                    index === 0
-                      ? "Write the first post…"
-                      : "Continue the thread…"
-                  }
-                  ref={registerTextarea(post.id)}
-                  rows={1}
-                  value={post.content}
-                />
-
-                <span
-                  className={cn(
-                    "self-end font-mono text-xs tabular-nums",
-                    counterColor
-                  )}
-                >
-                  {length}/{THREAD_POST_LIMIT}
-                </span>
-              </div>
-
-              {/* biome-ignore lint/a11y/noStaticElementInteractions: controls rail is part of the native drag-and-drop target area */}
-              {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: controls rail catches drops released outside the card body */}
-              <div
-                className="-right-18 absolute top-3 flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/post:opacity-100"
-                onDragOver={(event) => handleTargetDragOver(post.id, event)}
-                onDrop={(event) => handleTargetDrop(post.id, event)}
-              >
-                {showDrag && (
-                  <button
-                    aria-label={`Drag post ${index + 1}`}
-                    className="flex size-7 cursor-grab items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:cursor-grabbing"
-                    draggable
-                    onDragEnd={(event) => handleDragEnd(post.id, event)}
-                    onDragStart={(event) => handleDragStart(post.id, event)}
-                    type="button"
-                  >
-                    <HugeiconsIcon
-                      className="size-4"
-                      icon={DragDropVerticalIcon}
-                    />
-                  </button>
-                )}
-                {showDelete && (
-                  <button
-                    aria-label={`Delete post ${index + 1}`}
-                    className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                    onClick={() => removePost(post.id)}
-                    type="button"
-                  >
-                    <HugeiconsIcon className="size-3.5" icon={Cancel01Icon} />
-                  </button>
-                )}
-              </div>
-            </li>
-          );
-        })}
-      </ol>
+        <SortableContext
+          items={posts.map((post) => post.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <ol className="relative flex flex-col gap-2">
+            {posts.map((post, index) => (
+              <SortableThreadPost
+                authorAvatar={authorAvatar}
+                authorHandle={authorHandle}
+                authorInitials={avatarInitials}
+                authorName={authorName}
+                avatarInputRef={avatarInputRef}
+                dragId={dragId}
+                dragOverId={dragOverId}
+                hasMultiplePosts={hasMultiplePosts}
+                index={index}
+                key={post.id}
+                onAuthorHandleChange={handleHandleChange}
+                onAuthorNameChange={setAuthorName}
+                onPostChange={updatePost}
+                onPostKeyDown={handlePostKeyDown}
+                onRemovePost={removePost}
+                post={post}
+                postsCount={posts.length}
+                previewName={previewName}
+                registerTextarea={registerTextarea}
+              />
+            ))}
+          </ol>
+        </SortableContext>
+      </DndContext>
 
       <div className="mt-8 flex flex-col-reverse items-stretch gap-3 sm:flex-col sm:items-center sm:justify-between">
         <Button

--- a/bun.lock
+++ b/bun.lock
@@ -164,6 +164,9 @@
       "dependencies": {
         "@c15t/nextjs": "^2.0.4",
         "@databuddy/sdk": "^2.4.11",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@dualmark/converters": "0.5.0",
         "@dualmark/nextjs": "0.5.1",
         "@hugeicons/core-free-icons": "^4.1.1",
@@ -652,6 +655,14 @@
     "@databuddy/sdk": ["@databuddy/sdk@2.4.11", "", { "peerDependencies": { "react": ">=18", "vue": ">=3" }, "optionalPeers": ["react", "vue"] }, "sha512-pDT0tfsLOhuFnX0MHSOOt+qq9IPAB7rktuWclVgaRU3D6A6Mw7pN0oRttvPPKc3Ue7gUvq3kOtFkhmquLtmVQA=="],
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.65.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.4", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-v4FA/Lw3pTEloLxBqTOaYDX6MNo0Jo7lGBsPZhwnJBqRJp0AzQg1ZZNxrFsh6HVC6QWeWrfIKLn0y2eyIXaVDg=="],
 
@@ -1809,7 +1820,7 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -3129,7 +3140,7 @@
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
-    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
 
@@ -4345,8 +4356,6 @@
 
     "@upstash/workflow/@upstash/qstash": ["@upstash/qstash@2.10.1", "", { "dependencies": { "crypto-js": ">=4.2.0", "jose": "^5.2.3", "neverthrow": "^7.0.1" } }, "sha512-LsTAPxPk0dFvhlEnRqwObRS94b8mmDHYaBlF3IaONUL+Scq6i9cZraA6936KSUVe+Vq3eNQle3CjOZkStPUFTw=="],
 
-    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -4403,13 +4412,13 @@
 
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "engine.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "engine.io/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
-    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -4546,6 +4555,8 @@
     "simple-swizzle/is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
@@ -4809,6 +4820,8 @@
 
     "@mintlify/previewing/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "@mintlify/previewing/express/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "@mintlify/previewing/express/body-parser": ["body-parser@1.20.5", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.15.1", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA=="],
 
     "@mintlify/previewing/express/content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
@@ -4836,6 +4849,8 @@
     "@mintlify/previewing/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "@mintlify/previewing/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "@mintlify/previewing/socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "@mintlify/previewing/socket.io/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
@@ -4933,8 +4948,6 @@
 
     "@tanstack/react-pacer/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.8.1", "", {}, "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw=="],
 
-    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "better-opn/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
@@ -4955,7 +4968,9 @@
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
-    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "engine.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "engine.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "favicons/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
 
@@ -5110,6 +5125,10 @@
     "public-ip/got/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "react-email/nypm/citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "socket.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "tsc-alias/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -5317,6 +5336,10 @@
 
     "@mintlify/previewing/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "@mintlify/previewing/express/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@mintlify/previewing/express/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
     "@mintlify/previewing/express/body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "@mintlify/previewing/express/body-parser/qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
@@ -5328,6 +5351,10 @@
     "@mintlify/previewing/express/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
     "@mintlify/previewing/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@mintlify/previewing/socket.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@mintlify/previewing/socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "@mintlify/previewing/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -5393,6 +5420,8 @@
 
     "@supermemory/tools/ai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "engine.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "inquirer/@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "inquirer/@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -5410,6 +5439,8 @@
     "openai/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "openai/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "tsc-alias/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -5477,7 +5508,11 @@
 
     "@mintlify/prebuild/@mintlify/scraping/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@mintlify/previewing/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "@mintlify/previewing/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@mintlify/previewing/socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "@mintlify/previewing/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 


### PR DESCRIPTION
## Summary
- reorganize the thread builder into components/threads and extract inline editing
- refine thread builder UX copy, shortcut display, inline editing, and connector behavior
- ignore generated dashboard workflow output in Knip so pre-commit passes

## Checks
- bun x ultracite check apps/dashboard/knip.json apps/web/src/app/threads/page.tsx apps/web/src/components/threads/thread-builder.tsx apps/web/src/components/threads/inline-editable.tsx
- bun run knip (from apps/dashboard)
- pre-commit hook via git commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the thread builder UX with inline editing and accessible drag-and-drop. Adopts `@dnd-kit` for smoother, keyboard-friendly reordering and clearer author customization.

- **New Features**
  - `InlineEditable`: auto-width measuring, Enter/Escape to exit, cleaner placeholder.
  - Drag-and-drop via `@dnd-kit`: pointer + keyboard reordering, center collision, visual drop state, vertical drag handle.
  - Guidance: “Click the name, handle, or avatar…” and a platform-aware add‑post shortcut when inputs are focused.

- **Refactors**
  - Moved builder to `components/threads/thread-builder` and extracted `SortableThreadPost`; updated `threads/page.tsx` import.
  - Simplified layout and connector rendering; adjusted spacing and focus/hover styles.
  - Added `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`; updated `apps/dashboard/knip.json` to ignore `src/app/.well-known/**`.

<sup>Written for commit 1c5d4521bb28a04ef2e257f0cb8fa4ca12d27585. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

