### PR TITLE
refactor(dashboard): migrate schedule + content dialogs to tanstack-form + zod

### DIFF
--- a/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
+++ b/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
@@ -106,6 +106,7 @@ export function CreateScheduleDialog({
     getDefaultScheduleValues(editTrigger)
   );
   const [nameTouched, setNameTouched] = useState(isEditMode);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
   const [addRepoOpen, setAddRepoOpen] = useState(false);
   const comboboxAnchor = useComboboxAnchor();
 
@@ -113,6 +114,7 @@ export function CreateScheduleDialog({
     if (open) {
       setValues(getDefaultScheduleValues(editTrigger));
       setNameTouched(!!editTrigger);
+      setSubmitAttempted(false);
     }
   }, [open, editTrigger]);
 
@@ -298,30 +300,42 @@ export function CreateScheduleDialog({
     text: string;
     tone: "warning" | "muted";
   }>(() => {
-    if (values.repositoryIds.length === 0) {
+    if (submitAttempted && values.repositoryIds.length === 0) {
       return {
         text: "Pick at least one source to continue",
         tone: "warning",
       };
     }
-    if (githubRepoCount === 0) {
+    if (submitAttempted && githubRepoCount === 0) {
       return {
         text: "Schedules need at least one GitHub repository",
         tone: "warning",
       };
     }
-    if (values.name.trim().length === 0) {
+    if (submitAttempted && values.name.trim().length === 0) {
       return { text: "Give this schedule a name", tone: "warning" };
     }
     const count = values.repositoryIds.length;
+    if (count === 0) {
+      return { text: "No sources selected yet", tone: "muted" };
+    }
     return {
       text: `${count} source${count === 1 ? "" : "s"} selected`,
       tone: "muted",
     };
-  }, [values.name, values.repositoryIds.length, githubRepoCount]);
+  }, [
+    submitAttempted,
+    values.name,
+    values.repositoryIds.length,
+    githubRepoCount,
+  ]);
 
   const handleSubmit = useCallback(() => {
-    if (!isValid || mutation.isPending) {
+    if (mutation.isPending) {
+      return;
+    }
+    if (!isValid) {
+      setSubmitAttempted(true);
       return;
     }
     mutation.mutate(values);
@@ -627,7 +641,7 @@ export function CreateScheduleDialog({
                   Cancel
                 </Button>
                 <Button
-                  disabled={!isValid || mutation.isPending}
+                  disabled={mutation.isPending}
                   onClick={handleSubmit}
                   type="button"
                 >

--- a/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
+++ b/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
@@ -45,8 +45,9 @@ import {
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
 import { cn } from "@notra/ui/lib/utils";
+import { useForm, useStore } from "@tanstack/react-form";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BrandVoiceCombobox } from "@/components/brand-voice-combobox";
 import { FormatCard } from "@/components/content/create/format-card";
@@ -57,6 +58,10 @@ import { FORMAT_CARD_META, FORMAT_ORDER } from "@/constants/content-formats";
 import { supportsAutoPublish } from "@/constants/schedule-output-types";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import {
+  type ScheduleFormValues,
+  scheduleFormSchema,
+} from "@/schemas/automation/schedule-form";
+import {
   LOOKBACK_WINDOWS,
   type LookbackWindow,
   MAX_SCHEDULE_NAME_LENGTH,
@@ -64,7 +69,6 @@ import {
 import type {
   CreateScheduleDialogProps,
   ScheduleCron,
-  ScheduleFormValues,
   ScheduleIntegrationOption,
 } from "@/types/automation/schedule";
 import type { Trigger } from "@/types/triggers/triggers";
@@ -102,85 +106,8 @@ export function CreateScheduleDialog({
     [controlledOnOpenChange, isControlled]
   );
 
-  const [values, setValues] = useState<ScheduleFormValues>(() =>
-    getDefaultScheduleValues(editTrigger)
-  );
-  const [nameTouched, setNameTouched] = useState(isEditMode);
-  const [submitAttempted, setSubmitAttempted] = useState(false);
   const [addRepoOpen, setAddRepoOpen] = useState(false);
   const comboboxAnchor = useComboboxAnchor();
-
-  useEffect(() => {
-    if (open) {
-      setValues(getDefaultScheduleValues(editTrigger));
-      setNameTouched(!!editTrigger);
-      setSubmitAttempted(false);
-    }
-  }, [open, editTrigger]);
-
-  const autoName = useMemo(
-    () => buildAutoScheduleName(values.schedule.frequency, values.outputType),
-    [values.schedule.frequency, values.outputType]
-  );
-
-  useEffect(() => {
-    if (nameTouched) {
-      return;
-    }
-    setValues((prev) =>
-      prev.name === autoName ? prev : { ...prev, name: autoName }
-    );
-  }, [autoName, nameTouched]);
-
-  const { data: integrationsResponse, isLoading: isLoadingRepos } = useQuery(
-    dashboardOrpc.integrations.list.queryOptions({
-      input: { organizationId },
-      enabled: !!organizationId && open,
-    })
-  );
-
-  const { data: brandResponse } = useQuery(
-    dashboardOrpc.brand.voices.list.queryOptions({
-      input: { organizationId },
-      enabled: !!organizationId && open,
-    })
-  );
-
-  const brandVoices = brandResponse?.voices ?? [];
-
-  const { integrationOptions, githubIntegrationId } = useMemo(() => {
-    const githubIntegrations =
-      integrationsResponse?.integrations.filter(
-        (i) => i.type === "github" && i.enabled
-      ) ?? [];
-    const linearIntegrations =
-      integrationsResponse?.integrations.filter(
-        (i) => i.type === "linear" && i.enabled
-      ) ?? [];
-    const repos = githubIntegrations.flatMap((i) =>
-      i.repositories.filter((r) => r.enabled)
-    );
-
-    const options: ScheduleIntegrationOption[] = [
-      ...repos.map((r) => ({
-        value: r.id,
-        label: r.defaultBranch
-          ? `${r.owner}/${r.repo} · ${r.defaultBranch}`
-          : `${r.owner}/${r.repo}`,
-        type: "github" as const,
-      })),
-      ...linearIntegrations.map((i) => ({
-        value: `linear:${i.id}`,
-        label: i.displayName,
-        type: "linear" as const,
-      })),
-    ];
-
-    return {
-      integrationOptions: options,
-      githubIntegrationId: githubIntegrations[0]?.id,
-    };
-  }, [integrationsResponse]);
 
   const mutation = useMutation<{ trigger: Trigger }, Error, ScheduleFormValues>(
     {
@@ -241,105 +168,136 @@ export function CreateScheduleDialog({
     }
   );
 
-  const updateValues = useCallback((patch: Partial<ScheduleFormValues>) => {
-    setValues((prev) => ({ ...prev, ...patch }));
-  }, []);
+  const form = useForm({
+    defaultValues: getDefaultScheduleValues(editTrigger),
+    validators: {
+      onSubmit: scheduleFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      await mutation.mutateAsync(value);
+    },
+  });
 
-  const updateSchedule = useCallback((patch: Partial<ScheduleCron>) => {
-    setValues((prev) => ({
-      ...prev,
-      schedule: { ...prev.schedule, ...patch },
-    }));
-  }, []);
+  const previousAutoNameRef = useRef("");
+
+  useEffect(() => {
+    if (open) {
+      form.reset(getDefaultScheduleValues(editTrigger));
+      previousAutoNameRef.current = "";
+    }
+  }, [open, editTrigger, form]);
+
+  const outputType = useStore(form.store, (s) => s.values.outputType);
+  const schedule = useStore(form.store, (s) => s.values.schedule);
+  const { frequency, hour, minute, dayOfWeek, dayOfMonth } = schedule;
+  const repositoryCount = useStore(
+    form.store,
+    (s) => s.values.repositoryIds.length
+  );
+
+  useEffect(() => {
+    const newAutoName = buildAutoScheduleName(frequency, outputType);
+    const currentName = form.state.values.name;
+    if (
+      currentName === previousAutoNameRef.current ||
+      currentName.length === 0
+    ) {
+      form.setFieldValue("name", newAutoName);
+    }
+    previousAutoNameRef.current = newAutoName;
+  }, [outputType, frequency, form]);
+
+  const { data: integrationsResponse, isLoading: isLoadingRepos } = useQuery(
+    dashboardOrpc.integrations.list.queryOptions({
+      input: { organizationId },
+      enabled: !!organizationId && open,
+    })
+  );
+
+  const { data: brandResponse } = useQuery(
+    dashboardOrpc.brand.voices.list.queryOptions({
+      input: { organizationId },
+      enabled: !!organizationId && open,
+    })
+  );
+
+  const brandVoices = brandResponse?.voices ?? [];
+
+  const { integrationOptions, githubIntegrationId } = useMemo(() => {
+    const githubIntegrations =
+      integrationsResponse?.integrations.filter(
+        (i) => i.type === "github" && i.enabled
+      ) ?? [];
+    const linearIntegrations =
+      integrationsResponse?.integrations.filter(
+        (i) => i.type === "linear" && i.enabled
+      ) ?? [];
+    const repos = githubIntegrations.flatMap((i) =>
+      i.repositories.filter((r) => r.enabled)
+    );
+
+    const options: ScheduleIntegrationOption[] = [
+      ...repos.map((r) => ({
+        value: r.id,
+        label: r.defaultBranch
+          ? `${r.owner}/${r.repo} · ${r.defaultBranch}`
+          : `${r.owner}/${r.repo}`,
+        type: "github" as const,
+      })),
+      ...linearIntegrations.map((i) => ({
+        value: `linear:${i.id}`,
+        label: i.displayName,
+        type: "linear" as const,
+      })),
+    ];
+
+    return {
+      integrationOptions: options,
+      githubIntegrationId: githubIntegrations[0]?.id,
+    };
+  }, [integrationsResponse]);
 
   const handleFrequencyChange = useCallback(
-    (frequency: ScheduleCron["frequency"]) => {
-      setValues((prev) => {
-        const next: ScheduleCron = { ...prev.schedule, frequency };
-        if (frequency === "weekly") {
-          next.dayOfWeek = prev.schedule.dayOfWeek ?? 1;
-          next.dayOfMonth = undefined;
-        } else if (frequency === "monthly") {
-          next.dayOfMonth = prev.schedule.dayOfMonth ?? 1;
-          next.dayOfWeek = undefined;
-        } else {
-          next.dayOfWeek = undefined;
-          next.dayOfMonth = undefined;
-        }
-        return { ...prev, schedule: next };
+    (next: ScheduleCron["frequency"]) => {
+      const prev = form.state.values.schedule;
+      let dayOfWeek: number | undefined;
+      let dayOfMonth: number | undefined;
+      if (next === "weekly") {
+        dayOfWeek = prev.dayOfWeek ?? 1;
+      } else if (next === "monthly") {
+        dayOfMonth = prev.dayOfMonth ?? 1;
+      }
+      form.setFieldValue("schedule", {
+        ...prev,
+        frequency: next,
+        dayOfWeek,
+        dayOfMonth,
       });
     },
-    []
+    [form]
   );
 
-  const handleTimeChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const parsed = parseTimeValue(event.target.value);
-      if (parsed) {
-        updateSchedule(parsed);
+  const formError = useStore(form.store, (state) => {
+    if (state.submissionAttempts === 0) {
+      return null;
+    }
+    for (const meta of Object.values(state.fieldMeta)) {
+      const errors = meta?.errors;
+      if (errors && errors.length > 0) {
+        const first = errors[0];
+        if (typeof first === "string") {
+          return first;
+        }
+        if (first && typeof first === "object" && "message" in first) {
+          const message = (first as { message: unknown }).message;
+          if (typeof message === "string") {
+            return message;
+          }
+        }
       }
-    },
-    [updateSchedule]
-  );
-
-  const timeValue = formatTimeValue(
-    values.schedule.hour,
-    values.schedule.minute
-  );
-
-  const meta = FORMAT_CARD_META[values.outputType];
-
-  const githubRepoCount = useMemo(
-    () => values.repositoryIds.filter((id) => !id.startsWith("linear:")).length,
-    [values.repositoryIds]
-  );
-
-  const isValid = values.name.trim().length > 0 && githubRepoCount > 0;
-
-  const footerStatus = useMemo<{
-    text: string;
-    tone: "warning" | "muted";
-  }>(() => {
-    if (submitAttempted && values.repositoryIds.length === 0) {
-      return {
-        text: "Pick at least one source to continue",
-        tone: "warning",
-      };
     }
-    if (submitAttempted && githubRepoCount === 0) {
-      return {
-        text: "Schedules need at least one GitHub repository",
-        tone: "warning",
-      };
-    }
-    if (submitAttempted && values.name.trim().length === 0) {
-      return { text: "Give this schedule a name", tone: "warning" };
-    }
-    const count = values.repositoryIds.length;
-    if (count === 0) {
-      return { text: "No sources selected yet", tone: "muted" };
-    }
-    return {
-      text: `${count} source${count === 1 ? "" : "s"} selected`,
-      tone: "muted",
-    };
-  }, [
-    submitAttempted,
-    values.name,
-    values.repositoryIds.length,
-    githubRepoCount,
-  ]);
-
-  const handleSubmit = useCallback(() => {
-    if (mutation.isPending) {
-      return;
-    }
-    if (!isValid) {
-      setSubmitAttempted(true);
-      return;
-    }
-    mutation.mutate(values);
-  }, [isValid, mutation, values]);
+    return null;
+  });
 
   return (
     <>
@@ -356,313 +314,345 @@ export function CreateScheduleDialog({
             </p>
           </ResponsiveDialogHeader>
 
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            <div className="space-y-8 p-6">
-              <section className="space-y-3">
-                <div className="space-y-1">
-                  <h3 className="font-semibold text-base">Content format</h3>
-                  <p className="text-muted-foreground text-sm">
-                    What should we generate?
-                  </p>
-                </div>
-                <div className="grid gap-3 md:grid-cols-2">
-                  {FORMAT_ORDER.map((type) => (
-                    <FormatCard
-                      format={type}
-                      key={type}
-                      onToggle={() => updateValues({ outputType: type })}
-                      selected={values.outputType === type}
-                    />
-                  ))}
-                </div>
-              </section>
-
-              <section className="space-y-3">
-                <div className="space-y-1">
-                  <h3 className="flex items-center gap-1 font-semibold text-base">
-                    Name
-                    <span aria-hidden="true" className="text-destructive">
-                      *
-                    </span>
-                  </h3>
-                  <p className="text-muted-foreground text-sm">
-                    Just for you, won't appear in any output.
-                  </p>
-                </div>
-                <Input
-                  id="schedule-name"
-                  maxLength={MAX_SCHEDULE_NAME_LENGTH}
-                  onChange={(event) => {
-                    setNameTouched(true);
-                    updateValues({ name: event.target.value });
-                  }}
-                  placeholder={autoName}
-                  value={values.name}
-                />
-              </section>
-
-              <section className="space-y-3">
-                <div className="space-y-1">
-                  <h3 className="font-semibold text-base">Schedule</h3>
-                  <p className="text-muted-foreground text-sm">
-                    When should this run? Times use UTC.
-                  </p>
-                </div>
-                <ScheduleFrequencyTabs
-                  onChange={handleFrequencyChange}
-                  value={values.schedule.frequency}
-                />
-                <ScheduleDayPicker
-                  dayOfMonth={values.schedule.dayOfMonth}
-                  dayOfWeek={values.schedule.dayOfWeek}
-                  frequency={values.schedule.frequency}
-                  onDayOfMonthChange={(day) =>
-                    updateSchedule({ dayOfMonth: day })
-                  }
-                  onDayOfWeekChange={(day) =>
-                    updateSchedule({ dayOfWeek: day })
-                  }
-                />
-                <div className="space-y-2">
-                  <Label
-                    className="text-muted-foreground text-xs"
-                    htmlFor="schedule-time"
-                  >
-                    Time
-                  </Label>
-                  <Input
-                    className="w-full appearance-none bg-background sm:w-40 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
-                    id="schedule-time"
-                    onChange={handleTimeChange}
-                    type="time"
-                    value={timeValue}
-                  />
-                </div>
-                <ScheduleSummaryCard schedule={values.schedule} />
-              </section>
-
-              <section className="space-y-3">
-                <div className="space-y-1">
-                  <h3 className="flex items-center gap-1 font-semibold text-base">
-                    Sources
-                    <span aria-hidden="true" className="text-destructive">
-                      *
-                    </span>
-                  </h3>
-                  <p className="text-muted-foreground text-sm">
-                    Pick which integrations we should pull activity from.
-                  </p>
-                </div>
-                {isLoadingRepos && <Skeleton className="h-10 w-full" />}
-                {!isLoadingRepos && integrationOptions.length === 0 && (
-                  <div className="flex items-center gap-2 rounded-lg border border-dashed p-3">
-                    <span className="flex-1 text-muted-foreground text-xs">
-                      No integrations connected yet.
-                    </span>
-                    <AddRepositoryButton
-                      onAdd={() => {
-                        setOpen(false);
-                        setAddRepoOpen(true);
-                      }}
-                    />
+          <form
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              form.handleSubmit();
+            }}
+          >
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="space-y-8 p-6">
+                <section className="space-y-3">
+                  <div className="space-y-1">
+                    <h3 className="font-semibold text-base">Content format</h3>
+                    <p className="text-muted-foreground text-sm">
+                      What should we generate?
+                    </p>
                   </div>
-                )}
-                {!isLoadingRepos && integrationOptions.length > 0 && (
-                  <div ref={comboboxAnchor}>
-                    <Combobox
-                      items={integrationOptions.map((o) => o.value)}
-                      multiple
-                      onValueChange={(value) =>
-                        updateValues({
-                          repositoryIds: Array.isArray(value) ? value : [],
-                        })
-                      }
-                      value={values.repositoryIds}
-                    >
-                      <ComboboxChips>
-                        {values.repositoryIds.map((id) => {
-                          const opt = integrationOptions.find(
-                            (o) => o.value === id
-                          );
-                          if (!opt) {
-                            return null;
-                          }
-                          return (
-                            <ComboboxChip key={opt.value}>
-                              <span className="flex items-center gap-1.5">
-                                {opt.type === "github" ? (
-                                  <Github className="size-3 shrink-0" />
-                                ) : (
-                                  <Linear className="size-3 shrink-0" />
-                                )}
-                                {opt.label}
-                              </span>
-                            </ComboboxChip>
-                          );
-                        })}
-                        <ComboboxChipsInput placeholder="Search integrations" />
-                      </ComboboxChips>
-                      <ComboboxContent anchor={comboboxAnchor.current}>
-                        <ComboboxEmpty>No integrations found.</ComboboxEmpty>
-                        <ComboboxList>
-                          {integrationOptions.map((opt) => (
-                            <ComboboxItem key={opt.value} value={opt.value}>
-                              <span className="flex items-center gap-2">
-                                {opt.type === "github" ? (
-                                  <Github className="size-3.5 shrink-0" />
-                                ) : (
-                                  <Linear className="size-3.5 shrink-0" />
-                                )}
-                                {opt.label}
-                              </span>
-                            </ComboboxItem>
-                          ))}
-                        </ComboboxList>
-                      </ComboboxContent>
-                    </Combobox>
-                  </div>
-                )}
-              </section>
-
-              <section className="space-y-3">
-                <div className="space-y-1">
-                  <h3 className="font-semibold text-base">
-                    {meta.label} rules
-                  </h3>
-                  <p className="text-muted-foreground text-sm">
-                    How far back we look and how the post should sound.
-                  </p>
-                </div>
-                <div className="space-y-2">
-                  <Label
-                    className="text-muted-foreground text-xs"
-                    htmlFor="schedule-lookback"
-                  >
-                    Lookback window
-                  </Label>
-                  <Select
-                    onValueChange={(value) => {
-                      if (value) {
-                        updateValues({
-                          lookbackWindow: value as LookbackWindow,
-                        });
-                      }
-                    }}
-                    value={values.lookbackWindow}
-                  >
-                    <SelectTrigger className="w-full" id="schedule-lookback">
-                      <SelectValue placeholder="Lookback window">
-                        <span className="capitalize">
-                          {formatSnakeCaseLabel(values.lookbackWindow)}
-                        </span>
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      {LOOKBACK_WINDOWS.map((window) => (
-                        <SelectItem key={window} value={window}>
-                          <span className="capitalize">
-                            {formatSnakeCaseLabel(window)}
-                          </span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {brandVoices.length > 1 && (
-                  <BrandVoiceCombobox
-                    id="schedule-brand-voice"
-                    onChange={(value) => updateValues({ brandVoiceId: value })}
-                    value={values.brandVoiceId}
-                    voices={brandVoices}
-                  />
-                )}
-
-                {supportsAutoPublish(values.outputType) && (
-                  <div className="flex items-center justify-between rounded-lg border p-3">
-                    <div className="flex items-center gap-1.5">
-                      <Label
-                        className="cursor-pointer font-medium text-sm"
-                        htmlFor="schedule-auto-publish"
-                      >
-                        Auto-publish
-                      </Label>
-                      <Tooltip>
-                        <TooltipTrigger className="inline-flex cursor-help text-muted-foreground">
-                          <HugeiconsIcon
-                            icon={InformationCircleIcon}
-                            size={14}
+                  <form.Field name="outputType">
+                    {(field) => (
+                      <div className="grid gap-3 md:grid-cols-2">
+                        {FORMAT_ORDER.map((type) => (
+                          <FormatCard
+                            format={type}
+                            key={type}
+                            onToggle={() => field.handleChange(type)}
+                            selected={field.state.value === type}
                           />
-                        </TooltipTrigger>
-                        <TooltipContent side="top">
-                          <p className="max-w-50 text-xs">
-                            When on, posts are published immediately instead of
-                            saved as drafts.
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                    <Switch
-                      checked={values.autoPublish}
-                      id="schedule-auto-publish"
-                      onCheckedChange={(value) =>
-                        updateValues({ autoPublish: value })
-                      }
+                        ))}
+                      </div>
+                    )}
+                  </form.Field>
+                </section>
+
+                <section className="space-y-3">
+                  <div className="space-y-1">
+                    <h3 className="flex items-center gap-1 font-semibold text-base">
+                      Name
+                      <span aria-hidden="true" className="text-destructive">
+                        *
+                      </span>
+                    </h3>
+                    <p className="text-muted-foreground text-sm">
+                      Just for you, won't appear in any output.
+                    </p>
+                  </div>
+                  <form.Field name="name">
+                    {(field) => (
+                      <Input
+                        id={field.name}
+                        maxLength={MAX_SCHEDULE_NAME_LENGTH}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value);
+                        }}
+                        placeholder={buildAutoScheduleName(
+                          frequency,
+                          outputType
+                        )}
+                        value={field.state.value}
+                      />
+                    )}
+                  </form.Field>
+                </section>
+
+                <section className="space-y-3">
+                  <div className="space-y-1">
+                    <h3 className="font-semibold text-base">Schedule</h3>
+                    <p className="text-muted-foreground text-sm">
+                      When should this run? Times use UTC.
+                    </p>
+                  </div>
+                  <ScheduleFrequencyTabs
+                    onChange={handleFrequencyChange}
+                    value={frequency}
+                  />
+                  <ScheduleDayPicker
+                    dayOfMonth={dayOfMonth}
+                    dayOfWeek={dayOfWeek}
+                    frequency={frequency}
+                    onDayOfMonthChange={(day) =>
+                      form.setFieldValue("schedule.dayOfMonth", day)
+                    }
+                    onDayOfWeekChange={(day) =>
+                      form.setFieldValue("schedule.dayOfWeek", day)
+                    }
+                  />
+                  <div className="space-y-2">
+                    <Label
+                      className="text-muted-foreground text-xs"
+                      htmlFor="schedule-time"
+                    >
+                      Time
+                    </Label>
+                    <Input
+                      className="w-full appearance-none bg-background sm:w-40 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+                      id="schedule-time"
+                      onChange={(event) => {
+                        const parsed = parseTimeValue(event.target.value);
+                        if (parsed) {
+                          form.setFieldValue("schedule.hour", parsed.hour);
+                          form.setFieldValue("schedule.minute", parsed.minute);
+                        }
+                      }}
+                      type="time"
+                      value={formatTimeValue(hour, minute)}
                     />
                   </div>
-                )}
-              </section>
-            </div>
-          </div>
+                  <ScheduleSummaryCard schedule={schedule} />
+                </section>
 
-          <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
-            <div className="flex items-center justify-between gap-3">
-              <span
-                className={cn(
-                  "flex items-center gap-1.5 text-xs",
-                  footerStatus.tone === "warning"
-                    ? "font-medium text-destructive"
-                    : "text-muted-foreground"
-                )}
-              >
-                {footerStatus.tone === "warning" && (
-                  <HugeiconsIcon className="size-3.5" icon={AlertCircleIcon} />
-                )}
-                {footerStatus.text}
-              </span>
-              <div className="flex items-center gap-2">
-                <Button
-                  disabled={mutation.isPending}
-                  onClick={() => setOpen(false)}
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  disabled={mutation.isPending}
-                  onClick={handleSubmit}
-                  type="button"
-                >
-                  {mutation.isPending ? (
-                    <>
-                      <HugeiconsIcon
-                        className="size-4 animate-spin"
-                        icon={Loading03Icon}
+                <section className="space-y-3">
+                  <div className="space-y-1">
+                    <h3 className="flex items-center gap-1 font-semibold text-base">
+                      Sources
+                      <span aria-hidden="true" className="text-destructive">
+                        *
+                      </span>
+                    </h3>
+                    <p className="text-muted-foreground text-sm">
+                      Pick which integrations we should pull activity from.
+                    </p>
+                  </div>
+                  {isLoadingRepos && <Skeleton className="h-10 w-full" />}
+                  {!isLoadingRepos && integrationOptions.length === 0 && (
+                    <div className="flex items-center gap-2 rounded-lg border border-dashed p-3">
+                      <span className="flex-1 text-muted-foreground text-xs">
+                        No integrations connected yet.
+                      </span>
+                      <AddRepositoryButton
+                        onAdd={() => {
+                          setOpen(false);
+                          setAddRepoOpen(true);
+                        }}
                       />
-                      {isEditMode ? "Saving..." : "Adding..."}
-                    </>
-                  ) : (
-                    <>
-                      <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                      {isEditMode ? "Save changes" : "Add schedule"}
-                    </>
+                    </div>
                   )}
-                </Button>
+                  {!isLoadingRepos && integrationOptions.length > 0 && (
+                    <form.Field name="repositoryIds">
+                      {(field) => (
+                        <div ref={comboboxAnchor}>
+                          <Combobox
+                            items={integrationOptions.map((o) => o.value)}
+                            multiple
+                            onValueChange={(value) =>
+                              field.handleChange(
+                                Array.isArray(value) ? value : []
+                              )
+                            }
+                            value={field.state.value}
+                          >
+                            <ComboboxChips>
+                              {field.state.value.map((id) => {
+                                const opt = integrationOptions.find(
+                                  (o) => o.value === id
+                                );
+                                if (!opt) {
+                                  return null;
+                                }
+                                return (
+                                  <ComboboxChip key={opt.value}>
+                                    <span className="flex items-center gap-1.5">
+                                      {opt.type === "github" ? (
+                                        <Github className="size-3 shrink-0" />
+                                      ) : (
+                                        <Linear className="size-3 shrink-0" />
+                                      )}
+                                      {opt.label}
+                                    </span>
+                                  </ComboboxChip>
+                                );
+                              })}
+                              <ComboboxChipsInput placeholder="Search integrations" />
+                            </ComboboxChips>
+                            <ComboboxContent anchor={comboboxAnchor.current}>
+                              <ComboboxEmpty>
+                                No integrations found.
+                              </ComboboxEmpty>
+                              <ComboboxList>
+                                {integrationOptions.map((opt) => (
+                                  <ComboboxItem
+                                    key={opt.value}
+                                    value={opt.value}
+                                  >
+                                    <span className="flex items-center gap-2">
+                                      {opt.type === "github" ? (
+                                        <Github className="size-3.5 shrink-0" />
+                                      ) : (
+                                        <Linear className="size-3.5 shrink-0" />
+                                      )}
+                                      {opt.label}
+                                    </span>
+                                  </ComboboxItem>
+                                ))}
+                              </ComboboxList>
+                            </ComboboxContent>
+                          </Combobox>
+                        </div>
+                      )}
+                    </form.Field>
+                  )}
+                </section>
+
+                <section className="space-y-3">
+                  <div className="space-y-1">
+                    <h3 className="font-semibold text-base">
+                      {FORMAT_CARD_META[outputType].label} rules
+                    </h3>
+                    <p className="text-muted-foreground text-sm">
+                      How far back we look and how the post should sound.
+                    </p>
+                  </div>
+                  <form.Field name="lookbackWindow">
+                    {(field) => (
+                      <div className="space-y-2">
+                        <Label
+                          className="text-muted-foreground text-xs"
+                          htmlFor="schedule-lookback"
+                        >
+                          Lookback window
+                        </Label>
+                        <Select
+                          onValueChange={(value) => {
+                            if (value) {
+                              field.handleChange(value as LookbackWindow);
+                            }
+                          }}
+                          value={field.state.value}
+                        >
+                          <SelectTrigger
+                            className="w-full"
+                            id="schedule-lookback"
+                          >
+                            <SelectValue placeholder="Lookback window">
+                              <span className="capitalize">
+                                {formatSnakeCaseLabel(field.state.value)}
+                              </span>
+                            </SelectValue>
+                          </SelectTrigger>
+                          <SelectContent>
+                            {LOOKBACK_WINDOWS.map((window) => (
+                              <SelectItem key={window} value={window}>
+                                <span className="capitalize">
+                                  {formatSnakeCaseLabel(window)}
+                                </span>
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+                  </form.Field>
+
+                  {brandVoices.length > 1 && (
+                    <form.Field name="brandVoiceId">
+                      {(field) => (
+                        <BrandVoiceCombobox
+                          id={field.name}
+                          onChange={field.handleChange}
+                          value={field.state.value}
+                          voices={brandVoices}
+                        />
+                      )}
+                    </form.Field>
+                  )}
+
+                  {supportsAutoPublish(outputType) && (
+                    <form.Field name="autoPublish">
+                      {(field) => (
+                        <div className="flex items-center justify-between rounded-lg border p-3">
+                          <div className="flex items-center gap-1.5">
+                            <Label
+                              className="cursor-pointer font-medium text-sm"
+                              htmlFor={field.name}
+                            >
+                              Auto-publish
+                            </Label>
+                            <Tooltip>
+                              <TooltipTrigger className="inline-flex cursor-help text-muted-foreground">
+                                <HugeiconsIcon
+                                  icon={InformationCircleIcon}
+                                  size={14}
+                                />
+                              </TooltipTrigger>
+                              <TooltipContent side="top">
+                                <p className="max-w-50 text-xs">
+                                  When on, posts are published immediately
+                                  instead of saved as drafts.
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </div>
+                          <Switch
+                            checked={field.state.value}
+                            id={field.name}
+                            onCheckedChange={field.handleChange}
+                          />
+                        </div>
+                      )}
+                    </form.Field>
+                  )}
+                </section>
               </div>
             </div>
-          </div>
+
+            <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <FooterStatus
+                  errorMessage={formError}
+                  repositoryCount={repositoryCount}
+                />
+                <div className="flex items-center gap-2">
+                  <Button
+                    disabled={mutation.isPending}
+                    onClick={() => setOpen(false)}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    Cancel
+                  </Button>
+                  <Button disabled={mutation.isPending} type="submit">
+                    {mutation.isPending ? (
+                      <>
+                        <HugeiconsIcon
+                          className="size-4 animate-spin"
+                          icon={Loading03Icon}
+                        />
+                        {isEditMode ? "Saving..." : "Adding..."}
+                      </>
+                    ) : (
+                      <>
+                        <HugeiconsIcon className="size-4" icon={Add01Icon} />
+                        {isEditMode ? "Save changes" : "Add schedule"}
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </form>
         </ResponsiveDialogContent>
       </ResponsiveDialog>
       {githubIntegrationId ? (
@@ -690,5 +680,30 @@ export function CreateScheduleDialog({
         />
       )}
     </>
+  );
+}
+
+interface FooterStatusProps {
+  errorMessage: string | null;
+  repositoryCount: number;
+}
+
+function FooterStatus({ errorMessage, repositoryCount }: FooterStatusProps) {
+  if (errorMessage) {
+    return (
+      <span className="flex items-center gap-1.5 font-medium text-destructive text-xs">
+        <HugeiconsIcon className="size-3.5" icon={AlertCircleIcon} />
+        {errorMessage}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={cn("flex items-center gap-1.5 text-muted-foreground text-xs")}
+    >
+      {repositoryCount === 0
+        ? "No sources selected yet"
+        : `${repositoryCount} source${repositoryCount === 1 ? "" : "s"} selected`}
+    </span>
   );
 }

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -2,6 +2,7 @@
 
 import {
   Add01Icon,
+  AlertCircleIcon,
   ArrowLeft01Icon,
   ArrowRight01Icon,
   Loading03Icon,
@@ -383,6 +384,7 @@ export function CreateContentDialog({
     setSelectedReleaseKeys(new Set());
     setSelectedLinearKeys(new Set());
     setSearchQuery("");
+    setAttemptedAdvance(false);
     lastInitializedParamsRef.current = "";
     selectionsTouchedRef.current = false;
     integrationsInitializedRef.current = false;
@@ -565,16 +567,40 @@ export function CreateContentDialog({
     eventCounts,
   ]);
 
+  const [attemptedAdvance, setAttemptedAdvance] = useState(false);
+
   const goNext = useCallback(() => {
     const idx = STEP_ORDER.indexOf(step);
-    if (idx < STEP_ORDER.length - 1) {
-      setStep(STEP_ORDER[idx + 1] as WizardStep);
+    if (idx >= STEP_ORDER.length - 1) {
+      return;
     }
-  }, [step]);
+    if (step === "formats" && selectedFormats.length === 0) {
+      setAttemptedAdvance(true);
+      return;
+    }
+    if (
+      step === "activity" &&
+      (selectedRepoIds.length === 0 ||
+        isLoadingPreview ||
+        eventCounts.selected === 0)
+    ) {
+      setAttemptedAdvance(true);
+      return;
+    }
+    setAttemptedAdvance(false);
+    setStep(STEP_ORDER[idx + 1] as WizardStep);
+  }, [
+    step,
+    selectedFormats.length,
+    selectedRepoIds.length,
+    isLoadingPreview,
+    eventCounts.selected,
+  ]);
 
   const goBack = useCallback(() => {
     const idx = STEP_ORDER.indexOf(step);
     if (idx > 0) {
+      setAttemptedAdvance(false);
       setStep(STEP_ORDER[idx - 1] as WizardStep);
     }
   }, [step]);
@@ -634,6 +660,10 @@ export function CreateContentDialog({
   ]);
 
   const handleCreate = useCallback(() => {
+    if (selectedFormats.length === 0) {
+      setAttemptedAdvance(true);
+      return;
+    }
     const voiceIds =
       selectedBrandVoiceIds.length > 0 ? selectedBrandVoiceIds : [""];
     mutation.mutate({
@@ -677,14 +707,6 @@ export function CreateContentDialog({
     setOpen(true);
   }, []);
 
-  const canContinueFromFormats = selectedFormats.length > 0;
-  const canContinueFromActivity =
-    selectedRepoIds.length > 0 && !isLoadingPreview && eventCounts.selected > 0;
-
-  const continueDisabled =
-    (step === "formats" && !canContinueFromFormats) ||
-    (step === "activity" && !canContinueFromActivity);
-
   const identityButtonLabel =
     selectedBrandVoiceIds.length === 0
       ? "Skip & start creating"
@@ -692,20 +714,62 @@ export function CreateContentDialog({
 
   const stepIndex = STEP_ORDER.indexOf(step);
 
-  const footerLeft = useMemo(() => {
+  const footerLeft = useMemo<{
+    text: string;
+    tone: "warning" | "muted";
+  }>(() => {
+    if (
+      attemptedAdvance &&
+      step === "formats" &&
+      selectedFormats.length === 0
+    ) {
+      return {
+        text: "Select at least one content format",
+        tone: "warning",
+      };
+    }
+    if (attemptedAdvance && step === "activity") {
+      if (selectedRepoIds.length === 0) {
+        return { text: "Select at least one source", tone: "warning" };
+      }
+      if (eventCounts.selected === 0) {
+        return { text: "Select at least one event", tone: "warning" };
+      }
+    }
+    if (
+      attemptedAdvance &&
+      step === "identities" &&
+      selectedFormats.length === 0
+    ) {
+      return {
+        text: "Select a content format before creating",
+        tone: "warning",
+      };
+    }
     if (step === "formats") {
-      return `${selectedFormats.length} format${selectedFormats.length === 1 ? "" : "s"} selected`;
+      return {
+        text: `${selectedFormats.length} format${selectedFormats.length === 1 ? "" : "s"} selected`,
+        tone: "muted",
+      };
     }
     if (step === "activity") {
       if (selectedRepoIds.length === 0) {
-        return "Select at least one source";
+        return { text: "No sources selected yet", tone: "muted" };
       }
-      return `${eventCounts.selected} / ${eventCounts.total} events · ${selectedRepoIds.length} source${selectedRepoIds.length === 1 ? "" : "s"}`;
+      return {
+        text: `${eventCounts.selected} / ${eventCounts.total} events · ${selectedRepoIds.length} source${selectedRepoIds.length === 1 ? "" : "s"}`,
+        tone: "muted",
+      };
     }
-    return selectedBrandVoiceIds.length === 0
-      ? "No identities selected"
-      : `${selectedBrandVoiceIds.length} ${selectedBrandVoiceIds.length === 1 ? "identity" : "identities"} selected`;
+    return {
+      text:
+        selectedBrandVoiceIds.length === 0
+          ? "No identities selected"
+          : `${selectedBrandVoiceIds.length} ${selectedBrandVoiceIds.length === 1 ? "identity" : "identities"} selected`,
+      tone: "muted",
+    };
   }, [
+    attemptedAdvance,
     step,
     selectedFormats.length,
     selectedRepoIds.length,
@@ -846,15 +910,26 @@ export function CreateContentDialog({
                       Back
                     </Button>
                   )}
-                  <span className="text-muted-foreground text-xs">
-                    {footerLeft}
+                  <span
+                    className={cn(
+                      "flex items-center gap-1.5 text-xs",
+                      footerLeft.tone === "warning"
+                        ? "font-medium text-destructive"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    {footerLeft.tone === "warning" && (
+                      <HugeiconsIcon
+                        className="size-3.5"
+                        icon={AlertCircleIcon}
+                      />
+                    )}
+                    {footerLeft.text}
                   </span>
                 </div>
                 {step === "identities" ? (
                   <Button
-                    disabled={
-                      mutation.isPending || selectedFormats.length === 0
-                    }
+                    disabled={mutation.isPending}
                     onClick={handleCreate}
                     type="button"
                   >
@@ -878,7 +953,7 @@ export function CreateContentDialog({
                   </Button>
                 ) : (
                   <Button
-                    disabled={continueDisabled}
+                    disabled={mutation.isPending}
                     onClick={goNext}
                     type="button"
                   >

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from "@notra/ui/components/ui/button";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import { cn } from "@notra/ui/lib/utils";
+import { useForm, useStore } from "@tanstack/react-form";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -35,7 +36,10 @@ import type {
   OnDemandContentType,
   SelectedItems,
 } from "@/schemas/content";
-import type { LookbackWindow } from "@/schemas/integrations";
+import {
+  type CreateContentFormValues,
+  createContentFormSchema,
+} from "@/schemas/content/create-content-form";
 import type { IntegrationOption, WizardStep } from "@/types/content/create";
 import type { PrSelection, ReleaseSelection } from "@/types/content/preview";
 import {
@@ -63,6 +67,16 @@ const STEP_LABELS: Record<WizardStep, string> = {
   identities: "Identity",
 };
 
+function getDefaultContentFormValues(): CreateContentFormValues {
+  return {
+    formats: [],
+    repositoryIds: [],
+    brandVoiceIds: [],
+    lookbackWindow: "last_7_days",
+    dataPoints: DEFAULT_DATA_POINTS,
+  };
+}
+
 export function CreateContentDialog({
   organizationId,
 }: CreateContentDialogProps) {
@@ -81,17 +95,37 @@ export function CreateContentDialog({
   const queryClient = useQueryClient();
 
   const [step, setStep] = useState<WizardStep>("formats");
-  const [selectedFormats, setSelectedFormats] = useState<OnDemandContentType[]>(
-    []
+
+  const submitHandlerRef = useRef<
+    (value: CreateContentFormValues) => Promise<void>
+  >(async () => {
+    return;
+  });
+
+  const form = useForm({
+    defaultValues: getDefaultContentFormValues(),
+    validators: {
+      onSubmit: ({ value }) => {
+        const result = createContentFormSchema.safeParse(value);
+        if (!result.success) {
+          return result.error.issues[0]?.message ?? "Form is invalid";
+        }
+        return;
+      },
+    },
+    onSubmit: async ({ value }) => {
+      await submitHandlerRef.current(value);
+    },
+  });
+
+  const selectedFormats = useStore(form.store, (s) => s.values.formats);
+  const selectedRepoIds = useStore(form.store, (s) => s.values.repositoryIds);
+  const selectedBrandVoiceIds = useStore(
+    form.store,
+    (s) => s.values.brandVoiceIds
   );
-  const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>([]);
-  const [selectedBrandVoiceIds, setSelectedBrandVoiceIds] = useState<string[]>(
-    []
-  );
-  const [lookbackWindow, setLookbackWindow] =
-    useState<LookbackWindow>("last_7_days");
-  const [dataPoints, setDataPoints] =
-    useState<ContentDataPointSettings>(DEFAULT_DATA_POINTS);
+  const lookbackWindow = useStore(form.store, (s) => s.values.lookbackWindow);
+  const dataPoints = useStore(form.store, (s) => s.values.dataPoints);
 
   const [selectedCommitKeys, setSelectedCommitKeys] = useState<Set<string>>(
     new Set()
@@ -374,11 +408,7 @@ export function CreateContentDialog({
 
   const resetWizard = useCallback(() => {
     setStep("formats");
-    setSelectedFormats([]);
-    setSelectedRepoIds([]);
-    setSelectedBrandVoiceIds([]);
-    setLookbackWindow("last_7_days");
-    setDataPoints(DEFAULT_DATA_POINTS);
+    form.reset();
     setSelectedCommitKeys(new Set());
     setSelectedPrKeys(new Set());
     setSelectedReleaseKeys(new Set());
@@ -388,7 +418,7 @@ export function CreateContentDialog({
     lastInitializedParamsRef.current = "";
     selectionsTouchedRef.current = false;
     integrationsInitializedRef.current = false;
-  }, []);
+  }, [form]);
 
   useEffect(() => {
     if (
@@ -399,8 +429,11 @@ export function CreateContentDialog({
       return;
     }
     integrationsInitializedRef.current = true;
-    setSelectedRepoIds(integrationOptions.map((opt) => opt.value));
-  }, [integrationOptions, selectedRepoIds.length]);
+    form.setFieldValue(
+      "repositoryIds",
+      integrationOptions.map((opt) => opt.value)
+    );
+  }, [integrationOptions, selectedRepoIds.length, form]);
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
@@ -421,32 +454,61 @@ export function CreateContentDialog({
     [addRepoMode, resetWizard]
   );
 
-  const toggleFormat = useCallback((format: OnDemandContentType) => {
-    setSelectedFormats((prev) =>
-      prev.includes(format)
-        ? prev.filter((f) => f !== format)
-        : [...prev, format]
-    );
-  }, []);
+  const toggleFormat = useCallback(
+    (format: OnDemandContentType) => {
+      const current = form.state.values.formats;
+      form.setFieldValue(
+        "formats",
+        current.includes(format)
+          ? current.filter((f) => f !== format)
+          : [...current, format]
+      );
+    },
+    [form]
+  );
 
   const handleDataPointChange = useCallback(
     (key: keyof ContentDataPointSettings, value: boolean) => {
-      setDataPoints((prev) => ({ ...prev, [key]: value }));
+      form.setFieldValue("dataPoints", {
+        ...form.state.values.dataPoints,
+        [key]: value,
+      });
     },
-    []
+    [form]
   );
 
-  const toggleRepoId = useCallback((value: string) => {
-    setSelectedRepoIds((prev) =>
-      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
-    );
-  }, []);
+  const handleLookbackChange = useCallback(
+    (window: CreateContentFormValues["lookbackWindow"]) => {
+      form.setFieldValue("lookbackWindow", window);
+    },
+    [form]
+  );
 
-  const toggleVoiceId = useCallback((id: string) => {
-    setSelectedBrandVoiceIds((prev) =>
-      prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id]
-    );
-  }, []);
+  const toggleRepoId = useCallback(
+    (value: string) => {
+      const current = form.state.values.repositoryIds;
+      form.setFieldValue(
+        "repositoryIds",
+        current.includes(value)
+          ? current.filter((v) => v !== value)
+          : [...current, value]
+      );
+    },
+    [form]
+  );
+
+  const toggleVoiceId = useCallback(
+    (id: string) => {
+      const current = form.state.values.brandVoiceIds;
+      form.setFieldValue(
+        "brandVoiceIds",
+        current.includes(id)
+          ? current.filter((v) => v !== id)
+          : [...current, id]
+      );
+    },
+    [form]
+  );
 
   const eventCounts = useMemo(() => {
     let total = 0;
@@ -578,14 +640,14 @@ export function CreateContentDialog({
       setAttemptedAdvance(true);
       return;
     }
-    if (
-      step === "activity" &&
-      (selectedRepoIds.length === 0 ||
-        isLoadingPreview ||
-        eventCounts.selected === 0)
-    ) {
-      setAttemptedAdvance(true);
-      return;
+    if (step === "activity") {
+      if (isLoadingPreview) {
+        return;
+      }
+      if (selectedRepoIds.length === 0 || eventCounts.selected === 0) {
+        setAttemptedAdvance(true);
+        return;
+      }
     }
     setAttemptedAdvance(false);
     setStep(STEP_ORDER[idx + 1] as WizardStep);
@@ -659,19 +721,20 @@ export function CreateContentDialog({
     selectedLinearIds,
   ]);
 
-  const handleCreate = useCallback(() => {
-    if (selectedFormats.length === 0) {
-      setAttemptedAdvance(true);
-      return;
-    }
+  submitHandlerRef.current = async (value: CreateContentFormValues) => {
     const voiceIds =
-      selectedBrandVoiceIds.length > 0 ? selectedBrandVoiceIds : [""];
-    mutation.mutate({
-      formats: selectedFormats,
+      value.brandVoiceIds.length > 0 ? value.brandVoiceIds : [""];
+    await mutation.mutateAsync({
+      formats: value.formats,
       voiceIds,
       selectedItems: buildSelectedItems(),
     });
-  }, [selectedBrandVoiceIds, selectedFormats, mutation, buildSelectedItems]);
+  };
+
+  const handleCreate = useCallback(() => {
+    setAttemptedAdvance(true);
+    form.handleSubmit();
+  }, [form]);
 
   const handleOpenAddRepositoryFlow = useCallback(() => {
     openingAddRepoFlowRef.current = true;
@@ -806,7 +869,7 @@ export function CreateContentDialog({
                   dataPoints={dataPoints}
                   lookbackWindow={lookbackWindow}
                   onDataPointChange={handleDataPointChange}
-                  onLookbackChange={setLookbackWindow}
+                  onLookbackChange={handleLookbackChange}
                   onToggle={toggleFormat}
                   selected={selectedFormats}
                 />

--- a/apps/dashboard/src/schemas/automation/schedule-form.ts
+++ b/apps/dashboard/src/schemas/automation/schedule-form.ts
@@ -1,0 +1,40 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+import {
+  CRON_FREQUENCIES,
+  LOOKBACK_WINDOWS,
+  MAX_SCHEDULE_NAME_LENGTH,
+  SUPPORTED_SCHEDULE_OUTPUT_TYPES,
+} from "@/schemas/integrations";
+
+export const scheduleCronSchema = z.object({
+  frequency: z.enum(CRON_FREQUENCIES),
+  hour: z.number().int().min(0).max(23),
+  minute: z.number().int().min(0).max(59),
+  dayOfWeek: z.number().int().min(0).max(6).optional(),
+  dayOfMonth: z.number().int().min(1).max(31).optional(),
+});
+
+export type ScheduleCron = z.infer<typeof scheduleCronSchema>;
+
+export const scheduleFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Give this schedule a name")
+    .max(MAX_SCHEDULE_NAME_LENGTH),
+  outputType: z.enum(SUPPORTED_SCHEDULE_OUTPUT_TYPES),
+  schedule: scheduleCronSchema,
+  repositoryIds: z
+    .array(z.string())
+    .refine((ids) => ids.length > 0, "Pick at least one source to continue")
+    .refine(
+      (ids) => ids.some((id) => !id.startsWith("linear:")),
+      "Schedules need at least one GitHub repository"
+    ),
+  lookbackWindow: z.enum(LOOKBACK_WINDOWS),
+  brandVoiceId: z.string(),
+  autoPublish: z.boolean(),
+});
+
+export type ScheduleFormValues = z.infer<typeof scheduleFormSchema>;

--- a/apps/dashboard/src/schemas/content/create-content-form.ts
+++ b/apps/dashboard/src/schemas/content/create-content-form.ts
@@ -1,0 +1,19 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+import {
+  contentDataPointSettingsSchema,
+  onDemandContentTypeSchema,
+} from "@/schemas/content";
+import { LOOKBACK_WINDOWS } from "@/schemas/integrations";
+
+export const createContentFormSchema = z.object({
+  formats: z
+    .array(onDemandContentTypeSchema)
+    .min(1, "Select at least one content format"),
+  repositoryIds: z.array(z.string()).min(1, "Select at least one source"),
+  brandVoiceIds: z.array(z.string()),
+  lookbackWindow: z.enum(LOOKBACK_WINDOWS),
+  dataPoints: contentDataPointSettingsSchema,
+});
+
+export type CreateContentFormValues = z.infer<typeof createContentFormSchema>;

--- a/apps/dashboard/src/types/automation/schedule.ts
+++ b/apps/dashboard/src/types/automation/schedule.ts
@@ -1,26 +1,10 @@
-import type {
-  LookbackWindow,
-  ScheduleOutputType,
-} from "@/schemas/integrations";
+import type { ScheduleCron } from "@/schemas/automation/schedule-form";
 import type { Trigger } from "@/types/triggers/triggers";
 
-export interface ScheduleCron {
-  frequency: "daily" | "weekly" | "monthly";
-  hour: number;
-  minute: number;
-  dayOfWeek?: number;
-  dayOfMonth?: number;
-}
-
-export interface ScheduleFormValues {
-  name: string;
-  outputType: ScheduleOutputType;
-  schedule: ScheduleCron;
-  repositoryIds: string[];
-  lookbackWindow: LookbackWindow;
-  brandVoiceId: string;
-  autoPublish: boolean;
-}
+export type {
+  ScheduleCron,
+  ScheduleFormValues,
+} from "@/schemas/automation/schedule-form";
 
 export interface CreateScheduleDialogProps {
   organizationId: string;


### PR DESCRIPTION
### Description
Submit/Continue buttons in the schedule creation dialog and the create-content wizard stay enabled until the user clicks them. Validation hints only turn into the red footer warning after a submit attempt — before that the footer just shows neutral selection state. Keeps the buttons from looking broken when the user hasn't tried yet and matches how the rest of our forms behave.

### Screenshot/Recording (if applicable)
N/A

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did (disclosed: AI-assisted)

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers validation in the schedule and content dialogs until the user clicks Submit/Continue, and migrates both to `@tanstack/react-form` + `zod` so errors only appear after an attempt. Buttons stay enabled; only disable while `mutation.isPending`.

- **Refactors**
  - Moved schedule and content dialogs to `@tanstack/react-form` with `zod` schemas as the single source of truth.
  - Added `scheduleFormSchema` (name, output type, cron, repos with at least one GitHub, lookback, brand voice, auto-publish) and `createContentFormSchema` (formats, repos, brand voices, lookback, data points).
  - Types are now inferred from the schemas; removed manual submit-attempt plumbing.

- **Bug Fixes**
  - Footer shows the first validation error only after Submit/Continue; otherwise shows neutral counts. Buttons remain enabled and only disable while `mutation.isPending`.
  - Schedule dialog: keeps auto-name, validates via schema, and shows neutral “No sources selected yet” or selection counts until submit.
  - Content wizard: gates Next/Create when formats are empty or activity has no selections (shows warning after an attempt), keeps neutral footer counts, and no longer warns while preview is loading.

<sup>Written for commit c48158d263f4d08ccb1465779cba3a829b5264da. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

