### PR TITLE
feat(web): add code highlighting and copy buttons to the blog

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "postcss": "^8.5.8",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "shiki": "^4.1.0",
     "sonner": "^2.0.7",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ChangelogHtmlArticle } from "@/components/changelog-html-article";
+import { BlogArticle } from "@/components/blog-article";
 import { formatBlogDate, getNotraBlogPostBySlug } from "@/utils/blog";
 import {
   buildBlogArticleJsonLd,
   buildBlogFaqJsonLd,
 } from "@/utils/blog-jsonld";
+import { highlightCodeBlocks } from "@/utils/highlight-code";
 import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";
@@ -59,6 +60,7 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 
   const url = `${SITE_URL}/blog/${slug}`;
   const imageUrl = `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`;
+  const content = await highlightCodeBlocks(post.content);
   const articleJsonLd = buildBlogArticleJsonLd({ post, url, imageUrl });
   const faqJsonLd = buildBlogFaqJsonLd(post);
   const breadcrumbJsonLd = buildBreadcrumbJsonLd([
@@ -101,7 +103,7 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
         {formatBlogDate(post.createdAt)}
       </time>
 
-      <ChangelogHtmlArticle html={post.content} />
+      <BlogArticle html={content} />
     </>
   );
 }

--- a/apps/web/src/components/blog-article.tsx
+++ b/apps/web/src/components/blog-article.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ChangelogHtmlArticle } from "@/components/changelog-html-article";
+import { copyToClipboard } from "@/utils/copy-to-clipboard";
+import type { BlogArticleProps } from "~types/blog";
+
+const COPY_BUTTON_SELECTOR = "[data-copy-code]";
+
+export function BlogArticle({ html }: BlogArticleProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    async function handleCopyClick(event: MouseEvent) {
+      const { target } = event;
+
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const button = target.closest(COPY_BUTTON_SELECTOR);
+
+      if (!button) {
+        return;
+      }
+
+      const code =
+        button.parentElement?.querySelector("code")?.textContent ?? "";
+
+      await copyToClipboard(code, "Copied to clipboard");
+    }
+
+    container.addEventListener("click", handleCopyClick);
+
+    return () => {
+      container.removeEventListener("click", handleCopyClick);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef}>
+      <ChangelogHtmlArticle html={html} />
+    </div>
+  );
+}

--- a/apps/web/src/components/changelog-html-article.tsx
+++ b/apps/web/src/components/changelog-html-article.tsx
@@ -4,7 +4,7 @@ import type { ChangelogHtmlArticleProps } from "~types/changelog";
 export function ChangelogHtmlArticle({ html }: ChangelogHtmlArticleProps) {
   return (
     <article
-      className="prose prose-neutral dark:prose-invert mt-8 max-w-none prose-headings:font-sans prose-headings:font-semibold prose-p:font-sans prose-a:text-primary prose-li:text-foreground/80 prose-p:text-foreground/80 prose-strong:text-foreground prose-p:leading-7 prose-headings:tracking-tight prose-a:no-underline hover:prose-a:underline"
+      className="prose prose-neutral dark:prose-invert mt-8 max-w-none prose-headings:font-sans prose-headings:font-semibold prose-p:font-sans prose-a:text-primary prose-li:text-foreground/80 prose-p:text-foreground/80 prose-strong:text-foreground prose-p:leading-7 prose-headings:tracking-tight prose-a:no-underline prose-a:hover:underline"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: changelog HTML is from our own CMS
       dangerouslySetInnerHTML={{ __html: addExternalLinkAttrs(html) }}
     />

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -181,6 +181,66 @@
   }
 }
 
