### PR TITLE
fix: improve dashboard navigation performance

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -27,10 +27,15 @@ const nextConfig: NextConfig = {
     "@notra/utils",
   ],
   async rewrites() {
+    const c15tBackendUrl = process.env.NEXT_PUBLIC_C15T_BACKEND_URL;
+    if (!c15tBackendUrl) {
+      return [];
+    }
+
     return [
       {
         source: "/api/c15t/:path*",
-        destination: `${process.env.NEXT_PUBLIC_C15T_BACKEND_URL}/:path*`,
+        destination: `${c15tBackendUrl}/:path*`,
       },
     ];
   },

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/loading.tsx
@@ -1,0 +1,18 @@
+import { ContentPageSkeleton } from "./skeleton";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+      <div className="w-full space-y-6 px-4 lg:px-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <div className="h-9 w-36 rounded-md bg-muted" />
+            <div className="h-5 w-72 rounded-md bg-muted" />
+          </div>
+          <div className="h-9 w-36 rounded-md bg-muted" />
+        </div>
+        <ContentPageSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/components/content/content-card";
 import { ContentRowActions } from "@/components/content/content-row-actions";
 import { ContentSkeletonCard } from "@/components/content/content-skeleton-card";
-import { CreateContentDialog } from "@/components/content/create-content-dialog";
+import { LazyCreateContentDialog } from "@/components/content/lazy-create-content-dialog";
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -238,7 +238,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 <TooltipContent>Table view</TooltipContent>
               </Tooltip>
             </ButtonGroup>
-            <CreateContentDialog organizationId={organizationId} />
+            <LazyCreateContentDialog organizationId={organizationId} />
           </div>
         </div>
         {isPending && <ContentPageSkeleton />}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardPageSkeleton } from "./skeleton";
