### PR TITLE
Refactor chat tool helpers to Zod schemas

### DIFF
--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -14,58 +14,23 @@ import {
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
 import { cn } from "@notra/ui/lib/utils";
-import { useState } from "react";
-
-function getString(value: unknown, key: string): string | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const entry = (value as Record<string, unknown>)[key];
-  return typeof entry === "string" ? entry : undefined;
-}
-
-function getStringPath(
-  value: unknown,
-  path: readonly string[]
-): string | undefined {
-  let current = value;
-  for (const key of path) {
-    if (!current || typeof current !== "object") {
-      return undefined;
-    }
-    current = (current as Record<string, unknown>)[key];
-  }
-  return typeof current === "string" ? current : undefined;
-}
-
-function getNumber(value: unknown, key: string): number | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const entry = (value as Record<string, unknown>)[key];
-  return typeof entry === "number" ? entry : undefined;
-}
-
-function getArray(value: unknown, key: string): unknown[] | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const entry = (value as Record<string, unknown>)[key];
-  return Array.isArray(entry) ? entry : undefined;
-}
-
-function getRecord(
-  value: unknown,
-  key: string
-): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const entry = (value as Record<string, unknown>)[key];
-  return entry && typeof entry === "object" && !Array.isArray(entry)
-    ? (entry as Record<string, unknown>)
-    : undefined;
-}
+import { type ReactNode, useState } from "react";
+import {
+  commitsByTimeframeInputSchema,
+  type MemoryToolInput,
+  mcpToolMetadataSchema,
+  memoryIdentifierInputSchema,
+  memoryIdentifierOutputSchema,
+  memoryToolInputSchema,
+  pullRequestInputSchema,
+  pullRequestOutputSchema,
+  releaseInputSchema,
+  releaseOutputSchema,
+  type StringToolField,
+  stringToolFieldsSchema,
+  webSearchInputSchema,
+  webSearchOutputSchema,
+} from "@/schemas/ai/chat-tool-block";
 
 interface ToolCopy {
   verbs: readonly [present: string, past: string];
@@ -78,14 +43,36 @@ interface ToolCopy {
   suffix?: (input: unknown, output: unknown) => string | undefined;
 }
 
-function idSuffix(input: unknown, keys: readonly string[]): string | undefined {
+function firstStringValue<T extends object>(
+  values: T,
+  keys: readonly (keyof T)[]
+): string | undefined {
   for (const key of keys) {
-    const value = getString(input, key);
-    if (value) {
-      return value.slice(0, 8);
+    const value = values[key];
+    if (typeof value === "string" && value) {
+      return value;
     }
   }
   return undefined;
+}
+
+function idSuffixFromFields<T extends object>(
+  values: T,
+  keys: readonly (keyof T)[]
+): string | undefined {
+  const value = firstStringValue(values, keys);
+  return value ? value.slice(0, 8) : undefined;
+}
+
+function idSuffix(
+  input: unknown,
+  keys: readonly StringToolField[]
+): string | undefined {
+  const parsed = stringToolFieldsSchema.safeParse(input);
+  if (!parsed.success) {
+    return undefined;
+  }
+  return idSuffixFromFields(parsed.data, keys);
 }
 
 function shortPreview(value: string, maxLength = 72): string {
@@ -96,48 +83,70 @@ function shortPreview(value: string, maxLength = 72): string {
   return `${normalized.slice(0, maxLength - 1)}…`;
 }
 
-function quotedSuffix(
-  input: unknown,
-  keys: readonly string[]
+function quotedSuffixFromFields<T extends object>(
+  values: T,
+  keys: readonly (keyof T)[]
 ): string | undefined {
   for (const key of keys) {
-    const value = getString(input, key);
-    if (value) {
+    const value = values[key];
+    if (typeof value === "string" && value) {
       return `"${shortPreview(value)}"`;
     }
   }
   return undefined;
 }
 
+function quotedSuffix(
+  input: unknown,
+  keys: readonly StringToolField[]
+): string | undefined {
+  const parsed = stringToolFieldsSchema.safeParse(input);
+  if (!parsed.success) {
+    return undefined;
+  }
+  return quotedSuffixFromFields(parsed.data, keys);
+}
+
 function memoryIdSuffix(input: unknown, output: unknown): string | undefined {
+  const parsedInput = memoryIdentifierInputSchema.safeParse(input);
+  const parsedOutput = memoryIdentifierOutputSchema.safeParse(output);
+  const outputData = parsedOutput.success ? parsedOutput.data : undefined;
   return (
-    idSuffix(input, ["memoryId", "documentId", "id"]) ??
-    idSuffix(output, ["memoryId", "documentId", "id"]) ??
-    getStringPath(output, ["memory", "id"])?.slice(0, 8) ??
-    getStringPath(output, ["document", "id"])?.slice(0, 8)
+    (parsedInput.success
+      ? idSuffixFromFields(parsedInput.data, ["memoryId", "documentId", "id"])
+      : undefined) ??
+    (outputData
+      ? idSuffixFromFields(outputData, ["memoryId", "documentId", "id"])
+      : undefined) ??
+    outputData?.memory?.id?.slice(0, 8) ??
+    outputData?.document?.id?.slice(0, 8)
   );
 }
 
-function memoryPathSuffix(input: unknown): string | undefined {
-  const path = getString(input, "path");
-  const newPath = getString(input, "new_path");
-  if (path && newPath) {
-    return `${path} → ${newPath}`;
+function memoryPathSuffix(input: MemoryToolInput): string | undefined {
+  if (input.path && input.new_path) {
+    return `${input.path} → ${input.new_path}`;
   }
-  return path;
+  return input.path;
 }
 
-function claudeMemorySubtitle({
+function memoryToolSubtitle({
   input,
   isStreaming,
 }: {
   input: unknown;
   isStreaming: boolean;
 }): string | undefined {
-  const command = getString(input, "command");
-  const suffix =
-    memoryPathSuffix(input) ??
-    quotedSuffix(input, ["file_text", "insert_text", "new_str"]);
+  const parsed = memoryToolInputSchema.safeParse(input);
+  const command = parsed.success ? parsed.data.command : undefined;
+  const suffix = parsed.success
+    ? (memoryPathSuffix(parsed.data) ??
+      quotedSuffixFromFields(parsed.data, [
+        "file_text",
+        "insert_text",
+        "new_str",
+      ]))
+    : undefined;
 
   const withSuffix = (label: string) => (suffix ? `${label} ${suffix}` : label);
 
@@ -159,7 +168,10 @@ function claudeMemorySubtitle({
 }
 
 function webSearchSuffix(input: unknown, output: unknown): string | undefined {
-  const query = quotedSuffix(input, ["query"]);
+  const parsedInput = webSearchInputSchema.safeParse(input);
+  const query = parsedInput.success
+    ? quotedSuffixFromFields(parsedInput.data, ["query"])
+    : undefined;
   const count = getWebSearchResultCount(output);
   if (query && count !== undefined) {
     return `for ${query} (${count} ${count === 1 ? "result" : "results"})`;
@@ -168,26 +180,25 @@ function webSearchSuffix(input: unknown, output: unknown): string | undefined {
 }
 
 function getWebSearchResultCount(output: unknown): number | undefined {
-  const directResults = getArray(output, "results") ?? getArray(output, "data");
-  if (directResults) {
-    return directResults.length;
-  }
-
-  if (!output || typeof output !== "object") {
+  const parsed = webSearchOutputSchema.safeParse(output);
+  if (!parsed.success) {
     return undefined;
   }
 
-  const data = (output as Record<string, unknown>).data;
-  if (!data || typeof data !== "object" || Array.isArray(data)) {
-    return undefined;
+  if (parsed.data.results) {
+    return parsed.data.results.length;
   }
 
-  const resultGroups = ["web", "news", "images"].map((key) =>
-    getArray(data, key)
-  );
-  const counts = resultGroups
-    .filter((group): group is unknown[] => Boolean(group))
-    .map((group) => group.length);
+  if (Array.isArray(parsed.data.data)) {
+    return parsed.data.data.length;
+  }
+
+  const data = parsed.data.data;
+  const counts = data
+    ? [data.web, data.news, data.images]
+        .filter((group): group is unknown[] => Boolean(group))
+        .map((group) => group.length)
+    : [];
 
   return counts.length
     ? counts.reduce((total, count) => total + count, 0)
@@ -199,13 +210,20 @@ const TOOL_COPY: Record<string, ToolCopy> = {
     verbs: ["Fetching", "Fetched"],
     noun: "pull request",
     suffix: (input, output) => {
-      const repo = getString(output, "repository") ?? getString(output, "repo");
-      const number =
-        getNumber(output, "number") ?? getNumber(output, "pull_number");
+      const parsedOutput = pullRequestOutputSchema.safeParse(output);
+      const repo = parsedOutput.success
+        ? (parsedOutput.data.repository ?? parsedOutput.data.repo)
+        : undefined;
+      const number = parsedOutput.success
+        ? (parsedOutput.data.number ?? parsedOutput.data.pull_number)
+        : undefined;
       if (repo && number !== undefined) {
         return `${repo}#${number}`;
       }
-      const pullNumber = getNumber(input, "pull_number");
+      const parsedInput = pullRequestInputSchema.safeParse(input);
+      const pullNumber = parsedInput.success
+        ? parsedInput.data.pull_number
+        : undefined;
       return pullNumber !== undefined ? `#${pullNumber}` : undefined;
     },
   },
@@ -213,19 +231,26 @@ const TOOL_COPY: Record<string, ToolCopy> = {
     verbs: ["Fetching", "Fetched"],
     noun: "release",
     suffix: (input, output) => {
-      const repo = getString(output, "repository") ?? getString(output, "repo");
-      const tag = getString(output, "tag_name") ?? getString(output, "tag");
+      const parsedOutput = releaseOutputSchema.safeParse(output);
+      const repo = parsedOutput.success
+        ? (parsedOutput.data.repository ?? parsedOutput.data.repo)
+        : undefined;
+      const tag = parsedOutput.success
+        ? (parsedOutput.data.tag_name ?? parsedOutput.data.tag)
+        : undefined;
       if (repo && tag) {
         return `${repo} · ${tag}`;
       }
-      return getString(input, "tag");
+      const parsedInput = releaseInputSchema.safeParse(input);
+      return parsedInput.success ? parsedInput.data.tag : undefined;
     },
   },
   getCommitsByTimeframe: {
     verbs: ["Fetching", "Fetched"],
     noun: "commits",
     suffix: (input) => {
-      const days = getNumber(input, "days");
+      const parsed = commitsByTimeframeInputSchema.safeParse(input);
+      const days = parsed.success ? parsed.data.days : undefined;
       return days ? `from the last ${days} days` : undefined;
     },
   },
@@ -339,7 +364,7 @@ const TOOL_COPY: Record<string, ToolCopy> = {
   memory: {
     verbs: ["Using", "Used"],
     noun: "memory",
-    subtitle: claudeMemorySubtitle,
+    subtitle: memoryToolSubtitle,
   },
 };
 
@@ -355,16 +380,14 @@ function formatMcpToolName(toolName: string): string {
 }
 
 function getMcpToolLabel(toolName: string, toolMetadata: unknown) {
-  const notraMetadata = getRecord(toolMetadata, "notra");
-  const label = getString(notraMetadata, "label");
-  if (label) {
-    return label;
+  const parsed = mcpToolMetadataSchema.safeParse(toolMetadata);
+  const notraMetadata = parsed.success ? parsed.data.notra : undefined;
+  if (notraMetadata?.label) {
+    return notraMetadata.label;
   }
 
-  const serverName = getString(notraMetadata, "serverName");
-  const mcpToolName = getString(notraMetadata, "toolName");
-  if (serverName && mcpToolName) {
-    return `${serverName} - ${mcpToolName}`;
+  if (notraMetadata?.serverName && notraMetadata.toolName) {
+    return `${notraMetadata.serverName} - ${notraMetadata.toolName}`;
   }
 
   return formatMcpToolName(toolName);
@@ -519,6 +542,24 @@ export function ChatToolBlock({
   const hasInput = input != null;
   const hasOutput = output != null;
   const hasDetails = hasInput || hasOutput;
+  let toolIcon: ReactNode = null;
+
+  if (iconUrl) {
+    toolIcon = (
+      <Avatar className="size-4 shrink-0 rounded-sm after:hidden">
+        <AvatarImage className="rounded-sm" src={iconUrl} />
+        <AvatarFallback className="rounded-sm bg-transparent">
+          <HugeiconsIcon className="size-3" icon={CpuIcon} />
+        </AvatarFallback>
+      </Avatar>
+    );
+  } else if (isMcp) {
+    toolIcon = (
+      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-medium text-[0.625rem] text-muted-foreground uppercase tracking-wide">
+        MCP
+      </span>
+    );
+  }
 
   return (
     <Collapsible onOpenChange={setIsOpen} open={isOpen}>
@@ -526,18 +567,7 @@ export function ChatToolBlock({
         className="group flex w-full min-w-0 items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground disabled:cursor-default disabled:hover:text-muted-foreground"
         disabled={!hasDetails}
       >
-        {iconUrl ? (
-          <Avatar className="size-4 shrink-0 rounded-sm after:hidden">
-            <AvatarImage className="rounded-sm" src={iconUrl} />
-            <AvatarFallback className="rounded-sm bg-transparent">
-              <HugeiconsIcon className="size-3" icon={CpuIcon} />
-            </AvatarFallback>
-          </Avatar>
-        ) : isMcp ? (
-          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-medium text-[0.625rem] text-muted-foreground uppercase tracking-wide">
-            MCP
-          </span>
-        ) : null}
+        {toolIcon}
         {isStreaming ? (
           <Shimmer
             as="span"

--- a/apps/dashboard/src/schemas/ai/chat-tool-block.ts
+++ b/apps/dashboard/src/schemas/ai/chat-tool-block.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+
+const optionalStringSchema = z.preprocess(
+  (value) => (typeof value === "string" ? value : undefined),
+  z.string().optional()
+);
+const optionalNumberSchema = z.preprocess(
+  (value) => (typeof value === "number" ? value : undefined),
+  z.number().optional()
+);
+const optionalArraySchema = z.preprocess(
+  (value) => (Array.isArray(value) ? value : undefined),
+  z.array(z.unknown()).optional()
+);
+
+export const STRING_TOOL_FIELDS = [
+  "containerTag",
+  "content",
+  "description",
+  "documentId",
+  "id",
+  "informationToGet",
+  "memory",
+  "memoryContent",
+  "memoryId",
+  "name",
+  "postId",
+  "q",
+  "query",
+  "reason",
+  "status",
+  "tag",
+  "text",
+  "title",
+] as const;
+
+export type StringToolField = (typeof STRING_TOOL_FIELDS)[number];
+
+export const stringToolFieldsSchema = z
+  .object({
+    containerTag: optionalStringSchema,
+    content: optionalStringSchema,
+    description: optionalStringSchema,
+    documentId: optionalStringSchema,
+    id: optionalStringSchema,
+    informationToGet: optionalStringSchema,
+    memory: optionalStringSchema,
+    memoryContent: optionalStringSchema,
+    memoryId: optionalStringSchema,
+    name: optionalStringSchema,
+    postId: optionalStringSchema,
+    q: optionalStringSchema,
+    query: optionalStringSchema,
+    reason: optionalStringSchema,
+    status: optionalStringSchema,
+    tag: optionalStringSchema,
+    text: optionalStringSchema,
+    title: optionalStringSchema,
+  })
+  .passthrough();
+
+export const pullRequestInputSchema = z
+  .object({
+    pull_number: optionalNumberSchema,
+  })
+  .passthrough();
+
+export const pullRequestOutputSchema = z
+  .object({
+    number: optionalNumberSchema,
+    pull_number: optionalNumberSchema,
+    repo: optionalStringSchema,
+    repository: optionalStringSchema,
+  })
+  .passthrough();
+
+export const releaseInputSchema = z
+  .object({
+    tag: optionalStringSchema,
+  })
+  .passthrough();
+
+export const releaseOutputSchema = z
+  .object({
+    repo: optionalStringSchema,
+    repository: optionalStringSchema,
+    tag: optionalStringSchema,
+    tag_name: optionalStringSchema,
+  })
+  .passthrough();
+
+export const commitsByTimeframeInputSchema = z
+  .object({
+    days: optionalNumberSchema,
+  })
+  .passthrough();
+
+export const webSearchInputSchema = z
+  .object({
+    query: optionalStringSchema,
+  })
+  .passthrough();
+
+const webSearchDataSchema = z
+  .object({
+    images: optionalArraySchema,
+    news: optionalArraySchema,
+    web: optionalArraySchema,
+  })
+  .passthrough();
+
+const webSearchOutputDataSchema = z.preprocess(
+  (value) =>
+    Array.isArray(value) ||
+    (value && typeof value === "object" && !Array.isArray(value))
+      ? value
+      : undefined,
+  z.union([z.array(z.unknown()), webSearchDataSchema]).optional()
+);
+
+export const webSearchOutputSchema = z
+  .object({
+    data: webSearchOutputDataSchema,
+    results: optionalArraySchema,
+  })
+  .passthrough();
+
+export const memoryToolInputSchema = z
+  .object({
+    command: optionalStringSchema,
+    file_text: optionalStringSchema,
+    insert_text: optionalStringSchema,
+    new_path: optionalStringSchema,
+    new_str: optionalStringSchema,
+    path: optionalStringSchema,
+  })
+  .passthrough();
+
+export type MemoryToolInput = z.infer<typeof memoryToolInputSchema>;
+
+const idObjectSchema = z
+  .object({
+    id: optionalStringSchema,
+  })
+  .passthrough();
+const optionalIdObjectSchema = z.preprocess(
+  (value) =>
+    value && typeof value === "object" && !Array.isArray(value)
+      ? value
+      : undefined,
+  idObjectSchema.optional()
+);
+
+export const memoryIdentifierInputSchema = z
+  .object({
+    documentId: optionalStringSchema,
+    id: optionalStringSchema,
+    memoryId: optionalStringSchema,
+  })
+  .passthrough();
+
+export const memoryIdentifierOutputSchema = z
+  .object({
+    document: optionalIdObjectSchema,
+    documentId: optionalStringSchema,
+    id: optionalStringSchema,
+    memory: optionalIdObjectSchema,
+    memoryId: optionalStringSchema,
+  })
+  .passthrough();
+
+export const mcpToolMetadataSchema = z
+  .object({
+    notra: z.preprocess(
+      (value) =>
+        value && typeof value === "object" && !Array.isArray(value)
+          ? value
+          : undefined,
+      z
+        .object({
+          label: optionalStringSchema,
+          serverName: optionalStringSchema,
+          toolName: optionalStringSchema,
+        })
+        .passthrough()
+        .optional()
+    ),
+  })
+  .passthrough();

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -44,7 +44,7 @@ const SKILLS_MENTION_REGEX = /\bskills?\b/i;
 
 const TRIVIAL_HISTORY_LIMIT = 6;
 const MINIMAL_STANDALONE_PROMPT =
-  "You are Notra, an AI assistant for content teams. Reply briefly and warmly. Do not call tools on this turn.";
+  "You are Notra, an AI assistant for content teams. Reply briefly and warmly.";
 
 export async function orchestrateStandaloneChat(
   input: StandaloneChatInput,

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -45,10 +45,6 @@ const SKILLS_MENTION_REGEX = /\bskills?\b/i;
 const TRIVIAL_HISTORY_LIMIT = 6;
 const MINIMAL_STANDALONE_PROMPT =
   "You are Notra, an AI assistant for content teams. Reply briefly and warmly.";
-const OBSOLETE_NO_TOOLS_REFUSAL_PATTERNS = [
-  /Do not call tools on this turn/i,
-  /cannot call tools on this turn/i,
-];
 
 export async function orchestrateStandaloneChat(
   input: StandaloneChatInput,
@@ -197,9 +193,7 @@ export async function orchestrateStandaloneChat(
 
     const messagesForModel = await expandTextFileParts(
       stripIncompleteToolParts(
-        isSimpleNoTools
-          ? trimTrivialHistory(removeObsoleteNoToolsRefusals(messages))
-          : removeObsoleteNoToolsRefusals(messages)
+        isSimpleNoTools ? trimTrivialHistory(messages) : messages
       )
     );
 
@@ -358,23 +352,6 @@ function stripIncompleteToolParts(messages: UIMessage[]): UIMessage[] {
       return message;
     }
     return { ...message, parts: filtered };
-  });
-}
-
-function removeObsoleteNoToolsRefusals(messages: UIMessage[]): UIMessage[] {
-  return messages.filter((message) => {
-    if (message.role !== "assistant" || !Array.isArray(message.parts)) {
-      return true;
-    }
-
-    const text = message.parts
-      .filter((part) => part.type === "text")
-      .map((part) => part.text)
-      .join("\n");
-
-    return !OBSOLETE_NO_TOOLS_REFUSAL_PATTERNS.some((pattern) =>
-      pattern.test(text)
-    );
   });
 }
 

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -45,6 +45,10 @@ const SKILLS_MENTION_REGEX = /\bskills?\b/i;
 const TRIVIAL_HISTORY_LIMIT = 6;
 const MINIMAL_STANDALONE_PROMPT =
   "You are Notra, an AI assistant for content teams. Reply briefly and warmly.";
+const OBSOLETE_NO_TOOLS_REFUSAL_PATTERNS = [
+  /Do not call tools on this turn/i,
+  /cannot call tools on this turn/i,
+];
 
 export async function orchestrateStandaloneChat(
   input: StandaloneChatInput,
@@ -193,7 +197,9 @@ export async function orchestrateStandaloneChat(
 
     const messagesForModel = await expandTextFileParts(
       stripIncompleteToolParts(
-        isSimpleNoTools ? trimTrivialHistory(messages) : messages
+        isSimpleNoTools
+          ? trimTrivialHistory(removeObsoleteNoToolsRefusals(messages))
+          : removeObsoleteNoToolsRefusals(messages)
       )
     );
 
@@ -352,6 +358,23 @@ function stripIncompleteToolParts(messages: UIMessage[]): UIMessage[] {
       return message;
     }
     return { ...message, parts: filtered };
+  });
+}
+
+function removeObsoleteNoToolsRefusals(messages: UIMessage[]): UIMessage[] {
+  return messages.filter((message) => {
+    if (message.role !== "assistant" || !Array.isArray(message.parts)) {
+      return true;
+    }
+
+    const text = message.parts
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n");
+
+    return !OBSOLETE_NO_TOOLS_REFUSAL_PATTERNS.some((pattern) =>
+      pattern.test(text)
+    );
   });
 }
 

--- a/packages/ai/src/orchestration/router.ts
+++ b/packages/ai/src/orchestration/router.ts
@@ -36,12 +36,23 @@ const TRIVIAL_MESSAGE_PATTERNS = [
   /^(bye|cya|tschüss|ciao)\b[\s!.?]*$/i,
 ];
 
+const EXPLICIT_TOOL_REQUEST_PATTERNS = [
+  /\b(call|use|run|execute|invoke|exercise|trigger|test)\b[\s\S]{0,120}\btools?\b/i,
+  /\btools?\b[\s\S]{0,120}\b(call|use|run|execute|invoke|exercise|trigger|test)\b/i,
+];
+
 export function isTrivialMessage(userMessage: string): boolean {
   const trimmed = userMessage.trim();
   if (!trimmed || trimmed.length > 40) {
     return false;
   }
   return TRIVIAL_MESSAGE_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+function isExplicitToolRequest(userMessage: string): boolean {
+  return EXPLICIT_TOOL_REQUEST_PATTERNS.some((pattern) =>
+    pattern.test(userMessage)
+  );
 }
 
 function matchTrivialFastPath(
@@ -90,6 +101,16 @@ export async function routeMessage(
   );
   if (fastPath) {
     return fastPath;
+  }
+
+  if (isExplicitToolRequest(userMessage)) {
+    return {
+      complexity: "complex",
+      requiresTools: true,
+      reasoningHeavy: false,
+      reasoning:
+        "The user explicitly asked to call, test, or exercise tools, so tools are required.",
+    };
   }
 
   const contextHint = hasIntegrationContext

--- a/packages/ai/src/prompts/router.ts
+++ b/packages/ai/src/prompts/router.ts
@@ -6,6 +6,7 @@ Classify messages as:
 
 Determine if tools are needed:
 - Tools REQUIRED: Any editing, fetching data from connected sources, accessing skills
+- Tools REQUIRED: Explicit requests to call, test, exercise, run, invoke, or trigger tools
 - Tools NOT required: Answering questions, explaining concepts, conversation
 
 Determine if the task is reasoning-heavy:
@@ -22,5 +23,6 @@ Examples:
 - "Write a blog post about our latest release" → complex, tools required
 - "Analyze the PRs and create a changelog" → complex, tools required
 - "Research the commits and summarize what changed" → complex, tools required
+- "Test all available tools and summarize the results" → complex, tools required
 - "What's the difference between a PR and a commit?" → simple, no tools
 - "Thanks!" → simple, no tools`;


### PR DESCRIPTION
## Summary
- move chat tool input/output schemas into `apps/dashboard/src/schemas/ai/chat-tool-block.ts`
- refactor chat tool subtitles and suffix helpers to parse inputs/outputs with Zod before reading fields
- remove the hand-rolled unknown accessors from `chat-tool-block.tsx`

## Verification
- `bunx biome check apps/dashboard/src/components/ai/chat-tool-block.tsx apps/dashboard/src/schemas/ai/chat-tool-block.ts`
- `git diff --check`
- `bun run --cwd apps/dashboard check-types` still fails on existing `packages/ai` MCP/module resolution errors for `@modelcontextprotocol/sdk`, `@ai-sdk/mcp`, and `@notra/utils/url`

Linear: NOT-99

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors chat tool helpers to Zod schemas and improves routing: explicit tool requests now require tools, and the standalone prompt no longer forbids tool calls. Centralizes schemas and tightens subtitle/suffix logic; aligns with Linear NOT-99.

- **Refactors**
  - Centralized chat tool schemas in `apps/dashboard/src/schemas/ai/chat-tool-block.ts` (memory IO/identifiers, PR/release, commits timeframe, web search IO with grouped counts, MCP metadata); exported `MemoryToolInput` and `StringToolField`.
  - Updated `ChatToolBlock` to parse inputs/outputs with Zod, renamed `claudeMemorySubtitle` to `memoryToolSubtitle`, and unified icon rendering.

- **Bug Fixes**
  - Router now treats explicit requests to call/use/run/execute/invoke/test/trigger tools as tools-required and updates the routing prompt to reflect this.
  - Removed the “Do not call tools on this turn.” line from the standalone minimal prompt.

<sup>Written for commit b032bd10574e13604adbab1d542787aaa715384d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