+.prose .code-block {
+  position: relative;
+}
+
+.prose .code-copy-button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0.0625rem solid var(--border);
+  border-radius: 0.5rem;
+  background-color: color-mix(in oklab, var(--background) 80%, transparent);
+  color: color-mix(in oklab, var(--foreground) 55%, transparent);
+  cursor: pointer;
+  opacity: 0;
+  z-index: 1;
+  backdrop-filter: blur(0.25rem);
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.prose .code-block:hover .code-copy-button {
+  opacity: 1;
+}
+
+.prose .code-copy-button:hover {
+  color: var(--foreground);
+  background-color: var(--background);
+}
+
+.prose .code-copy-button:focus-visible {
+  opacity: 1;
+  outline: 0.125rem solid var(--ring);
+  outline-offset: 0.125rem;
+}
+
+.prose .code-copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.prose .shiki {
+  border: 0.0625rem solid var(--border);
+}
+
+.dark .prose .shiki,
+.dark .prose .shiki span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
 @layer components {
   .page-container {
     width: 100%;

--- a/apps/web/src/utils/highlight-code.ts
+++ b/apps/web/src/utils/highlight-code.ts
@@ -1,0 +1,133 @@
+import { Copy01Icon } from "@hugeicons/core-free-icons";
+import { createHighlighter } from "shiki";
+
+const SHIKI_THEMES = {
+  light: "github-light",
+  dark: "github-dark",
+} as const;
+
+const SHIKI_LANGS = [
+  "bash",
+  "css",
+  "diff",
+  "go",
+  "html",
+  "java",
+  "javascript",
+  "json",
+  "jsx",
+  "markdown",
+  "php",
+  "python",
+  "ruby",
+  "rust",
+  "sql",
+  "toml",
+  "tsx",
+  "typescript",
+  "yaml",
+] as const;
+
+const PLAINTEXT_LANG = "text";
+
+const CODE_BLOCK_REGEX =
+  /<pre([^>]*)>\s*<code([^>]*)>([\s\S]*?)<\/code>\s*<\/pre>/g;
+const LANGUAGE_CLASS_REGEX = /(?:language|lang)-([\w-]+)/;
+
+const HTML_ENTITY_REPLACEMENTS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/&lt;/g, "<"],
+  [/&gt;/g, ">"],
+  [/&quot;/g, '"'],
+  [/&#0?39;/g, "'"],
+  [/&#x27;/gi, "'"],
+  [/&amp;/g, "&"],
+];
+
+const SVG_ATTRIBUTE_CASE_REGEX = /[A-Z]/g;
+
+function iconToSvg(icon: typeof Copy01Icon, className: string) {
+  const children = icon
+    .map(([tag, attributes]) => {
+      const serializedAttributes = Object.entries(attributes)
+        .filter(([attributeName]) => attributeName !== "key")
+        .map(
+          ([attributeName, value]) =>
+            `${attributeName.replace(
+              SVG_ATTRIBUTE_CASE_REGEX,
+              (char) => `-${char.toLowerCase()}`
+            )}="${value}"`
+        )
+        .join(" ");
+
+      return `<${tag} ${serializedAttributes} />`;
+    })
+    .join("");
+
+  return `<svg aria-hidden="true" class="${className}" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">${children}</svg>`;
+}
+
+const COPY_BUTTON_HTML = `<button aria-label="Copy code" class="code-copy-button" data-copy-code type="button">${iconToSvg(
+  Copy01Icon,
+  "code-copy-icon"
+)}</button>`;
+
+let highlighterPromise: ReturnType<typeof createHighlighter> | null = null;
+
+function getHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: [SHIKI_THEMES.light, SHIKI_THEMES.dark],
+      langs: [...SHIKI_LANGS],
+    });
+  }
+  return highlighterPromise;
+}
+
+function decodeHtmlEntities(value: string) {
+  let decoded = value;
+  for (const [pattern, replacement] of HTML_ENTITY_REPLACEMENTS) {
+    decoded = decoded.replace(pattern, replacement);
+  }
+  return decoded;
+}
+
+function resolveLanguage(attributes: string, loadedLangs: ReadonlySet<string>) {
+  const match = attributes.match(LANGUAGE_CLASS_REGEX);
+  const requested = match?.[1]?.toLowerCase();
+
+  if (requested && loadedLangs.has(requested)) {
+    return requested;
+  }
+
+  return PLAINTEXT_LANG;
+}
+
+export async function highlightCodeBlocks(html: string): Promise<string> {
+  if (!html.includes("<pre")) {
+    return html;
+  }
+
+  const highlighter = await getHighlighter();
+  const loadedLangs = new Set(highlighter.getLoadedLanguages());
+
+  return html.replace(
+    CODE_BLOCK_REGEX,
+    (block, preAttributes: string, codeAttributes: string, code: string) => {
+      const lang = resolveLanguage(
+        `${codeAttributes} ${preAttributes}`,
+        loadedLangs
+      );
+
+      try {
+        const highlighted = highlighter.codeToHtml(decodeHtmlEntities(code), {
+          lang,
+          themes: SHIKI_THEMES,
+        });
+
+        return `<div class="code-block">${COPY_BUTTON_HTML}${highlighted}</div>`;
+      } catch {
+        return block;
+      }
+    }
+  );
+}

