### PR TITLE
feat: expose Supermemory tools in chat

### DIFF
--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -19,6 +19,20 @@ function getString(value: unknown, key: string): string | undefined {
   return typeof entry === "string" ? entry : undefined;
 }
 
+function getStringPath(
+  value: unknown,
+  path: readonly string[]
+): string | undefined {
+  let current = value;
+  for (const key of path) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === "string" ? current : undefined;
+}
+
 function getNumber(value: unknown, key: string): number | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
@@ -30,6 +44,11 @@ function getNumber(value: unknown, key: string): number | undefined {
 interface ToolCopy {
   verbs: readonly [present: string, past: string];
   noun: string;
+  subtitle?: (params: {
+    input: unknown;
+    output: unknown;
+    isStreaming: boolean;
+  }) => string | undefined;
   suffix?: (input: unknown, output: unknown) => string | undefined;
 }
 
@@ -54,6 +73,85 @@ function quotedSuffix(
     }
   }
   return undefined;
+}
+
+const LABEL_PREVIEW_MAX_CHARS = 80;
+
+function compactText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function previewText(value: string): string | undefined {
+  const compacted = compactText(value);
+  if (!compacted) {
+    return undefined;
+  }
+  return compacted.length > LABEL_PREVIEW_MAX_CHARS
+    ? `${compacted.slice(0, LABEL_PREVIEW_MAX_CHARS - 1)}…`
+    : compacted;
+}
+
+function quotedPreviewSuffix(
+  input: unknown,
+  keys: readonly string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = getString(input, key);
+    const preview = value ? previewText(value) : undefined;
+    if (preview) {
+      return `"${preview}"`;
+    }
+  }
+  return undefined;
+}
+
+function memoryIdSuffix(input: unknown, output: unknown): string | undefined {
+  return (
+    idSuffix(input, ["memoryId", "documentId", "id"]) ??
+    idSuffix(output, ["memoryId", "documentId", "id"]) ??
+    getStringPath(output, ["memory", "id"])?.slice(0, 8) ??
+    getStringPath(output, ["document", "id"])?.slice(0, 8)
+  );
+}
+
+function memoryPathSuffix(input: unknown): string | undefined {
+  const path = getString(input, "path");
+  const newPath = getString(input, "new_path");
+  if (path && newPath) {
+    return `${path} → ${newPath}`;
+  }
+  return path;
+}
+
+function claudeMemorySubtitle({
+  input,
+  isStreaming,
+}: {
+  input: unknown;
+  isStreaming: boolean;
+}): string | undefined {
+  const command = getString(input, "command");
+  const suffix =
+    memoryPathSuffix(input) ??
+    quotedPreviewSuffix(input, ["file_text", "insert_text", "new_str"]);
+
+  const withSuffix = (label: string) => (suffix ? `${label} ${suffix}` : label);
+
+  switch (command) {
+    case "view":
+      return withSuffix(isStreaming ? "Viewing memory" : "Viewed memory");
+    case "create":
+      return withSuffix(isStreaming ? "Saving memory" : "Saved memory");
+    case "delete":
+      return withSuffix(isStreaming ? "Deleting memory" : "Deleted memory");
+    case "rename":
+      return withSuffix(isStreaming ? "Renaming memory" : "Renamed memory");
+    case "insert":
+    case "str_replace":
+      return withSuffix(isStreaming ? "Updating memory" : "Updated memory");
+    default:
+      return withSuffix(isStreaming ? "Using memory" : "Used memory");
+  }
 }
 
 const TOOL_COPY: Record<string, ToolCopy> = {
@@ -133,6 +231,68 @@ const TOOL_COPY: Record<string, ToolCopy> = {
     noun: "skill",
     suffix: (input) => quotedSuffix(input, ["name"]),
   },
+  searchMemories: {
+    verbs: ["Searching", "Searched"],
+    noun: "memory",
+    suffix: (input) =>
+      quotedPreviewSuffix(input, ["informationToGet", "query", "q"]),
+  },
+  recall: {
+    verbs: ["Searching", "Searched"],
+    noun: "memory",
+    suffix: (input) =>
+      quotedPreviewSuffix(input, ["informationToGet", "query", "q"]),
+  },
+  addMemory: {
+    verbs: ["Saving", "Saved"],
+    noun: "memory",
+    suffix: (input, output) =>
+      quotedPreviewSuffix(input, ["memory", "content"]) ??
+      memoryIdSuffix(input, output),
+  },
+  fetchMemory: {
+    verbs: ["Fetching", "Fetched"],
+    noun: "memory",
+    suffix: memoryIdSuffix,
+  },
+  getProfile: {
+    verbs: ["Checking", "Checked"],
+    noun: "memory profile",
+    suffix: (input) => quotedPreviewSuffix(input, ["query", "containerTag"]),
+  },
+  whoAmI: {
+    verbs: ["Checking", "Checked"],
+    noun: "memory account",
+  },
+  documentList: {
+    verbs: ["Listing", "Listed"],
+    noun: "memory documents",
+    suffix: (input) => quotedPreviewSuffix(input, ["containerTag", "status"]),
+  },
+  documentAdd: {
+    verbs: ["Saving", "Saved"],
+    noun: "memory document",
+    suffix: (input, output) =>
+      quotedPreviewSuffix(input, ["title", "description", "content"]) ??
+      memoryIdSuffix(input, output),
+  },
+  documentDelete: {
+    verbs: ["Deleting", "Deleted"],
+    noun: "memory document",
+    suffix: (input) => idSuffix(input, ["documentId"]),
+  },
+  memoryForget: {
+    verbs: ["Forgetting", "Forgot"],
+    noun: "memory",
+    suffix: (input) =>
+      idSuffix(input, ["memoryId"]) ??
+      quotedPreviewSuffix(input, ["memoryContent", "reason"]),
+  },
+  memory: {
+    verbs: ["Using", "Used"],
+    noun: "memory",
+    subtitle: claudeMemorySubtitle,
+  },
 };
 
 function getSubtitle({
@@ -149,6 +309,10 @@ function getSubtitle({
   const copy = TOOL_COPY[toolName];
   if (!copy) {
     return isStreaming ? `Running ${toolName}` : `Ran ${toolName}`;
+  }
+  const subtitle = copy.subtitle?.({ input, output, isStreaming });
+  if (subtitle) {
+    return subtitle;
   }
   const verb = copy.verbs[isStreaming ? 0 : 1];
   const suffix = copy.suffix?.(input, isStreaming ? undefined : output);
@@ -181,7 +345,7 @@ function JsonView({ value }: { value: unknown }) {
     ? `${raw.slice(0, MAX_JSON_RENDER_CHARS)}\n… (${raw.length - MAX_JSON_RENDER_CHARS} more characters truncated)`
     : raw;
 
-  const parts: Array<{ text: string; className: string }> = [];
+  const parts: Array<{ text: string; className: string; key: string }> = [];
   let lastIndex = 0;
   for (const match of text.matchAll(JSON_TOKEN_RE)) {
     const start = match.index ?? 0;
@@ -189,6 +353,7 @@ function JsonView({ value }: { value: unknown }) {
       parts.push({
         text: text.slice(lastIndex, start),
         className: "text-muted-foreground/70",
+        key: `plain-${lastIndex}-${start}`,
       });
     }
     const token = match[0];
@@ -204,20 +369,25 @@ function JsonView({ value }: { value: unknown }) {
     } else {
       className = "text-foreground tabular-nums";
     }
-    parts.push({ text: token, className });
+    parts.push({
+      text: token,
+      className,
+      key: `token-${start}-${token.length}`,
+    });
     lastIndex = start + token.length;
   }
   if (lastIndex < text.length) {
     parts.push({
       text: text.slice(lastIndex),
       className: "text-muted-foreground/70",
+      key: `plain-${lastIndex}-${text.length}`,
     });
   }
 
   return (
     <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md border border-border/50 bg-muted/30 p-3 font-mono text-[0.75rem] leading-relaxed">
-      {parts.map((part, index) => (
-        <span className={part.className} key={index}>
+      {parts.map((part) => (
+        <span className={part.className} key={part.key}>
           {part.text}
         </span>
       ))}
@@ -260,15 +430,21 @@ export function ChatToolBlock({
   return (
     <Collapsible onOpenChange={setIsOpen} open={isOpen}>
       <CollapsibleTrigger
-        className="group flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground disabled:cursor-default disabled:hover:text-muted-foreground"
+        className="group flex w-full min-w-0 items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground disabled:cursor-default disabled:hover:text-muted-foreground"
         disabled={!hasDetails}
       >
         {isStreaming ? (
-          <Shimmer as="span" className="text-sm leading-5" duration={1.8}>
+          <Shimmer
+            as="span"
+            className="min-w-0 truncate text-sm leading-5"
+            duration={1.8}
+          >
             {subtitle}
           </Shimmer>
         ) : (
-          <span className="inline-block leading-5">{subtitle}</span>
+          <span className="inline-block min-w-0 truncate leading-5">
+            {subtitle}
+          </span>
         )}
         <HugeiconsIcon
           aria-hidden

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -5,6 +5,7 @@ import {
   createUpdatePostTool,
   createViewPostTool,
 } from "@notra/ai/tools/post";
+import { hasSupermemoryToolsConfigured } from "@notra/ai/tools/supermemory";
 import type {
   AutoThinkingLevel,
   IntegrationFetchers,
@@ -128,11 +129,13 @@ export async function orchestrateStandaloneChat(
 
   const isSimpleNoTools =
     routingDecision.complexity === "simple" && !routingDecision.requiresTools;
+  const useExplicitMemoryTools =
+    !isSimpleNoTools && hasSupermemoryToolsConfigured();
 
-  const modelWithMemory = createModel(
+  const model = createModel(
     organizationId,
     routingDecision.model,
-    { disableMemory: isSimpleNoTools },
+    { disableMemory: isSimpleNoTools || useExplicitMemoryTools },
     log
   );
 
@@ -190,7 +193,7 @@ export async function orchestrateStandaloneChat(
 
   let firstChunkFired = false;
   const stream = streamText({
-    model: modelWithMemory,
+    model,
     system: systemPrompt,
     messages: modelMessages,
     tools,

--- a/packages/ai/src/orchestration/standalone-tool-registry.ts
+++ b/packages/ai/src/orchestration/standalone-tool-registry.ts
@@ -25,6 +25,7 @@ import {
   getCreatePostToolName,
 } from "@notra/ai/tools/post";
 import { getSkillByName, listAvailableSkills } from "@notra/ai/tools/skills";
+import { createSupermemoryToolSet } from "@notra/ai/tools/supermemory";
 import type {
   ResolveIntegrationContext,
   ResolveLinearIntegrationContext,
@@ -100,6 +101,10 @@ export function buildStandaloneToolSet(
   descriptions.push(
     "**Skills**: Access knowledge and writing guidelines using listAvailableSkills and getSkillByName"
   );
+
+  const memoryToolSet = createSupermemoryToolSet(organizationId);
+  Object.assign(tools, memoryToolSet.tools);
+  descriptions.push(...memoryToolSet.descriptions);
 
   if (process.env.NODE_ENV === "development") {
     tools.example = exampleTool();

--- a/packages/ai/src/prompts/standalone-chat.ts
+++ b/packages/ai/src/prompts/standalone-chat.ts
@@ -61,6 +61,13 @@ export function getStandaloneChatPrompt(params: StandaloneChatPromptParams) {
     - When asked about GitHub activity, use the GitHub tools to fetch PRs, commits, and releases.
     - When asked about Linear issues or projects, use the Linear tools.${exampleToolLine}
 
+    ## Memory
+    - When memory tools are available, use searchMemories or getProfile when prior user, organization, brand, or project context would materially improve the answer.
+    - Use addMemory when the user explicitly asks you to remember something or shares a durable preference, fact, reusable context, brand rule, or project detail.
+    - Use memoryForget when the user asks you to forget or remove a specific memory.
+    - Do not save secrets, credentials, payment details, private keys, transient drafting requests, or one-off instructions that are only relevant to the current turn.
+    - When you use memory, mention it briefly only if it is helpful to the user; do not narrate every lookup.
+
     ## Content Types
     Available content types: changelog, blog_post, twitter_post, linkedin_post, investor_update
 

--- a/packages/ai/src/tools/supermemory.ts
+++ b/packages/ai/src/tools/supermemory.ts
@@ -1,0 +1,24 @@
+import { supermemoryTools } from "@supermemory/tools/ai-sdk";
+import type { Tool } from "ai";
+import type { ToolSet } from "../types/orchestration";
+
+const MEMORY_DESCRIPTION =
+  "**Memory**: Search, save, inspect, add, list, delete, and forget organization memory using Supermemory";
+
+export function hasSupermemoryToolsConfigured(): boolean {
+  return Boolean(process.env.SUPERMEMORY_API_KEY?.trim());
+}
+
+export function createSupermemoryToolSet(organizationId: string): ToolSet {
+  const apiKey = process.env.SUPERMEMORY_API_KEY?.trim();
+  if (!apiKey) {
+    return { tools: {}, descriptions: [] };
+  }
+
+  return {
+    tools: supermemoryTools(apiKey, {
+      containerTags: [organizationId],
+    }) as Record<string, Tool>,
+    descriptions: [MEMORY_DESCRIPTION],
+  };
+}


### PR DESCRIPTION
## Summary
- add Supermemory as explicit AI SDK tools for standalone chat
- disable hidden Supermemory middleware when explicit memory tools are active
- render readable Supermemory tool labels in the chat timeline
- add prompt guidance for searching, saving, and forgetting memory

## Checks
- bun run --filter=@notra/ai check-types
- bun run --filter=dashboard check-types
- bun run --filter=api check-types
- bunx ultracite check packages/ai/src/tools/supermemory.ts packages/ai/src/orchestration/standalone-tool-registry.ts packages/ai/src/orchestration/orchestrate-standalone.ts packages/ai/src/prompts/standalone-chat.ts apps/dashboard/src/components/ai/chat-tool-block.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed organization-scoped Supermemory tools in standalone chat with clear, human-readable action labels. Built‑in memory is disabled when these tools are active, and the prompt now guides when to search, save, update, or forget memory.

- **New Features**
  - Registered `@supermemory/tools/ai-sdk` tools for the org and added tool descriptions.
  - Improved chat timeline labels with command-aware subtitles (incl. Claude memory ops), smarter suffixes/IDs, truncation, and stable JSON rendering.
  - Expanded prompt guidance for memory use and safety (e.g., avoid saving secrets; mention memory only when helpful).

- **Migration**
  - Set `SUPERMEMORY_API_KEY` to enable the tools; without it, nothing changes.
  - No code changes required; built‑in memory is auto-disabled when the tools are active.

<sup>Written for commit 66b17a18645fd84157f0c71802748b1bb6265202. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/355?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