+
+export default function Loading() {
+  return <DashboardPageSkeleton />;
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { useId } from "react";
 import { ContentCard } from "@/components/content/content-card";
 import { ContentSkeletonCard } from "@/components/content/content-skeleton-card";
-import { CreateContentDialog } from "@/components/content/create-content-dialog";
+import { LazyCreateContentDialog } from "@/components/content/lazy-create-content-dialog";
 import { ContentActivityCard } from "@/components/dashboard/content-activity-card";
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/layout/container";
@@ -126,7 +126,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 Latest items created today
               </p>
             </div>
-            <CreateContentDialog organizationId={organizationId} />
+            <LazyCreateContentDialog organizationId={organizationId} />
           </div>
 
           {todayContent}

--- a/apps/dashboard/src/components/content/create-content-button.tsx
+++ b/apps/dashboard/src/components/content/create-content-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@notra/ui/components/ui/button";
+import { Kbd } from "@notra/ui/components/ui/kbd";
+import type { ComponentProps } from "react";
+
+type CreateContentButtonProps = Omit<ComponentProps<typeof Button>, "children">;
+
+export function CreateContentButton(props: CreateContentButtonProps) {
+  return (
+    <Button className="gap-1.5" {...props}>
+      <HugeiconsIcon className="size-4" icon={Add01Icon} />
+      Create Content
+      <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+    </Button>
+  );
+}

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Add01Icon,
   AlertCircleIcon,
   ArrowLeft01Icon,
   ArrowRight01Icon,
@@ -17,7 +16,6 @@ import {
   ResponsiveDialogTrigger,
 } from "@notra/ui/components/shared/responsive-dialog";
 import { Button } from "@notra/ui/components/ui/button";
-import { Kbd } from "@notra/ui/components/ui/kbd";
 import { cn } from "@notra/ui/lib/utils";
 import { useForm, useStore } from "@tanstack/react-form";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -27,6 +25,7 @@ import { toast } from "sonner";
 import { StepActivity } from "@/components/content/create/step-activity";
 import { StepBrandIdentities } from "@/components/content/create/step-brand-identities";
 import { StepFormats } from "@/components/content/create/step-formats";
+import { CreateContentButton } from "@/components/content/create-content-button";
 import { AddIntegrationDialog } from "@/components/integrations/add-integration-dialog";
 import { AddRepositoryDialog } from "@/components/integrations/add-repository-dialog";
 import { DEFAULT_DATA_POINTS } from "@/constants/content-preview";
@@ -50,6 +49,9 @@ import {
 } from "@/utils/content-preview";
 
 interface CreateContentDialogProps {
+  hideTrigger?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
   organizationId: string;
 }
 
@@ -78,15 +80,28 @@ function getDefaultContentFormValues(): CreateContentFormValues {
 }
 
 export function CreateContentDialog({
+  hideTrigger = false,
+  onOpenChange,
+  open: controlledOpen,
   organizationId,
 }: CreateContentDialogProps) {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setDialogOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (controlledOpen === undefined) {
+        setUncontrolledOpen(nextOpen);
+      }
+      onOpenChange?.(nextOpen);
+    },
+    [controlledOpen, onOpenChange]
+  );
 
   useHotkey(
     "C",
     () => {
       if (organizationId) {
-        setOpen(true);
+        setDialogOpen(true);
       }
     },
     { enabled: !open }
@@ -383,7 +398,7 @@ export function CreateContentDialog({
       return { succeeded, total: results.length };
     },
     onSuccess: ({ succeeded, total }) => {
-      setOpen(false);
+      setDialogOpen(false);
       if (succeeded === total) {
         toast.success(
           succeeded === 1
@@ -437,7 +452,7 @@ export function CreateContentDialog({
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      setOpen(next);
+      setDialogOpen(next);
       if (!next) {
         const preserveState =
           openingAddRepoFlowRef.current || addRepoMode !== null;
@@ -451,7 +466,7 @@ export function CreateContentDialog({
         resetWizard();
       }
     },
-    [addRepoMode, resetWizard]
+    [addRepoMode, resetWizard, setDialogOpen]
   );
 
   const toggleFormat = useCallback(
@@ -744,8 +759,8 @@ export function CreateContentDialog({
     setAddRepoMode(githubIntegrationId ? "repository" : "integration");
     setWaitingForWebhookSetup(false);
     setAddRepoOpen(true);
-    setOpen(false);
-  }, [githubIntegrationId]);
+    setDialogOpen(false);
+  }, [githubIntegrationId, setDialogOpen]);
 
   const handleAddRepoOpenChange = useCallback(
     (isOpen: boolean) => {
@@ -758,9 +773,9 @@ export function CreateContentDialog({
       }
       setAddRepoMode(null);
       setWaitingForWebhookSetup(false);
-      setOpen(true);
+      setDialogOpen(true);
     },
-    [addRepoMode, waitingForWebhookSetup]
+    [addRepoMode, waitingForWebhookSetup, setDialogOpen]
   );
 
   const handleIntegrationSuccess = useCallback(() => {
@@ -770,8 +785,8 @@ export function CreateContentDialog({
   const handleIntegrationFlowComplete = useCallback(() => {
     setAddRepoMode(null);
     setWaitingForWebhookSetup(false);
-    setOpen(true);
-  }, []);
+    setDialogOpen(true);
+  }, [setDialogOpen]);
 
   const identityButtonLabel = selectedBrandVoiceId
     ? "Start creating"
@@ -844,15 +859,11 @@ export function CreateContentDialog({
   return (
     <>
       <ResponsiveDialog onOpenChange={handleOpenChange} open={open}>
-        <ResponsiveDialogTrigger
-          render={
-            <Button className="gap-1.5" disabled={!organizationId}>
-              <HugeiconsIcon className="size-4" icon={Add01Icon} />
-              Create Content
-              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
-            </Button>
-          }
-        />
+        {!hideTrigger && (
+          <ResponsiveDialogTrigger
+            render={<CreateContentButton disabled={!organizationId} />}
+          />
+        )}
         <ResponsiveDialogContent className="flex h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">
           <ResponsiveDialogHeader className="shrink-0 border-b p-4 pr-14">
             <div className="flex items-center justify-between gap-4">

--- a/apps/dashboard/src/components/content/lazy-create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/lazy-create-content-dialog.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useHotkey } from "@tanstack/react-hotkeys";
+import dynamic from "next/dynamic";
+import { useState } from "react";
+import { CreateContentButton } from "@/components/content/create-content-button";
+
+const loadCreateContentDialog = () =>
+  import("@/components/content/create-content-dialog").then(
+    (mod) => mod.CreateContentDialog
+  );
+
+const CreateContentDialog = dynamic(loadCreateContentDialog, { ssr: false });
+
+interface LazyCreateContentDialogProps {
+  organizationId: string;
+}
+
+export function LazyCreateContentDialog({
+  organizationId,
+}: LazyCreateContentDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  useHotkey(
+    "C",
+    () => {
+      if (organizationId) {
+        setOpen(true);
+      }
+    },
+    { enabled: !open }
+  );
+
+  return (
+    <>
+      <CreateContentButton
+        disabled={!organizationId}
+        onClick={() => setOpen(true)}
+        onFocus={() => {
+          loadCreateContentDialog();
+        }}
+        onMouseEnter={() => {
+          loadCreateContentDialog();
+        }}
+      />
+      {open && (
+        <CreateContentDialog
+          hideTrigger
+          onOpenChange={setOpen}
+          open={open}
+          organizationId={organizationId}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -1,4 +1,3 @@
-import { getCalApi } from "@calcom/embed-react";
 import {
   ArrowRight01Icon,
   Calendar03Icon,
@@ -115,6 +114,7 @@ export function SiteHeader() {
 
   useEffect(() => {
     (async () => {
+      const { getCalApi } = await import("@calcom/embed-react");
       const cal = await getCalApi({ namespace: "15min" });
       cal("ui", { hideEventTypeDetails: false, layout: "month_view" });
     })();

--- a/apps/dashboard/src/components/providers/organization-provider.tsx
+++ b/apps/dashboard/src/components/providers/organization-provider.tsx
@@ -115,11 +115,20 @@ export function OrganizationsProvider({
 
     return initialActiveOrganization as Organization;
   }, [initialActiveOrganization, slugFromPath]);
-  const resolvedActiveOrganization =
-    activeOrganization ??
-    optimisticActiveOrg ??
-    organizationFromPath ??
-    seededActiveOrganization;
+  const activeOrganizationForPath =
+    !slugFromPath || activeOrganization?.slug === slugFromPath
+      ? activeOrganization
+      : null;
+  const optimisticActiveOrgForPath =
+    !slugFromPath || optimisticActiveOrg?.slug === slugFromPath
+      ? optimisticActiveOrg
+      : null;
+  const resolvedActiveOrganization = slugFromPath
+    ? (organizationFromPath ??
+      activeOrganizationForPath ??
+      optimisticActiveOrgForPath ??
+      seededActiveOrganization)
+    : (activeOrganization ?? optimisticActiveOrg ?? seededActiveOrganization);
 
   // Clear optimistic state when real data arrives
   useEffect(() => {

--- a/apps/dashboard/src/utils/providers.tsx
+++ b/apps/dashboard/src/utils/providers.tsx
@@ -8,9 +8,9 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { RealtimeProvider } from "@upstash/realtime/client";
 import { AutumnProvider } from "autumn-js/react";
+import dynamic from "next/dynamic";
 import { ThemeProvider } from "next-themes";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { toast } from "sonner";
@@ -21,6 +21,17 @@ import {
 
 const databuddyClientID =
   process.env.NEXT_PUBLIC_DATABUDDY_DASHBOARD_WEBSITE_ID;
+
+const ReactQueryDevtools =
+  process.env.NODE_ENV === "development"
+    ? dynamic(
+        () =>
+          import("@tanstack/react-query-devtools").then(
+            (mod) => mod.ReactQueryDevtools
+          ),
+        { ssr: false }
+      )
+    : null;
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -68,7 +79,7 @@ function DatabuddyAnalytics() {
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {ReactQueryDevtools ? <ReactQueryDevtools initialIsOpen={false} /> : null}
       <ThemeProvider attribute="class" disableTransitionOnChange enableSystem>
         <TooltipProvider>
           <AutumnProvider includeCredentials>


### PR DESCRIPTION
### Description
Improve dashboard route navigation performance by lazy-loading heavy UI that was shipped on initial page load, adding route-level loading states, and tightening organization resolution for slug-based dashboard pages.

Changes include:
- Lazy-load the create-content wizard behind a small shared trigger button.
- Add dashboard and content route loading fallbacks.
- Keep React Query Devtools out of production bundles.
- Lazy-import the Cal embed from the dashboard header.
- Prefer the current route organization when resolving organization context.
- Skip the c15t rewrite when `NEXT_PUBLIC_C15T_BACKEND_URL` is not configured.

### Screenshot/Recording (if applicable)
N/A - performance and routing behavior change only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Verification:
- `bun run --filter=dashboard check-types`
- `bun run --filter=dashboard knip`
- Pre-commit hook completed successfully (`ultracite fix`, root knip, commitlint); it still reports existing warning diagnostics in unrelated files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up dashboard navigation by lazy-loading heavy UI and adding route-level loading states. Also trims production bundles and fixes org context resolution on slug routes.

- **Performance**
  - Lazy-load the create-content dialog behind a lightweight `CreateContentButton` with prefetch on hover/focus and hotkey C.
  - Add route-level skeletons for `[slug]` and `[slug]/content`.
  - Dynamically import the Cal embed (`@calcom/embed-react`) and load `@tanstack/react-query-devtools` only in development.
  - Prefer the current route’s organization when resolving context to avoid cross-org flashes.
  - Skip the `/api/c15t` rewrite when `NEXT_PUBLIC_C15T_BACKEND_URL` is not set.

<sup>Written for commit 2fc090024be11939397d6e94bb62c963ba174eae. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/362?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

