### PR TITLE
Fix failed schedule billing

### DIFF
--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -550,25 +550,25 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
         const autumnClient = autumn;
         if (aiCreditReservation.reserved && autumnClient) {
           await context.run(
-            "refund-ai-credit-after-generation-failure",
+            "track-ai-credit-after-generation-failure",
             async () => {
               try {
                 await autumnClient.track({
                   customerId: trigger.organizationId,
                   featureId: FEATURES.AI_CREDITS,
-                  value: 0,
+                  value: 1,
                   properties: {
                     source: "workflow_schedule",
                     output_type: trigger.outputType,
                     trigger_name: trigger.name.trim() || trigger.outputType,
                     trigger_id: triggerId,
                     run_id: runId,
-                    refund_reason: "generation_failed",
+                    billing_reason: "generation_failed",
                   },
                 });
               } catch (error) {
                 console.error(
-                  "[Schedule] Failed to refund AI credit after generation failure",
+                  "[Schedule] Failed to track AI credit after generation failure",
                   {
                     triggerId,
                     organizationId: trigger.organizationId,
@@ -1129,28 +1129,28 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
 
       const autumnClient = autumn;
       if (aiCreditReservation.reserved && autumnClient) {
-        await context.run("refund-ai-credit-after-failure", async () => {
+        await context.run("track-ai-credit-after-failure", async () => {
           try {
             await autumnClient.track({
               customerId: trigger.organizationId,
               featureId: FEATURES.AI_CREDITS,
-              value: 0,
+              value: 1,
               properties: {
                 source: "workflow_schedule",
                 output_type: trigger.outputType,
                 trigger_name: trigger.name.trim() || trigger.outputType,
                 trigger_id: triggerId,
                 run_id: runId,
-                refund_reason: "workflow_error",
+                billing_reason: "workflow_error",
               },
             });
-          } catch (refundError) {
+          } catch (trackError) {
             console.error(
-              "[Schedule] Failed to refund AI credit after failure",
+              "[Schedule] Failed to track AI credit after failure",
               {
                 triggerId,
                 organizationId: trigger.organizationId,
-                error: refundError,
+                error: trackError,
               }
             );
           }


### PR DESCRIPTION
## Summary
- Charge failed scheduled content generation runs with a minimum AI credit usage event instead of emitting a zero-value refund
- Keep skipped schedule runs on the existing refund path
- Tag failed schedule usage events with billing_reason for easier auditing

## Linear
Fixes NOT-94

## Verification
- bun run check-types --filter=dashboard
- bun run check (passes with existing warnings unrelated to this change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing for failed scheduled runs by tracking a minimum AI credit usage (value: 1) instead of emitting a zero-value refund, and tagging events with billing_reason for easier audits. Skipped runs stay on the existing refund path. Addresses NOT-94.

- **Bug Fixes**
  - Replace refund calls with usage tracking on generation and workflow failures; include billing_reason (generation_failed/workflow_error).
  - Update context names and error logs to reflect tracking instead of refunding.

<sup>Written for commit 26cf207f909d569763b3865229a794a3856b99b7. Summary will update on new commits. <a href="https://cubic.dev/pr/usenotra/notra/pull/363?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