--- a/apps/web/types/blog.ts
+++ b/apps/web/types/blog.ts
@@ -53,3 +53,7 @@ export interface BlogJsonLdInput {
   url: string;
   imageUrl: string;
 }
+
+export interface BlogArticleProps {
+  html: string;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -183,6 +183,7 @@
         "postcss": "^8.5.8",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "shiki": "^4.1.0",
         "sonner": "^2.0.7",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.3.6",
@@ -4483,6 +4484,8 @@
 
     "web/@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
 
+    "web/shiki": ["shiki@4.1.0", "", { "dependencies": { "@shikijs/core": "4.1.0", "@shikijs/engine-javascript": "4.1.0", "@shikijs/engine-oniguruma": "4.1.0", "@shikijs/langs": "4.1.0", "@shikijs/themes": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q=="],
+
     "xss/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "@ai-sdk-tools/cache/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.89", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oIIsLOTgfuFIg6HGQ3d5gXjUvgx2YKav10T4t+sexnQj1anw6WoMDdSAT24igbfgWrC+Cf2tmlLeRhBUxdsZ9g=="],
@@ -5176,6 +5179,18 @@
     "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
+
+    "web/shiki/@shikijs/core": ["@shikijs/core@4.1.0", "", { "dependencies": { "@shikijs/primitive": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ=="],
+
+    "web/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ=="],
+
+    "web/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg=="],
+
+    "web/shiki/@shikijs/langs": ["@shikijs/langs@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0" } }, "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg=="],
+
+    "web/shiki/@shikijs/themes": ["@shikijs/themes@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0" } }, "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw=="],
+
+    "web/shiki/@shikijs/types": ["@shikijs/types@4.1.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA=="],
 
     "@ai-sdk-tools/cache/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 


### PR DESCRIPTION
### Description

Adds syntax highlighting and a copy button to code snippets on the blog (`apps/web`), following the Marble CMS recipe (https://docs.marblecms.com/guides/recipes/code-highlighting).

- Highlights fenced code blocks server-side with Shiki using dual `github-light`/`github-dark` themes, plus CSS that switches themes for the class-based dark mode. Scoped to the blog (`.prose .shiki`) so the fumadocs docs pages are untouched.
- Injects a copy button into each highlighted block (hugeicons copy icon serialized to inline SVG). A single delegated click listener on the article wrapper copies the snippet and shows a toast. The button stays hidden until the code block is hovered.
- Also fixes a pre-existing bug where hovering anywhere in article content underlined every link at once. The cause was variant order: `hover:prose-a:underline` compiles to `.prose:hover :where(a)`. Reordered to `prose-a:hover:underline` so only the hovered link underlines. This lives in the shared article component, so it fixes the changelog too.

Verified in a real browser (headless Chrome) on a post with 5 code blocks: highlighting renders in both themes, the button reveals on hover at the top-right (32x32), and clicking copies the snippet and toasts.

### Screenshot/Recording (if applicable)

Verified locally via headless Chrome: button opacity 0 to 1 on hover, positioned top-right, click copies the code and fires the toast. No screenshot attached.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side code highlighting and copy buttons to blog posts to improve readability and sharing. Also fixes a hover bug that underlined every link in article content.

- **New Features**
  - Server-side highlight of fenced code blocks with `shiki` using `github-light`/`github-dark`, scoped to blog only.
  - Copy button per block (reveals on hover); a single delegated handler copies the code and shows a toast.
  - New `highlightCodeBlocks` util and `BlogArticle` wrapper; docs pages remain unchanged.

- **Bug Fixes**
  - Only underline the hovered link in article content by reordering Tailwind variants.
  - Fix lives in the shared article component, so the changelog is fixed too.

<sup>Written for commit 6fe8847aa2870c5d039bfca08dd15889148f88ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/366?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

