### PR TITLE
fix: disable TCC outside production

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
   "name": "api",
   "type": "module",
   "scripts": {
-    "dev": "bun --watch src/index.ts",
+    "dev": "NODE_ENV=development bun --watch src/index.ts",
     "build": "tsup",
     "start": "node dist/index.mjs",
     "check-types": "bunx tsc --noEmit",

--- a/apps/api/src/tcc.ts
+++ b/apps/api/src/tcc.ts
@@ -1,8 +1,10 @@
-import { TCCSpanProcessor } from "@contextcompany/otel";
-import { NodeSDK } from "@opentelemetry/sdk-node";
+if (process.env.NODE_ENV === "production") {
+  const { TCCSpanProcessor } = await import("@contextcompany/otel");
+  const { NodeSDK } = await import("@opentelemetry/sdk-node");
 
-const tcc = new NodeSDK({
-  spanProcessors: [new TCCSpanProcessor()],
-});
+  const tcc = new NodeSDK({
+    spanProcessors: [new TCCSpanProcessor()],
+  });
 
-tcc.start();
+  tcc.start();
+}

--- a/apps/dashboard/src/instrumentation.ts
+++ b/apps/dashboard/src/instrumentation.ts
@@ -7,7 +7,10 @@ const evlogInstrumentation = defineNodeInstrumentation(
 export async function register() {
   await evlogInstrumentation.register();
 
-  if (process.env.NEXT_RUNTIME === "nodejs") {
+  if (
+    process.env.NEXT_RUNTIME === "nodejs" &&
+    process.env.NODE_ENV === "production"
+  ) {
     const { registerOTelTCC } = await import("@contextcompany/otel/nextjs");
     registerOTelTCC();
   }


### PR DESCRIPTION
### Description
disable tcc in dev

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable TCC tracing outside production to stop sending spans in dev/preview and reduce local overhead. Gates OTel init behind production checks in the API and dashboard.

- **Bug Fixes**
  - API: start `@contextcompany/otel`/`@opentelemetry/sdk-node` only when `NODE_ENV === "production"` (dynamic imports).
  - Dashboard: call `registerOTelTCC` only when `NEXT_RUNTIME === "nodejs"` and `NODE_ENV === "production"`.
  - Dev: set `NODE_ENV=development` in `api` `dev` script so instrumentation stays off locally.

<sup>Written for commit 43f5e49f5e17f22b745d8961deb7edde3f054858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

