### PR TITLE
fix(dashboard): reject executable skill frontmatter

### DIFF
--- a/apps/dashboard/src/lib/skills/parse-frontmatter.ts
+++ b/apps/dashboard/src/lib/skills/parse-frontmatter.ts
@@ -7,6 +7,16 @@ export interface ParsedSkillFrontmatter {
 }
 
 const BOM_REGEX = /^\uFEFF/;
+const PLAIN_YAML_DELIMITER_REGEX = /^---[ \t]*(?:\r?\n|$)/;
+
+const FRONTMATTER_OPTIONS = {
+  language: "yaml",
+  engines: {
+    javascript: () => {
+      throw new Error("JavaScript frontmatter is not supported");
+    },
+  },
+} satisfies matter.GrayMatterOption<string, never>;
 
 export function parseSkillFrontmatter(
   input: string
@@ -15,10 +25,13 @@ export function parseSkillFrontmatter(
   if (!trimmed.startsWith("---")) {
     return null;
   }
+  if (!PLAIN_YAML_DELIMITER_REGEX.test(trimmed)) {
+    return null;
+  }
 
   let parsed: matter.GrayMatterFile<string>;
   try {
-    parsed = matter(trimmed);
+    parsed = matter(trimmed, FRONTMATTER_OPTIONS);
   } catch {
     return null;
   }


### PR DESCRIPTION
### Description
Fixes NOT-170 by rejecting skill frontmatter opening lines with language markers such as `---js` before parsing. The parser now uses explicit gray-matter options with YAML as the language and a JavaScript engine override that throws if reached.

Validation:
- `bun -e` runtime check confirmed `---js` returns `null` and does not execute while normal YAML still parses.
- `bunx biome check apps/dashboard/src/lib/skills/parse-frontmatter.ts` passed.
- Focused TypeScript compile for `parse-frontmatter.ts` passed.
- `bun run --filter=dashboard check-types` is currently blocked by existing stale `.next/types/validator.ts` references to missing page modules, unrelated to this change.

### Screenshot/Recording (if applicable)
N/A

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

AI disclosure: Codex assisted with this change.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject executable skill frontmatter by only accepting plain YAML `---` and forcing `gray-matter` to parse as YAML. Fixes NOT-170 and ensures `---js` or similar markers don’t execute and return null instead.

- **Bug Fixes**
  - Skip frontmatter unless it starts with a plain YAML delimiter (`---` + newline).
  - Use `gray-matter` with `language: "yaml"` and a JavaScript engine override that throws.
  - Valid YAML still parses; non-YAML frontmatter returns null.

<sup>Written for commit 10838ea6c982e0efcac8fb6e4ba2c7d65ca23302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

