### PR TITLE
feat(onboarding): add auto-renew disclaimer to pricing

### DIFF
--- a/apps/dashboard/src/app/onboarding/pricing-client.tsx
+++ b/apps/dashboard/src/app/onboarding/pricing-client.tsx
@@ -156,6 +156,11 @@ export function PricingClient({ slug }: PricingClientProps) {
         </Tabs>
       </div>
 
+      <p className="mt-3 text-center text-muted-foreground text-xs">
+        Your plan renews automatically every {isYearly ? "year" : "month"} until
+        you cancel.
+      </p>
+
       {plansLoading ? (
         <div className="mt-8 grid gap-6 lg:grid-cols-2">
           <Skeleton className="h-[28rem] rounded-lg" />


### PR DESCRIPTION
### Description
Adds a short auto-renewal disclaimer below the onboarding pricing billing interval selector so users understand that monthly and yearly plans renew automatically until cancellation.

### Screenshot/Recording (if applicable)
Not attached. Copy-only onboarding pricing update.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a short auto-renew disclaimer under the onboarding pricing interval selector so users know plans renew until canceled. The copy updates with the selected interval (month/year).

<sup>Written for commit 223f8cbae552aa6ef2289993916b53549e4f0927. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

