### PR TITLE
feat(dashboard): redesign create-content as 3-step wizard

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -50,7 +50,6 @@
     "@tanstack/react-pacer": "^0.19.0",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-devtools": "^5.91.2",
-    "@tanstack/react-store": "^0.9.2",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.14",
     "@toolwind/corner-shape": "^0.0.8-3",

--- a/apps/dashboard/src/app/(auth-public)/invitation/[id]/page.tsx
+++ b/apps/dashboard/src/app/(auth-public)/invitation/[id]/page.tsx
@@ -39,17 +39,17 @@ async function InvitePageComponent({ invitationId }: { invitationId: string }) {
 
   // If invitation is expired or already accepted/rejected, show error
   if (invitationData.expired || invitationData.status !== "pending") {
+    let initialError = "This invitation is no longer valid.";
+    if (invitationData.expired) {
+      initialError = "This invitation has expired.";
+    } else if (invitationData.status === "accepted") {
+      initialError = "This invitation has already been accepted.";
+    } else if (invitationData.status === "rejected") {
+      initialError = "This invitation has been declined.";
+    }
     return (
       <PageClient
-        initialError={
-          invitationData.expired
-            ? "This invitation has expired."
-            : invitationData.status === "accepted"
-              ? "This invitation has already been accepted."
-              : invitationData.status === "rejected"
-                ? "This invitation has been declined."
-                : "This invitation is no longer valid."
-        }
+        initialError={initialError}
         invitation={invitationData}
         invitationId={invitationId}
         user={session?.user ?? null}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -790,11 +790,14 @@ export default function PageClient({
                   className="size-4"
                   icon={content.status === "published" ? TextIcon : SentIcon}
                 />
-                {isTogglingStatus
-                  ? "Updating..."
-                  : content.status === "published"
+                {(() => {
+                  if (isTogglingStatus) {
+                    return "Updating...";
+                  }
+                  return content.status === "published"
                     ? "Move to draft"
-                    : "Publish"}
+                    : "Publish";
+                })()}
               </Button>
               {content.contentType === "linkedin_post" && (
                 <Button

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page-client.tsx
@@ -334,17 +334,18 @@ function EventsSection({
           </Link>
         )}
       </div>
-      {isLoadingEvents ? (
-        <Skeleton className="h-18 w-full rounded-lg" />
-      ) : isError ? (
+      {isLoadingEvents && <Skeleton className="h-18 w-full rounded-lg" />}
+      {!isLoadingEvents && isError && (
         <div className="flex items-center justify-center rounded-lg border border-destructive/50 border-dashed p-8 text-destructive text-sm">
           Failed to load event triggers.
         </div>
-      ) : displayEvents.length === 0 ? (
+      )}
+      {!isLoadingEvents && !isError && displayEvents.length === 0 && (
         <div className="flex items-center justify-center rounded-lg border border-dashed p-8 text-muted-foreground text-sm">
           No event triggers configured yet.
         </div>
-      ) : (
+      )}
+      {!isLoadingEvents && !isError && displayEvents.length > 0 && (
         <div className="divide-y rounded-lg border">
           {displayEvents.map((event) => (
             <div
@@ -427,17 +428,18 @@ function SchedulesSection({
           </Link>
         )}
       </div>
-      {isLoadingSchedules ? (
-        <Skeleton className="h-18 w-full rounded-lg" />
-      ) : isError ? (
+      {isLoadingSchedules && <Skeleton className="h-18 w-full rounded-lg" />}
+      {!isLoadingSchedules && isError && (
         <div className="flex items-center justify-center rounded-lg border border-destructive/50 border-dashed p-8 text-destructive text-sm">
           Failed to load schedules.
         </div>
-      ) : displaySchedules.length === 0 ? (
+      )}
+      {!isLoadingSchedules && !isError && displaySchedules.length === 0 && (
         <div className="flex items-center justify-center rounded-lg border border-dashed p-8 text-muted-foreground text-sm">
           No schedules configured yet.
         </div>
-      ) : (
+      )}
+      {!isLoadingSchedules && !isError && displaySchedules.length > 0 && (
         <div className="divide-y rounded-lg border">
           {displaySchedules.map((schedule) => (
             <div

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
@@ -330,79 +330,83 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
           <TabsContent value="installed">
             <div className="space-y-8 pt-4">
-              {isPending ? (
-                <IntegrationsPageSkeleton />
-              ) : inputIntegrations.length === 0 &&
-                outputIntegrations.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <p className="text-muted-foreground">
-                    No integrations installed yet.
-                  </p>
-                  <p className="text-muted-foreground text-sm">
-                    Switch to the "All" tab to browse and connect integrations.
-                  </p>
-                </div>
-              ) : (
-                <>
-                  {inputIntegrations.length > 0 && (
-                    <section>
-                      <h2 className="mb-4 font-semibold text-lg">
-                        Input Sources
-                      </h2>
-                      <p className="mb-4 text-muted-foreground text-sm">
-                        Connected services pulling data and updates
-                      </p>
-                      <div className="grid gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
-                        {inputIntegrations.map((integration) => {
-                          const config = ALL_INTEGRATIONS.find(
-                            (i) => i.id === integration.type
-                          );
-                          return (
-                            <InstalledIntegrationCard
-                              accentColor={config?.accentColor}
-                              icon={config?.icon}
-                              integration={integration}
-                              key={integration.id}
-                              onUpdate={() => refetch()}
-                              organizationId={organizationId}
-                              organizationSlug={organizationSlug}
-                            />
-                          );
-                        })}
-                      </div>
-                    </section>
-                  )}
+              {isPending && <IntegrationsPageSkeleton />}
+              {!isPending &&
+                inputIntegrations.length === 0 &&
+                outputIntegrations.length === 0 && (
+                  <div className="flex flex-col items-center justify-center py-12 text-center">
+                    <p className="text-muted-foreground">
+                      No integrations installed yet.
+                    </p>
+                    <p className="text-muted-foreground text-sm">
+                      Switch to the "All" tab to browse and connect
+                      integrations.
+                    </p>
+                  </div>
+                )}
+              {!isPending &&
+                (inputIntegrations.length > 0 ||
+                  outputIntegrations.length > 0) && (
+                  <>
+                    {inputIntegrations.length > 0 && (
+                      <section>
+                        <h2 className="mb-4 font-semibold text-lg">
+                          Input Sources
+                        </h2>
+                        <p className="mb-4 text-muted-foreground text-sm">
+                          Connected services pulling data and updates
+                        </p>
+                        <div className="grid gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
+                          {inputIntegrations.map((integration) => {
+                            const config = ALL_INTEGRATIONS.find(
+                              (i) => i.id === integration.type
+                            );
+                            return (
+                              <InstalledIntegrationCard
+                                accentColor={config?.accentColor}
+                                icon={config?.icon}
+                                integration={integration}
+                                key={integration.id}
+                                onUpdate={() => refetch()}
+                                organizationId={organizationId}
+                                organizationSlug={organizationSlug}
+                              />
+                            );
+                          })}
+                        </div>
+                      </section>
+                    )}
 
-                  {outputIntegrations.length > 0 && (
-                    <section>
-                      <h2 className="mb-4 font-semibold text-lg">
-                        Output Sources
-                      </h2>
-                      <p className="mb-4 text-muted-foreground text-sm">
-                        Connected services publishing and syncing content
-                      </p>
-                      <div className="grid gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
-                        {outputIntegrations.map((integration) => {
-                          const config = ALL_INTEGRATIONS.find(
-                            (i) => i.id === integration.type
-                          );
-                          return (
-                            <InstalledIntegrationCard
-                              accentColor={config?.accentColor}
-                              icon={config?.icon}
-                              integration={integration}
-                              key={integration.id}
-                              onUpdate={() => refetch()}
-                              organizationId={organizationId}
-                              organizationSlug={organizationSlug}
-                            />
-                          );
-                        })}
-                      </div>
-                    </section>
-                  )}
-                </>
-              )}
+                    {outputIntegrations.length > 0 && (
+                      <section>
+                        <h2 className="mb-4 font-semibold text-lg">
+                          Output Sources
+                        </h2>
+                        <p className="mb-4 text-muted-foreground text-sm">
+                          Connected services publishing and syncing content
+                        </p>
+                        <div className="grid gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
+                          {outputIntegrations.map((integration) => {
+                            const config = ALL_INTEGRATIONS.find(
+                              (i) => i.id === integration.type
+                            );
+                            return (
+                              <InstalledIntegrationCard
+                                accentColor={config?.accentColor}
+                                icon={config?.icon}
+                                integration={integration}
+                                key={integration.id}
+                                onUpdate={() => refetch()}
+                                organizationId={organizationId}
+                                organizationSlug={organizationSlug}
+                              />
+                            );
+                          })}
+                        </div>
+                      </section>
+                    )}
+                  </>
+                )}
             </div>
           </TabsContent>
         </Tabs>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
@@ -90,7 +90,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const has14DayRetention = customer
     ? check({ featureId: FEATURES.LOG_RETENTION_14_DAYS }).allowed
     : false;
-  const logRetentionDays = has30DayRetention ? 30 : has14DayRetention ? 14 : 7;
+  let logRetentionDays = 7;
+  if (has30DayRetention) {
+    logRetentionDays = 30;
+  } else if (has14DayRetention) {
+    logRetentionDays = 14;
+  }
 
   const resetPage = () => {
     if (page !== 1) {

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/success/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/success/page.tsx
@@ -20,12 +20,12 @@ export default function BillingSuccessPage() {
     (sub) => !sub.addOn && sub.status === "active"
   );
   const planId = activeSubscription?.plan?.id ?? activeSubscription?.planId;
-  const planName =
-    planId === "pro" || planId === "pro_yearly"
-      ? "Pro"
-      : planId === "basic" || planId === "basic_yearly"
-        ? "Basic"
-        : "your new plan";
+  let planName = "your new plan";
+  if (planId === "pro" || planId === "pro_yearly") {
+    planName = "Pro";
+  } else if (planId === "basic" || planId === "basic_yearly") {
+    planName = "Basic";
+  }
 
   async function handleManageBilling() {
     try {

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
@@ -283,13 +283,14 @@ export default function PageClient({ slug, name }: PageClientProps) {
           )}
         </div>
 
-        {organizationId && isPending ? (
+        {organizationId && isPending && (
           <div className="space-y-4">
             <Skeleton className="h-10 w-full" />
             <Skeleton className="h-20 w-full" />
             <Skeleton className="h-96 w-full" />
           </div>
-        ) : skill ? (
+        )}
+        {!(organizationId && isPending) && skill && (
           <div className="space-y-4">
             <Field>
               <FieldLabel>Name</FieldLabel>
@@ -348,7 +349,7 @@ export default function PageClient({ slug, name }: PageClientProps) {
               </Tabs>
             </Field>
           </div>
-        ) : null}
+        )}
       </div>
 
       <ResponsiveAlertDialog onOpenChange={setDeleteOpen} open={deleteOpen}>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -152,6 +152,8 @@ export default function PageClient({ slug }: PageClientProps) {
     }));
   };
 
+  const isLoadingSkills = !!organizationId && isPending;
+
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
@@ -169,7 +171,7 @@ export default function PageClient({ slug }: PageClientProps) {
           </Button>
         </div>
 
-        {organizationId && isPending && (
+        {isLoadingSkills && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton cards
@@ -182,10 +184,10 @@ export default function PageClient({ slug }: PageClientProps) {
             ))}
           </div>
         )}
-        {!(organizationId && isPending) && skills.length === 0 && (
+        {!isLoadingSkills && skills.length === 0 && (
           <p className="text-muted-foreground">No skills yet.</p>
         )}
-        {!(organizationId && isPending) && skills.length > 0 && (
+        {!isLoadingSkills && skills.length > 0 && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {skills.map((skill) => (
               <Link

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -169,7 +169,7 @@ export default function PageClient({ slug }: PageClientProps) {
           </Button>
         </div>
 
-        {organizationId && isPending ? (
+        {organizationId && isPending && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton cards
@@ -181,9 +181,11 @@ export default function PageClient({ slug }: PageClientProps) {
               </Card>
             ))}
           </div>
-        ) : skills.length === 0 ? (
+        )}
+        {!(organizationId && isPending) && skills.length === 0 && (
           <p className="text-muted-foreground">No skills yet.</p>
-        ) : (
+        )}
+        {!(organizationId && isPending) && skills.length > 0 && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {skills.map((skill) => (
               <Link

--- a/apps/dashboard/src/components/PixelBlast.tsx
+++ b/apps/dashboard/src/components/PixelBlast.tsx
@@ -137,8 +137,7 @@ const createTouchTexture = (): TouchTexture => {
         trail.splice(i, 1);
       }
     }
-    for (let i = 0; i < trail.length; i++) {
-      const point = trail[i];
+    for (const point of trail) {
       if (point) {
         drawPoint(point);
       }
@@ -462,7 +461,9 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
       if (threeRef.current) {
         const t = threeRef.current;
         t.resizeObserver?.disconnect();
-        cancelAnimationFrame(t.raf!);
+        if (t.raf !== undefined) {
+          cancelAnimationFrame(t.raf);
+        }
         t.quad?.geometry.dispose();
         t.material.dispose();
         t.composer?.dispose();
@@ -702,7 +703,10 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
         liquidEffect,
       };
     } else {
-      const t = threeRef.current!;
+      const t = threeRef.current;
+      if (!t) {
+        return;
+      }
       t.uniforms.uShapeType.value = SHAPE_MAP[variant] ?? 0;
       t.uniforms.uPixelSize.value = pixelSize * t.renderer.getPixelRatio();
       t.uniforms.uColor.value.set(color);
@@ -746,7 +750,9 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
       }
       const t = threeRef.current;
       t.resizeObserver?.disconnect();
-      cancelAnimationFrame(t.raf!);
+      if (t.raf !== undefined) {
+        cancelAnimationFrame(t.raf);
+      }
       t.quad?.geometry.dispose();
       t.material.dispose();
       t.composer?.dispose();
@@ -781,9 +787,9 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
 
   return (
     <div
-      aria-label="PixelBlast interactive background"
       className={`relative h-full w-full overflow-hidden ${className ?? ""}`}
       ref={containerRef}
+      role="presentation"
       style={style}
     />
   );

--- a/apps/dashboard/src/components/affected-triggers-warning.tsx
+++ b/apps/dashboard/src/components/affected-triggers-warning.tsx
@@ -59,12 +59,15 @@ export function AffectedTriggersWarning({
         />
       )}
       <p className="text-muted-foreground text-xs">
-        {hasSchedules && hasEvents
-          ? `These schedules and events use this ${resourceLabel} and will be disabled.`
-          : hasSchedules
-            ? `These schedules use this ${resourceLabel} and will be disabled.`
-            : `These events use this ${resourceLabel} and will be disabled.`}{" "}
-        You&apos;ll need to edit them before re-enabling.
+        {(() => {
+          if (hasSchedules && hasEvents) {
+            return `These schedules and events use this ${resourceLabel} and will be disabled.`;
+          }
+          if (hasSchedules) {
+            return `These schedules use this ${resourceLabel} and will be disabled.`;
+          }
+          return `These events use this ${resourceLabel} and will be disabled.`;
+        })()} You&apos;ll need to edit them before re-enabling.
       </p>
     </div>
   );

--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -27,11 +27,11 @@ function getNumber(value: unknown, key: string): number | undefined {
   return typeof entry === "number" ? entry : undefined;
 }
 
-type ToolCopy = {
+interface ToolCopy {
   verbs: readonly [present: string, past: string];
   noun: string;
   suffix?: (input: unknown, output: unknown) => string | undefined;
-};
+}
 
 function idSuffix(input: unknown, keys: readonly string[]): string | undefined {
   for (const key of keys) {
@@ -274,11 +274,11 @@ export function ChatToolBlock({
           aria-hidden
           className={cn(
             "size-3.5 shrink-0 text-muted-foreground/60 transition-all",
-            hasDetails
-              ? isOpen
-                ? "rotate-180 opacity-100"
-                : "rotate-0 opacity-0 group-hover:opacity-100"
-              : "invisible"
+            !hasDetails && "invisible",
+            hasDetails && isOpen && "rotate-180 opacity-100",
+            hasDetails &&
+              !isOpen &&
+              "rotate-0 opacity-0 group-hover:opacity-100"
           )}
           icon={ArrowDown01Icon}
         />

--- a/apps/dashboard/src/components/automation/triggers/trigger-sheet.tsx
+++ b/apps/dashboard/src/components/automation/triggers/trigger-sheet.tsx
@@ -154,8 +154,11 @@ export function AddTriggerDialog({
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
+  const noopOpenChange = () => {
+    return;
+  };
   const setOpen = isControlled
-    ? (controlledOnOpenChange ?? (() => {}))
+    ? (controlledOnOpenChange ?? noopOpenChange)
     : setInternalOpen;
   const comboboxAnchor = useComboboxAnchor();
 

--- a/apps/dashboard/src/components/billing/credit-topup-content.tsx
+++ b/apps/dashboard/src/components/billing/credit-topup-content.tsx
@@ -58,11 +58,10 @@ export function CreditTopupContent({ onSuccess }: CreditTopupContentProps) {
     parsedCustom >= TOPUP_MIN_DOLLARS &&
     parsedCustom <= TOPUP_MAX_DOLLARS;
 
-  const activeAmount = isCustom
-    ? isCustomValid
-      ? parsedCustom
-      : null
-    : selected;
+  let activeAmount: number | null = selected;
+  if (isCustom) {
+    activeAmount = isCustomValid ? parsedCustom : null;
+  }
 
   async function handleTopup() {
     if (!activeAmount) {
@@ -190,13 +189,9 @@ export function CreditTopupContent({ onSuccess }: CreditTopupContentProps) {
         disabled={!activeAmount || loading}
         onClick={handleTopup}
       >
-        {loading ? (
-          <Loader2Icon className="size-4 animate-spin" />
-        ) : activeAmount ? (
-          `Add $${activeAmount} in credits`
-        ) : (
-          "Select an amount"
-        )}
+        {loading && <Loader2Icon className="size-4 animate-spin" />}
+        {!loading && activeAmount && `Add $${activeAmount} in credits`}
+        {!(loading || activeAmount) && "Select an amount"}
       </Button>
 
       <p className="text-center text-muted-foreground text-xs">

--- a/apps/dashboard/src/components/billing/usage-section.tsx
+++ b/apps/dashboard/src/components/billing/usage-section.tsx
@@ -126,7 +126,12 @@ export function UsageSection() {
     logRetention7DaysFeature !== undefined ||
     logRetention14DaysFeature !== undefined ||
     logRetention30DaysFeature !== undefined;
-  const retentionDays = has30DayRetention ? 30 : has14DayRetention ? 14 : 7;
+  let retentionDays = 7;
+  if (has30DayRetention) {
+    retentionDays = 30;
+  } else if (has14DayRetention) {
+    retentionDays = 14;
+  }
 
   if (customerLoading && !customer) {
     return (

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -193,29 +193,36 @@ export function CreateContentDialog({
     [githubRepoIds, selectedLinearIds, lookbackWindow, dataPoints]
   );
 
+  const previewQueryOptions = dashboardOrpc.content.preview.queryOptions({
+    input: {
+      organizationId,
+      repositoryIds: githubRepoIds,
+      lookbackWindow,
+      includeCommits: dataPoints.includeCommits,
+      includePullRequests: dataPoints.includePullRequests,
+      includeReleases: dataPoints.includeReleases,
+      linearIntegrationIds:
+        selectedLinearIds.length > 0 ? selectedLinearIds : undefined,
+    },
+  });
+
   const {
     data: previewResponse,
     isFetching: isLoadingPreview,
     isError: isPreviewError,
+    refetch: refetchPreview,
   } = useQuery({
-    ...dashboardOrpc.content.preview.queryOptions({
-      input: {
-        organizationId,
-        repositoryIds: githubRepoIds,
-        lookbackWindow,
-        includeCommits: dataPoints.includeCommits,
-        includePullRequests: dataPoints.includePullRequests,
-        includeReleases: dataPoints.includeReleases,
-        linearIntegrationIds:
-          selectedLinearIds.length > 0 ? selectedLinearIds : undefined,
-      },
-    }),
+    ...previewQueryOptions,
     enabled:
       open &&
       step === "activity" &&
       (githubRepoIds.length > 0 || selectedLinearIds.length > 0),
     staleTime: 60_000,
   });
+
+  const handleRetryPreview = useCallback(() => {
+    refetchPreview();
+  }, [refetchPreview]);
 
   const previewData = useMemo(
     () =>
@@ -726,6 +733,7 @@ export function CreateContentDialog({
                   isLoadingPreview={isLoadingPreview}
                   isPreviewError={isPreviewError}
                   onConnect={handleOpenAddRepositoryFlow}
+                  onRetryPreview={handleRetryPreview}
                   onSearchQueryChange={setSearchQuery}
                   onToggleCommit={(key) => {
                     selectionsTouchedRef.current = true;

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -2,76 +2,32 @@
 
 import {
   Add01Icon,
-  ArrowDown01Icon,
-  ArrowReloadHorizontalIcon,
-  GitCommitIcon,
-  GitPullRequestIcon,
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
   Loading03Icon,
-  Rocket01Icon,
   Tick01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
-  ResponsiveDialogDescription,
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
   ResponsiveDialogTrigger,
 } from "@notra/ui/components/shared/responsive-dialog";
-import { Badge } from "@notra/ui/components/ui/badge";
 import { Button } from "@notra/ui/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@notra/ui/components/ui/collapsible";
-import {
-  Combobox,
-  ComboboxChip,
-  ComboboxChips,
-  ComboboxChipsInput,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxItem,
-  ComboboxList,
-  useComboboxAnchor,
-} from "@notra/ui/components/ui/combobox";
 import { Kbd } from "@notra/ui/components/ui/kbd";
-import { Label } from "@notra/ui/components/ui/label";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@notra/ui/components/ui/pagination";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@notra/ui/components/ui/select";
-import { Skeleton } from "@notra/ui/components/ui/skeleton";
-import { Switch } from "@notra/ui/components/ui/switch";
 import { cn } from "@notra/ui/lib/utils";
-import { useForm } from "@tanstack/react-form";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useStore } from "@tanstack/react-store";
-import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { BrandVoiceCombobox } from "@/components/brand-voice-combobox";
-import {
-  DEFAULT_CONTENT_TYPE,
-  DEFAULT_DATA_POINTS,
-  EVENT_BADGE,
-  EVENTS_PER_PAGE,
-} from "@/constants/content-preview";
+import { StepActivity } from "@/components/content/create/step-activity";
+import { StepBrandIdentities } from "@/components/content/create/step-brand-identities";
+import { StepFormats } from "@/components/content/create/step-formats";
+import { AddIntegrationDialog } from "@/components/integrations/add-integration-dialog";
+import { AddRepositoryDialog } from "@/components/integrations/add-repository-dialog";
+import { DEFAULT_DATA_POINTS } from "@/constants/content-preview";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type {
   ContentDataPointSettings,
@@ -79,56 +35,36 @@ import type {
   SelectedItems,
 } from "@/schemas/content";
 import type { LookbackWindow } from "@/schemas/integrations";
+import type { IntegrationOption, WizardStep } from "@/types/content/create";
+import type { PrSelection, ReleaseSelection } from "@/types/content/preview";
 import {
-  LOOKBACK_WINDOWS,
-  SUPPORTED_SCHEDULE_OUTPUT_TYPES,
-} from "@/schemas/integrations";
-import type {
-  CommitPreview,
-  EventType,
-  PreviewResponse,
-  PrSelection,
-  PullRequestPreview,
-  ReleasePreview,
-  ReleaseSelection,
-  RepositoryPreview,
-} from "@/types/content/preview";
-import type { GitHubIntegration } from "@/types/integrations";
-import {
-  formatEventDate,
-  getPageNumbers,
   prSelectionFromKey,
   prSelectionToKey,
   releaseSelectionFromKey,
   releaseSelectionToKey,
 } from "@/utils/content-preview";
-import { formatSnakeCaseLabel } from "@/utils/format";
-
-const EVENT_ICON: Record<EventType, typeof GitPullRequestIcon> = {
-  PR: GitPullRequestIcon,
-  Commit: GitCommitIcon,
-  Release: Rocket01Icon,
-  LinearIssue: Tick01Icon,
-};
-
-import { Github } from "@notra/ui/components/ui/svgs/github";
-import { Linear } from "@notra/ui/components/ui/svgs/linear";
-import { AddIntegrationDialog } from "@/components/integrations/add-integration-dialog";
-import { AddRepositoryButton } from "@/components/integrations/add-repository-button";
-import { AddRepositoryDialog } from "@/components/integrations/add-repository-dialog";
-import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 
 interface CreateContentDialogProps {
   organizationId: string;
 }
 
-type Step = "configure" | "review";
+const STEP_ORDER: WizardStep[] = ["formats", "activity", "identities"];
+
+const STEP_TITLES: Record<WizardStep, string> = {
+  formats: "Create Content",
+  activity: "Activity",
+  identities: "Brand Identity",
+};
+
+const STEP_LABELS: Record<WizardStep, string> = {
+  formats: "Formats",
+  activity: "Activity",
+  identities: "Identity",
+};
 
 export function CreateContentDialog({
   organizationId,
 }: CreateContentDialogProps) {
-  const { slug } = useParams<{ slug: string }>();
-  const router = useRouter();
   const [open, setOpen] = useState(false);
 
   useHotkey(
@@ -141,14 +77,21 @@ export function CreateContentDialog({
     { enabled: !open }
   );
 
-  const [addRepoOpen, setAddRepoOpen] = useState(false);
-  const [addRepoMode, setAddRepoMode] = useState<
-    "integration" | "repository" | null
-  >(null);
-  const [waitingForWebhookSetup, setWaitingForWebhookSetup] = useState(false);
-  const [step, setStep] = useState<Step>("configure");
-  const [dataSourcesOpen, setDataSourcesOpen] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
+  const queryClient = useQueryClient();
+
+  const [step, setStep] = useState<WizardStep>("formats");
+  const [selectedFormats, setSelectedFormats] = useState<OnDemandContentType[]>(
+    []
+  );
+  const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>([]);
+  const [selectedBrandVoiceIds, setSelectedBrandVoiceIds] = useState<string[]>(
+    []
+  );
+  const [lookbackWindow, setLookbackWindow] =
+    useState<LookbackWindow>("last_7_days");
+  const [dataPoints, setDataPoints] =
+    useState<ContentDataPointSettings>(DEFAULT_DATA_POINTS);
+
   const [selectedCommitKeys, setSelectedCommitKeys] = useState<Set<string>>(
     new Set()
   );
@@ -159,32 +102,26 @@ export function CreateContentDialog({
   const [selectedLinearKeys, setSelectedLinearKeys] = useState<Set<string>>(
     new Set()
   );
-  const lastInitializedParamsRef = useRef("");
-  const previewWarningKeyRef = useRef<string>("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const integrationsInitializedRef = useRef(false);
+
   const selectionsTouchedRef = useRef(false);
+  const lastInitializedParamsRef = useRef("");
+  const previewWarningKeyRef = useRef("");
+
+  const [addRepoOpen, setAddRepoOpen] = useState(false);
+  const [addRepoMode, setAddRepoMode] = useState<
+    "integration" | "repository" | null
+  >(null);
+  const [waitingForWebhookSetup, setWaitingForWebhookSetup] = useState(false);
   const openingAddRepoFlowRef = useRef(false);
 
-  const queryClient = useQueryClient();
-  const comboboxAnchor = useComboboxAnchor();
-
-  const form = useForm({
-    defaultValues: {
-      contentType: DEFAULT_CONTENT_TYPE,
-      lookbackWindow: "last_7_days" as LookbackWindow,
-      repositoryIds: [] as string[],
-      linearIntegrationIds: [] as string[],
-      brandVoiceId: "" as string,
-      dataPoints: DEFAULT_DATA_POINTS,
-    },
-  });
-
-  const { data: brandResponse } = useQuery(
+  const { data: brandResponse, isLoading: isLoadingVoices } = useQuery(
     dashboardOrpc.brand.voices.list.queryOptions({
       input: { organizationId },
       enabled: !!organizationId,
     })
   );
-
   const brandVoices = brandResponse?.voices ?? [];
 
   const { data: integrationsResponse, isLoading: isLoadingRepos } = useQuery(
@@ -194,12 +131,7 @@ export function CreateContentDialog({
     })
   );
 
-  const {
-    repositories,
-    integrationOptions,
-    githubIntegrationId,
-    hasLinearIntegrations,
-  } = useMemo(() => {
+  const { integrationOptions, githubIntegrationId } = useMemo(() => {
     const githubIntegrations =
       integrationsResponse?.integrations.filter(
         (i) => i.type === "github" && i.enabled
@@ -212,48 +144,40 @@ export function CreateContentDialog({
       i.repositories.filter((r) => r.enabled)
     );
 
-    const options: Array<{
-      value: string;
-      label: string;
-      type: "github" | "linear";
-    }> = [
+    const options: IntegrationOption[] = [
       ...repos.map((r) => ({
         value: r.id,
         label: r.defaultBranch
           ? `${r.owner}/${r.repo} · ${r.defaultBranch}`
           : `${r.owner}/${r.repo}`,
+        ownerRepo: `${r.owner}/${r.repo}`,
         type: "github" as const,
       })),
       ...linearIntegrationsList.map((i) => ({
         value: `linear:${i.id}`,
         label: i.displayName,
+        ownerRepo: null,
         type: "linear" as const,
       })),
     ];
 
     return {
-      repositories: repos,
       integrationOptions: options,
       githubIntegrationId: githubIntegrations[0]?.id,
-      hasLinearIntegrations: linearIntegrationsList.length > 0,
     };
   }, [integrationsResponse]);
 
-  const repositoryIds = useStore(form.store, (s) => s.values.repositoryIds);
-  const lookbackWindow = useStore(form.store, (s) => s.values.lookbackWindow);
-  const dataPoints = useStore(form.store, (s) => s.values.dataPoints);
-
   const githubRepoIds = useMemo(
-    () => repositoryIds.filter((id) => !id.startsWith("linear:")),
-    [repositoryIds]
+    () => selectedRepoIds.filter((id) => !id.startsWith("linear:")),
+    [selectedRepoIds]
   );
 
   const selectedLinearIds = useMemo(
     () =>
-      repositoryIds
+      selectedRepoIds
         .filter((id) => id.startsWith("linear:"))
         .map((id) => id.replace("linear:", "")),
-    [repositoryIds]
+    [selectedRepoIds]
   );
 
   const previewParamsKey = useMemo(
@@ -288,7 +212,7 @@ export function CreateContentDialog({
     }),
     enabled:
       open &&
-      step === "review" &&
+      step === "activity" &&
       (githubRepoIds.length > 0 || selectedLinearIds.length > 0),
     staleTime: 60_000,
   });
@@ -317,7 +241,6 @@ export function CreateContentDialog({
     }
     lastInitializedParamsRef.current = previewParamsKey;
     selectionsTouchedRef.current = false;
-    setCurrentPage(1);
     const commitKeys = new Set<string>();
     const prKeys = new Set<string>();
     const relKeys = new Set<string>();
@@ -358,40 +281,47 @@ export function CreateContentDialog({
     if (!previewFailures.length) {
       return;
     }
-
     const warningKey = `${previewParamsKey}:${previewFailures
       .map((failure) => `${failure.repositoryId}:${failure.stage}`)
       .sort()
       .join("|")}`;
-
     if (previewWarningKeyRef.current === warningKey) {
       return;
     }
-
     previewWarningKeyRef.current = warningKey;
     toast.warning(
-      `${previewFailures.length} repository preview ${previewFailures.length === 1 ? "issue was" : "issues were"} detected. Review warnings before generating content.`
+      `${previewFailures.length} repository preview ${previewFailures.length === 1 ? "issue was" : "issues were"} detected.`
     );
   }, [previewParamsKey, previewFailures]);
 
   const mutation = useMutation<
-    { success: boolean; runId: string },
+    void,
     Error,
     {
-      contentType: OnDemandContentType;
-      lookbackWindow: LookbackWindow;
-      repositoryIds: string[];
-      linearIntegrationIds?: string[];
-      brandVoiceId?: string;
-      dataPoints: ContentDataPointSettings;
-      selectedItems?: SelectedItems;
+      formats: OnDemandContentType[];
+      voiceIds: string[];
+      selectedItems: SelectedItems;
     }
   >({
-    mutationFn: async (value) => {
-      return await dashboardOrpc.content.generate.call({
-        organizationId,
-        ...value,
-      });
+    mutationFn: async ({ formats, voiceIds, selectedItems }) => {
+      const hasLinear = selectedLinearIds.length > 0;
+      const calls = formats.flatMap((format) =>
+        voiceIds.map((voiceId) => ({ format, voiceId }))
+      );
+      await Promise.all(
+        calls.map(({ format, voiceId }) =>
+          dashboardOrpc.content.generate.call({
+            organizationId,
+            contentType: format,
+            lookbackWindow,
+            repositoryIds: githubRepoIds,
+            linearIntegrationIds: hasLinear ? selectedLinearIds : undefined,
+            brandVoiceId: voiceId || undefined,
+            dataPoints: { ...dataPoints, includeLinearData: hasLinear },
+            selectedItems,
+          })
+        )
+      );
     },
     onSuccess: () => {
       setOpen(false);
@@ -407,6 +337,35 @@ export function CreateContentDialog({
     },
   });
 
+  const resetWizard = useCallback(() => {
+    setStep("formats");
+    setSelectedFormats([]);
+    setSelectedRepoIds([]);
+    setSelectedBrandVoiceIds([]);
+    setLookbackWindow("last_7_days");
+    setDataPoints(DEFAULT_DATA_POINTS);
+    setSelectedCommitKeys(new Set());
+    setSelectedPrKeys(new Set());
+    setSelectedReleaseKeys(new Set());
+    setSelectedLinearKeys(new Set());
+    setSearchQuery("");
+    lastInitializedParamsRef.current = "";
+    selectionsTouchedRef.current = false;
+    integrationsInitializedRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    if (
+      integrationsInitializedRef.current ||
+      integrationOptions.length === 0 ||
+      selectedRepoIds.length > 0
+    ) {
+      return;
+    }
+    integrationsInitializedRef.current = true;
+    setSelectedRepoIds(integrationOptions.map((opt) => opt.value));
+  }, [integrationOptions, selectedRepoIds.length]);
+
   const handleOpenChange = useCallback(
     (next: boolean) => {
       setOpen(next);
@@ -414,112 +373,44 @@ export function CreateContentDialog({
         const preserveState =
           openingAddRepoFlowRef.current || addRepoMode !== null;
         openingAddRepoFlowRef.current = false;
-
         if (preserveState) {
           return;
         }
-
         setAddRepoOpen(false);
         setAddRepoMode(null);
         setWaitingForWebhookSetup(false);
-        form.reset();
-        setStep("configure");
-        setCurrentPage(1);
-        setSelectedCommitKeys(new Set());
-        setSelectedPrKeys(new Set());
-        setSelectedReleaseKeys(new Set());
-        setSelectedLinearKeys(new Set());
-        lastInitializedParamsRef.current = "";
-        selectionsTouchedRef.current = false;
+        resetWizard();
       }
     },
-    [addRepoMode, form]
+    [addRepoMode, resetWizard]
   );
 
-  const handleContinue = useCallback(() => {
-    setStep("review");
+  const toggleFormat = useCallback((format: OnDemandContentType) => {
+    setSelectedFormats((prev) =>
+      prev.includes(format)
+        ? prev.filter((f) => f !== format)
+        : [...prev, format]
+    );
   }, []);
 
-  const handleBack = useCallback(() => {
-    setStep("configure");
-    setCurrentPage(1);
+  const handleDataPointChange = useCallback(
+    (key: keyof ContentDataPointSettings, value: boolean) => {
+      setDataPoints((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const toggleRepoId = useCallback((value: string) => {
+    setSelectedRepoIds((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+    );
   }, []);
 
-  const handleCreate = useCallback(() => {
-    const value = form.state.values;
-    const githubRepoIds = value.repositoryIds.filter(
-      (id) => !id.startsWith("linear:")
+  const toggleVoiceId = useCallback((id: string) => {
+    setSelectedBrandVoiceIds((prev) =>
+      prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id]
     );
-    const hasLinear = value.repositoryIds.some((id) =>
-      id.startsWith("linear:")
-    );
-
-    const selectedLinearIssues = Array.from(selectedLinearKeys).map((key) => {
-      const separatorIdx = key.indexOf(":");
-      return {
-        integrationId: key.slice(0, separatorIdx),
-        issueId: key.slice(separatorIdx + 1),
-      };
-    });
-
-    const commitShas =
-      selectionsTouchedRef.current && value.dataPoints.includeCommits
-        ? Array.from(selectedCommitKeys)
-        : undefined;
-    const pullRequestNumbers =
-      selectionsTouchedRef.current && value.dataPoints.includePullRequests
-        ? Array.from(selectedPrKeys)
-            .map((key) => prSelectionFromKey(key))
-            .filter((selection): selection is PrSelection => selection !== null)
-        : undefined;
-    const releaseTagNames =
-      selectionsTouchedRef.current && value.dataPoints.includeReleases
-        ? Array.from(selectedReleaseKeys)
-            .map((key) => releaseSelectionFromKey(key))
-            .filter(
-              (selection): selection is ReleaseSelection => selection !== null
-            )
-        : undefined;
-    const linearIssueIds =
-      selectionsTouchedRef.current &&
-      hasLinear &&
-      selectedLinearIssues.length > 0
-        ? selectedLinearIssues
-        : undefined;
-
-    const selectedItems: SelectedItems =
-      commitShas?.length ||
-      pullRequestNumbers?.length ||
-      releaseTagNames?.length ||
-      linearIssueIds?.length
-        ? {
-            commitShas,
-            pullRequestNumbers,
-            releaseTagNames,
-            linearIssueIds,
-          }
-        : undefined;
-
-    mutation.mutate({
-      ...value,
-      repositoryIds: githubRepoIds,
-      linearIntegrationIds: hasLinear ? selectedLinearIds : undefined,
-      dataPoints: {
-        ...value.dataPoints,
-        includeLinearData: hasLinear,
-      },
-      brandVoiceId: value.brandVoiceId || undefined,
-      selectedItems,
-    });
-  }, [
-    form,
-    mutation,
-    selectedCommitKeys,
-    selectedPrKeys,
-    selectedReleaseKeys,
-    selectedLinearKeys,
-    selectedLinearIds,
-  ]);
+  }, []);
 
   const eventCounts = useMemo(() => {
     let total = 0;
@@ -527,8 +418,8 @@ export function CreateContentDialog({
     for (const repo of previewData ?? []) {
       if (dataPoints.includeCommits) {
         total += repo.commits.length;
-        for (const commit of repo.commits) {
-          if (selectedCommitKeys.has(commit.sha)) {
+        for (const c of repo.commits) {
+          if (selectedCommitKeys.has(c.sha)) {
             selected++;
           }
         }
@@ -583,101 +474,6 @@ export function CreateContentDialog({
     selectedLinearKeys,
   ]);
 
-  const { paginatedRepos, totalPages } = useMemo(() => {
-    if (!previewData) {
-      return { paginatedRepos: [], totalPages: 1 };
-    }
-
-    type FlatEvent =
-      | {
-          type: "release";
-          repositoryId: string;
-          owner: string;
-          repo: string;
-          data: ReleasePreview;
-        }
-      | {
-          type: "pr";
-          repositoryId: string;
-          owner: string;
-          repo: string;
-          data: PullRequestPreview;
-        }
-      | {
-          type: "commit";
-          repositoryId: string;
-          owner: string;
-          repo: string;
-          data: CommitPreview;
-        };
-
-    const flatEvents: FlatEvent[] = [];
-    for (const repo of previewData) {
-      if (dataPoints.includeReleases) {
-        for (const release of repo.releases) {
-          flatEvents.push({
-            type: "release",
-            repositoryId: repo.repositoryId,
-            owner: repo.owner,
-            repo: repo.repo,
-            data: release,
-          });
-        }
-      }
-      if (dataPoints.includePullRequests) {
-        for (const pr of repo.pullRequests) {
-          flatEvents.push({
-            type: "pr",
-            repositoryId: repo.repositoryId,
-            owner: repo.owner,
-            repo: repo.repo,
-            data: pr,
-          });
-        }
-      }
-      if (dataPoints.includeCommits) {
-        for (const commit of repo.commits) {
-          flatEvents.push({
-            type: "commit",
-            repositoryId: repo.repositoryId,
-            owner: repo.owner,
-            repo: repo.repo,
-            data: commit,
-          });
-        }
-      }
-    }
-
-    const pages = Math.max(1, Math.ceil(flatEvents.length / EVENTS_PER_PAGE));
-    const start = (currentPage - 1) * EVENTS_PER_PAGE;
-    const pageSlice = flatEvents.slice(start, start + EVENTS_PER_PAGE);
-
-    const repoMap = new Map<string, RepositoryPreview>();
-    for (const event of pageSlice) {
-      let repo = repoMap.get(event.repositoryId);
-      if (!repo) {
-        repo = {
-          repositoryId: event.repositoryId,
-          owner: event.owner,
-          repo: event.repo,
-          commits: [],
-          pullRequests: [],
-          releases: [],
-        };
-        repoMap.set(event.repositoryId, repo);
-      }
-      if (event.type === "release") {
-        repo.releases.push(event.data);
-      } else if (event.type === "pr") {
-        repo.pullRequests.push(event.data);
-      } else {
-        repo.commits.push(event.data);
-      }
-    }
-
-    return { paginatedRepos: Array.from(repoMap.values()), totalPages: pages };
-  }, [previewData, dataPoints, currentPage]);
-
   const handleToggleAll = useCallback(() => {
     selectionsTouchedRef.current = true;
     const allSelected = eventCounts.selected === eventCounts.total;
@@ -686,48 +482,48 @@ export function CreateContentDialog({
       setSelectedPrKeys(new Set());
       setSelectedReleaseKeys(new Set());
       setSelectedLinearKeys(new Set());
-    } else {
-      const commitKeys = new Set<string>();
-      const prKeys = new Set<string>();
-      const relKeys = new Set<string>();
-      const linearKeys = new Set<string>();
-      for (const repo of previewData ?? []) {
-        if (dataPoints.includeCommits) {
-          for (const c of repo.commits) {
-            commitKeys.add(c.sha);
-          }
-        }
-        if (dataPoints.includePullRequests) {
-          for (const pr of repo.pullRequests) {
-            prKeys.add(
-              prSelectionToKey({
-                repositoryId: repo.repositoryId,
-                number: pr.number,
-              })
-            );
-          }
-        }
-        if (dataPoints.includeReleases) {
-          for (const rel of repo.releases) {
-            relKeys.add(
-              releaseSelectionToKey({
-                repositoryId: repo.repositoryId,
-                tagName: rel.tagName,
-              })
-            );
-          }
-        }
-      }
-      for (const li of previewResponse?.linearIntegrations ?? []) {
-        for (const issue of li.issues) {
-          linearKeys.add(`${li.integrationId}:${issue.id}`);
-        }
-      }
-      setSelectedCommitKeys(commitKeys);
-      setSelectedPrKeys(prKeys);
-      setSelectedReleaseKeys(relKeys);
-      setSelectedLinearKeys(linearKeys);
+      return;
     }
+    const commitKeys = new Set<string>();
+    const prKeys = new Set<string>();
+    const relKeys = new Set<string>();
+    const linearKeys = new Set<string>();
+    for (const repo of previewData ?? []) {
+      if (dataPoints.includeCommits) {
+        for (const c of repo.commits) {
+          commitKeys.add(c.sha);
+        }
+      }
+      if (dataPoints.includePullRequests) {
+        for (const pr of repo.pullRequests) {
+          prKeys.add(
+            prSelectionToKey({
+              repositoryId: repo.repositoryId,
+              number: pr.number,
+            })
+          );
+        }
+      }
+      if (dataPoints.includeReleases) {
+        for (const rel of repo.releases) {
+          relKeys.add(
+            releaseSelectionToKey({
+              repositoryId: repo.repositoryId,
+              tagName: rel.tagName,
+            })
+          );
+        }
+      }
+    }
+    for (const li of previewResponse?.linearIntegrations ?? []) {
+      for (const issue of li.issues) {
+        linearKeys.add(`${li.integrationId}:${issue.id}`);
+      }
+    }
+    setSelectedCommitKeys(commitKeys);
+    setSelectedPrKeys(prKeys);
+    setSelectedReleaseKeys(relKeys);
+    setSelectedLinearKeys(linearKeys);
   }, [
     previewData,
     previewResponse?.linearIntegrations,
@@ -735,15 +531,83 @@ export function CreateContentDialog({
     eventCounts,
   ]);
 
-  const hasSelectableEvents =
-    dataPoints.includeCommits ||
-    dataPoints.includePullRequests ||
-    dataPoints.includeReleases;
+  const goNext = useCallback(() => {
+    const idx = STEP_ORDER.indexOf(step);
+    if (idx < STEP_ORDER.length - 1) {
+      setStep(STEP_ORDER[idx + 1] as WizardStep);
+    }
+  }, [step]);
 
-  const hasAnyGitHubDataPointActive =
-    dataPoints.includePullRequests ||
-    dataPoints.includeCommits ||
-    dataPoints.includeReleases;
+  const goBack = useCallback(() => {
+    const idx = STEP_ORDER.indexOf(step);
+    if (idx > 0) {
+      setStep(STEP_ORDER[idx - 1] as WizardStep);
+    }
+  }, [step]);
+
+  const buildSelectedItems = useCallback((): SelectedItems => {
+    if (!selectionsTouchedRef.current) {
+      return undefined;
+    }
+    const hasLinear = selectedLinearIds.length > 0;
+    const commitShas = dataPoints.includeCommits
+      ? Array.from(selectedCommitKeys)
+      : undefined;
+    const pullRequestNumbers = dataPoints.includePullRequests
+      ? Array.from(selectedPrKeys)
+          .map((key) => prSelectionFromKey(key))
+          .filter((sel): sel is PrSelection => sel !== null)
+      : undefined;
+    const releaseTagNames = dataPoints.includeReleases
+      ? Array.from(selectedReleaseKeys)
+          .map((key) => releaseSelectionFromKey(key))
+          .filter((sel): sel is ReleaseSelection => sel !== null)
+      : undefined;
+    const linearIssueIds =
+      hasLinear && selectedLinearKeys.size > 0
+        ? Array.from(selectedLinearKeys).map((key) => {
+            const sep = key.indexOf(":");
+            return {
+              integrationId: key.slice(0, sep),
+              issueId: key.slice(sep + 1),
+            };
+          })
+        : undefined;
+
+    if (
+      !(
+        commitShas?.length ||
+        pullRequestNumbers?.length ||
+        releaseTagNames?.length ||
+        linearIssueIds?.length
+      )
+    ) {
+      return undefined;
+    }
+    return {
+      commitShas,
+      pullRequestNumbers,
+      releaseTagNames,
+      linearIssueIds,
+    };
+  }, [
+    dataPoints,
+    selectedCommitKeys,
+    selectedPrKeys,
+    selectedReleaseKeys,
+    selectedLinearKeys,
+    selectedLinearIds,
+  ]);
+
+  const handleCreate = useCallback(() => {
+    const voiceIds =
+      selectedBrandVoiceIds.length > 0 ? selectedBrandVoiceIds : [""];
+    mutation.mutate({
+      formats: selectedFormats,
+      voiceIds,
+      selectedItems: buildSelectedItems(),
+    });
+  }, [selectedBrandVoiceIds, selectedFormats, mutation, buildSelectedItems]);
 
   const handleOpenAddRepositoryFlow = useCallback(() => {
     openingAddRepoFlowRef.current = true;
@@ -756,15 +620,12 @@ export function CreateContentDialog({
   const handleAddRepoOpenChange = useCallback(
     (isOpen: boolean) => {
       setAddRepoOpen(isOpen);
-
       if (isOpen) {
         return;
       }
-
       if (addRepoMode === "integration" && waitingForWebhookSetup) {
         return;
       }
-
       setAddRepoMode(null);
       setWaitingForWebhookSetup(false);
       setOpen(true);
@@ -782,6 +643,47 @@ export function CreateContentDialog({
     setOpen(true);
   }, []);
 
+  const hasAnyDataPoint =
+    dataPoints.includePullRequests ||
+    dataPoints.includeCommits ||
+    dataPoints.includeReleases;
+
+  const canContinueFromFormats = selectedFormats.length > 0 && hasAnyDataPoint;
+  const canContinueFromActivity =
+    selectedRepoIds.length > 0 && !isLoadingPreview && eventCounts.selected > 0;
+
+  const continueDisabled =
+    (step === "formats" && !canContinueFromFormats) ||
+    (step === "activity" && !canContinueFromActivity);
+
+  const identityButtonLabel =
+    selectedBrandVoiceIds.length === 0
+      ? "Skip & start creating"
+      : `Start creating with ${selectedBrandVoiceIds.length} ${selectedBrandVoiceIds.length === 1 ? "identity" : "identities"}`;
+
+  const stepIndex = STEP_ORDER.indexOf(step);
+
+  const footerLeft = useMemo(() => {
+    if (step === "formats") {
+      return `${selectedFormats.length} format${selectedFormats.length === 1 ? "" : "s"} selected`;
+    }
+    if (step === "activity") {
+      if (selectedRepoIds.length === 0) {
+        return "Select at least one source";
+      }
+      return `${eventCounts.selected} / ${eventCounts.total} events · ${selectedRepoIds.length} source${selectedRepoIds.length === 1 ? "" : "s"}`;
+    }
+    return selectedBrandVoiceIds.length === 0
+      ? "No identities selected"
+      : `${selectedBrandVoiceIds.length} ${selectedBrandVoiceIds.length === 1 ? "identity" : "identities"} selected`;
+  }, [
+    step,
+    selectedFormats.length,
+    selectedRepoIds.length,
+    eventCounts,
+    selectedBrandVoiceIds.length,
+  ]);
+
   return (
     <>
       <ResponsiveDialog onOpenChange={handleOpenChange} open={open}>
@@ -794,548 +696,134 @@ export function CreateContentDialog({
             </Button>
           }
         />
-        <ResponsiveDialogContent className="flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl">
-          <ResponsiveDialogHeader className="shrink-0 space-y-1 border-b p-4">
-            <ResponsiveDialogTitle>
-              {step === "configure" ? "Create Content" : "Review Events"}
-            </ResponsiveDialogTitle>
-            <ResponsiveDialogDescription>
-              {step === "configure"
-                ? "Configure content type, timeframe, and sources."
-                : "Select the events to include in your content."}
-            </ResponsiveDialogDescription>
+        <ResponsiveDialogContent className="flex h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">
+          <ResponsiveDialogHeader className="shrink-0 border-b p-4 pr-14">
+            <div className="flex items-center justify-between gap-4">
+              <ResponsiveDialogTitle className="text-base">
+                {STEP_TITLES[step]}
+              </ResponsiveDialogTitle>
+              <StepProgress activeIndex={stepIndex} />
+            </div>
           </ResponsiveDialogHeader>
 
-          <form
-            className="flex min-h-0 flex-1 flex-col overflow-hidden px-0!"
-            onSubmit={(e) => e.preventDefault()}
-          >
-            {/* ── Step 1: Configure ── */}
-            {step === "configure" && (
-              <div className="min-h-0 flex-1 overflow-y-auto">
-                <div className="space-y-4 p-4">
-                  <form.Field name="contentType">
-                    {(field) => (
-                      <div className="space-y-2">
-                        <Label htmlFor={field.name}>Content Type</Label>
-                        <Select
-                          onValueChange={(v) => {
-                            if (v) {
-                              field.handleChange(v as OnDemandContentType);
-                            }
-                          }}
-                          value={field.state.value}
-                        >
-                          <SelectTrigger className="w-full" id={field.name}>
-                            <SelectValue placeholder="Select content type">
-                              <span className="flex items-center gap-2">
-                                <OutputTypeIcon
-                                  className="size-4"
-                                  outputType={field.state.value}
-                                />
-                                {getOutputTypeLabel(field.state.value)}
-                              </span>
-                            </SelectValue>
-                          </SelectTrigger>
-                          <SelectContent>
-                            {SUPPORTED_SCHEDULE_OUTPUT_TYPES.map((type) => (
-                              <SelectItem key={type} value={type}>
-                                <span className="flex items-center gap-2">
-                                  <OutputTypeIcon
-                                    className="size-4"
-                                    outputType={type}
-                                  />
-                                  {getOutputTypeLabel(type)}
-                                </span>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    )}
-                  </form.Field>
-
-                  {brandVoices.length === 0 ? (
-                    <div className="space-y-2">
-                      <Label>Brand Identity</Label>
-                      <div className="flex items-center gap-2 rounded-md border border-dashed p-3">
-                        <span className="flex-1 text-muted-foreground text-xs">
-                          No brand identity set up.
-                        </span>
-                        <Button
-                          className="h-6 shrink-0 gap-1 rounded px-2 text-xs"
-                          onClick={() => router.push(`/${slug}/brand/identity`)}
-                          size="sm"
-                          type="button"
-                        >
-                          <HugeiconsIcon className="size-3" icon={Add01Icon} />
-                          Add
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <form.Field name="brandVoiceId">
-                      {(field) => (
-                        <BrandVoiceCombobox
-                          id={field.name}
-                          onChange={field.handleChange}
-                          value={field.state.value}
-                          voices={brandVoices}
-                        />
-                      )}
-                    </form.Field>
-                  )}
-
-                  <form.Field name="lookbackWindow">
-                    {(field) => (
-                      <div className="space-y-2">
-                        <Label htmlFor={field.name}>Timeframe</Label>
-                        <Select
-                          onValueChange={(v) => {
-                            if (v) {
-                              field.handleChange(v as LookbackWindow);
-                            }
-                          }}
-                          value={field.state.value}
-                        >
-                          <SelectTrigger className="w-full" id={field.name}>
-                            <SelectValue placeholder="Select timeframe">
-                              <span className="capitalize">
-                                {formatSnakeCaseLabel(field.state.value)}
-                              </span>
-                            </SelectValue>
-                          </SelectTrigger>
-                          <SelectContent>
-                            {LOOKBACK_WINDOWS.map((w) => (
-                              <SelectItem key={w} value={w}>
-                                <span className="capitalize">
-                                  {formatSnakeCaseLabel(w)}
-                                </span>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <p className="text-muted-foreground text-xs">
-                          How far back to look when gathering activity data.
-                        </p>
-                      </div>
-                    )}
-                  </form.Field>
-
-                  <form.Field name="repositoryIds">
-                    {(field) => (
-                      <div className="space-y-2">
-                        <Label htmlFor={field.name}>Integrations</Label>
-                        {isLoadingRepos && <Skeleton className="h-10 w-full" />}
-                        {!isLoadingRepos && integrationOptions.length === 0 && (
-                          <div className="flex items-start justify-between gap-3 rounded-md border border-dashed p-4">
-                            <div className="flex-1 space-y-1">
-                              <p className="font-medium text-sm">
-                                No integrations connected
-                              </p>
-                              <p className="text-muted-foreground text-xs">
-                                Connect GitHub or Linear so Notra can pull
-                                recent activity for this content.
-                              </p>
-                            </div>
-                            <AddRepositoryButton
-                              label="Connect"
-                              onAdd={handleOpenAddRepositoryFlow}
-                            />
-                          </div>
-                        )}
-                        {!isLoadingRepos && integrationOptions.length > 0 && (
-                          <div ref={comboboxAnchor}>
-                            <Combobox
-                              items={integrationOptions.map((o) => o.value)}
-                              multiple
-                              onValueChange={(v) =>
-                                field.handleChange(Array.isArray(v) ? v : [])
-                              }
-                              value={field.state.value}
-                            >
-                              <ComboboxChips>
-                                {field.state.value.map((id) => {
-                                  const opt = integrationOptions.find(
-                                    (o) => o.value === id
-                                  );
-                                  if (!opt) {
-                                    return null;
-                                  }
-                                  return (
-                                    <ComboboxChip key={opt.value}>
-                                      <span className="flex items-center gap-1.5">
-                                        {opt.type === "github" ? (
-                                          <Github className="size-3 shrink-0" />
-                                        ) : (
-                                          <Linear className="size-3 shrink-0" />
-                                        )}
-                                        {opt.label}
-                                      </span>
-                                    </ComboboxChip>
-                                  );
-                                })}
-                                <ComboboxChipsInput placeholder="Search integrations" />
-                              </ComboboxChips>
-                              <ComboboxContent anchor={comboboxAnchor.current}>
-                                <ComboboxEmpty>
-                                  No integrations found.
-                                </ComboboxEmpty>
-                                <ComboboxList>
-                                  {integrationOptions.map((opt) => (
-                                    <ComboboxItem
-                                      key={opt.value}
-                                      value={opt.value}
-                                    >
-                                      <span className="flex items-center gap-2">
-                                        {opt.type === "github" ? (
-                                          <Github className="size-3.5 shrink-0" />
-                                        ) : (
-                                          <Linear className="size-3.5 shrink-0" />
-                                        )}
-                                        {opt.label}
-                                      </span>
-                                    </ComboboxItem>
-                                  ))}
-                                </ComboboxList>
-                              </ComboboxContent>
-                            </Combobox>
-                          </div>
-                        )}
-                        <p className="text-muted-foreground text-xs">
-                          Pick one or more integrations to pull data from.
-                        </p>
-                      </div>
-                    )}
-                  </form.Field>
-
-                  <Collapsible
-                    defaultOpen={false}
-                    onOpenChange={setDataSourcesOpen}
-                    open={dataSourcesOpen}
-                  >
-                    <CollapsibleTrigger className="flex w-full items-center gap-2 font-medium text-sm">
-                      <HugeiconsIcon
-                        className={`size-4 transition-transform ${dataSourcesOpen ? "" : "-rotate-90"}`}
-                        icon={ArrowDown01Icon}
-                      />
-                      Data Sources
-                    </CollapsibleTrigger>
-                    <CollapsibleContent className="mt-3 space-y-3">
-                      <form.Field name="dataPoints.includePullRequests">
-                        {(field) => (
-                          <DataPointToggle
-                            checked={field.state.value}
-                            description="Include PR metadata and summaries."
-                            disabled={mutation.isPending}
-                            label="Pull Requests"
-                            onCheckedChange={field.handleChange}
-                          />
-                        )}
-                      </form.Field>
-                      <form.Field name="dataPoints.includeCommits">
-                        {(field) => (
-                          <DataPointToggle
-                            checked={field.state.value}
-                            description="Include commit-level change data."
-                            disabled={mutation.isPending}
-                            label="Commits"
-                            onCheckedChange={field.handleChange}
-                          />
-                        )}
-                      </form.Field>
-                      <form.Field name="dataPoints.includeReleases">
-                        {(field) => (
-                          <DataPointToggle
-                            checked={field.state.value}
-                            description="Include GitHub releases and changelogs."
-                            disabled={mutation.isPending}
-                            label="Releases"
-                            onCheckedChange={field.handleChange}
-                          />
-                        )}
-                      </form.Field>
-                    </CollapsibleContent>
-                  </Collapsible>
-                </div>
-              </div>
-            )}
-
-            {/* ── Step 2: Review Events ── */}
-            {step === "review" && (
-              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                {isLoadingPreview && (
-                  <div className="space-y-2 p-4">
-                    <Skeleton className="h-8 w-full" />
-                    <Skeleton className="h-8 w-full" />
-                    <Skeleton className="h-8 w-full" />
-                    <Skeleton className="h-6 w-40" />
-                    <Skeleton className="h-8 w-full" />
-                  </div>
-                )}
-                {!isLoadingPreview && isPreviewError && (
-                  <div className="p-4">
-                    <div className="flex flex-col items-center gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4 text-center text-sm">
-                      <p>Failed to load events.</p>
-                      <Button
-                        onClick={() =>
-                          queryClient.invalidateQueries({
-                            queryKey: ["content-preview", organizationId],
-                          })
-                        }
-                        size="sm"
-                        type="button"
-                        variant="outline"
-                      >
-                        <HugeiconsIcon
-                          className="size-3.5"
-                          icon={ArrowReloadHorizontalIcon}
-                        />
-                        Retry
-                      </Button>
-                    </div>
-                  </div>
-                )}
-                {!isLoadingPreview &&
-                  !isPreviewError &&
-                  previewFailures.length > 0 && (
-                    <div className="shrink-0 px-4 pt-4">
-                      <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900 text-xs dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200">
-                        <p className="font-medium text-sm">
-                          Partial preview ({previewFailures.length} warning
-                          {previewFailures.length === 1 ? "" : "s"})
-                        </p>
-                        {previewFailures.slice(0, 3).map((failure) => (
-                          <p
-                            className="mt-1"
-                            key={`${failure.repositoryId}:${failure.stage}`}
-                          >
-                            {(failure.owner && failure.repo
-                              ? `${failure.owner}/${failure.repo}`
-                              : failure.repositoryId) +
-                              ": " +
-                              failure.message}
-                          </p>
-                        ))}
-                        {previewFailures.length > 3 && (
-                          <p className="mt-1">
-                            +{previewFailures.length - 3} more warnings
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                {!isLoadingPreview && !isPreviewError && previewResponse && (
-                  <>
-                    {eventCounts.total > 0 && (
-                      <div className="flex shrink-0 items-center justify-between border-b px-4 py-2">
-                        <span className="text-muted-foreground text-xs">
-                          {eventCounts.selected} / {eventCounts.total} selected
-                          {totalPages > 1 &&
-                            ` · Page ${currentPage} of ${totalPages}`}
-                        </span>
-                        <Button
-                          onClick={handleToggleAll}
-                          size="sm"
-                          type="button"
-                          variant="ghost"
-                        >
-                          {eventCounts.selected === eventCounts.total
-                            ? "Deselect all"
-                            : "Select all"}
-                        </Button>
-                      </div>
-                    )}
-                    <div className="min-h-0 flex-1 overflow-y-auto">
-                      <div className="space-y-3 p-4">
-                        {eventCounts.total === 0 ? (
-                          <div className="rounded-md border border-dashed p-4 text-center text-muted-foreground text-xs">
-                            No events found for the selected timeframe.
-                          </div>
-                        ) : (
-                          paginatedRepos.map((repo) => (
-                            <RepoSection
-                              dataPoints={dataPoints}
-                              key={repo.repositoryId}
-                              onToggleCommit={(sha) => {
-                                selectionsTouchedRef.current = true;
-                                setSelectedCommitKeys((prev) => {
-                                  const next = new Set(prev);
-                                  if (next.has(sha)) {
-                                    next.delete(sha);
-                                  } else {
-                                    next.add(sha);
-                                  }
-                                  return next;
-                                });
-                              }}
-                              onTogglePr={(key) => {
-                                selectionsTouchedRef.current = true;
-                                setSelectedPrKeys((prev) => {
-                                  const next = new Set(prev);
-                                  if (next.has(key)) {
-                                    next.delete(key);
-                                  } else {
-                                    next.add(key);
-                                  }
-                                  return next;
-                                });
-                              }}
-                              onToggleRelease={(tag) => {
-                                selectionsTouchedRef.current = true;
-                                setSelectedReleaseKeys((prev) => {
-                                  const next = new Set(prev);
-                                  if (next.has(tag)) {
-                                    next.delete(tag);
-                                  } else {
-                                    next.add(tag);
-                                  }
-                                  return next;
-                                });
-                              }}
-                              repo={repo}
-                              selectedCommitKeys={selectedCommitKeys}
-                              selectedPrKeys={selectedPrKeys}
-                              selectedReleaseKeys={selectedReleaseKeys}
-                            />
-                          ))
-                        )}
-                        {previewResponse?.linearIntegrations?.map(
-                          (li) =>
-                            li.issues.length > 0 && (
-                              <div
-                                className="overflow-hidden rounded-lg border"
-                                key={li.integrationId}
-                              >
-                                <div className="flex items-center gap-2 bg-muted/30 px-3 py-2">
-                                  <Linear className="size-4 shrink-0" />
-                                  <span className="font-medium text-sm">
-                                    {li.displayName}
-                                  </span>
-                                </div>
-                                <div className="divide-y">
-                                  {li.issues.map((issue) => {
-                                    const key = `${li.integrationId}:${issue.id}`;
-                                    return (
-                                      <EventRow
-                                        key={issue.id}
-                                        label={`${issue.identifier} ${issue.title}`}
-                                        meta={`${issue.assignee ?? "Unassigned"} · ${issue.completedAt ? formatEventDate(issue.completedAt) : ""}`}
-                                        onToggle={() => {
-                                          selectionsTouchedRef.current = true;
-                                          setSelectedLinearKeys((prev) => {
-                                            const next = new Set(prev);
-                                            if (next.has(key)) {
-                                              next.delete(key);
-                                            } else {
-                                              next.add(key);
-                                            }
-                                            return next;
-                                          });
-                                        }}
-                                        selected={selectedLinearKeys.has(key)}
-                                        type="LinearIssue"
-                                      />
-                                    );
-                                  })}
-                                </div>
-                              </div>
-                            )
-                        )}
-                        {totalPages > 1 && (
-                          <Pagination>
-                            <PaginationContent>
-                              <PaginationItem>
-                                <PaginationPrevious
-                                  className={cn(
-                                    currentPage === 1 &&
-                                      "pointer-events-none opacity-50"
-                                  )}
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    setCurrentPage((p) => Math.max(1, p - 1));
-                                  }}
-                                />
-                              </PaginationItem>
-                              {getPageNumbers(currentPage, totalPages).map(
-                                (page, i) =>
-                                  page === "ellipsis" ? (
-                                    <PaginationItem key={`ellipsis-${i}`}>
-                                      <PaginationEllipsis />
-                                    </PaginationItem>
-                                  ) : (
-                                    <PaginationItem key={page}>
-                                      <PaginationLink
-                                        isActive={page === currentPage}
-                                        onClick={(e) => {
-                                          e.preventDefault();
-                                          setCurrentPage(page);
-                                        }}
-                                      >
-                                        {page}
-                                      </PaginationLink>
-                                    </PaginationItem>
-                                  )
-                              )}
-                              <PaginationItem>
-                                <PaginationNext
-                                  className={cn(
-                                    currentPage === totalPages &&
-                                      "pointer-events-none opacity-50"
-                                  )}
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    setCurrentPage((p) =>
-                                      Math.min(totalPages, p + 1)
-                                    );
-                                  }}
-                                />
-                              </PaginationItem>
-                            </PaginationContent>
-                          </Pagination>
-                        )}
-                      </div>
-                    </div>
-                  </>
-                )}
-              </div>
-            )}
-
-            {/* ── Footer ── */}
-            <div className="shrink-0 rounded-b-xl border-t bg-muted/50 p-4">
-              {step === "configure" && (
-                <div className="flex items-center justify-between gap-3">
-                  {repositoryIds.length === 0 ? (
-                    <p className="text-muted-foreground text-xs">
-                      Select or add an integration to continue.
-                    </p>
-                  ) : (
-                    <span />
-                  )}
-                  <Button
-                    disabled={repositoryIds.length === 0}
-                    onClick={handleContinue}
-                    type="button"
-                  >
-                    Continue
-                  </Button>
-                </div>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="min-h-0 flex-1 overflow-y-auto p-6">
+              {step === "formats" && (
+                <StepFormats
+                  dataPoints={dataPoints}
+                  lookbackWindow={lookbackWindow}
+                  onDataPointChange={handleDataPointChange}
+                  onLookbackChange={setLookbackWindow}
+                  onToggle={toggleFormat}
+                  selected={selectedFormats}
+                />
               )}
-              {step === "review" && (
-                <div className="flex items-center justify-between">
-                  <Button
-                    disabled={mutation.isPending}
-                    onClick={handleBack}
-                    type="button"
-                    variant="outline"
-                  >
-                    Back
-                  </Button>
+              {step === "activity" && (
+                <StepActivity
+                  dataPoints={dataPoints}
+                  integrationOptions={integrationOptions}
+                  isLoadingIntegrations={isLoadingRepos}
+                  isLoadingPreview={isLoadingPreview}
+                  isPreviewError={isPreviewError}
+                  onConnect={handleOpenAddRepositoryFlow}
+                  onSearchQueryChange={setSearchQuery}
+                  onToggleCommit={(key) => {
+                    selectionsTouchedRef.current = true;
+                    setSelectedCommitKeys((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(key)) {
+                        next.delete(key);
+                      } else {
+                        next.add(key);
+                      }
+                      return next;
+                    });
+                  }}
+                  onToggleIntegration={toggleRepoId}
+                  onToggleLinear={(key) => {
+                    selectionsTouchedRef.current = true;
+                    setSelectedLinearKeys((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(key)) {
+                        next.delete(key);
+                      } else {
+                        next.add(key);
+                      }
+                      return next;
+                    });
+                  }}
+                  onTogglePr={(key) => {
+                    selectionsTouchedRef.current = true;
+                    setSelectedPrKeys((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(key)) {
+                        next.delete(key);
+                      } else {
+                        next.add(key);
+                      }
+                      return next;
+                    });
+                  }}
+                  onToggleRelease={(key) => {
+                    selectionsTouchedRef.current = true;
+                    setSelectedReleaseKeys((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(key)) {
+                        next.delete(key);
+                      } else {
+                        next.add(key);
+                      }
+                      return next;
+                    });
+                  }}
+                  organizationId={organizationId}
+                  preview={previewResponse}
+                  repositories={previewData}
+                  searchQuery={searchQuery}
+                  selectedCommitKeys={selectedCommitKeys}
+                  selectedIntegrationIds={selectedRepoIds}
+                  selectedLinearKeys={selectedLinearKeys}
+                  selectedPrKeys={selectedPrKeys}
+                  selectedReleaseKeys={selectedReleaseKeys}
+                />
+              )}
+              {step === "identities" && (
+                <StepBrandIdentities
+                  isLoading={isLoadingVoices}
+                  onToggle={toggleVoiceId}
+                  organizationId={organizationId}
+                  selected={selectedBrandVoiceIds}
+                  voices={brandVoices}
+                />
+              )}
+            </div>
+
+            <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  {step !== "formats" && (
+                    <Button
+                      disabled={mutation.isPending}
+                      onClick={goBack}
+                      size="sm"
+                      type="button"
+                      variant="ghost"
+                    >
+                      <HugeiconsIcon
+                        className="size-3.5"
+                        icon={ArrowLeft01Icon}
+                      />
+                      Back
+                    </Button>
+                  )}
+                  <span className="text-muted-foreground text-xs">
+                    {footerLeft}
+                  </span>
+                </div>
+                {step === "identities" ? (
                   <Button
                     disabled={
-                      mutation.isPending ||
-                      isLoadingPreview ||
-                      eventCounts.selected === 0
+                      mutation.isPending || selectedFormats.length === 0
                     }
                     onClick={handleCreate}
                     type="button"
@@ -1349,23 +837,42 @@ export function CreateContentDialog({
                         Generating...
                       </>
                     ) : (
-                      "Create content"
+                      <>
+                        {identityButtonLabel}
+                        <HugeiconsIcon
+                          className="size-3.5"
+                          icon={ArrowRight01Icon}
+                        />
+                      </>
                     )}
                   </Button>
-                </div>
-              )}
+                ) : (
+                  <Button
+                    disabled={continueDisabled}
+                    onClick={goNext}
+                    type="button"
+                  >
+                    Continue
+                    <HugeiconsIcon
+                      className="size-3.5"
+                      icon={ArrowRight01Icon}
+                    />
+                  </Button>
+                )}
+              </div>
             </div>
-          </form>
+          </div>
         </ResponsiveDialogContent>
       </ResponsiveDialog>
-      {addRepoMode === "repository" ? (
+      {addRepoMode === "repository" && githubIntegrationId && (
         <AddRepositoryDialog
-          integrationId={githubIntegrationId!}
+          integrationId={githubIntegrationId}
           onOpenChange={handleAddRepoOpenChange}
           open={addRepoOpen}
           organizationId={organizationId}
         />
-      ) : addRepoMode === "integration" ? (
+      )}
+      {addRepoMode === "integration" && (
         <AddIntegrationDialog
           onFlowComplete={handleIntegrationFlowComplete}
           onOpenChange={handleAddRepoOpenChange}
@@ -1373,166 +880,58 @@ export function CreateContentDialog({
           open={addRepoOpen}
           organizationId={organizationId}
         />
-      ) : null}
+      )}
     </>
   );
 }
 
-function DataPointToggle({
-  label,
-  description,
-  checked,
-  disabled,
-  onCheckedChange,
-}: {
-  label: string;
-  description: string;
-  checked: boolean;
-  disabled: boolean;
-  onCheckedChange: (checked: boolean) => void;
-}) {
-  return (
-    <div className="flex items-start justify-between gap-4 rounded-lg border p-3">
-      <div>
-        <p className="font-medium text-sm">{label}</p>
-        <p className="text-muted-foreground text-xs">{description}</p>
-      </div>
-      <Switch
-        checked={checked}
-        disabled={disabled}
-        onCheckedChange={onCheckedChange}
-      />
-    </div>
-  );
+interface StepProgressProps {
+  activeIndex: number;
 }
 
-function RepoSection({
-  repo,
-  dataPoints,
-  selectedCommitKeys,
-  selectedPrKeys,
-  selectedReleaseKeys,
-  onToggleCommit,
-  onTogglePr,
-  onToggleRelease,
-}: {
-  repo: RepositoryPreview;
-  dataPoints: ContentDataPointSettings;
-  selectedCommitKeys: Set<string>;
-  selectedPrKeys: Set<string>;
-  selectedReleaseKeys: Set<string>;
-  onToggleCommit: (sha: string) => void;
-  onTogglePr: (key: string) => void;
-  onToggleRelease: (key: string) => void;
-}) {
-  const showCommits = dataPoints.includeCommits && repo.commits.length > 0;
-  const showPrs =
-    dataPoints.includePullRequests && repo.pullRequests.length > 0;
-  const showReleases = dataPoints.includeReleases && repo.releases.length > 0;
-
-  if (!showCommits && !showPrs && !showReleases) {
-    return null;
-  }
-
+function StepProgress({ activeIndex }: StepProgressProps) {
   return (
-    <div className="overflow-hidden rounded-lg border">
-      <div className="flex items-center gap-2 bg-muted/30 px-3 py-2">
-        <Github className="size-4 shrink-0" />
-        <span className="font-medium text-sm">
-          {repo.owner}/{repo.repo}
-        </span>
-      </div>
-      <div className="divide-y">
-        {showReleases &&
-          repo.releases.map((release) => {
-            const releaseKey = releaseSelectionToKey({
-              repositoryId: repo.repositoryId,
-              tagName: release.tagName,
-            });
-            return (
-              <EventRow
-                key={releaseKey}
-                label={release.name || release.tagName}
-                meta={`${release.authorLogin} · ${formatEventDate(release.publishedAt)}${release.prerelease ? " · pre-release" : ""}`}
-                onToggle={() => onToggleRelease(releaseKey)}
-                selected={selectedReleaseKeys.has(releaseKey)}
-                type="Release"
+    <div className="flex items-center gap-2">
+      {STEP_ORDER.map((stepKey, idx) => {
+        const isCompleted = idx < activeIndex;
+        const isActive = idx === activeIndex;
+        return (
+          <div className="flex items-center gap-2" key={stepKey}>
+            <div
+              className={cn(
+                "flex size-5 shrink-0 items-center justify-center rounded-full font-medium text-[10px] transition-colors",
+                isActive && "bg-foreground text-background",
+                isCompleted && "bg-foreground/80 text-background",
+                !(isActive || isCompleted) && "bg-muted text-muted-foreground"
+              )}
+            >
+              {isCompleted ? (
+                <HugeiconsIcon className="size-3" icon={Tick01Icon} />
+              ) : (
+                idx + 1
+              )}
+            </div>
+            <span
+              className={cn(
+                "hidden text-xs sm:inline",
+                isActive
+                  ? "font-medium text-foreground"
+                  : "text-muted-foreground"
+              )}
+            >
+              {STEP_LABELS[stepKey]}
+            </span>
+            {idx < STEP_ORDER.length - 1 && (
+              <div
+                className={cn(
+                  "hidden h-px w-4 sm:block",
+                  isCompleted ? "bg-foreground/40" : "bg-border"
+                )}
               />
-            );
-          })}
-        {showPrs &&
-          repo.pullRequests.map((pr) => {
-            const prKey = prSelectionToKey({
-              repositoryId: repo.repositoryId,
-              number: pr.number,
-            });
-            return (
-              <EventRow
-                key={prKey}
-                label={`#${pr.number} ${pr.title}`}
-                meta={`${pr.authorLogin} · ${pr.mergedAt ? formatEventDate(pr.mergedAt) : ""}`}
-                onToggle={() => onTogglePr(prKey)}
-                selected={selectedPrKeys.has(prKey)}
-                type="PR"
-              />
-            );
-          })}
-        {showCommits &&
-          repo.commits.map((commit) => (
-            <EventRow
-              key={commit.sha}
-              label={commit.message}
-              meta={`${commit.authorName} · ${commit.authoredAt ? formatEventDate(commit.authoredAt) : ""} · ${commit.sha.slice(0, 7)}`}
-              onToggle={() => onToggleCommit(commit.sha)}
-              selected={selectedCommitKeys.has(commit.sha)}
-              type="Commit"
-            />
-          ))}
-      </div>
+            )}
+          </div>
+        );
+      })}
     </div>
-  );
-}
-
-function EventRow({
-  label,
-  meta,
-  type,
-  selected,
-  onToggle,
-}: {
-  label: string;
-  meta: string;
-  type: EventType;
-  selected: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      className={cn(
-        "flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50",
-        selected && "bg-muted/20"
-      )}
-      onClick={onToggle}
-      type="button"
-    >
-      <div
-        className={cn(
-          "flex size-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
-          selected
-            ? "border-primary bg-primary text-primary-foreground"
-            : "border-muted-foreground/30"
-        )}
-      >
-        {selected && <HugeiconsIcon className="size-3" icon={Tick01Icon} />}
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm">{label}</p>
-        <p className="truncate text-muted-foreground text-xs">{meta}</p>
-      </div>
-      <Badge className={cn("shrink-0", EVENT_BADGE[type])}>
-        <HugeiconsIcon className="size-3!" icon={EVENT_ICON[type]} />
-        {type === "LinearIssue" ? "Issue" : type}
-      </Badge>
-    </button>
   );
 }

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -302,7 +302,7 @@ export function CreateContentDialog({
   }, [previewParamsKey, previewFailures]);
 
   const mutation = useMutation<
-    void,
+    { succeeded: number; total: number },
     Error,
     {
       formats: OnDemandContentType[];
@@ -315,7 +315,7 @@ export function CreateContentDialog({
       const calls = formats.flatMap((format) =>
         voiceIds.map((voiceId) => ({ format, voiceId }))
       );
-      await Promise.all(
+      const results = await Promise.allSettled(
         calls.map(({ format, voiceId }) =>
           dashboardOrpc.content.generate.call({
             organizationId,
@@ -329,10 +329,33 @@ export function CreateContentDialog({
           })
         )
       );
+      const failures = results.filter((r) => r.status === "rejected");
+      const succeeded = results.length - failures.length;
+      if (succeeded === 0) {
+        const reason = failures[0];
+        const message =
+          reason &&
+          reason.status === "rejected" &&
+          reason.reason instanceof Error
+            ? reason.reason.message
+            : "Failed to start any content generation";
+        throw new Error(message);
+      }
+      return { succeeded, total: results.length };
     },
-    onSuccess: () => {
+    onSuccess: ({ succeeded, total }) => {
       setOpen(false);
-      toast.success("Content generation started");
+      if (succeeded === total) {
+        toast.success(
+          succeeded === 1
+            ? "Content generation started"
+            : `${succeeded} content generations started`
+        );
+      } else {
+        toast.warning(
+          `${succeeded} of ${total} content generations started; ${total - succeeded} failed`
+        );
+      }
       queryClient.invalidateQueries({
         queryKey: dashboardOrpc.content.activeGenerations.list.queryKey({
           input: { organizationId },
@@ -650,12 +673,7 @@ export function CreateContentDialog({
     setOpen(true);
   }, []);
 
-  const hasAnyDataPoint =
-    dataPoints.includePullRequests ||
-    dataPoints.includeCommits ||
-    dataPoints.includeReleases;
-
-  const canContinueFromFormats = selectedFormats.length > 0 && hasAnyDataPoint;
+  const canContinueFromFormats = selectedFormats.length > 0;
   const canContinueFromActivity =
     selectedRepoIds.length > 0 && !isLoadingPreview && eventCounts.selected > 0;
 

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -315,6 +315,10 @@ export function CreateContentDialog({
       const calls = formats.flatMap((format) =>
         voiceIds.map((voiceId) => ({ format, voiceId }))
       );
+      // TODO: replace this client-side fan-out with a single boss agent
+      // that delegates to N sub-agents (one per format), with the boss
+      // deciding the angle / topic each sub-agent writes about so the
+      // outputs are coordinated instead of independently drafted.
       const results = await Promise.allSettled(
         calls.map(({ format, voiceId }) =>
           dashboardOrpc.content.generate.call({

--- a/apps/dashboard/src/components/content/create/data-point-toggle.tsx
+++ b/apps/dashboard/src/components/content/create/data-point-toggle.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Switch } from "@notra/ui/components/ui/switch";
+
+interface DataPointToggleProps {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled?: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export function DataPointToggle({
+  label,
+  description,
+  checked,
+  disabled,
+  onCheckedChange,
+}: DataPointToggleProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border bg-card px-3 py-2.5">
+      <div className="min-w-0">
+        <p className="font-medium text-sm">{label}</p>
+        <p className="truncate text-muted-foreground text-xs">{description}</p>
+      </div>
+      <Switch
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/content/create/data-point-toggle.tsx
+++ b/apps/dashboard/src/components/content/create/data-point-toggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Switch } from "@notra/ui/components/ui/switch";
+import { useId } from "react";
 
 interface DataPointToggleProps {
   label: string;
@@ -17,13 +18,24 @@ export function DataPointToggle({
   disabled,
   onCheckedChange,
 }: DataPointToggleProps) {
+  const labelId = useId();
+  const descriptionId = useId();
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border bg-card px-3 py-2.5">
       <div className="min-w-0">
-        <p className="font-medium text-sm">{label}</p>
-        <p className="truncate text-muted-foreground text-xs">{description}</p>
+        <p className="font-medium text-sm" id={labelId}>
+          {label}
+        </p>
+        <p
+          className="truncate text-muted-foreground text-xs"
+          id={descriptionId}
+        >
+          {description}
+        </p>
       </div>
       <Switch
+        aria-describedby={descriptionId}
+        aria-labelledby={labelId}
         checked={checked}
         disabled={disabled}
         onCheckedChange={onCheckedChange}

--- a/apps/dashboard/src/components/content/create/event-row.tsx
+++ b/apps/dashboard/src/components/content/create/event-row.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import {
+  GitCommitIcon,
+  GitPullRequestIcon,
+  Rocket01Icon,
+  Tick01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Badge } from "@notra/ui/components/ui/badge";
+import { cn } from "@notra/ui/lib/utils";
+import { EVENT_BADGE } from "@/constants/content-preview";
+import type { EventType } from "@/types/content/preview";
+
+const EVENT_ICON: Record<EventType, typeof GitPullRequestIcon> = {
+  PR: GitPullRequestIcon,
+  Commit: GitCommitIcon,
+  Release: Rocket01Icon,
+  LinearIssue: Tick01Icon,
+};
+
+interface EventRowProps {
+  label: string;
+  meta: string;
+  type: EventType;
+  selected: boolean;
+  onToggle: () => void;
+}
+
+export function EventRow({
+  label,
+  meta,
+  type,
+  selected,
+  onToggle,
+}: EventRowProps) {
+  return (
+    <button
+      className={cn(
+        "flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50",
+        selected && "bg-muted/20"
+      )}
+      onClick={onToggle}
+      type="button"
+    >
+      <div
+        className={cn(
+          "flex size-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
+          selected
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-muted-foreground/30"
+        )}
+      >
+        {selected && <HugeiconsIcon className="size-3" icon={Tick01Icon} />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm">{label}</p>
+        <p className="truncate text-muted-foreground text-xs">{meta}</p>
+      </div>
+      <Badge className={cn("shrink-0", EVENT_BADGE[type])}>
+        <HugeiconsIcon className="size-3!" icon={EVENT_ICON[type]} />
+        {type === "LinearIssue" ? "Issue" : type}
+      </Badge>
+    </button>
+  );
+}

--- a/apps/dashboard/src/components/content/create/format-card.tsx
+++ b/apps/dashboard/src/components/content/create/format-card.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Tick01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { cn } from "@notra/ui/lib/utils";
+import { FORMAT_CARD_META } from "@/constants/content-formats";
+import type { OnDemandContentType } from "@/schemas/content";
+import { OutputTypeIcon } from "@/utils/output-types";
+
+interface FormatCardProps {
+  format: OnDemandContentType;
+  selected: boolean;
+  onToggle: () => void;
+}
+
+export function FormatCard({ format, selected, onToggle }: FormatCardProps) {
+  const meta = FORMAT_CARD_META[format];
+
+  return (
+    <button
+      aria-pressed={selected}
+      className={cn(
+        "group relative flex flex-col gap-3 rounded-lg border bg-card p-4 text-left transition-colors",
+        "hover:border-foreground/20",
+        selected ? "border-foreground/40 bg-foreground/[0.02]" : "border-border"
+      )}
+      onClick={onToggle}
+      type="button"
+    >
+      <div className="flex items-start justify-between">
+        <OutputTypeIcon
+          className={cn("size-5", meta.iconClass)}
+          outputType={format}
+        />
+        <div
+          className={cn(
+            "flex size-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
+            selected
+              ? "border-foreground bg-foreground text-background"
+              : "border-muted-foreground/30 group-hover:border-muted-foreground/50"
+          )}
+        >
+          {selected && (
+            <HugeiconsIcon
+              className="size-3"
+              icon={Tick01Icon}
+              strokeWidth={3}
+            />
+          )}
+        </div>
+      </div>
+      <div className="space-y-1">
+        <p className="font-medium text-sm">{meta.label}</p>
+        <p className="text-muted-foreground text-xs leading-relaxed">
+          {meta.description}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/apps/dashboard/src/components/content/create/repo-section.tsx
+++ b/apps/dashboard/src/components/content/create/repo-section.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Github } from "@notra/ui/components/ui/svgs/github";
+import type { ContentDataPointSettings } from "@/schemas/content";
+import type { RepositoryPreview } from "@/types/content/preview";
+import {
+  formatEventDate,
+  prSelectionToKey,
+  releaseSelectionToKey,
+} from "@/utils/content-preview";
+import { EventRow } from "./event-row";
+
+interface RepoSectionProps {
+  repo: RepositoryPreview;
+  dataPoints: ContentDataPointSettings;
+  selectedCommitKeys: Set<string>;
+  selectedPrKeys: Set<string>;
+  selectedReleaseKeys: Set<string>;
+  onToggleCommit: (sha: string) => void;
+  onTogglePr: (key: string) => void;
+  onToggleRelease: (key: string) => void;
+}
+
+export function RepoSection({
+  repo,
+  dataPoints,
+  selectedCommitKeys,
+  selectedPrKeys,
+  selectedReleaseKeys,
+  onToggleCommit,
+  onTogglePr,
+  onToggleRelease,
+}: RepoSectionProps) {
+  const showCommits = dataPoints.includeCommits && repo.commits.length > 0;
+  const showPrs =
+    dataPoints.includePullRequests && repo.pullRequests.length > 0;
+  const showReleases = dataPoints.includeReleases && repo.releases.length > 0;
+
+  if (!(showCommits || showPrs || showReleases)) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <div className="flex items-center gap-2 bg-muted/30 px-3 py-2">
+        <Github className="size-4 shrink-0" />
+        <span className="font-medium text-sm">
+          {repo.owner}/{repo.repo}
+        </span>
+      </div>
+      <div className="divide-y">
+        {showReleases &&
+          repo.releases.map((release) => {
+            const releaseKey = releaseSelectionToKey({
+              repositoryId: repo.repositoryId,
+              tagName: release.tagName,
+            });
+            return (
+              <EventRow
+                key={releaseKey}
+                label={release.name || release.tagName}
+                meta={`${release.authorLogin} · ${formatEventDate(release.publishedAt)}${release.prerelease ? " · pre-release" : ""}`}
+                onToggle={() => onToggleRelease(releaseKey)}
+                selected={selectedReleaseKeys.has(releaseKey)}
+                type="Release"
+              />
+            );
+          })}
+        {showPrs &&
+          repo.pullRequests.map((pr) => {
+            const prKey = prSelectionToKey({
+              repositoryId: repo.repositoryId,
+              number: pr.number,
+            });
+            return (
+              <EventRow
+                key={prKey}
+                label={`#${pr.number} ${pr.title}`}
+                meta={`${pr.authorLogin} · ${pr.mergedAt ? formatEventDate(pr.mergedAt) : ""}`}
+                onToggle={() => onTogglePr(prKey)}
+                selected={selectedPrKeys.has(prKey)}
+                type="PR"
+              />
+            );
+          })}
+        {showCommits &&
+          repo.commits.map((commit) => (
+            <EventRow
+              key={commit.sha}
+              label={commit.message}
+              meta={`${commit.authorLogin ?? commit.authorName} · ${commit.authoredAt ? formatEventDate(commit.authoredAt) : ""} · ${commit.sha.slice(0, 7)}`}
+              onToggle={() => onToggleCommit(commit.sha)}
+              selected={selectedCommitKeys.has(commit.sha)}
+              type="Commit"
+            />
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/content/create/step-activity.tsx
+++ b/apps/dashboard/src/components/content/create/step-activity.tsx
@@ -98,9 +98,9 @@ export function StepActivity(props: ActivityStepProps) {
   const hasAnyVisible =
     visibleRepos.some(
       (r) =>
-        r.commits.length > 0 ||
-        r.pullRequests.length > 0 ||
-        r.releases.length > 0
+        (dataPoints.includeCommits && r.commits.length > 0) ||
+        (dataPoints.includePullRequests && r.pullRequests.length > 0) ||
+        (dataPoints.includeReleases && r.releases.length > 0)
     ) || visibleLinear.some((li) => li.issues.length > 0);
 
   const hasSelectedIntegrations = selectedIntegrationIds.length > 0;
@@ -266,11 +266,15 @@ export function StepActivity(props: ActivityStepProps) {
                       <div className="divide-y">
                         {li.issues.map((issue) => {
                           const key = `${li.integrationId}:${issue.id}`;
+                          const metaParts = [issue.assignee ?? "Unassigned"];
+                          if (issue.completedAt) {
+                            metaParts.push(formatEventDate(issue.completedAt));
+                          }
                           return (
                             <EventRow
                               key={issue.id}
                               label={`${issue.identifier} ${issue.title}`}
-                              meta={`${issue.assignee ?? "Unassigned"} · ${issue.completedAt ? formatEventDate(issue.completedAt) : ""}`}
+                              meta={metaParts.join(" · ")}
                               onToggle={() => onToggleLinear(key)}
                               selected={selectedLinearKeys.has(key)}
                               type="LinearIssue"

--- a/apps/dashboard/src/components/content/create/step-activity.tsx
+++ b/apps/dashboard/src/components/content/create/step-activity.tsx
@@ -60,6 +60,7 @@ export function StepActivity(props: ActivityStepProps) {
     preview,
     isLoadingPreview,
     isPreviewError,
+    onRetryPreview,
     dataPoints,
     selectedCommitKeys,
     selectedPrKeys,
@@ -217,7 +218,12 @@ export function StepActivity(props: ActivityStepProps) {
         {hasSelectedIntegrations && !isLoadingPreview && isPreviewError && (
           <div className="flex flex-col items-center gap-3 rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center text-sm">
             <p>Failed to load events.</p>
-            <Button size="sm" type="button" variant="outline">
+            <Button
+              onClick={onRetryPreview}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
               <HugeiconsIcon
                 className="size-3.5"
                 icon={ArrowReloadHorizontalIcon}

--- a/apps/dashboard/src/components/content/create/step-activity.tsx
+++ b/apps/dashboard/src/components/content/create/step-activity.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import {
+  Add01Icon,
+  ArrowReloadHorizontalIcon,
+  Search01Icon,
+  Tick01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@notra/ui/components/ui/button";
+import { Input } from "@notra/ui/components/ui/input";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { Github } from "@notra/ui/components/ui/svgs/github";
+import { Linear } from "@notra/ui/components/ui/svgs/linear";
+import { cn } from "@notra/ui/lib/utils";
+import { useMemo } from "react";
+import type { ActivityStepProps } from "@/types/content/create";
+import type { RepositoryPreview } from "@/types/content/preview";
+import { formatEventDate } from "@/utils/content-preview";
+import { EventRow } from "./event-row";
+import { RepoSection } from "./repo-section";
+
+function filterRepo(repo: RepositoryPreview, query: string): RepositoryPreview {
+  if (!query) {
+    return repo;
+  }
+  const q = query.toLowerCase();
+  return {
+    ...repo,
+    commits: repo.commits.filter(
+      (c) =>
+        c.message.toLowerCase().includes(q) ||
+        c.authorName.toLowerCase().includes(q) ||
+        (c.authorLogin ?? "").toLowerCase().includes(q) ||
+        c.sha.toLowerCase().includes(q)
+    ),
+    pullRequests: repo.pullRequests.filter(
+      (pr) =>
+        pr.title.toLowerCase().includes(q) ||
+        pr.authorLogin.toLowerCase().includes(q) ||
+        String(pr.number).includes(q)
+    ),
+    releases: repo.releases.filter(
+      (r) =>
+        (r.name || "").toLowerCase().includes(q) ||
+        r.tagName.toLowerCase().includes(q) ||
+        r.authorLogin.toLowerCase().includes(q)
+    ),
+  };
+}
+
+export function StepActivity(props: ActivityStepProps) {
+  const {
+    integrationOptions,
+    selectedIntegrationIds,
+    onToggleIntegration,
+    isLoadingIntegrations,
+    onConnect,
+    repositories,
+    preview,
+    isLoadingPreview,
+    isPreviewError,
+    dataPoints,
+    selectedCommitKeys,
+    selectedPrKeys,
+    selectedReleaseKeys,
+    selectedLinearKeys,
+    onToggleCommit,
+    onTogglePr,
+    onToggleRelease,
+    onToggleLinear,
+    searchQuery,
+    onSearchQueryChange,
+  } = props;
+
+  const visibleRepos = useMemo(() => {
+    return (repositories ?? []).map((r) => filterRepo(r, searchQuery));
+  }, [repositories, searchQuery]);
+
+  const visibleLinear = useMemo(() => {
+    const list = preview?.linearIntegrations ?? [];
+    if (!searchQuery) {
+      return list;
+    }
+    const q = searchQuery.toLowerCase();
+    return list.map((li) => ({
+      ...li,
+      issues: li.issues.filter(
+        (issue) =>
+          issue.title.toLowerCase().includes(q) ||
+          issue.identifier.toLowerCase().includes(q) ||
+          (issue.assignee ?? "").toLowerCase().includes(q)
+      ),
+    }));
+  }, [preview?.linearIntegrations, searchQuery]);
+
+  const hasAnyVisible =
+    visibleRepos.some(
+      (r) =>
+        r.commits.length > 0 ||
+        r.pullRequests.length > 0 ||
+        r.releases.length > 0
+    ) || visibleLinear.some((li) => li.issues.length > 0);
+
+  const hasSelectedIntegrations = selectedIntegrationIds.length > 0;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="space-y-1">
+        <h2 className="font-semibold text-xl tracking-tight">
+          Pick the activity to include
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Search recent activity and pick the events to package.
+        </p>
+      </div>
+
+      <div className="relative">
+        <HugeiconsIcon
+          className="-translate-y-1/2 absolute top-1/2 left-3 size-4 text-muted-foreground"
+          icon={Search01Icon}
+        />
+        <Input
+          className="pl-9"
+          onChange={(e) => onSearchQueryChange(e.target.value)}
+          placeholder="Search by title, author, or label..."
+          value={searchQuery}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1 overflow-x-auto">
+          <div className="flex items-center gap-2 pr-1">
+            {isLoadingIntegrations && (
+              <>
+                <Skeleton className="h-8 w-32 shrink-0" />
+                <Skeleton className="h-8 w-32 shrink-0" />
+              </>
+            )}
+
+            {!isLoadingIntegrations && integrationOptions.length === 0 && (
+              <span className="text-muted-foreground text-xs">
+                No integrations connected yet.
+              </span>
+            )}
+
+            {!isLoadingIntegrations &&
+              integrationOptions.map((opt) => {
+                const isSelected = selectedIntegrationIds.includes(opt.value);
+                return (
+                  <button
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "flex h-8 shrink-0 items-center gap-2 rounded-md border bg-card px-2.5 text-xs transition-colors hover:border-foreground/20",
+                      isSelected
+                        ? "border-foreground/40 bg-foreground/5"
+                        : "border-border"
+                    )}
+                    key={opt.value}
+                    onClick={() => onToggleIntegration(opt.value)}
+                    type="button"
+                  >
+                    <div
+                      className={cn(
+                        "flex size-3.5 shrink-0 items-center justify-center rounded-sm border transition-colors",
+                        isSelected
+                          ? "border-foreground bg-foreground text-background"
+                          : "border-muted-foreground/40"
+                      )}
+                    >
+                      {isSelected && (
+                        <HugeiconsIcon
+                          className="size-2.5"
+                          icon={Tick01Icon}
+                          strokeWidth={3}
+                        />
+                      )}
+                    </div>
+                    {opt.type === "github" ? (
+                      <Github className="size-3.5 shrink-0" />
+                    ) : (
+                      <Linear className="size-3.5 shrink-0" />
+                    )}
+                    <span className="truncate">{opt.label}</span>
+                  </button>
+                );
+              })}
+          </div>
+        </div>
+        <Button
+          className="shrink-0"
+          onClick={onConnect}
+          size="icon-sm"
+          type="button"
+          variant="outline"
+        >
+          <HugeiconsIcon className="size-3.5" icon={Add01Icon} />
+          <span className="sr-only">Add integration</span>
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {!hasSelectedIntegrations && (
+          <div className="flex h-full items-center justify-center p-8 text-center text-muted-foreground text-sm">
+            Pick a source above to load activity.
+          </div>
+        )}
+
+        {hasSelectedIntegrations && isLoadingPreview && (
+          <div className="space-y-2">
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+          </div>
+        )}
+
+        {hasSelectedIntegrations && !isLoadingPreview && isPreviewError && (
+          <div className="flex flex-col items-center gap-3 rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center text-sm">
+            <p>Failed to load events.</p>
+            <Button size="sm" type="button" variant="outline">
+              <HugeiconsIcon
+                className="size-3.5"
+                icon={ArrowReloadHorizontalIcon}
+              />
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {hasSelectedIntegrations &&
+          !(isLoadingPreview || isPreviewError) &&
+          (hasAnyVisible ? (
+            <div className="space-y-3">
+              {visibleRepos.map((repo) => (
+                <RepoSection
+                  dataPoints={dataPoints}
+                  key={repo.repositoryId}
+                  onToggleCommit={onToggleCommit}
+                  onTogglePr={onTogglePr}
+                  onToggleRelease={onToggleRelease}
+                  repo={repo}
+                  selectedCommitKeys={selectedCommitKeys}
+                  selectedPrKeys={selectedPrKeys}
+                  selectedReleaseKeys={selectedReleaseKeys}
+                />
+              ))}
+              {visibleLinear.map(
+                (li) =>
+                  li.issues.length > 0 && (
+                    <div
+                      className="overflow-hidden rounded-lg border"
+                      key={li.integrationId}
+                    >
+                      <div className="flex items-center gap-2 bg-muted/30 px-3 py-2">
+                        <Linear className="size-4 shrink-0" />
+                        <span className="font-medium text-sm">
+                          {li.displayName}
+                        </span>
+                      </div>
+                      <div className="divide-y">
+                        {li.issues.map((issue) => {
+                          const key = `${li.integrationId}:${issue.id}`;
+                          return (
+                            <EventRow
+                              key={issue.id}
+                              label={`${issue.identifier} ${issue.title}`}
+                              meta={`${issue.assignee ?? "Unassigned"} · ${issue.completedAt ? formatEventDate(issue.completedAt) : ""}`}
+                              onToggle={() => onToggleLinear(key)}
+                              selected={selectedLinearKeys.has(key)}
+                              type="LinearIssue"
+                            />
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )
+              )}
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center p-8 text-center text-muted-foreground text-sm">
+              {searchQuery
+                ? "No events match your search."
+                : "No events in this timeframe."}
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/content/create/step-brand-identities.tsx
+++ b/apps/dashboard/src/components/content/create/step-brand-identities.tsx
@@ -56,9 +56,7 @@ function InlineCreateForm({ organizationId }: InlineCreateFormProps) {
       return;
     }
 
-    const websiteUrl = trimmedUrl.startsWith("https://")
-      ? trimmedUrl
-      : `https://${trimmedUrl}`;
+    const websiteUrl = `https://${trimmedUrl}`;
 
     const parseRes = z.url().safeParse(websiteUrl);
     if (!parseRes.success) {

--- a/apps/dashboard/src/components/content/create/step-brand-identities.tsx
+++ b/apps/dashboard/src/components/content/create/step-brand-identities.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import {
+  Loading03Icon,
+  Tick01Icon,
+  UserGroupIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@notra/ui/components/ui/button";
+import { Label } from "@notra/ui/components/ui/label";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { cn } from "@notra/ui/lib/utils";
+import { useState } from "react";
+import { toast } from "sonner";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+import {
+  useAnalyzeBrand,
+  useBrandAnalysisProgress,
+  useCreateBrandVoice,
+} from "@/lib/hooks/use-brand-analysis";
+import type { BrandIdentitiesStepProps } from "@/types/content/create";
+
+const HTTP_PREFIX_RE = /^https?:\/\//i;
+const WWW_PREFIX_RE = /^www\./;
+
+function sanitizeUrlInput(input: string): string {
+  return input.replace(HTTP_PREFIX_RE, "").trim();
+}
+
+interface InlineCreateFormProps {
+  organizationId: string;
+}
+
+function deriveNameFromUrl(websiteUrl: string): string {
+  try {
+    const host = new URL(websiteUrl).hostname.replace(WWW_PREFIX_RE, "");
+    return host || "Default";
+  } catch {
+    return "Default";
+  }
+}
+
+function InlineCreateForm({ organizationId }: InlineCreateFormProps) {
+  const [url, setUrl] = useState("");
+  const { startPolling } = useBrandAnalysisProgress(organizationId);
+  const createMutation = useCreateBrandVoice(organizationId);
+  const analyzeMutation = useAnalyzeBrand(organizationId, startPolling);
+
+  const isSubmitting = createMutation.isPending || analyzeMutation.isPending;
+
+  const handleSubmit = async () => {
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) {
+      toast.error("Please enter a website URL");
+      return;
+    }
+
+    const websiteUrl = trimmedUrl.startsWith("https://")
+      ? trimmedUrl
+      : `https://${trimmedUrl}`;
+
+    const parseRes = z.url().safeParse(websiteUrl);
+    if (!parseRes.success) {
+      toast.error("Please enter a valid website URL");
+      return;
+    }
+
+    try {
+      const result = await createMutation.mutateAsync({
+        name: deriveNameFromUrl(websiteUrl),
+        websiteUrl,
+      });
+      setUrl("");
+      analyzeMutation
+        .mutateAsync({ url: websiteUrl, voiceId: result.voice.id })
+        .then(() => {
+          toast.success("Brand identity created, analysis started");
+        })
+        .catch(() => {
+          toast.error(
+            "Brand identity created, but failed to start analysis. You can re-analyze from the identity settings."
+          );
+        });
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to create brand identity"
+      );
+    }
+  };
+
+  return (
+    <div className="flex min-h-[20rem] items-center justify-center">
+      <form
+        className="w-full max-w-md space-y-5 text-center"
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <div className="space-y-1">
+          <p className="font-semibold text-base">No brand identity yet</p>
+          <p className="text-muted-foreground text-xs">
+            Drop in your website and we'll learn your tone and audience.
+          </p>
+        </div>
+        <div className="space-y-2 text-left">
+          <Label className="sr-only" htmlFor="identity-url">
+            Website
+          </Label>
+          <div className="flex w-full flex-row items-center rounded-md border border-border transition-colors focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/50">
+            <label
+              className="border-border border-r px-2.5 py-2 text-muted-foreground text-sm"
+              htmlFor="identity-url"
+            >
+              https://
+            </label>
+            <input
+              autoFocus
+              className="flex-1 bg-transparent px-2.5 py-2 text-sm outline-none"
+              id="identity-url"
+              onChange={(e) => setUrl(sanitizeUrlInput(e.target.value))}
+              placeholder="example.com"
+              type="text"
+              value={url}
+            />
+          </div>
+        </div>
+        <Button
+          className="w-full justify-center"
+          disabled={!url.trim() || isSubmitting}
+          type="submit"
+        >
+          {isSubmitting ? (
+            <>
+              <HugeiconsIcon
+                className="size-3.5 animate-spin"
+                icon={Loading03Icon}
+              />
+              Creating...
+            </>
+          ) : (
+            "Create brand identity"
+          )}
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+export function StepBrandIdentities({
+  voices,
+  selected,
+  onToggle,
+  isLoading,
+  organizationId,
+}: BrandIdentitiesStepProps) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="font-semibold text-xl tracking-tight">
+          Which brand identity should this use?
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Select one or more brand identities, or skip to write for a general
+          audience.
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2">
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+      )}
+
+      {!isLoading && voices.length === 0 && (
+        <InlineCreateForm organizationId={organizationId} />
+      )}
+
+      {!isLoading && voices.length > 0 && (
+        <div className="space-y-2">
+          {voices.map((voice) => {
+            const isSelected = selected.includes(voice.id);
+            return (
+              <button
+                aria-pressed={isSelected}
+                className={cn(
+                  "flex w-full items-center gap-3 rounded-lg border bg-card px-3 py-3 text-left transition-colors",
+                  "hover:border-foreground/20",
+                  isSelected
+                    ? "border-foreground/40 ring-2 ring-foreground/10"
+                    : "border-border"
+                )}
+                key={voice.id}
+                onClick={() => onToggle(voice.id)}
+                type="button"
+              >
+                <div
+                  className={cn(
+                    "flex size-5 shrink-0 items-center justify-center rounded-md border transition-colors",
+                    isSelected
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-muted-foreground/30"
+                  )}
+                >
+                  {isSelected && (
+                    <HugeiconsIcon className="size-3" icon={Tick01Icon} />
+                  )}
+                </div>
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
+                  <HugeiconsIcon
+                    className="size-4 text-muted-foreground"
+                    icon={UserGroupIcon}
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium text-sm">{voice.name}</p>
+                  <p className="truncate text-muted-foreground text-xs">
+                    {voice.isDefault
+                      ? "Default brand identity"
+                      : "Brand identity"}
+                  </p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/content/create/step-formats.tsx
+++ b/apps/dashboard/src/components/content/create/step-formats.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@notra/ui/components/ui/select";
+import { FORMAT_ORDER } from "@/constants/content-formats";
+import { LOOKBACK_WINDOWS, type LookbackWindow } from "@/schemas/integrations";
+import type { FormatsStepProps } from "@/types/content/create";
+import { formatSnakeCaseLabel } from "@/utils/format";
+import { DataPointToggle } from "./data-point-toggle";
+import { FormatCard } from "./format-card";
+
+export function StepFormats({
+  selected,
+  onToggle,
+  lookbackWindow,
+  onLookbackChange,
+  dataPoints,
+  onDataPointChange,
+}: FormatsStepProps) {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-1">
+        <h2 className="font-semibold text-xl tracking-tight">
+          What do you want to create?
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Select one or more content formats. We'll help you craft each one.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {FORMAT_ORDER.map((format) => (
+          <FormatCard
+            format={format}
+            key={format}
+            onToggle={() => onToggle(format)}
+            selected={selected.includes(format)}
+          />
+        ))}
+      </div>
+
+      <div className="space-y-4 rounded-xl border bg-muted/30 p-4">
+        <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+          <div className="min-w-0 space-y-1">
+            <p className="font-medium text-sm">Timeframe</p>
+            <p className="text-muted-foreground text-xs">
+              How far back to look when gathering activity data.
+            </p>
+          </div>
+          <Select
+            onValueChange={(v) => {
+              if (v) {
+                onLookbackChange(v as LookbackWindow);
+              }
+            }}
+            value={lookbackWindow}
+          >
+            <SelectTrigger className="w-full md:w-56">
+              <SelectValue placeholder="Select timeframe">
+                <span className="capitalize">
+                  {formatSnakeCaseLabel(lookbackWindow)}
+                </span>
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {LOOKBACK_WINDOWS.map((w) => (
+                <SelectItem key={w} value={w}>
+                  <span className="capitalize">{formatSnakeCaseLabel(w)}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-3">
+          <DataPointToggle
+            checked={dataPoints.includePullRequests}
+            description="Merged PR metadata"
+            label="Pull Requests"
+            onCheckedChange={(v) => onDataPointChange("includePullRequests", v)}
+          />
+          <DataPointToggle
+            checked={dataPoints.includeCommits}
+            description="Commit-level changes"
+            label="Commits"
+            onCheckedChange={(v) => onDataPointChange("includeCommits", v)}
+          />
+          <DataPointToggle
+            checked={dataPoints.includeReleases}
+            description="GitHub releases"
+            label="Releases"
+            onCheckedChange={(v) => onDataPointChange("includeReleases", v)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -108,7 +108,7 @@ export function DashboardSidebar({
       </SidebarHeader>
       <SidebarContent>
         <AnimatePresence initial={false} mode="popLayout">
-          {isSettingsRoute ? (
+          {isSettingsRoute && (
             <motion.div
               animate="animate"
               className="flex flex-1 flex-col"
@@ -120,7 +120,8 @@ export function DashboardSidebar({
             >
               <NavSettings slug={slug} />
             </motion.div>
-          ) : isChatRoute ? (
+          )}
+          {!isSettingsRoute && isChatRoute && (
             <motion.div
               animate="animate"
               className="flex flex-1 flex-col"
@@ -135,7 +136,8 @@ export function DashboardSidebar({
                 <NavSecondary />
               </div>
             </motion.div>
-          ) : (
+          )}
+          {!(isSettingsRoute || isChatRoute) && (
             <motion.div
               animate="animate"
               className="flex flex-1 flex-col"

--- a/apps/dashboard/src/constants/content-formats.ts
+++ b/apps/dashboard/src/constants/content-formats.ts
@@ -1,0 +1,37 @@
+import type { OnDemandContentType } from "@/schemas/content";
+
+interface FormatCardMeta {
+  label: string;
+  description: string;
+  iconClass: string;
+}
+
+export const FORMAT_CARD_META: Record<OnDemandContentType, FormatCardMeta> = {
+  changelog: {
+    label: "Changelog entry",
+    description: "A concise summary of what shipped and why it matters.",
+    iconClass: "text-violet-500 dark:text-violet-300",
+  },
+  blog_post: {
+    label: "Blog post",
+    description: "A longer-form article explaining the feature in depth.",
+    iconClass: "text-emerald-500 dark:text-emerald-300",
+  },
+  linkedin_post: {
+    label: "LinkedIn post",
+    description: "A professional update to share with your network.",
+    iconClass: "text-[#0A66C2]",
+  },
+  twitter_post: {
+    label: "Tweet",
+    description: "A short, punchy announcement for X / Twitter.",
+    iconClass: "text-foreground",
+  },
+};
+
+export const FORMAT_ORDER: OnDemandContentType[] = [
+  "changelog",
+  "blog_post",
+  "linkedin_post",
+  "twitter_post",
+];

--- a/apps/dashboard/src/lib/orpc/routers/content.ts
+++ b/apps/dashboard/src/lib/orpc/routers/content.ts
@@ -123,6 +123,7 @@ function serializeContent(post: {
 
 export interface CommitPreview {
   authorName: string;
+  authorLogin: string | null;
   authoredAt: string;
   htmlUrl: string;
   message: string;
@@ -434,6 +435,7 @@ async function fetchCommitsPreview(params: {
         sha: commit.sha,
         message: commit.commit.message.split("\n")[0] ?? "",
         authorName: commit.commit.author?.name ?? "Unknown",
+        authorLogin: commit.author?.login ?? null,
         authoredAt: commit.commit.author?.date ?? "",
         htmlUrl: commit.html_url,
       });

--- a/apps/dashboard/src/types/cli-auth/poll.ts
+++ b/apps/dashboard/src/types/cli-auth/poll.ts
@@ -5,9 +5,9 @@ export type CliPollResponse =
 
 export type CliAuthorizeResponse = { status: "ok" } | { error: string };
 
-export type CliAuthOrganization = {
+export interface CliAuthOrganization {
   id: string;
   name: string;
   slug: string;
   logo: string | null;
-};
+}

--- a/apps/dashboard/src/types/content/create.ts
+++ b/apps/dashboard/src/types/content/create.ts
@@ -48,6 +48,7 @@ export interface ActivityStepProps {
   preview: PreviewResponse | undefined;
   isLoadingPreview: boolean;
   isPreviewError: boolean;
+  onRetryPreview: () => void;
   dataPoints: ContentDataPointSettings;
   selectedCommitKeys: Set<string>;
   selectedPrKeys: Set<string>;

--- a/apps/dashboard/src/types/content/create.ts
+++ b/apps/dashboard/src/types/content/create.ts
@@ -1,0 +1,77 @@
+import type {
+  ContentDataPointSettings,
+  OnDemandContentType,
+} from "@/schemas/content";
+import type { LookbackWindow } from "@/schemas/integrations";
+import type {
+  PreviewResponse,
+  RepositoryPreview,
+} from "@/types/content/preview";
+
+export type WizardStep = "formats" | "activity" | "identities";
+
+export interface WizardFormValues {
+  formats: OnDemandContentType[];
+  lookbackWindow: LookbackWindow;
+  dataPoints: ContentDataPointSettings;
+  repositoryIds: string[];
+  brandVoiceIds: string[];
+}
+
+export interface IntegrationOption {
+  value: string;
+  label: string;
+  ownerRepo: string | null;
+  type: "github" | "linear";
+}
+
+export interface FormatsStepProps {
+  selected: OnDemandContentType[];
+  onToggle: (format: OnDemandContentType) => void;
+  lookbackWindow: LookbackWindow;
+  onLookbackChange: (window: LookbackWindow) => void;
+  dataPoints: ContentDataPointSettings;
+  onDataPointChange: (
+    key: keyof ContentDataPointSettings,
+    value: boolean
+  ) => void;
+}
+
+export interface ActivityStepProps {
+  organizationId: string;
+  integrationOptions: IntegrationOption[];
+  selectedIntegrationIds: string[];
+  onToggleIntegration: (value: string) => void;
+  isLoadingIntegrations: boolean;
+  onConnect: () => void;
+  repositories: RepositoryPreview[] | undefined;
+  preview: PreviewResponse | undefined;
+  isLoadingPreview: boolean;
+  isPreviewError: boolean;
+  dataPoints: ContentDataPointSettings;
+  selectedCommitKeys: Set<string>;
+  selectedPrKeys: Set<string>;
+  selectedReleaseKeys: Set<string>;
+  selectedLinearKeys: Set<string>;
+  onToggleCommit: (key: string) => void;
+  onTogglePr: (key: string) => void;
+  onToggleRelease: (key: string) => void;
+  onToggleLinear: (key: string) => void;
+  searchQuery: string;
+  onSearchQueryChange: (q: string) => void;
+}
+
+export interface BrandIdentitiesStepProps {
+  voices: Array<{ id: string; name: string; isDefault: boolean }>;
+  selected: string[];
+  onToggle: (id: string) => void;
+  isLoading: boolean;
+  organizationId: string;
+}
+
+export interface SelectionState {
+  commits: Set<string>;
+  prs: Set<string>;
+  releases: Set<string>;
+  linear: Set<string>;
+}

--- a/apps/dashboard/src/types/content/preview.ts
+++ b/apps/dashboard/src/types/content/preview.ts
@@ -2,6 +2,7 @@ export interface CommitPreview {
   sha: string;
   message: string;
   authorName: string;
+  authorLogin: string | null;
   authoredAt: string;
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,6 @@
         "@tanstack/react-pacer": "^0.19.0",
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-query-devtools": "^5.91.2",
-        "@tanstack/react-store": "^0.9.2",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.14",
         "@toolwind/corner-shape": "^0.0.8-3",
@@ -1809,7 +1808,7 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -3129,7 +3128,7 @@
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
-    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
 
@@ -4345,8 +4344,6 @@
 
     "@upstash/workflow/@upstash/qstash": ["@upstash/qstash@2.10.1", "", { "dependencies": { "crypto-js": ">=4.2.0", "jose": "^5.2.3", "neverthrow": "^7.0.1" } }, "sha512-LsTAPxPk0dFvhlEnRqwObRS94b8mmDHYaBlF3IaONUL+Scq6i9cZraA6936KSUVe+Vq3eNQle3CjOZkStPUFTw=="],
 
-    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -4403,13 +4400,13 @@
 
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "engine.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "engine.io/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
-    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -4546,6 +4543,8 @@
     "simple-swizzle/is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
@@ -4809,6 +4808,8 @@
 
     "@mintlify/previewing/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "@mintlify/previewing/express/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "@mintlify/previewing/express/body-parser": ["body-parser@1.20.5", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.15.1", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA=="],
 
     "@mintlify/previewing/express/content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
@@ -4836,6 +4837,8 @@
     "@mintlify/previewing/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "@mintlify/previewing/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "@mintlify/previewing/socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "@mintlify/previewing/socket.io/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
@@ -4933,8 +4936,6 @@
 
     "@tanstack/react-pacer/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.8.1", "", {}, "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw=="],
 
-    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "better-opn/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
@@ -4955,7 +4956,9 @@
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
-    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "engine.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "engine.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "favicons/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
 
@@ -5110,6 +5113,10 @@
     "public-ip/got/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "react-email/nypm/citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "socket.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "tsc-alias/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -5317,6 +5324,10 @@
 
     "@mintlify/previewing/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "@mintlify/previewing/express/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@mintlify/previewing/express/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
     "@mintlify/previewing/express/body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "@mintlify/previewing/express/body-parser/qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
@@ -5328,6 +5339,10 @@
     "@mintlify/previewing/express/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
     "@mintlify/previewing/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@mintlify/previewing/socket.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@mintlify/previewing/socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "@mintlify/previewing/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -5393,6 +5408,8 @@
 
     "@supermemory/tools/ai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "engine.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "inquirer/@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "inquirer/@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -5410,6 +5427,8 @@
     "openai/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "openai/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "tsc-alias/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -5477,7 +5496,11 @@
 
     "@mintlify/prebuild/@mintlify/scraping/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@mintlify/previewing/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "@mintlify/previewing/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@mintlify/previewing/socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "@mintlify/previewing/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 


### PR DESCRIPTION
### Description
Rewrites the **Create Content** dialog into a wider, three-step wizard:

1. **Formats** — multi-select tile cards (Changelog, Blog post, LinkedIn post, Tweet) with timeframe + data-source toggles (PRs / commits / releases). Clean tile layout with brand-colored icon top-left + checkbox top-right — no chunky accent block.
2. **Activity** — unifies the previous Sources + Events steps. Search input on top, horizontally scrollable source chips below (with a fixed `+` button outside the scroll for adding integrations), then the repo-grouped event list reusing the existing `EventRow` / `RepoSection`.
3. **Brand Identity** — multi-select list of existing brand voices. When none exist, a centered inline form (URL only — name auto-derived from hostname) creates one without leaving the dialog and kicks off the analysis in the background.

Other tweaks:
- Commits in the event list now show the GitHub author **login** (`mezotv`) via a new `authorLogin` field on `CommitPreview`, falling back to the git-config display name only when GitHub couldn't link the commit.
- Multi-format and multi-identity selection: generation fans out as `formats × max(identities, 1)` parallel `content.generate` calls.

### Screenshot/Recording (if applicable)
N/A — UI changes are scoped to the Create Content dialog.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally (`bun run build`, `bun x ultracite check`)
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did — AI-assisted

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Create Content flow into a wider, 3-step wizard for faster selection with multi-format and multi-identity generation. Adds partial-success generation, supports Linear-only flows, and improves a11y and preview details.

- **New Features**
  - 3-step wizard (Formats → Activity → Brand Identity) replaces the old dialog.
  - Formats: multi-select cards with a lookback window and PR/commit/release toggles.
  - Activity: unified source + events with search and repo grouping; respects data-point toggles; supports GitHub and Linear; Retry now re-fetches previews.
  - Brand Identity: select multiple voices or create one inline; generation runs in parallel with Promise.allSettled to keep partial successes.
  - Commit previews show GitHub `authorLogin` when available.

- **Refactors & Fixes**
  - Dropped unused `@tanstack/react-store`.
  - Improved loading/empty/error states and simplified conditionals; centralized `isLoadingSkills`.
  - A11y: `DataPointToggle` associates the switch with its label/description; removed unreachable URL branch; fixed Linear issue meta trailing separator.
  - Hardened `PixelBlast` cleanup (cancel RAF when defined, null guards) to prevent leaks.

<sup>Written for commit bedbc2c0f349dba1e13be3089efa807ec3ad35ff. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/348?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

