### PR TITLE
fix(billing): charge sandbox images by tokens

### DIFF
--- a/apps/api/src/lib/chat/direct-stream.ts
+++ b/apps/api/src/lib/chat/direct-stream.ts
@@ -86,6 +86,7 @@ export async function createDirectStandaloneChatResponse({
         timezone,
         abortSignal: combinedAbortSignal,
         telemetryMetadata,
+        useMarkup,
       },
       {
         preValidatedIntegrations: validatedIntegrations,

--- a/apps/api/src/lib/chat/workflow-handler.ts
+++ b/apps/api/src/lib/chat/workflow-handler.ts
@@ -51,6 +51,7 @@ export const chatWorkflowHandler = serve<ChatWorkflowPayload>(
       requestId,
       organizationId,
       chatId,
+      userId,
       context: standaloneContext,
       useMarkup,
       model,
@@ -145,6 +146,8 @@ export const chatWorkflowHandler = serve<ChatWorkflowPayload>(
           enableThinking,
           thinkingLevel,
           timezone,
+          userId,
+          useMarkup,
         },
         {
           integrationFetchers: {

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -388,6 +388,7 @@ async function createDirectStandaloneChatResponse({
         timezone,
         abortSignal: combinedAbortSignal,
         telemetryMetadata,
+        useMarkup,
       },
       {
         preValidatedIntegrations: validatedIntegrations,

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
@@ -149,6 +149,7 @@ export const POST = withEvlog(async function POST(
         maxSteps: 50,
         log,
         timezone,
+        useMarkup,
         telemetryMetadata: {
           contentId,
           contentType: contentType ?? "unknown",

--- a/apps/dashboard/src/app/api/workflows/chat/route.ts
+++ b/apps/dashboard/src/app/api/workflows/chat/route.ts
@@ -147,6 +147,7 @@ export const { POST } = serve<ChatWorkflowPayload>(async (context) => {
         enableThinking,
         thinkingLevel,
         timezone,
+        useMarkup,
         telemetryMetadata: {
           chatId,
           feature: "standalone_chat",

--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -631,7 +631,7 @@ export const { POST } = serve<EventWorkflowPayload>(
         await context.run("track-ai-credit-usage", async () => {
           const costCents = calculateTokenCostCents(
             contentUsage,
-            "anthropic/claude-haiku-4.5",
+            contentUsage.modelId ?? "anthropic/claude-haiku-4.5",
             aiCreditReservation.useMarkup
           );
           await autumnClientSuccess.track({
@@ -642,11 +642,15 @@ export const { POST } = serve<EventWorkflowPayload>(
               source: "workflow_event",
               output_type: trigger.outputType,
               trigger_name: trigger.name,
+              model: contentResult.usage?.modelId,
+              billing_basis: "tokens",
               input_tokens: contentResult.usage?.inputTokens,
               output_tokens: contentResult.usage?.outputTokens,
               cache_read_tokens: contentResult.usage?.cacheReadTokens,
               cache_write_tokens: contentResult.usage?.cacheWriteTokens,
               total_tokens: contentResult.usage?.totalTokens,
+              sandbox_total_usd: contentResult.usage?.totalUsd,
+              markup_applied: aiCreditReservation.useMarkup,
               cost_cents: costCents,
             },
           });

--- a/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
+++ b/apps/dashboard/src/app/api/workflows/on-demand-content/route.ts
@@ -832,28 +832,11 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
 
       const autumnClient = autumn;
       const contentUsage = contentResult.usage;
-      if (
-        aiCreditReserved &&
-        autumnClient &&
-        Number.isFinite(contentResult.usageCostCents)
-      ) {
-        await context.run("track-ai-credit-usage-cost", async () => {
-          await autumnClient.track({
-            customerId: organizationId,
-            featureId: FEATURES.AI_CREDITS,
-            value: contentResult.usageCostCents ?? 1,
-            properties: {
-              source: "manual",
-              output_type: contentType,
-              cost_cents: contentResult.usageCostCents,
-            },
-          });
-        });
-      } else if (aiCreditReserved && autumnClient && contentUsage) {
+      if (aiCreditReserved && autumnClient && contentUsage) {
         await context.run("track-ai-credit-usage", async () => {
           const costCents = calculateTokenCostCents(
             contentUsage,
-            "anthropic/claude-haiku-4.5",
+            contentUsage.modelId ?? "anthropic/claude-haiku-4.5",
             aiCreditMarkup
           );
           await autumnClient.track({
@@ -863,11 +846,15 @@ export const { POST } = serve<ContentGenerationWorkflowPayload>(
             properties: {
               source: "manual",
               output_type: contentType,
+              model: contentResult.usage?.modelId,
+              billing_basis: "tokens",
               input_tokens: contentResult.usage?.inputTokens,
               output_tokens: contentResult.usage?.outputTokens,
               cache_read_tokens: contentResult.usage?.cacheReadTokens,
               cache_write_tokens: contentResult.usage?.cacheWriteTokens,
               total_tokens: contentResult.usage?.totalTokens,
+              sandbox_total_usd: contentResult.usage?.totalUsd,
+              markup_applied: aiCreditMarkup,
               cost_cents: costCents,
             },
           });

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -1170,33 +1170,11 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
 
       const autumnClientSuccess = autumn;
       const contentUsage = contentResult.usage;
-      if (
-        aiCreditReservation.reserved &&
-        autumnClientSuccess &&
-        Number.isFinite(contentResult.usageCostCents)
-      ) {
-        await context.run("track-ai-credit-usage-cost", async () => {
-          await autumnClientSuccess.track({
-            customerId: trigger.organizationId,
-            featureId: FEATURES.AI_CREDITS,
-            value: contentResult.usageCostCents ?? 1,
-            properties: {
-              source: "workflow_schedule",
-              output_type: trigger.outputType,
-              trigger_name: trigger.name,
-              cost_cents: contentResult.usageCostCents,
-            },
-          });
-        });
-      } else if (
-        aiCreditReservation.reserved &&
-        autumnClientSuccess &&
-        contentUsage
-      ) {
+      if (aiCreditReservation.reserved && autumnClientSuccess && contentUsage) {
         await context.run("track-ai-credit-usage", async () => {
           const costCents = calculateTokenCostCents(
             contentUsage,
-            "anthropic/claude-haiku-4.5",
+            contentUsage.modelId ?? "anthropic/claude-haiku-4.5",
             aiCreditReservation.useMarkup
           );
           await autumnClientSuccess.track({
@@ -1207,11 +1185,15 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
               source: "workflow_schedule",
               output_type: trigger.outputType,
               trigger_name: trigger.name,
+              model: contentResult.usage?.modelId,
+              billing_basis: "tokens",
               input_tokens: contentResult.usage?.inputTokens,
               output_tokens: contentResult.usage?.outputTokens,
               cache_read_tokens: contentResult.usage?.cacheReadTokens,
               cache_write_tokens: contentResult.usage?.cacheWriteTokens,
               total_tokens: contentResult.usage?.totalTokens,
+              sandbox_total_usd: contentResult.usage?.totalUsd,
+              markup_applied: aiCreditReservation.useMarkup,
               cost_cents: costCents,
             },
           });

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/image.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/image.ts
@@ -85,7 +85,7 @@ export async function handleImage(
       postId,
       title,
       posts: [{ postId, title, recommendations: null }],
-      usageCostCents: getUsageCostCents(result.usage),
+      usage: result.usage,
     };
   } catch (error) {
     if (isGitHubRateLimitError(error)) {
@@ -117,12 +117,4 @@ function buildImagePrompt(ctx: ContentGenerationContext) {
   ];
 
   return promptParts.filter(Boolean).join("\n");
-}
-
-function getUsageCostCents(usage: { totalUsd?: number } | undefined) {
-  if (typeof usage?.totalUsd !== "number" || !Number.isFinite(usage.totalUsd)) {
-    return undefined;
-  }
-
-  return Math.max(1, Math.ceil(usage.totalUsd * 100));
 }

--- a/apps/dashboard/src/lib/workflows/schedule/types.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/types.ts
@@ -58,7 +58,6 @@ export type ContentGenerationResult =
       title: string;
       posts: PostSummary[];
       usage?: AgentTokenUsage;
-      usageCostCents?: number;
     }
   | { status: "skipped"; reason: string }
   | { status: "rate_limited"; retryAfterSeconds?: number }

--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -26,6 +26,7 @@ import { Agent, Box, OpenCodeModel } from "@upstash/box";
 const BOX_BASE_URL =
   process.env.UPSTASH_BOX_BASE_URL ?? "https://us-east-1.box.upstash.com";
 const TRAILING_SLASH_RE = /\/$/;
+export const REPO_IMAGE_MODEL_ID = OpenCodeModel.Claude_Sonnet_4_6;
 
 export class RepoImageError extends Error {
   readonly code:
@@ -302,7 +303,7 @@ export async function generateRepoImage(params: {
       },
       agent: {
         harness: Agent.OpenCode,
-        model: OpenCodeModel.Claude_Sonnet_4_6,
+        model: REPO_IMAGE_MODEL_ID,
       },
       timeout: AGENT_TIMEOUT_MS,
     };
@@ -335,7 +336,7 @@ export async function generateRepoImage(params: {
         timeout: AGENT_TIMEOUT_MS,
         label: restoreSnapshotId ? "revision" : "initial",
       });
-      usage = extractRepoImageUsage(initialRun.cost);
+      usage = extractRepoImageUsage(initialRun.cost, REPO_IMAGE_MODEL_ID);
 
       if (!(await hasRepoImageOutput(box))) {
         console.warn(
@@ -349,7 +350,7 @@ export async function generateRepoImage(params: {
         });
         usage = mergeRepoImageUsage(
           usage,
-          extractRepoImageUsage(recoveryRun.cost)
+          extractRepoImageUsage(recoveryRun.cost, REPO_IMAGE_MODEL_ID)
         );
       }
 
@@ -464,18 +465,38 @@ function readSnapshotNumber(snapshot: unknown, key: string) {
 }
 
 function extractRepoImageUsage(
-  cost: unknown
+  cost: unknown,
+  modelId: string
 ): GenerateRepoImageResult["usage"] {
   if (!cost || typeof cost !== "object") {
     return undefined;
   }
 
+  const inputTokens =
+    "inputTokens" in cost && typeof cost.inputTokens === "number"
+      ? cost.inputTokens
+      : 0;
+  const outputTokens =
+    "outputTokens" in cost && typeof cost.outputTokens === "number"
+      ? cost.outputTokens
+      : 0;
+  const computeMs =
+    "computeMs" in cost && typeof cost.computeMs === "number"
+      ? cost.computeMs
+      : undefined;
   const totalUsd =
     "totalUsd" in cost && typeof cost.totalUsd === "number"
       ? cost.totalUsd
       : undefined;
 
   return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    modelId,
+    ...(computeMs === undefined ? {} : { computeMs }),
     ...(totalUsd === undefined ? {} : { totalUsd }),
     raw: cost,
   };
@@ -492,6 +513,16 @@ function mergeRepoImageUsage(
     return current;
   }
   return {
+    inputTokens: current.inputTokens + next.inputTokens,
+    outputTokens: current.outputTokens + next.outputTokens,
+    totalTokens: current.totalTokens + next.totalTokens,
+    cacheReadTokens: current.cacheReadTokens + next.cacheReadTokens,
+    cacheWriteTokens: current.cacheWriteTokens + next.cacheWriteTokens,
+    modelId: current.modelId ?? next.modelId,
+    computeMs:
+      current.computeMs === undefined && next.computeMs === undefined
+        ? undefined
+        : (current.computeMs ?? 0) + (next.computeMs ?? 0),
     totalUsd:
       current.totalUsd === undefined && next.totalUsd === undefined
         ? undefined

--- a/packages/ai/src/billing/token-pricing.ts
+++ b/packages/ai/src/billing/token-pricing.ts
@@ -1,14 +1,17 @@
 import type { Balance } from "autumn-js";
 import type { AgentTokenUsage } from "../types/agents";
+import type { ModelPricing } from "../types/billing";
 
-export interface ModelPricing {
-  inputPerMillionTokens: number;
-  outputPerMillionTokens: number;
-  cacheReadPerMillionTokens: number;
-  cacheWritePerMillionTokens: number;
-}
+const CLAUDE_SONNET_4_6_PRICING: ModelPricing = {
+  inputPerMillionTokens: 3.0,
+  outputPerMillionTokens: 15.0,
+  cacheReadPerMillionTokens: 0.3,
+  cacheWritePerMillionTokens: 3.75,
+};
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
+  "opencode/claude-sonnet-4-6": CLAUDE_SONNET_4_6_PRICING,
+  "anthropic/claude-sonnet-4.6": CLAUDE_SONNET_4_6_PRICING,
   "anthropic/claude-haiku-4.5": {
     inputPerMillionTokens: 0.8,
     outputPerMillionTokens: 4.0,

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -62,6 +62,7 @@ export async function orchestrateStandaloneChat(
     abortSignal,
     timezone,
     telemetryMetadata,
+    useMarkup,
   } = input;
 
   const log = deps?.log ?? inputLog;
@@ -148,6 +149,7 @@ export async function orchestrateStandaloneChat(
           organizationId,
           chatId,
           userId,
+          useMarkup,
           validatedIntegrations,
           postResult,
         },

--- a/packages/ai/src/orchestration/orchestrate.ts
+++ b/packages/ai/src/orchestration/orchestrate.ts
@@ -36,6 +36,7 @@ export async function orchestrateChat(
     currentPostId,
     userId,
     imageDefaults,
+    useMarkup,
     selection,
     context = [],
     maxSteps = 1,
@@ -84,6 +85,7 @@ export async function orchestrateChat(
       currentPostId,
       userId,
       imageDefaults,
+      useMarkup,
       validatedIntegrations,
     },
     {

--- a/packages/ai/src/orchestration/standalone-tool-registry.ts
+++ b/packages/ai/src/orchestration/standalone-tool-registry.ts
@@ -40,8 +40,14 @@ export function buildStandaloneToolSet(
   params: BuildStandaloneToolSetParams,
   deps?: BuildStandaloneToolSetDeps
 ): ToolSet {
-  const { chatId, organizationId, userId, validatedIntegrations, postResult } =
-    params;
+  const {
+    chatId,
+    organizationId,
+    userId,
+    useMarkup,
+    validatedIntegrations,
+    postResult,
+  } = params;
 
   const tools: Record<string, Tool> = {};
   const descriptions: string[] = [];
@@ -57,7 +63,12 @@ export function buildStandaloneToolSet(
   }
 
   if (userId) {
-    tools.createImage = createImageTool({ chatId, organizationId, userId });
+    tools.createImage = createImageTool({
+      chatId,
+      organizationId,
+      userId,
+      useMarkup,
+    });
   }
 
   tools.updatePost = createUpdatePostTool(

--- a/packages/ai/src/orchestration/tool-registry.ts
+++ b/packages/ai/src/orchestration/tool-registry.ts
@@ -38,6 +38,7 @@ export function buildToolSet(
     currentPostId,
     userId,
     imageDefaults,
+    useMarkup,
     onMarkdownUpdate,
     validatedIntegrations,
   } = params;
@@ -64,6 +65,7 @@ export function buildToolSet(
         title: imageDefaults.title,
         integrationId: imageDefaults.integrationId,
         branch: imageDefaults.branch,
+        useMarkup,
       });
       descriptions.unshift(
         "**Image Editing**: Revise the current image using reviseImage. It restores the saved sandbox snapshot, applies the visual change, saves the updated image back to this content item, and stores a new snapshot."

--- a/packages/ai/src/tools/image.ts
+++ b/packages/ai/src/tools/image.ts
@@ -1,10 +1,12 @@
 import {
   deleteRepoImageSnapshot,
   generateRepoImage,
+  REPO_IMAGE_MODEL_ID,
   RepoImageError,
 } from "@notra/ai/agents/repo-image";
 import { autumn } from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
+import { calculateTokenCostCents } from "@notra/ai/billing/token-pricing";
 import {
   imageRevisionToolInputSchema,
   imageToolInputSchema,
@@ -89,6 +91,7 @@ export function createImageTool(config: ImageToolConfig): Tool {
         organizationId: config.organizationId,
         postId,
         usage: result.usage,
+        useMarkup: config.useMarkup,
       });
 
       return {
@@ -177,6 +180,7 @@ export function createImageRevisionTool(config: ImageRevisionToolConfig): Tool {
         organizationId: config.organizationId,
         postId: config.postId,
         usage: result.usage,
+        useMarkup: config.useMarkup,
       });
 
       return {
@@ -232,13 +236,18 @@ async function buildRevisionSourceMetadata(params: {
 async function trackImageGenerationUsage(params: {
   organizationId: string;
   postId: string;
-  usage: { totalUsd?: number; raw?: unknown } | undefined;
+  usage: Awaited<ReturnType<typeof generateRepoImage>>["usage"];
+  useMarkup?: boolean;
 }) {
-  if (!autumn || params.usage?.totalUsd === undefined) {
+  if (!autumn || !params.usage) {
     return;
   }
 
-  const costCents = Math.max(1, Math.ceil(params.usage.totalUsd * 100));
+  const costCents = calculateTokenCostCents(
+    params.usage,
+    params.usage.modelId ?? REPO_IMAGE_MODEL_ID,
+    params.useMarkup ?? false
+  );
 
   try {
     await autumn.track({
@@ -248,7 +257,15 @@ async function trackImageGenerationUsage(params: {
       properties: {
         source: "image_generation",
         post_id: params.postId,
-        total_usd: params.usage.totalUsd,
+        model: params.usage.modelId ?? REPO_IMAGE_MODEL_ID,
+        billing_basis: "tokens",
+        input_tokens: params.usage.inputTokens,
+        output_tokens: params.usage.outputTokens,
+        cache_read_tokens: params.usage.cacheReadTokens,
+        cache_write_tokens: params.usage.cacheWriteTokens,
+        total_tokens: params.usage.totalTokens,
+        sandbox_total_usd: params.usage.totalUsd,
+        markup_applied: params.useMarkup ?? false,
         cost_cents: costCents,
       },
     });

--- a/packages/ai/src/types/agents.ts
+++ b/packages/ai/src/types/agents.ts
@@ -3,7 +3,6 @@ import type { ToneProfile } from "@notra/ai/schemas/brand";
 import type { ContentType } from "@notra/ai/schemas/content";
 import type { AgentType } from "@notra/ai/types/brand-references";
 import type { PostSourceMetadata } from "@notra/db/schema";
-import type { LanguageModelUsage } from "ai";
 import type { PostSummary } from "./posts";
 import type {
   BaseTonePromptInput,
@@ -45,7 +44,10 @@ export interface AgentTokenUsage {
   totalTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
-  raw?: LanguageModelUsage;
+  modelId?: string;
+  computeMs?: number;
+  totalUsd?: number;
+  raw?: unknown;
 }
 
 export interface ChangelogAgentResult {

--- a/packages/ai/src/types/billing.ts
+++ b/packages/ai/src/types/billing.ts
@@ -1,0 +1,6 @@
+export interface ModelPricing {
+  inputPerMillionTokens: number;
+  outputPerMillionTokens: number;
+  cacheReadPerMillionTokens: number;
+  cacheWritePerMillionTokens: number;
+}

--- a/packages/ai/src/types/orchestration.ts
+++ b/packages/ai/src/types/orchestration.ts
@@ -125,6 +125,7 @@ export interface OrchestrateInput {
   log?: AILogTarget;
   timezone?: string;
   telemetryMetadata?: TccMetadata;
+  useMarkup?: boolean;
 }
 
 export interface OrchestrateResult {
@@ -154,6 +155,7 @@ export interface BuildToolSetParams {
   currentPostId?: string;
   userId?: string;
   imageDefaults?: ImageDefaults;
+  useMarkup?: boolean;
   onMarkdownUpdate?: (markdown: string) => void;
   validatedIntegrations: ValidatedIntegration[];
 }
@@ -168,6 +170,7 @@ export interface BuildStandaloneToolSetParams {
   organizationId: string;
   chatId?: string;
   userId?: string;
+  useMarkup?: boolean;
   validatedIntegrations: ValidatedIntegration[];
   postResult: PostToolsResult;
 }

--- a/packages/ai/src/types/repo-image.ts
+++ b/packages/ai/src/types/repo-image.ts
@@ -2,6 +2,7 @@ import type {
   generateRepoImageInputSchema,
   repoImageModeSchema,
 } from "@notra/ai/schemas/repo-image";
+import type { AgentTokenUsage } from "@notra/ai/types/agents";
 import type { z } from "zod";
 
 export type RepoImageMode = z.infer<typeof repoImageModeSchema>;
@@ -21,16 +22,14 @@ export interface GenerateRepoImageResult {
     snapshotSizeBytes?: number;
     snapshotCreatedAt?: string;
   } | null;
-  usage?: {
-    totalUsd?: number;
-    raw?: unknown;
-  };
+  usage?: AgentTokenUsage;
 }
 
 export interface ImageToolConfig {
   chatId?: string;
   organizationId: string;
   userId: string;
+  useMarkup?: boolean;
 }
 
 export interface ImageRevisionToolConfig {
@@ -40,6 +39,7 @@ export interface ImageRevisionToolConfig {
   title: string;
   integrationId: string;
   branch: string;
+  useMarkup?: boolean;
 }
 
 export interface FontSpec {

--- a/packages/ai/src/types/standalone-chat.ts
+++ b/packages/ai/src/types/standalone-chat.ts
@@ -26,6 +26,7 @@ export interface StandaloneChatInput {
   abortSignal?: AbortSignal;
   timezone?: string;
   telemetryMetadata?: TccMetadata;
+  useMarkup?: boolean;
 }
 
 export interface StandaloneChatDeps {


### PR DESCRIPTION
## Summary
- normalize sandbox image usage into token usage with the repo image model id
- charge image generation from token pricing instead of sandbox-reported USD cost
- pass the existing additional-credit markup decision into image creation and revision tools
- retain sandbox total USD only as metadata for diagnostics

## Verification
- bun run --filter=@notra/ai check-types
- bun run --filter=dashboard check-types
- bun run --filter=api check-types
- bunx biome check <changed files>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch image billing from sandbox USD to token-based pricing using the image model ID. Pass `useMarkup` end-to-end so markup applies to image create/revise and standalone chat; keep sandbox USD only for diagnostics.

- **Bug Fixes**
  - Normalize repo image usage to tokens (input/output/total) with `modelId`; merge across retries; expose via `AgentTokenUsage`.
  - Compute image and workflow costs with model pricing; added pricing for `opencode/claude-sonnet-4-6` and `anthropic/claude-sonnet-4.6`.
  - Thread `useMarkup` through API routes, orchestration, and image tools; apply during cost calculation and Autumn tracking.
  - Replace USD-only analytics with token-based fields; log `model`, `billing_basis=tokens`, token counts, `sandbox_total_usd`, and `markup_applied`.
  - Remove legacy `usageCostCents` in handlers and types; default cost calc to `contentUsage.modelId ?? "anthropic/claude-haiku-4.5"` when missing.

<sup>Written for commit 80af603ce4aaed12741c573f9d78e8d821e6ad39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

