### PR TITLE
fix(web): allow cdn.contentport.io images in CSP img-src

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -116,7 +116,7 @@ const nextConfig: NextConfig = {
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' databuddy.cc *.databuddy.cc va.vercel-scripts.com",
             "style-src 'self' 'unsafe-inline'",
             "font-src 'self'",
-            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com",
+            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io",
             "connect-src 'self' databuddy.cc *.databuddy.cc *.inth.app *.c15t.com *.c15t.dev",
             "frame-src 'none'",
             "frame-ancestors 'none'",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -136,6 +136,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "avatars.githubusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "cdn.contentport.io",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Add `cdn.contentport.io` to the `img-src` directive in `apps/web/next.config.ts`.

## Why
Blog content embeds images served from `https://cdn.contentport.io/...` (CloudFront in front of the contentport S3 bucket). The CSP `img-src` directive didn't include that host, so browsers blocked the images with a Content-Security-Policy violation.

## Test plan
- [x] Ran `apps/web` locally and confirmed an `<img>` from `cdn.contentport.io` renders with no CSP violation in the console.
- [x] Verified the response `Content-Security-Policy` header now includes `cdn.contentport.io` in `img-src`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow images from cdn.contentport.io by adding it to the CSP img-src and `next/image` `remotePatterns` in `apps/web/next.config.ts`. Fixes CSP violations and enables rendering blog images from the Contentport CDN via `next/image`.

<sup>Written for commit 071c3df948558488b904ad6c670824316b1507f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/365?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

