### PR TITLE
fix: rate limit onboarding brand analysis

### DIFF
--- a/apps/dashboard/src/app/onboarding/workspace/actions.ts
+++ b/apps/dashboard/src/app/onboarding/workspace/actions.ts
@@ -1,12 +1,33 @@
 "use server";
 
+import { redis } from "@notra/ai/utils/redis";
 import { db } from "@notra/db/drizzle";
-import { members } from "@notra/db/schema";
+import { brandSettings, members } from "@notra/db/schema";
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth/server";
 import { queueBrandAnalysisForOnboarding } from "@/lib/brand-analysis";
 import type { TriggerOnboardingBrandAnalysisInput } from "@/types/brand-analysis";
+import { ratelimit } from "@/utils/ratelimit";
+
+const ANALYSIS_LOCK_TTL_SECONDS = 60;
+
+async function tryAcquireBrandAnalysisLock(organizationId: string) {
+  if (!redis) {
+    return true;
+  }
+
+  const result = await redis.set(
+    `onboarding:brand-analysis:lock:${organizationId}`,
+    "1",
+    {
+      ex: ANALYSIS_LOCK_TTL_SECONDS,
+      nx: true,
+    }
+  );
+
+  return result === "OK";
+}
 
 export async function triggerOnboardingBrandAnalysis({
   organizationId,
@@ -29,6 +50,30 @@ export async function triggerOnboardingBrandAnalysis({
 
   if (!membership) {
     throw new Error("Forbidden");
+  }
+
+  const { success: withinLimit } =
+    await ratelimit.onboardingBrandAnalysis.limit(organizationId);
+
+  if (!withinLimit) {
+    throw new Error(
+      "Too many onboarding brand analysis requests. Please try again shortly."
+    );
+  }
+
+  const acquiredLock = await tryAcquireBrandAnalysisLock(organizationId);
+
+  if (!acquiredLock) {
+    throw new Error("Onboarding brand analysis is already in progress.");
+  }
+
+  const existingBrand = await db.query.brandSettings.findFirst({
+    where: eq(brandSettings.organizationId, organizationId),
+    columns: { id: true },
+  });
+
+  if (existingBrand) {
+    throw new Error("Onboarding brand analysis has already been requested.");
   }
 
   try {

--- a/apps/dashboard/src/utils/ratelimit.ts
+++ b/apps/dashboard/src/utils/ratelimit.ts
@@ -23,6 +23,12 @@ export const ratelimit = {
     prefix: "ratelimit:import-tweets",
     limiter: Ratelimit.slidingWindow(20, "1m"),
   }),
+  onboardingBrandAnalysis: new Ratelimit({
+    redis,
+    analytics: true,
+    prefix: "ratelimit:onboarding-brand-analysis",
+    limiter: Ratelimit.slidingWindow(2, "10m"),
+  }),
   commandPaletteNavigate: new Ratelimit({
     redis,
     analytics: true,


### PR DESCRIPTION
### Description
Adds server-side protection to the onboarding brand analysis action so a free user cannot repeatedly trigger paid Firecrawl and Claude work for the same workspace.

This PR:
- adds an `onboardingBrandAnalysis` Upstash limiter set to 2 requests per workspace per 10 minutes
- rejects onboarding analysis requests when the workspace already has a brand identity
- keeps membership authorization before the rate-limit and existing-brand checks

Closes NOT-40.

### Screenshot/Recording (if applicable)
Not applicable. Server-side guard only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

AI assistance disclosed: this PR was implemented with Codex.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side guards to onboarding brand analysis: per-workspace rate limit (2 requests/10 min), a 60s Redis lock to prevent concurrent runs, and a block if the workspace already has a brand identity. Prevents repeated paid runs and duplicate processing; closes NOT-40.

<sup>Written for commit abf1d793a82e6f77c21ed6e087538a8be7f6cbee. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/359?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

