### PR TITLE
feat(dashboard): redesign create-schedule as dialog

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
@@ -54,18 +54,16 @@ import { Loader2Icon, PlusIcon } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { BrandVoiceCell } from "@/components/automation/brand-voice-cell";
-import { AddTriggerDialog } from "@/components/automation/triggers/trigger-sheet";
+import { CreateScheduleDialog } from "@/components/automation/schedules/create-schedule-dialog";
 import { TriggerStatusBadge } from "@/components/automation/triggers/trigger-status-badge";
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
-import type { Trigger, TriggerSourceType } from "@/types/triggers/triggers";
+import type { Trigger } from "@/types/triggers/triggers";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 import { SchedulePageSkeleton } from "./skeleton";
-
-const CRON_SOURCE_TYPES: TriggerSourceType[] = ["cron"];
 
 function formatFrequency(cron?: Trigger["sourceConfig"]["cron"]) {
   if (!cron) {
@@ -383,9 +381,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
               Configure cron schedules that run daily, weekly, or monthly
             </p>
           </div>
-          <AddTriggerDialog
-            allowedSourceTypes={CRON_SOURCE_TYPES}
-            initialSourceType="cron"
+          <CreateScheduleDialog
             onSuccess={() => {
               queryClient.invalidateQueries({
                 queryKey: dashboardOrpc.automation.schedules.list.queryKey({
@@ -415,9 +411,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         {!isPending && scheduleTriggers.length === 0 && (
           <EmptyState
             action={
-              <AddTriggerDialog
-                allowedSourceTypes={CRON_SOURCE_TYPES}
-                initialSourceType="cron"
+              <CreateScheduleDialog
                 onSuccess={() => {
                   queryClient.invalidateQueries({
                     queryKey: dashboardOrpc.automation.schedules.list.queryKey({
@@ -578,10 +572,8 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
       </ResponsiveAlertDialog>
 
       {editTrigger && (
-        <AddTriggerDialog
-          allowedSourceTypes={CRON_SOURCE_TYPES}
+        <CreateScheduleDialog
           editTrigger={editTrigger}
-          initialSourceType="cron"
           onOpenChange={(open) => !open && setEditTrigger(null)}
           onSuccess={() => {
             setEditTrigger(null);

--- a/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
+++ b/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
@@ -1,0 +1,670 @@
+"use client";
+
+import {
+  Add01Icon,
+  AlertCircleIcon,
+  InformationCircleIcon,
+  Loading03Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogTrigger,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { Button } from "@notra/ui/components/ui/button";
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  useComboboxAnchor,
+} from "@notra/ui/components/ui/combobox";
+import { Input } from "@notra/ui/components/ui/input";
+import { Label } from "@notra/ui/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@notra/ui/components/ui/select";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { Github } from "@notra/ui/components/ui/svgs/github";
+import { Linear } from "@notra/ui/components/ui/svgs/linear";
+import { Switch } from "@notra/ui/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@notra/ui/components/ui/tooltip";
+import { cn } from "@notra/ui/lib/utils";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { BrandVoiceCombobox } from "@/components/brand-voice-combobox";
+import { FormatCard } from "@/components/content/create/format-card";
+import { AddIntegrationDialog } from "@/components/integrations/add-integration-dialog";
+import { AddRepositoryButton } from "@/components/integrations/add-repository-button";
+import { AddRepositoryDialog } from "@/components/integrations/add-repository-dialog";
+import { FORMAT_CARD_META, FORMAT_ORDER } from "@/constants/content-formats";
+import { supportsAutoPublish } from "@/constants/schedule-output-types";
+import { dashboardOrpc } from "@/lib/orpc/query";
+import {
+  LOOKBACK_WINDOWS,
+  type LookbackWindow,
+  MAX_SCHEDULE_NAME_LENGTH,
+} from "@/schemas/integrations";
+import type {
+  CreateScheduleDialogProps,
+  ScheduleCron,
+  ScheduleFormValues,
+  ScheduleIntegrationOption,
+} from "@/types/automation/schedule";
+import type { Trigger } from "@/types/triggers/triggers";
+import { formatSnakeCaseLabel } from "@/utils/format";
+import {
+  buildAutoScheduleName,
+  formatTimeValue,
+  getDefaultScheduleValues,
+  parseTimeValue,
+} from "@/utils/schedule-form";
+import { ScheduleDayPicker } from "./schedule-day-picker";
+import { ScheduleFrequencyTabs } from "./schedule-frequency-tabs";
+import { ScheduleSummaryCard } from "./schedule-summary-card";
+
+export function CreateScheduleDialog({
+  organizationId,
+  onSuccess,
+  trigger,
+  editTrigger,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: CreateScheduleDialogProps) {
+  const isEditMode = !!editTrigger;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (isControlled) {
+        controlledOnOpenChange?.(next);
+      } else {
+        setInternalOpen(next);
+      }
+    },
+    [controlledOnOpenChange, isControlled]
+  );
+
+  const [values, setValues] = useState<ScheduleFormValues>(() =>
+    getDefaultScheduleValues(editTrigger)
+  );
+  const [nameTouched, setNameTouched] = useState(isEditMode);
+  const [addRepoOpen, setAddRepoOpen] = useState(false);
+  const comboboxAnchor = useComboboxAnchor();
+
+  useEffect(() => {
+    if (open) {
+      setValues(getDefaultScheduleValues(editTrigger));
+      setNameTouched(!!editTrigger);
+    }
+  }, [open, editTrigger]);
+
+  const autoName = useMemo(
+    () => buildAutoScheduleName(values.schedule.frequency, values.outputType),
+    [values.schedule.frequency, values.outputType]
+  );
+
+  useEffect(() => {
+    if (nameTouched) {
+      return;
+    }
+    setValues((prev) =>
+      prev.name === autoName ? prev : { ...prev, name: autoName }
+    );
+  }, [autoName, nameTouched]);
+
+  const { data: integrationsResponse, isLoading: isLoadingRepos } = useQuery(
+    dashboardOrpc.integrations.list.queryOptions({
+      input: { organizationId },
+      enabled: !!organizationId && open,
+    })
+  );
+
+  const { data: brandResponse } = useQuery(
+    dashboardOrpc.brand.voices.list.queryOptions({
+      input: { organizationId },
+      enabled: !!organizationId && open,
+    })
+  );
+
+  const brandVoices = brandResponse?.voices ?? [];
+
+  const { integrationOptions, githubIntegrationId } = useMemo(() => {
+    const githubIntegrations =
+      integrationsResponse?.integrations.filter(
+        (i) => i.type === "github" && i.enabled
+      ) ?? [];
+    const linearIntegrations =
+      integrationsResponse?.integrations.filter(
+        (i) => i.type === "linear" && i.enabled
+      ) ?? [];
+    const repos = githubIntegrations.flatMap((i) =>
+      i.repositories.filter((r) => r.enabled)
+    );
+
+    const options: ScheduleIntegrationOption[] = [
+      ...repos.map((r) => ({
+        value: r.id,
+        label: r.defaultBranch
+          ? `${r.owner}/${r.repo} · ${r.defaultBranch}`
+          : `${r.owner}/${r.repo}`,
+        type: "github" as const,
+      })),
+      ...linearIntegrations.map((i) => ({
+        value: `linear:${i.id}`,
+        label: i.displayName,
+        type: "linear" as const,
+      })),
+    ];
+
+    return {
+      integrationOptions: options,
+      githubIntegrationId: githubIntegrations[0]?.id,
+    };
+  }, [integrationsResponse]);
+
+  const mutation = useMutation<{ trigger: Trigger }, Error, ScheduleFormValues>(
+    {
+      mutationFn: async (value) => {
+        const githubRepoIds = value.repositoryIds.filter(
+          (id) => !id.startsWith("linear:")
+        );
+
+        const schedulePayload = {
+          organizationId,
+          name: value.name.trim(),
+          sourceType: "cron" as const,
+          sourceConfig: { cron: value.schedule },
+          targets: { repositoryIds: githubRepoIds },
+          outputType: value.outputType,
+          outputConfig: {
+            ...(value.brandVoiceId ? { brandVoiceId: value.brandVoiceId } : {}),
+          },
+          enabled: isEditMode ? editTrigger.enabled : true,
+          autoPublish: supportsAutoPublish(value.outputType)
+            ? value.autoPublish
+            : false,
+          lookbackWindow: value.lookbackWindow,
+        };
+
+        try {
+          if (isEditMode) {
+            return await dashboardOrpc.automation.schedules.update.call({
+              triggerId: editTrigger.id,
+              ...schedulePayload,
+            });
+          }
+          return await dashboardOrpc.automation.schedules.create.call(
+            schedulePayload
+          );
+        } catch (error) {
+          if (error instanceof Error && error.message === "Duplicate trigger") {
+            throw new Error("Schedule already exists");
+          }
+          if (error instanceof Error && error.message) {
+            throw error;
+          }
+          throw new Error(
+            isEditMode
+              ? "Failed to update schedule"
+              : "Failed to create schedule"
+          );
+        }
+      },
+      onSuccess: (data) => {
+        toast.success(isEditMode ? "Schedule updated" : "Schedule added");
+        onSuccess?.(data.trigger);
+        setOpen(false);
+      },
+      onError: (error) => {
+        toast.error(error.message);
+      },
+    }
+  );
+
+  const updateValues = useCallback((patch: Partial<ScheduleFormValues>) => {
+    setValues((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const updateSchedule = useCallback((patch: Partial<ScheduleCron>) => {
+    setValues((prev) => ({
+      ...prev,
+      schedule: { ...prev.schedule, ...patch },
+    }));
+  }, []);
+
+  const handleFrequencyChange = useCallback(
+    (frequency: ScheduleCron["frequency"]) => {
+      setValues((prev) => {
+        const next: ScheduleCron = { ...prev.schedule, frequency };
+        if (frequency === "weekly") {
+          next.dayOfWeek = prev.schedule.dayOfWeek ?? 1;
+          next.dayOfMonth = undefined;
+        } else if (frequency === "monthly") {
+          next.dayOfMonth = prev.schedule.dayOfMonth ?? 1;
+          next.dayOfWeek = undefined;
+        } else {
+          next.dayOfWeek = undefined;
+          next.dayOfMonth = undefined;
+        }
+        return { ...prev, schedule: next };
+      });
+    },
+    []
+  );
+
+  const handleTimeChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const parsed = parseTimeValue(event.target.value);
+      if (parsed) {
+        updateSchedule(parsed);
+      }
+    },
+    [updateSchedule]
+  );
+
+  const timeValue = formatTimeValue(
+    values.schedule.hour,
+    values.schedule.minute
+  );
+
+  const meta = FORMAT_CARD_META[values.outputType];
+
+  const isValid =
+    values.name.trim().length > 0 && values.repositoryIds.length > 0;
+
+  const footerStatus = useMemo<{
+    text: string;
+    tone: "warning" | "muted";
+  }>(() => {
+    if (values.repositoryIds.length === 0) {
+      return {
+        text: "Pick at least one source to continue",
+        tone: "warning",
+      };
+    }
+    if (values.name.trim().length === 0) {
+      return { text: "Give this schedule a name", tone: "warning" };
+    }
+    const count = values.repositoryIds.length;
+    return {
+      text: `${count} source${count === 1 ? "" : "s"} selected`,
+      tone: "muted",
+    };
+  }, [values.name, values.repositoryIds.length]);
+
+  const handleSubmit = useCallback(() => {
+    if (!isValid || mutation.isPending) {
+      return;
+    }
+    mutation.mutate(values);
+  }, [isValid, mutation, values]);
+
+  return (
+    <>
+      <ResponsiveDialog onOpenChange={setOpen} open={open}>
+        {trigger && <ResponsiveDialogTrigger render={trigger} />}
+        <ResponsiveDialogContent className="flex h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+          <ResponsiveDialogHeader className="shrink-0 border-b p-4 pr-14">
+            <ResponsiveDialogTitle className="text-base">
+              {isEditMode ? "Edit schedule" : "New schedule"}
+            </ResponsiveDialogTitle>
+            <p className="text-muted-foreground text-sm">
+              Pick a content type, set a schedule, and we'll handle the rest on
+              autopilot.
+            </p>
+          </ResponsiveDialogHeader>
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="space-y-8 p-6">
+              <section className="space-y-3">
+                <div className="space-y-1">
+                  <h3 className="font-semibold text-base">Content format</h3>
+                  <p className="text-muted-foreground text-sm">
+                    What should we generate?
+                  </p>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {FORMAT_ORDER.map((type) => (
+                    <FormatCard
+                      format={type}
+                      key={type}
+                      onToggle={() => updateValues({ outputType: type })}
+                      selected={values.outputType === type}
+                    />
+                  ))}
+                </div>
+              </section>
+
+              <section className="space-y-3">
+                <div className="space-y-1">
+                  <h3 className="flex items-center gap-1 font-semibold text-base">
+                    Name
+                    <span aria-hidden="true" className="text-destructive">
+                      *
+                    </span>
+                  </h3>
+                  <p className="text-muted-foreground text-sm">
+                    Just for you, won't appear in any output.
+                  </p>
+                </div>
+                <Input
+                  id="schedule-name"
+                  maxLength={MAX_SCHEDULE_NAME_LENGTH}
+                  onChange={(event) => {
+                    setNameTouched(true);
+                    updateValues({ name: event.target.value });
+                  }}
+                  placeholder={autoName}
+                  value={values.name}
+                />
+              </section>
+
+              <section className="space-y-3">
+                <div className="space-y-1">
+                  <h3 className="font-semibold text-base">Schedule</h3>
+                  <p className="text-muted-foreground text-sm">
+                    When should this run? Times use UTC.
+                  </p>
+                </div>
+                <ScheduleFrequencyTabs
+                  onChange={handleFrequencyChange}
+                  value={values.schedule.frequency}
+                />
+                <ScheduleDayPicker
+                  dayOfMonth={values.schedule.dayOfMonth}
+                  dayOfWeek={values.schedule.dayOfWeek}
+                  frequency={values.schedule.frequency}
+                  onDayOfMonthChange={(day) =>
+                    updateSchedule({ dayOfMonth: day })
+                  }
+                  onDayOfWeekChange={(day) =>
+                    updateSchedule({ dayOfWeek: day })
+                  }
+                />
+                <div className="space-y-2">
+                  <Label
+                    className="text-muted-foreground text-xs"
+                    htmlFor="schedule-time"
+                  >
+                    Time
+                  </Label>
+                  <Input
+                    className="w-full appearance-none bg-background sm:w-40 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+                    id="schedule-time"
+                    onChange={handleTimeChange}
+                    type="time"
+                    value={timeValue}
+                  />
+                </div>
+                <ScheduleSummaryCard schedule={values.schedule} />
+              </section>
+
+              <section className="space-y-3">
+                <div className="space-y-1">
+                  <h3 className="flex items-center gap-1 font-semibold text-base">
+                    Sources
+                    <span aria-hidden="true" className="text-destructive">
+                      *
+                    </span>
+                  </h3>
+                  <p className="text-muted-foreground text-sm">
+                    Pick which integrations we should pull activity from.
+                  </p>
+                </div>
+                {isLoadingRepos && <Skeleton className="h-10 w-full" />}
+                {!isLoadingRepos && integrationOptions.length === 0 && (
+                  <div className="flex items-center gap-2 rounded-lg border border-dashed p-3">
+                    <span className="flex-1 text-muted-foreground text-xs">
+                      No integrations connected yet.
+                    </span>
+                    <AddRepositoryButton
+                      onAdd={() => {
+                        setOpen(false);
+                        setAddRepoOpen(true);
+                      }}
+                    />
+                  </div>
+                )}
+                {!isLoadingRepos && integrationOptions.length > 0 && (
+                  <div ref={comboboxAnchor}>
+                    <Combobox
+                      items={integrationOptions.map((o) => o.value)}
+                      multiple
+                      onValueChange={(value) =>
+                        updateValues({
+                          repositoryIds: Array.isArray(value) ? value : [],
+                        })
+                      }
+                      value={values.repositoryIds}
+                    >
+                      <ComboboxChips>
+                        {values.repositoryIds.map((id) => {
+                          const opt = integrationOptions.find(
+                            (o) => o.value === id
+                          );
+                          if (!opt) {
+                            return null;
+                          }
+                          return (
+                            <ComboboxChip key={opt.value}>
+                              <span className="flex items-center gap-1.5">
+                                {opt.type === "github" ? (
+                                  <Github className="size-3 shrink-0" />
+                                ) : (
+                                  <Linear className="size-3 shrink-0" />
+                                )}
+                                {opt.label}
+                              </span>
+                            </ComboboxChip>
+                          );
+                        })}
+                        <ComboboxChipsInput placeholder="Search integrations" />
+                      </ComboboxChips>
+                      <ComboboxContent anchor={comboboxAnchor.current}>
+                        <ComboboxEmpty>No integrations found.</ComboboxEmpty>
+                        <ComboboxList>
+                          {integrationOptions.map((opt) => (
+                            <ComboboxItem key={opt.value} value={opt.value}>
+                              <span className="flex items-center gap-2">
+                                {opt.type === "github" ? (
+                                  <Github className="size-3.5 shrink-0" />
+                                ) : (
+                                  <Linear className="size-3.5 shrink-0" />
+                                )}
+                                {opt.label}
+                              </span>
+                            </ComboboxItem>
+                          ))}
+                        </ComboboxList>
+                      </ComboboxContent>
+                    </Combobox>
+                  </div>
+                )}
+              </section>
+
+              <section className="space-y-3">
+                <div className="space-y-1">
+                  <h3 className="font-semibold text-base">
+                    {meta.label} rules
+                  </h3>
+                  <p className="text-muted-foreground text-sm">
+                    How far back we look and how the post should sound.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label
+                    className="text-muted-foreground text-xs"
+                    htmlFor="schedule-lookback"
+                  >
+                    Lookback window
+                  </Label>
+                  <Select
+                    onValueChange={(value) => {
+                      if (value) {
+                        updateValues({
+                          lookbackWindow: value as LookbackWindow,
+                        });
+                      }
+                    }}
+                    value={values.lookbackWindow}
+                  >
+                    <SelectTrigger className="w-full" id="schedule-lookback">
+                      <SelectValue placeholder="Lookback window">
+                        <span className="capitalize">
+                          {formatSnakeCaseLabel(values.lookbackWindow)}
+                        </span>
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LOOKBACK_WINDOWS.map((window) => (
+                        <SelectItem key={window} value={window}>
+                          <span className="capitalize">
+                            {formatSnakeCaseLabel(window)}
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {brandVoices.length > 1 && (
+                  <BrandVoiceCombobox
+                    id="schedule-brand-voice"
+                    onChange={(value) => updateValues({ brandVoiceId: value })}
+                    value={values.brandVoiceId}
+                    voices={brandVoices}
+                  />
+                )}
+
+                {supportsAutoPublish(values.outputType) && (
+                  <div className="flex items-center justify-between rounded-lg border p-3">
+                    <div className="flex items-center gap-1.5">
+                      <Label
+                        className="cursor-pointer font-medium text-sm"
+                        htmlFor="schedule-auto-publish"
+                      >
+                        Auto-publish
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger className="inline-flex cursor-help text-muted-foreground">
+                          <HugeiconsIcon
+                            icon={InformationCircleIcon}
+                            size={14}
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent side="top">
+                          <p className="max-w-50 text-xs">
+                            When on, posts are published immediately instead of
+                            saved as drafts.
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                    <Switch
+                      checked={values.autoPublish}
+                      id="schedule-auto-publish"
+                      onCheckedChange={(value) =>
+                        updateValues({ autoPublish: value })
+                      }
+                    />
+                  </div>
+                )}
+              </section>
+            </div>
+          </div>
+
+          <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <span
+                className={cn(
+                  "flex items-center gap-1.5 text-xs",
+                  footerStatus.tone === "warning"
+                    ? "font-medium text-destructive"
+                    : "text-muted-foreground"
+                )}
+              >
+                {footerStatus.tone === "warning" && (
+                  <HugeiconsIcon className="size-3.5" icon={AlertCircleIcon} />
+                )}
+                {footerStatus.text}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  disabled={mutation.isPending}
+                  onClick={() => setOpen(false)}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  disabled={!isValid || mutation.isPending}
+                  onClick={handleSubmit}
+                  type="button"
+                >
+                  {mutation.isPending ? (
+                    <>
+                      <HugeiconsIcon
+                        className="size-4 animate-spin"
+                        icon={Loading03Icon}
+                      />
+                      {isEditMode ? "Saving..." : "Adding..."}
+                    </>
+                  ) : (
+                    <>
+                      <HugeiconsIcon className="size-4" icon={Add01Icon} />
+                      {isEditMode ? "Save changes" : "Add schedule"}
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+      {githubIntegrationId ? (
+        <AddRepositoryDialog
+          integrationId={githubIntegrationId}
+          onOpenChange={(isOpen) => {
+            setAddRepoOpen(isOpen);
+            if (!isOpen) {
+              setOpen(true);
+            }
+          }}
+          open={addRepoOpen}
+          organizationId={organizationId}
+        />
+      ) : (
+        <AddIntegrationDialog
+          onOpenChange={(isOpen) => {
+            setAddRepoOpen(isOpen);
+            if (!isOpen) {
+              setOpen(true);
+            }
+          }}
+          open={addRepoOpen}
+          organizationId={organizationId}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
+++ b/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
@@ -287,8 +287,12 @@ export function CreateScheduleDialog({
 
   const meta = FORMAT_CARD_META[values.outputType];
 
-  const isValid =
-    values.name.trim().length > 0 && values.repositoryIds.length > 0;
+  const githubRepoCount = useMemo(
+    () => values.repositoryIds.filter((id) => !id.startsWith("linear:")).length,
+    [values.repositoryIds]
+  );
+
+  const isValid = values.name.trim().length > 0 && githubRepoCount > 0;
 
   const footerStatus = useMemo<{
     text: string;
@@ -300,6 +304,12 @@ export function CreateScheduleDialog({
         tone: "warning",
       };
     }
+    if (githubRepoCount === 0) {
+      return {
+        text: "Schedules need at least one GitHub repository",
+        tone: "warning",
+      };
+    }
     if (values.name.trim().length === 0) {
       return { text: "Give this schedule a name", tone: "warning" };
     }
@@ -308,7 +318,7 @@ export function CreateScheduleDialog({
       text: `${count} source${count === 1 ? "" : "s"} selected`,
       tone: "muted",
     };
-  }, [values.name, values.repositoryIds.length]);
+  }, [values.name, values.repositoryIds.length, githubRepoCount]);
 
   const handleSubmit = useCallback(() => {
     if (!isValid || mutation.isPending) {

--- a/apps/dashboard/src/components/automation/schedules/schedule-day-picker.tsx
+++ b/apps/dashboard/src/components/automation/schedules/schedule-day-picker.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Label } from "@notra/ui/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@notra/ui/components/ui/select";
+import { cn } from "@notra/ui/lib/utils";
+import { DAYS_OF_MONTH, DAYS_OF_WEEK } from "@/constants/schedule";
+import type { ScheduleDayPickerProps } from "@/types/automation/schedule";
+
+export function ScheduleDayPicker({
+  frequency,
+  dayOfWeek,
+  dayOfMonth,
+  onDayOfWeekChange,
+  onDayOfMonthChange,
+}: ScheduleDayPickerProps) {
+  if (frequency === "daily") {
+    return null;
+  }
+
+  if (frequency === "weekly") {
+    const selectedDay = dayOfWeek ?? 1;
+    return (
+      <div className="space-y-2">
+        <Label className="text-muted-foreground text-xs">Day of week</Label>
+        <div className="flex flex-wrap gap-2">
+          {DAYS_OF_WEEK.map((day) => {
+            const isActive = day.value === selectedDay;
+            return (
+              <button
+                aria-pressed={isActive}
+                className={cn(
+                  "h-10 min-w-12 rounded-lg border px-3 font-medium text-sm transition-colors",
+                  isActive
+                    ? "border-foreground bg-foreground text-background"
+                    : "border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                )}
+                key={day.value}
+                onClick={() => onDayOfWeekChange(day.value)}
+                type="button"
+              >
+                {day.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  const selectedMonthDay = dayOfMonth ?? 1;
+  const isShortMonthDay = selectedMonthDay >= 29;
+  return (
+    <div className="space-y-2">
+      <Label className="text-muted-foreground text-xs" htmlFor="day-of-month">
+        Day of month
+      </Label>
+      <Select
+        onValueChange={(val) => {
+          if (val) {
+            onDayOfMonthChange(Number.parseInt(val, 10));
+          }
+        }}
+        value={String(selectedMonthDay)}
+      >
+        <SelectTrigger className="w-full sm:w-40" id="day-of-month">
+          <SelectValue placeholder="Day" />
+        </SelectTrigger>
+        <SelectContent>
+          {DAYS_OF_MONTH.map((day) => (
+            <SelectItem key={day} value={String(day)}>
+              Day {day}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-muted-foreground text-xs">
+        {isShortMonthDay
+          ? `Months without day ${selectedMonthDay} are skipped (e.g. February).`
+          : "If a month is shorter than the selected day, the run is skipped that month."}
+      </p>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/automation/schedules/schedule-day-picker.tsx
+++ b/apps/dashboard/src/components/automation/schedules/schedule-day-picker.tsx
@@ -54,7 +54,7 @@ export function ScheduleDayPicker({
   }
 
   const selectedMonthDay = dayOfMonth ?? 1;
-  const isShortMonthDay = selectedMonthDay >= 29;
+  const skipNote = getMonthDaySkipNote(selectedMonthDay);
   return (
     <div className="space-y-2">
       <Label className="text-muted-foreground text-xs" htmlFor="day-of-month">
@@ -79,11 +79,20 @@ export function ScheduleDayPicker({
           ))}
         </SelectContent>
       </Select>
-      <p className="text-muted-foreground text-xs">
-        {isShortMonthDay
-          ? `Months without day ${selectedMonthDay} are skipped (e.g. February).`
-          : "If a month is shorter than the selected day, the run is skipped that month."}
-      </p>
+      <p className="text-muted-foreground text-xs">{skipNote}</p>
     </div>
   );
+}
+
+function getMonthDaySkipNote(day: number): string {
+  if (day === 31) {
+    return "Skipped in February, April, June, September, and November.";
+  }
+  if (day === 30) {
+    return "Skipped in February.";
+  }
+  if (day === 29) {
+    return "Skipped in February except leap years.";
+  }
+  return "If a month is shorter than the selected day, the run is skipped that month.";
 }

--- a/apps/dashboard/src/components/automation/schedules/schedule-frequency-tabs.tsx
+++ b/apps/dashboard/src/components/automation/schedules/schedule-frequency-tabs.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+import { FREQUENCY_OPTIONS } from "@/constants/schedule";
+import type { ScheduleFrequencyTabsProps } from "@/types/automation/schedule";
+
+export function ScheduleFrequencyTabs({
+  value,
+  onChange,
+}: ScheduleFrequencyTabsProps) {
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {FREQUENCY_OPTIONS.map((option) => {
+        const isActive = option.value === value;
+        return (
+          <button
+            aria-pressed={isActive}
+            className={cn(
+              "h-10 rounded-lg border px-3 font-medium text-sm transition-all",
+              isActive
+                ? "border-foreground bg-muted font-semibold text-foreground"
+                : "border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+            )}
+            key={option.value}
+            onClick={() => onChange(option.value)}
+            type="button"
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/automation/schedules/schedule-summary-card.tsx
+++ b/apps/dashboard/src/components/automation/schedules/schedule-summary-card.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Calendar02Icon, Clock04Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState } from "react";
+import type { ScheduleSummaryCardProps } from "@/types/automation/schedule";
+import {
+  computeNextRun,
+  formatNextRunDate,
+  formatNextRunRelative,
+  formatScheduleSummary,
+  getLocalTimezone,
+} from "@/utils/schedule-summary";
+
+export function ScheduleSummaryCard({ schedule }: ScheduleSummaryCardProps) {
+  const [now, setNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setNow(new Date());
+    const interval = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const summary = formatScheduleSummary(schedule);
+
+  if (!now) {
+    return (
+      <div className="rounded-xl border bg-muted/30 p-4">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon
+            className="size-4 text-muted-foreground"
+            icon={Calendar02Icon}
+          />
+          <p className="font-medium text-sm">{summary}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const nextRun = computeNextRun(schedule, now);
+  const relative = formatNextRunRelative(nextRun, now);
+  const formatted = formatNextRunDate(nextRun);
+  const tz = getLocalTimezone();
+
+  return (
+    <div className="space-y-2 rounded-xl border bg-muted/30 p-4">
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon
+          className="size-4 text-muted-foreground"
+          icon={Calendar02Icon}
+        />
+        <p className="font-medium text-sm">
+          {summary}{" "}
+          <span className="font-normal text-muted-foreground">
+            &middot; UTC
+          </span>
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon
+          className="size-4 text-muted-foreground"
+          icon={Clock04Icon}
+        />
+        <p className="text-muted-foreground text-sm">
+          Next run: {formatted} ({relative}) &middot;{" "}
+          <span className="text-muted-foreground/80">{tz}</span>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/constants/schedule-output-types.ts
+++ b/apps/dashboard/src/constants/schedule-output-types.ts
@@ -1,0 +1,7 @@
+import type { ScheduleOutputType } from "@/schemas/integrations";
+
+const AUTO_PUBLISH_SUPPORTED: ScheduleOutputType[] = ["changelog", "blog_post"];
+
+export function supportsAutoPublish(outputType: ScheduleOutputType): boolean {
+  return AUTO_PUBLISH_SUPPORTED.includes(outputType);
+}

--- a/apps/dashboard/src/constants/schedule.ts
+++ b/apps/dashboard/src/constants/schedule.ts
@@ -1,0 +1,47 @@
+import { CRON_FREQUENCIES, type CronFrequency } from "@/schemas/integrations";
+import type { ScheduleCron } from "@/types/automation/schedule";
+
+export const DEFAULT_SCHEDULE: ScheduleCron = {
+  frequency: "daily",
+  hour: 9,
+  minute: 0,
+};
+
+export const FREQUENCY_LABELS: Record<CronFrequency, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  monthly: "Monthly",
+};
+
+export const FREQUENCY_OPTIONS: Array<{
+  value: CronFrequency;
+  label: string;
+}> = CRON_FREQUENCIES.map((value) => ({
+  value,
+  label: FREQUENCY_LABELS[value],
+}));
+
+export const DAY_NAMES_LONG = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+export const DAYS_OF_WEEK: Array<{ value: number; label: string }> = [
+  { value: 1, label: "Mon" },
+  { value: 2, label: "Tue" },
+  { value: 3, label: "Wed" },
+  { value: 4, label: "Thu" },
+  { value: 5, label: "Fri" },
+  { value: 6, label: "Sat" },
+  { value: 0, label: "Sun" },
+];
+
+export const DAYS_OF_MONTH: number[] = Array.from(
+  { length: 31 },
+  (_, i) => i + 1
+);

--- a/apps/dashboard/src/types/automation/schedule.ts
+++ b/apps/dashboard/src/types/automation/schedule.ts
@@ -1,0 +1,55 @@
+import type {
+  LookbackWindow,
+  ScheduleOutputType,
+} from "@/schemas/integrations";
+import type { Trigger } from "@/types/triggers/triggers";
+
+export interface ScheduleCron {
+  frequency: "daily" | "weekly" | "monthly";
+  hour: number;
+  minute: number;
+  dayOfWeek?: number;
+  dayOfMonth?: number;
+}
+
+export interface ScheduleFormValues {
+  name: string;
+  outputType: ScheduleOutputType;
+  schedule: ScheduleCron;
+  repositoryIds: string[];
+  lookbackWindow: LookbackWindow;
+  brandVoiceId: string;
+  autoPublish: boolean;
+}
+
+export interface CreateScheduleDialogProps {
+  organizationId: string;
+  onSuccess?: (trigger: Trigger) => void;
+  trigger?: React.ReactElement;
+  editTrigger?: Trigger;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export interface ScheduleFrequencyTabsProps {
+  value: ScheduleCron["frequency"];
+  onChange: (next: ScheduleCron["frequency"]) => void;
+}
+
+export interface ScheduleDayPickerProps {
+  frequency: ScheduleCron["frequency"];
+  dayOfWeek?: number;
+  dayOfMonth?: number;
+  onDayOfWeekChange: (day: number) => void;
+  onDayOfMonthChange: (day: number) => void;
+}
+
+export interface ScheduleSummaryCardProps {
+  schedule: ScheduleCron;
+}
+
+export interface ScheduleIntegrationOption {
+  value: string;
+  label: string;
+  type: "github" | "linear";
+}

--- a/apps/dashboard/src/utils/schedule-form.ts
+++ b/apps/dashboard/src/utils/schedule-form.ts
@@ -1,0 +1,78 @@
+import { FORMAT_CARD_META } from "@/constants/content-formats";
+import { DEFAULT_SCHEDULE, FREQUENCY_LABELS } from "@/constants/schedule";
+import type { CronFrequency, ScheduleOutputType } from "@/schemas/integrations";
+import type { ScheduleFormValues } from "@/types/automation/schedule";
+import type { Trigger } from "@/types/triggers/triggers";
+
+const TIME_PATTERN = /^(\d{1,2}):(\d{2})$/;
+
+export function padTimeUnit(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+export function parseTimeValue(
+  time: string
+): { hour: number; minute: number } | null {
+  const match = TIME_PATTERN.exec(time);
+  if (!match) {
+    return null;
+  }
+  const hour = Number.parseInt(match[1] ?? "", 10);
+  const minute = Number.parseInt(match[2] ?? "", 10);
+  if (
+    Number.isNaN(hour) ||
+    Number.isNaN(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+  return { hour, minute };
+}
+
+export function formatTimeValue(hour: number, minute: number): string {
+  return `${padTimeUnit(hour)}:${padTimeUnit(minute)}`;
+}
+
+export function getDefaultScheduleValues(
+  editTrigger?: Trigger
+): ScheduleFormValues {
+  if (editTrigger) {
+    const supportedType: ScheduleOutputType =
+      editTrigger.outputType === "investor_update"
+        ? "changelog"
+        : (editTrigger.outputType as ScheduleOutputType);
+    return {
+      name: editTrigger.name ?? "",
+      outputType: supportedType,
+      schedule: editTrigger.sourceConfig.cron ?? DEFAULT_SCHEDULE,
+      repositoryIds: editTrigger.targets.repositoryIds,
+      lookbackWindow: editTrigger.lookbackWindow ?? "last_7_days",
+      brandVoiceId:
+        editTrigger.outputConfig?.brandVoiceId &&
+        editTrigger.outputConfig.brandVoiceId !== "__default__"
+          ? editTrigger.outputConfig.brandVoiceId
+          : "",
+      autoPublish: editTrigger.autoPublish ?? false,
+    };
+  }
+  return {
+    name: "",
+    outputType: "changelog",
+    schedule: DEFAULT_SCHEDULE,
+    repositoryIds: [],
+    lookbackWindow: "last_7_days",
+    brandVoiceId: "",
+    autoPublish: false,
+  };
+}
+
+export function buildAutoScheduleName(
+  frequency: CronFrequency,
+  outputType: ScheduleOutputType
+): string {
+  const typeLabel = FORMAT_CARD_META[outputType].label.toLowerCase();
+  return `${FREQUENCY_LABELS[frequency]} ${typeLabel}`;
+}

--- a/apps/dashboard/src/utils/schedule-summary.ts
+++ b/apps/dashboard/src/utils/schedule-summary.ts
@@ -73,7 +73,7 @@ export function formatNextRunRelative(
   now: Date = new Date()
 ): string {
   const diffMs = nextRun.getTime() - now.getTime();
-  const diffMinutes = Math.round(diffMs / 60_000);
+  const diffMinutes = Math.floor(diffMs / 60_000);
 
   if (diffMinutes < 1) {
     return "any moment";
@@ -81,11 +81,11 @@ export function formatNextRunRelative(
   if (diffMinutes < 60) {
     return `in ${diffMinutes}m`;
   }
-  const diffHours = Math.round(diffMinutes / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
   if (diffHours < 24) {
     return `in ${diffHours}h`;
   }
-  const diffDays = Math.round(diffHours / 24);
+  const diffDays = Math.floor(diffHours / 24);
   return `in ${diffDays}d`;
 }
 

--- a/apps/dashboard/src/utils/schedule-summary.ts
+++ b/apps/dashboard/src/utils/schedule-summary.ts
@@ -1,0 +1,108 @@
+import { DAY_NAMES_LONG } from "@/constants/schedule";
+import type { ScheduleCron } from "@/types/automation/schedule";
+import { padTimeUnit } from "@/utils/schedule-form";
+
+function formatTime(hour: number, minute: number): string {
+  const period = hour >= 12 ? "PM" : "AM";
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  return `${displayHour}:${padTimeUnit(minute)} ${period}`;
+}
+
+export function formatScheduleSummary(value: ScheduleCron): string {
+  const time = formatTime(value.hour, value.minute);
+  if (value.frequency === "weekly") {
+    const day = DAY_NAMES_LONG[value.dayOfWeek ?? 1];
+    return `Every ${day} at ${time}`;
+  }
+  if (value.frequency === "monthly") {
+    const day = value.dayOfMonth ?? 1;
+    return `Monthly on day ${day} at ${time}`;
+  }
+  return `Every day at ${time}`;
+}
+
+export function computeNextRun(
+  value: ScheduleCron,
+  now: Date = new Date()
+): Date {
+  const next = new Date(now);
+  next.setUTCSeconds(0, 0);
+
+  if (value.frequency === "daily") {
+    next.setUTCHours(value.hour, value.minute, 0, 0);
+    if (next.getTime() <= now.getTime()) {
+      next.setUTCDate(next.getUTCDate() + 1);
+    }
+    return next;
+  }
+
+  if (value.frequency === "weekly") {
+    const targetDay = value.dayOfWeek ?? 1;
+    next.setUTCHours(value.hour, value.minute, 0, 0);
+    const currentDay = next.getUTCDay();
+    let dayDelta = targetDay - currentDay;
+    if (dayDelta < 0 || (dayDelta === 0 && next.getTime() <= now.getTime())) {
+      dayDelta += 7;
+    }
+    next.setUTCDate(next.getUTCDate() + dayDelta);
+    return next;
+  }
+
+  const targetDay = value.dayOfMonth ?? 1;
+  next.setUTCDate(1);
+  next.setUTCHours(value.hour, value.minute, 0, 0);
+
+  for (let i = 0; i < 13; i++) {
+    const lastDayOfMonth = new Date(
+      Date.UTC(next.getUTCFullYear(), next.getUTCMonth() + 1, 0)
+    ).getUTCDate();
+    if (targetDay <= lastDayOfMonth) {
+      const candidate = new Date(next);
+      candidate.setUTCDate(targetDay);
+      if (candidate.getTime() > now.getTime()) {
+        return candidate;
+      }
+    }
+    next.setUTCMonth(next.getUTCMonth() + 1);
+  }
+  return next;
+}
+
+export function formatNextRunRelative(
+  nextRun: Date,
+  now: Date = new Date()
+): string {
+  const diffMs = nextRun.getTime() - now.getTime();
+  const diffMinutes = Math.round(diffMs / 60_000);
+
+  if (diffMinutes < 1) {
+    return "any moment";
+  }
+  if (diffMinutes < 60) {
+    return `in ${diffMinutes}m`;
+  }
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `in ${diffHours}h`;
+  }
+  const diffDays = Math.round(diffHours / 24);
+  return `in ${diffDays}d`;
+}
+
+export function formatNextRunDate(nextRun: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(nextRun);
+}
+
+export function getLocalTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return "UTC";
+  }
+}


### PR DESCRIPTION
### Description
Moves schedule creation from a side sheet to a ResponsiveDialog matching the create-content wizard chrome. Reuses `FormatCard` for the content type picker; adds frequency pills (Daily / Weekly / Monthly), day-of-week and day-of-month selectors, a styled time input, and a live summary card with computed next-run + local timezone. The name field auto-fills from frequency + type and stops syncing once the user edits it. Auto-publish is hidden (and forced to `false`) for LinkedIn and Tweet outputs.

### Screenshot/Recording (if applicable)
N/A

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did (disclosed: AI-assisted)

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned schedule creation from a side sheet to a modal dialog that matches the create-content wizard. Adds clearer frequency controls, live preview, better defaults, edit support, and stricter source validation.

- New Features
  - Dialog with Daily/Weekly/Monthly tabs, day-of-week/day-of-month pickers, and UTC time input.
  - Live summary card with next run time and local timezone.
  - Name auto-fills from frequency + content type until edited.
  - Source picker for GitHub repos and Linear with multi-select chips and add-integration flow.
  - Lookback window and optional brand voice selection.
  - Auto-publish shown only when supported; hidden and forced off for LinkedIn/Tweet.

- Bug Fixes
  - Require at least one GitHub repository to submit; Linear-only selections are not allowed.
  - Use floor-based conversion in relative time so 23h doesn't show as "in 1d".
  - Updated day-of-month help text with accurate skip notes, including leap years.

<sup>Written for commit 075c53864ed8e55d82f590e996dc1d7be395fd2b. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/349?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

