### PR TITLE
fix(web): tweak prose content styles

### DIFF
--- a/apps/web/src/components/changelog-html-article.tsx
+++ b/apps/web/src/components/changelog-html-article.tsx
@@ -4,7 +4,7 @@ import type { ChangelogHtmlArticleProps } from "~types/changelog";
 export function ChangelogHtmlArticle({ html }: ChangelogHtmlArticleProps) {
   return (
     <article
-      className="prose prose-neutral dark:prose-invert mt-8 max-w-none prose-headings:font-sans prose-headings:font-semibold prose-p:font-sans prose-a:text-primary prose-li:text-foreground/80 prose-p:text-foreground/80 prose-strong:text-foreground prose-p:leading-7 prose-headings:tracking-tight prose-a:no-underline prose-a:hover:underline"
+      className="prose prose-neutral dark:prose-invert mt-8 max-w-none prose-figcaption:text-center prose-headings:font-sans prose-headings:font-semibold prose-p:font-sans prose-a:text-primary prose-li:text-foreground/80 prose-p:text-foreground/80 prose-strong:text-foreground prose-p:leading-7 prose-headings:tracking-tight prose-a:no-underline prose-code:before:content-none prose-code:after:content-none prose-a:hover:underline"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: changelog HTML is from our own CMS
       dangerouslySetInnerHTML={{ __html: addExternalLinkAttrs(html) }}
     />


### PR DESCRIPTION
## Summary
- center prose figure captions in article content
- remove Tailwind Typography code pseudo-content around inline code

## Verification
- pre-commit hook ran ultracite fix and knip
- ultracite reported existing warnings in unrelated dashboard files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centered figure captions in changelog articles and removed inline code pseudo-content in prose for cleaner formatting.

<sup>Written for commit 186f42ede929b46185588b466785f077ac6db50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/368?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

