### PR TITLE
feat(web): redesign blog post header and add author pages

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -116,7 +116,7 @@ const nextConfig: NextConfig = {
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' databuddy.cc *.databuddy.cc va.vercel-scripts.com",
             "style-src 'self' 'unsafe-inline'",
             "font-src 'self'",
-            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com",
+            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com media.marblecms.com",
             "connect-src 'self' databuddy.cc *.databuddy.cc *.inth.app *.c15t.com *.c15t.dev",
             "frame-src 'none'",
             "frame-ancestors 'none'",
@@ -143,6 +143,10 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "images.marblecms.com",
+      },
+      {
+        protocol: "https",
+        hostname: "media.marblecms.com",
       },
     ],
   },

--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,8 +1,19 @@
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BlogArticle } from "@/components/blog-article";
-import { formatBlogDate, getNotraBlogPostBySlug } from "@/utils/blog";
+import { BlogCopyArticle } from "@/components/blog-copy-article";
+import { getAuthorHref } from "@/utils/authors";
+import {
+  formatBlogDate,
+  getNotraBlogPostBySlug,
+  listNotraBlogPosts,
+} from "@/utils/blog";
 import {
   buildBlogArticleJsonLd,
   buildBlogFaqJsonLd,
@@ -10,8 +21,16 @@ import {
 import { highlightCodeBlocks } from "@/utils/highlight-code";
 import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
+import { getReadingTimeMinutes } from "@/utils/reading-time";
 import { SITE_URL } from "@/utils/urls";
 import type { BlogEntryPageProps } from "~types/blog";
+
+export const revalidate = 3000;
+
+export async function generateStaticParams() {
+  const posts = await listNotraBlogPosts();
+  return posts.map((post) => ({ slug: post.slug }));
+}
 
 export async function generateMetadata({
   params,
@@ -57,8 +76,11 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
   }
 
   const url = `${SITE_URL}/blog/${slug}`;
+  const markdownUrl = `${SITE_URL}/blog/${slug}.md`;
   const imageUrl = `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`;
   const content = await highlightCodeBlocks(post.content);
+  const readingMinutes = getReadingTimeMinutes(post.markdown);
+  const author = post.authors.at(0) ?? null;
   const articleJsonLd = buildBlogArticleJsonLd({ post, url, imageUrl });
   const faqJsonLd = buildBlogFaqJsonLd(post);
   const breadcrumbJsonLd = buildBreadcrumbJsonLd([
@@ -87,19 +109,42 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
         />
       ) : null}
 
-      <Link
-        className="mb-6 inline-flex items-center gap-1 font-sans text-foreground/50 text-sm transition-colors hover:text-foreground"
-        href="/blog"
-      >
-        &larr; All posts
-      </Link>
+      <time className="block font-mono text-foreground/40 text-sm">
+        Published {formatBlogDate(post.createdAt)}
+      </time>
 
-      <h1 className="font-sans font-semibold text-3xl tracking-tight sm:text-4xl">
+      <h1 className="mt-6 max-w-3xl text-balance font-sans font-semibold text-4xl leading-[1.05] tracking-tight sm:text-5xl">
         {post.title}
       </h1>
-      <time className="mt-2 block font-sans text-foreground/40 text-sm">
-        {formatBlogDate(post.createdAt)}
-      </time>
+
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-4 border-border border-b pb-6">
+        <div className="flex items-center gap-3 font-mono text-foreground/50 text-sm">
+          <span>{readingMinutes} min read</span>
+          {author ? (
+            <>
+              <span aria-hidden="true">&middot;</span>
+              <Link
+                className="inline-flex items-center gap-2 transition-colors hover:text-foreground"
+                href={getAuthorHref(author.slug)}
+              >
+                <Avatar size="sm">
+                  {author.image ? (
+                    <AvatarImage alt={author.name} src={author.image} />
+                  ) : null}
+                  <AvatarFallback>{author.name.charAt(0)}</AvatarFallback>
+                </Avatar>
+                <span>{author.name}</span>
+              </Link>
+            </>
+          ) : null}
+        </div>
+
+        <BlogCopyArticle
+          markdown={post.markdown}
+          markdownUrl={markdownUrl}
+          title={post.title}
+        />
+      </div>
 
       <BlogArticle html={content} />
     </>

--- a/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
@@ -76,7 +76,9 @@ export default async function BlogAuthorPage({ params }: BlogAuthorPageProps) {
   const posts = await listNotraBlogPosts();
   const authorPosts = filterPostsByAuthorSlug(posts, slug);
   const timelineItems = buildBlogTimelineItems(authorPosts);
-  const socials = author.socials.map(resolveSocialLink);
+  const socials = author.socials
+    .map(resolveSocialLink)
+    .filter((social) => social !== null);
   const postLabel = authorPosts.length === 1 ? "post" : "posts";
 
   return (

--- a/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
@@ -1,0 +1,164 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
+import { buttonVariants } from "@notra/ui/components/ui/button";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { resolveSocialLink } from "@/utils/author-socials";
+import {
+  filterPostsByAuthorSlug,
+  getNotraAuthorBySlug,
+  listNotraAuthors,
+} from "@/utils/authors";
+import {
+  buildBlogTimelineItems,
+  formatBlogDate,
+  listNotraBlogPosts,
+} from "@/utils/blog";
+import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
+import { SITE_URL } from "@/utils/urls";
+import type { BlogAuthorPageProps } from "~types/blog";
+
+export const revalidate = 3000;
+
+export async function generateStaticParams() {
+  const authors = await listNotraAuthors();
+  return authors.map((author) => ({ slug: author.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: BlogAuthorPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const author = await getNotraAuthorBySlug(slug);
+
+  if (!author) {
+    return {};
+  }
+
+  const url = `${SITE_URL}/blog/author/${slug}`;
+  const description = author.bio ?? `Articles written by ${author.name}.`;
+
+  return {
+    title: { absolute: `${author.name} — Notra Blog` },
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: author.name,
+      description,
+      url,
+      type: "profile",
+      siteName: "Notra",
+      images: [DEFAULT_SOCIAL_IMAGE],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: author.name,
+      description,
+      site: TWITTER_HANDLE,
+      creator: TWITTER_HANDLE,
+    },
+  };
+}
+
+export default async function BlogAuthorPage({ params }: BlogAuthorPageProps) {
+  const { slug } = await params;
+  const author = await getNotraAuthorBySlug(slug);
+
+  if (!author) {
+    notFound();
+  }
+
+  const posts = await listNotraBlogPosts();
+  const authorPosts = filterPostsByAuthorSlug(posts, slug);
+  const timelineItems = buildBlogTimelineItems(authorPosts);
+  const socials = author.socials.map(resolveSocialLink);
+  const postLabel = authorPosts.length === 1 ? "post" : "posts";
+
+  return (
+    <>
+      <div className="flex flex-col items-start gap-5">
+        <Avatar className="size-20" size="default">
+          {author.image ? (
+            <AvatarImage alt={author.name} src={author.image} />
+          ) : null}
+          <AvatarFallback className="text-2xl">
+            {author.name.charAt(0)}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="flex flex-col gap-1">
+          <h1 className="font-sans font-semibold text-4xl tracking-tight">
+            {author.name}
+          </h1>
+          {author.role ? (
+            <p className="font-mono text-foreground/50 text-sm">
+              {author.role}
+            </p>
+          ) : null}
+        </div>
+
+        {socials.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {socials.map((social) => (
+              <a
+                aria-label={social.displayUrl}
+                className={buttonVariants({ size: "icon", variant: "outline" })}
+                href={social.url}
+                key={social.url}
+                rel="noopener"
+                target="_blank"
+              >
+                <HugeiconsIcon
+                  className="size-4"
+                  icon={social.icon}
+                  strokeWidth={2}
+                />
+              </a>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-14 border-border border-t pt-8">
+        <h2 className="font-mono text-foreground/40 text-sm">
+          {authorPosts.length} {postLabel}
+        </h2>
+
+        {timelineItems.length > 0 ? (
+          <div className="mt-2 divide-y divide-border">
+            {timelineItems.map((item) => (
+              <Link
+                className="group block py-8 first:pt-6"
+                href={item.href}
+                key={item.id}
+              >
+                <article>
+                  <div className="flex items-start justify-between gap-4">
+                    <h3 className="font-sans font-semibold text-foreground text-xl tracking-tight sm:text-2xl">
+                      {item.title}
+                    </h3>
+                    <time className="shrink-0 pt-1 font-mono text-muted-foreground text-sm">
+                      {formatBlogDate(item.date)}
+                    </time>
+                  </div>
+                  <p className="mt-3 line-clamp-3 font-sans text-base text-muted-foreground leading-7">
+                    {item.description}
+                  </p>
+                </article>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-4 font-sans text-muted-foreground text-sm leading-6">
+            No posts published yet.
+          </p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/blog-copy-article.tsx
+++ b/apps/web/src/components/blog-copy-article.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import {
+  ArrowDown01Icon,
+  Copy01Icon,
+  File01Icon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@notra/ui/components/ui/dropdown-menu";
+import { ClaudeAiIcon } from "@notra/ui/components/ui/svgs/claudeAiIcon";
+import { Openai } from "@notra/ui/components/ui/svgs/openai";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import {
+  buildChatGptUrl,
+  buildClaudeUrl,
+  openInNewTab,
+} from "@/utils/article-ai-links";
+import { copyToClipboard } from "@/utils/copy-to-clipboard";
+import type {
+  BlogCopyArticleItemProps,
+  BlogCopyArticleProps,
+} from "~types/blog";
+
+const COPIED_STATE_DURATION_MS = 2000;
+
+function CopyArticleMenuItemContent({
+  icon,
+  title,
+  description,
+}: BlogCopyArticleItemProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-foreground">
+        {icon}
+      </span>
+      <span className="flex flex-col">
+        <span className="font-medium text-foreground text-sm">{title}</span>
+        <span className="text-muted-foreground text-xs">{description}</span>
+      </span>
+    </div>
+  );
+}
+
+export function BlogCopyArticle({
+  markdown,
+  markdownUrl,
+  title,
+}: BlogCopyArticleProps) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  async function handleCopy() {
+    const success = await copyToClipboard(
+      markdown,
+      "Article copied as Markdown"
+    );
+
+    if (!success) {
+      return;
+    }
+
+    setCopied(true);
+
+    if (copiedTimer.current) {
+      clearTimeout(copiedTimer.current);
+    }
+
+    copiedTimer.current = setTimeout(() => {
+      setCopied(false);
+    }, COPIED_STATE_DURATION_MS);
+  }
+
+  return (
+    <div className="flex items-center gap-2 font-mono text-foreground/60 text-sm">
+      <button
+        className="inline-flex items-center gap-1.5 transition-colors hover:text-foreground"
+        onClick={handleCopy}
+        type="button"
+      >
+        <HugeiconsIcon
+          className="size-4"
+          icon={copied ? Tick02Icon : Copy01Icon}
+          strokeWidth={2}
+        />
+        <span>{copied ? "Copied" : "Copy article"}</span>
+      </button>
+
+      <span aria-hidden="true" className="text-foreground/20">
+        |
+      </span>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          aria-label="More article options"
+          className="inline-flex items-center transition-colors hover:text-foreground"
+        >
+          <HugeiconsIcon
+            className="size-4"
+            icon={ArrowDown01Icon}
+            strokeWidth={2}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="w-80 p-2"
+          showBackdrop={false}
+        >
+          <DropdownMenuItem
+            className="px-2 py-2"
+            closeOnClick={false}
+            onClick={handleCopy}
+          >
+            <CopyArticleMenuItemContent
+              description="Copy article as Markdown for LLMs"
+              icon={<HugeiconsIcon className="size-5" icon={Copy01Icon} />}
+              title="Copy article"
+            />
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            className="px-2 py-2"
+            render={<Link href={markdownUrl} />}
+          >
+            <CopyArticleMenuItemContent
+              description="View this article as plain text"
+              icon={<HugeiconsIcon className="size-5" icon={File01Icon} />}
+              title="View as Markdown"
+            />
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            className="px-2 py-2"
+            onClick={() => openInNewTab(buildChatGptUrl(title, markdownUrl))}
+          >
+            <CopyArticleMenuItemContent
+              description="Ask questions about this article"
+              icon={<Openai className="size-5 dark:invert" />}
+              title="Open in ChatGPT"
+            />
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            className="px-2 py-2"
+            onClick={() => openInNewTab(buildClaudeUrl(title, markdownUrl))}
+          >
+            <CopyArticleMenuItemContent
+              description="Ask questions about this article"
+              icon={<ClaudeAiIcon className="size-5" />}
+              title="Open in Claude"
+            />
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -479,7 +479,7 @@ export function Navbar() {
 
                 <div
                   aria-hidden="true"
-                  className="-z-10 pointer-events-none invisible absolute top-full left-0"
+                  className="-z-10 pointer-events-none invisible absolute top-full left-0 size-0 overflow-hidden"
                 >
                   {groups.map((group) => (
                     <div

--- a/apps/web/src/components/site-shell.tsx
+++ b/apps/web/src/components/site-shell.tsx
@@ -8,7 +8,7 @@ export function SiteShell({ children }: SiteShellProps) {
     <div className="relative flex min-h-screen w-full flex-col items-center justify-start bg-background">
       <div className="relative isolate flex w-full flex-col items-center justify-start">
         <HeroGradient />
-        <div className="relative flex w-full max-w-none flex-col items-start justify-start px-4 sm:px-6 md:px-8 lg:w-7xl lg:max-w-7xl lg:px-0">
+        <div className="relative flex w-full max-w-none flex-col items-start justify-start px-4 sm:px-6 md:px-8 lg:max-w-7xl lg:px-0">
           <div className="absolute top-0 left-4 z-0 h-full w-px bg-border/60 [-webkit-mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] [mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] sm:left-6 md:left-8 lg:left-0" />
           <div className="absolute top-0 right-4 z-0 h-full w-px bg-border/60 [-webkit-mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] [mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] sm:right-6 md:right-8 lg:right-0" />
 

--- a/apps/web/src/utils/article-ai-links.ts
+++ b/apps/web/src/utils/article-ai-links.ts
@@ -1,0 +1,15 @@
+function buildArticlePrompt(title: string, markdownUrl: string) {
+  return `Read the article "${title}" at ${markdownUrl} and help me with any questions I have about it.`;
+}
+
+export function buildChatGptUrl(title: string, markdownUrl: string) {
+  return `https://chatgpt.com/?q=${encodeURIComponent(buildArticlePrompt(title, markdownUrl))}`;
+}
+
+export function buildClaudeUrl(title: string, markdownUrl: string) {
+  return `https://claude.ai/new?q=${encodeURIComponent(buildArticlePrompt(title, markdownUrl))}`;
+}
+
+export function openInNewTab(url: string) {
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/apps/web/src/utils/author-socials.ts
+++ b/apps/web/src/utils/author-socials.ts
@@ -1,0 +1,70 @@
+import {
+  BlueskyIcon,
+  DiscordIcon,
+  DribbbleIcon,
+  Facebook01Icon,
+  Github01Icon,
+  Globe02Icon,
+  InstagramIcon,
+  Linkedin01Icon,
+  MastodonIcon,
+  NewTwitterIcon,
+  TelegramIcon,
+  ThreadsIcon,
+  TiktokIcon,
+  YoutubeIcon,
+} from "@hugeicons/core-free-icons";
+import type { IconSvgElement } from "@hugeicons/react";
+import type { NotraAuthorSocial, ResolvedSocialLink } from "~types/blog";
+
+interface SocialPlatform {
+  label: string;
+  icon: IconSvgElement;
+}
+
+const SOCIAL_PLATFORMS: Record<string, SocialPlatform> = {
+  x: { label: "X", icon: NewTwitterIcon },
+  twitter: { label: "X", icon: NewTwitterIcon },
+  github: { label: "GitHub", icon: Github01Icon },
+  linkedin: { label: "LinkedIn", icon: Linkedin01Icon },
+  youtube: { label: "YouTube", icon: YoutubeIcon },
+  instagram: { label: "Instagram", icon: InstagramIcon },
+  facebook: { label: "Facebook", icon: Facebook01Icon },
+  tiktok: { label: "TikTok", icon: TiktokIcon },
+  mastodon: { label: "Mastodon", icon: MastodonIcon },
+  threads: { label: "Threads", icon: ThreadsIcon },
+  discord: { label: "Discord", icon: DiscordIcon },
+  bluesky: { label: "Bluesky", icon: BlueskyIcon },
+  dribbble: { label: "Dribbble", icon: DribbbleIcon },
+  telegram: { label: "Telegram", icon: TelegramIcon },
+};
+
+const FALLBACK_PLATFORM: SocialPlatform = {
+  label: "Website",
+  icon: Globe02Icon,
+};
+
+const PROTOCOL_PREFIX_REGEX = /^https?:\/\//;
+const WWW_PREFIX_REGEX = /^www\./;
+const TRAILING_SLASH_REGEX = /\/$/;
+
+function toDisplayUrl(url: string) {
+  return url
+    .replace(PROTOCOL_PREFIX_REGEX, "")
+    .replace(WWW_PREFIX_REGEX, "")
+    .replace(TRAILING_SLASH_REGEX, "");
+}
+
+export function resolveSocialLink(
+  social: NotraAuthorSocial
+): ResolvedSocialLink {
+  const platform =
+    SOCIAL_PLATFORMS[social.platform.toLowerCase()] ?? FALLBACK_PLATFORM;
+
+  return {
+    label: platform.label,
+    icon: platform.icon,
+    url: social.url,
+    displayUrl: toDisplayUrl(social.url),
+  };
+}

--- a/apps/web/src/utils/author-socials.ts
+++ b/apps/web/src/utils/author-socials.ts
@@ -48,6 +48,27 @@ const PROTOCOL_PREFIX_REGEX = /^https?:\/\//;
 const WWW_PREFIX_REGEX = /^www\./;
 const TRAILING_SLASH_REGEX = /\/$/;
 
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function toSafeUrl(rawUrl: string): string | null {
+  const trimmed = rawUrl.trim();
+  const candidate = PROTOCOL_PREFIX_REGEX.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(candidate);
+
+    if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+      return null;
+    }
+
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
 function toDisplayUrl(url: string) {
   return url
     .replace(PROTOCOL_PREFIX_REGEX, "")
@@ -57,14 +78,20 @@ function toDisplayUrl(url: string) {
 
 export function resolveSocialLink(
   social: NotraAuthorSocial
-): ResolvedSocialLink {
+): ResolvedSocialLink | null {
+  const safeUrl = toSafeUrl(social.url);
+
+  if (!safeUrl) {
+    return null;
+  }
+
   const platform =
     SOCIAL_PLATFORMS[social.platform.toLowerCase()] ?? FALLBACK_PLATFORM;
 
   return {
     label: platform.label,
     icon: platform.icon,
-    url: social.url,
-    displayUrl: toDisplayUrl(social.url),
+    url: safeUrl,
+    displayUrl: toDisplayUrl(safeUrl),
   };
 }

--- a/apps/web/src/utils/authors.ts
+++ b/apps/web/src/utils/authors.ts
@@ -1,0 +1,73 @@
+import { unstable_cache } from "next/cache";
+import {
+  BLOG_AUTHOR_PATH,
+  MARBLE_CACHE_KEYS,
+  MARBLE_CACHE_TAGS,
+  MARBLE_REVALIDATE_SECONDS,
+} from "@/utils/constants";
+import { listMarbleAuthors } from "@/utils/marble";
+import type { NotraAuthor, NotraBlogPost } from "~types/blog";
+
+function normalizeAuthor(author: {
+  id: string;
+  name: string;
+  image: string | null;
+  slug: string;
+  bio: string | null;
+  role: string | null;
+  socials: { url: string; platform: string }[];
+  count?: { posts: number };
+}): NotraAuthor {
+  return {
+    id: author.id,
+    name: author.name,
+    image: author.image,
+    slug: author.slug,
+    bio: author.bio,
+    role: author.role,
+    socials: author.socials.map((social) => ({
+      url: social.url,
+      platform: social.platform,
+    })),
+    postCount: author.count?.posts ?? 0,
+  };
+}
+
+const fetchAuthors = unstable_cache(
+  async () => {
+    try {
+      const authors = await listMarbleAuthors();
+      return authors.map(normalizeAuthor);
+    } catch (error) {
+      console.error("Failed to load Marble authors", error);
+      return [] satisfies NotraAuthor[];
+    }
+  },
+  [MARBLE_CACHE_KEYS.blogAuthors],
+  {
+    revalidate: MARBLE_REVALIDATE_SECONDS.blogAuthors,
+    tags: [MARBLE_CACHE_TAGS.blogAuthors],
+  }
+);
+
+export function getAuthorHref(slug: string) {
+  return `${BLOG_AUTHOR_PATH}/${slug}`;
+}
+
+export async function listNotraAuthors() {
+  return fetchAuthors();
+}
+
+export async function getNotraAuthorBySlug(slug: string) {
+  const authors = await listNotraAuthors();
+  return authors.find((author) => author.slug === slug) ?? null;
+}
+
+export function filterPostsByAuthorSlug(
+  posts: NotraBlogPost[],
+  slug: string
+): NotraBlogPost[] {
+  return posts.filter((post) =>
+    post.authors.some((author) => author.slug === slug)
+  );
+}

--- a/apps/web/src/utils/blog.ts
+++ b/apps/web/src/utils/blog.ts
@@ -78,7 +78,13 @@ function normalizePost(post: MarblePublishedPost): NotraBlogPost {
     id: author.id,
     name: author.name,
     image: author.image,
+    slug: author.slug,
+    bio: author.bio,
     role: author.role,
+    socials: author.socials.map((social) => ({
+      url: social.url,
+      platform: social.platform,
+    })),
   }));
 
   return {

--- a/apps/web/src/utils/constants.ts
+++ b/apps/web/src/utils/constants.ts
@@ -13,6 +13,7 @@ export const RSS_FEED_DESCRIPTION =
 export const RSS_FEED_LANGUAGE = "en-us";
 
 export const BLOG_INDEX_PATH = "/blog";
+export const BLOG_AUTHOR_PATH = "/blog/author";
 export const CHANGELOG_INDEX_PATH = "/changelog";
 export const NOTRA_CHANGELOG_INDEX_PATH = "/changelog/notra";
 export const SITEMAP_PATH = "/sitemap.xml";
@@ -24,12 +25,14 @@ export const MARBLE_CHANGELOG_CATEGORY_SLUG = "changelog";
 export const MARBLE_DEFAULT_POST_LIMIT = 100;
 
 export const MARBLE_CACHE_KEYS = {
-  blogPosts: "marble-blog-posts-v3",
+  blogPosts: "marble-blog-posts-v4",
+  blogAuthors: "marble-blog-authors-v1",
   changelogPosts: "marble-changelog-posts-v2",
 } as const;
 
 export const MARBLE_CACHE_TAGS = {
   blogPosts: "marble-blog-posts",
+  blogAuthors: "marble-blog-authors",
   changelogPosts: "marble-changelog-posts",
 } as const;
 
@@ -37,6 +40,7 @@ export const MARBLE_POST_CACHE_TAG_PREFIX = "marble-post";
 
 export const MARBLE_REVALIDATE_SECONDS = {
   blogPosts: 3000,
+  blogAuthors: 3000,
   changelogPosts: 300,
 } as const;
 

--- a/apps/web/src/utils/marble-webhook.ts
+++ b/apps/web/src/utils/marble-webhook.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { revalidatePath, revalidateTag } from "next/cache";
 import {
+  BLOG_AUTHOR_PATH,
   BLOG_INDEX_PATH,
   CHANGELOG_INDEX_PATH,
   LLMS_FULL_PATH,
@@ -85,6 +86,15 @@ function revalidateChangelogContent(slug?: string) {
   }
 }
 
+function revalidateAuthorContent(slug?: string) {
+  revalidateTag(MARBLE_CACHE_TAGS.blogAuthors, { expire: 0 });
+  revalidateBlogContent();
+
+  if (slug) {
+    revalidatePath(`${BLOG_AUTHOR_PATH}/${slug}`);
+  }
+}
+
 export function verifyMarbleSignature(
   secret: string,
   signatureHeader: string,
@@ -142,6 +152,18 @@ export function revalidateMarbleContent({
 
 export function handleMarbleWebhookEvent(payload: MarbleWebhookPayload) {
   const event = payload.event ?? payload.type;
+
+  if (event?.startsWith("author.")) {
+    revalidateAuthorContent(payload.data?.slug);
+
+    return {
+      event,
+      revalidated: true,
+      revalidatedAuthors: true,
+      slug: payload.data?.slug ?? null,
+      now: Date.now(),
+    };
+  }
 
   if (!event?.startsWith("post.")) {
     return {

--- a/apps/web/src/utils/marble.ts
+++ b/apps/web/src/utils/marble.ts
@@ -1,5 +1,5 @@
 import { Marble } from "@usemarble/sdk";
-import { ContentFormat, type Post } from "@usemarble/sdk/models";
+import { type Author, ContentFormat, type Post } from "@usemarble/sdk/models";
 import {
   MARBLE_DEFAULT_POST_LIMIT,
   MARBLE_POST_CACHE_TAG_PREFIX,
@@ -89,4 +89,25 @@ export async function listMarblePublishedPosts({
       markdown: markdownById.get(post.id) ?? "",
     }))
   );
+}
+
+export async function listMarbleAuthors(): Promise<Author[]> {
+  const { apiKey } = getMarbleConfig();
+
+  if (!apiKey) {
+    return [];
+  }
+
+  const client = createMarbleClient(apiKey);
+  const iterator = await client.authors.list({
+    limit: MARBLE_DEFAULT_POST_LIMIT,
+  });
+
+  const authors: Author[] = [];
+
+  for await (const page of iterator) {
+    authors.push(...page.result.authors);
+  }
+
+  return authors;
 }

--- a/apps/web/src/utils/reading-time.ts
+++ b/apps/web/src/utils/reading-time.ts
@@ -1,0 +1,7 @@
+const WORDS_PER_MINUTE = 200;
+const WHITESPACE_REGEX = /\s+/;
+
+export function getReadingTimeMinutes(markdown: string) {
+  const words = markdown.trim().split(WHITESPACE_REGEX).filter(Boolean).length;
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}

--- a/apps/web/src/utils/sanitize-html-links.ts
+++ b/apps/web/src/utils/sanitize-html-links.ts
@@ -1,15 +1,61 @@
 const EXTERNAL_HREF_REGEX = /^(https?:)?\/\//;
 const ANCHOR_TAG_REGEX = /<a\s([^>]*)>/gi;
 const HREF_ATTR_REGEX = /href=["']([^"']*)["']/;
+const HREF_ATTR_REPLACE_REGEX = /href=["'][^"']*["']/;
 const REL_ATTR_MATCH_REGEX = /rel=["']([^"']*)["']/;
 const REL_SPLIT_REGEX = /\s+/;
 const REL_ATTR_REPLACE_REGEX = /rel=["'][^"']*["']/;
 const TARGET_ATTR_REGEX = /target=["'][^"']*["']/;
 
+const HEX_ENTITY_REGEX = /&#x([0-9a-f]+);?/gi;
+const DECIMAL_ENTITY_REGEX = /&#(\d+);?/g;
+const STRIPPED_URL_CHARS_REGEX = /[\t\n\r]/g;
+const URL_SCHEME_REGEX = /^([a-z][a-z0-9+.-]*):/;
+const MAX_CODE_POINT = 0x10_ff_ff;
+const SAFE_SCHEMES = new Set(["http", "https", "mailto", "tel"]);
+
+function decodeCodePoint(code: number): string {
+  if (Number.isNaN(code) || code < 0 || code > MAX_CODE_POINT) {
+    return "";
+  }
+
+  return String.fromCodePoint(code);
+}
+
+function isSafeHref(href: string): boolean {
+  const normalized = href
+    .replace(HEX_ENTITY_REGEX, (_, hex: string) =>
+      decodeCodePoint(Number.parseInt(hex, 16))
+    )
+    .replace(DECIMAL_ENTITY_REGEX, (_, dec: string) =>
+      decodeCodePoint(Number.parseInt(dec, 10))
+    )
+    .replace(STRIPPED_URL_CHARS_REGEX, "")
+    .trimStart()
+    .toLowerCase();
+
+  const scheme = normalized.match(URL_SCHEME_REGEX)?.[1];
+
+  if (!scheme) {
+    return true;
+  }
+
+  return SAFE_SCHEMES.has(scheme);
+}
+
 export function addExternalLinkAttrs(html: string): string {
   return html.replace(ANCHOR_TAG_REGEX, (match, attrs: string) => {
     const hrefMatch = attrs.match(HREF_ATTR_REGEX);
     const href = hrefMatch?.[1];
+
+    if (href && !isSafeHref(href)) {
+      const neutralizedAttrs = attrs.replace(
+        HREF_ATTR_REPLACE_REGEX,
+        'href="#"'
+      );
+
+      return `<a ${neutralizedAttrs}>`;
+    }
 
     if (!href || !EXTERNAL_HREF_REGEX.test(href)) {
       return match;

--- a/apps/web/types/blog.ts
+++ b/apps/web/types/blog.ts
@@ -1,10 +1,39 @@
+import type { IconSvgElement } from "@hugeicons/react";
 import type { ReactNode } from "react";
+
+export interface NotraAuthorSocial {
+  url: string;
+  platform: string;
+}
 
 export interface NotraBlogAuthor {
   id: string;
   name: string;
   image: string | null;
+  slug: string;
+  bio: string | null;
   role: string | null;
+  socials: NotraAuthorSocial[];
+}
+
+export interface NotraAuthor extends NotraBlogAuthor {
+  postCount: number;
+}
+
+export interface BlogAuthorPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export interface BlogCopyArticleProps {
+  markdown: string;
+  markdownUrl: string;
+  title: string;
+}
+
+export interface BlogCopyArticleItemProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
 }
 
 export interface NotraBlogPost {
@@ -64,4 +93,11 @@ export interface BlogJsonLdInput {
 
 export interface BlogArticleProps {
   html: string;
+}
+
+export interface ResolvedSocialLink {
+  label: string;
+  displayUrl: string;
+  url: string;
+  icon: IconSvgElement;
 }


### PR DESCRIPTION
## Summary
- Redesign the blog post header to match the new design: published date, balanced title (`text-balance`), reading time, author link, and a **Copy article** split-button with a dropdown (Copy as Markdown, View as Markdown, Open in ChatGPT/Claude).
- Add `/blog/author/[slug]` profile pages: avatar, role, and icon-only social links (brand icons via hugeicons, globe fallback for unknown platforms). Author name on a post links here.
- Make blog posts and author pages **true ISR** (`generateStaticParams` + `export const revalidate = 3000`) — both now prerender at build and regenerate on a timer instead of rendering dynamically per request.
- Handle `author.*` Marble webhook events: revalidate the `blogAuthors` tag, the author profile path, and the blog posts (author fields are embedded in each post).
- Fix horizontal overflow at `lg` viewports (1024–1280px): removed the fixed `lg:w-7xl` on the site shell and clamped the navbar's hidden mega-menu measurement layer to a `size-0 overflow-hidden` box.
- Allow `media.marblecms.com` avatars in the CSP `img-src` and Next image `remotePatterns` (Josh's avatar host).

## Test plan
- [ ] `/blog/<slug>` renders the new header; Copy article copies markdown; dropdown opens Markdown view + ChatGPT/Claude in a new tab.
- [ ] Author name links to `/blog/author/<slug>`; profile shows role, social icon buttons (globe for unmapped platforms), and the author's posts.
- [ ] No horizontal scroll at 1094×778 on landing and blog pages.
- [ ] Build shows `/blog/[slug]` and `/blog/author/[slug]` as static (ISR, 50m revalidate).
- [ ] Publishing/updating an author in Marble refreshes the profile and posts via webhook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the blog post header and added author profile pages to improve reading and discovery. Switched posts and author pages to ISR and hooked up Marble webhooks; hardened external links.

- **New Features**
  - Blog header: published date, balanced title, reading time, author link with avatar, and a Copy article split-button (copy Markdown, view Markdown, open in ChatGPT/Claude).
  - Author pages at /blog/author/[slug]: avatar, role, icon-only socials (brand icons with globe fallback), and authored posts list.
  - True ISR for posts and authors via generateStaticParams and revalidate.
  - Marble `author.*` webhooks revalidate the authors cache tag, the author path, and affected posts.

- **Bug Fixes**
  - Removed fixed `lg:w-7xl` shell width and clamped the navbar’s hidden measurement layer to a `size-0 overflow-hidden` box to stop horizontal overflow at lg breakpoints.
  - Allowed `media.marblecms.com` in CSP `img-src` and Next `images.remotePatterns` for avatar hosts.
  - Sanitized author social URLs and CMS anchors: drop non-http(s) socials and neutralize unsafe `javascript:`/`data:` hrefs (incl. obfuscated variants).

<sup>Written for commit 8e2fecb56bb6421e658e4684c24633f3de4c9325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/367?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

