### PR TITLE
feat(web): add liquid glass effects to navbar menus

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -421,6 +421,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
                 <GlassDropdownMenuContent
                   align="start"
                   className="w-56 bg-white/60 dark:bg-neutral-950/60"
+                  glassClassName="border-black/5 dark:border-white/10"
                   glassVariant="liquid-refract"
                   showBackdrop
                   side="bottom"
@@ -544,7 +545,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
                           blur={5}
                           className="h-full w-full rounded-2xl border-0 bg-transparent shadow-none"
                         >
-                          <div className="relative inset-shadow-lg inset-shadow-white h-full w-full overflow-hidden rounded-2xl bg-white/70 shadow-black/8 shadow-lg ring-1 ring-black/5 dark:inset-shadow-white/3 dark:bg-neutral-950/70 dark:shadow-black/50 dark:shadow-xl dark:ring-white/10">
+                          <div className="relative inset-shadow-lg inset-shadow-white h-full w-full overflow-hidden rounded-2xl bg-white/85 shadow-black/8 shadow-lg ring-1 ring-black/5 dark:inset-shadow-white/3 dark:bg-neutral-950/85 dark:shadow-black/50 dark:shadow-xl dark:ring-white/10">
                             <AnimatePresence custom={direction} initial={false}>
                               <m.div
                                 animate="center"

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -14,6 +14,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
+import { GlassDropdownMenuContent } from "@notra/ui/components/ui/glasscn/glass-dropdown-menu";
+import { LiquidGlass } from "@notra/ui/components/ui/glasscn/liquid-glass";
 import {
   AnimatePresence,
   domAnimation,
@@ -105,7 +107,7 @@ function MegaCard({
   onSelect: () => void;
 }) {
   const className =
-    "flex h-40 w-44 flex-col justify-between rounded-xl border border-neutral-200/70 bg-neutral-50 p-4 transition-colors hover:border-neutral-300 hover:bg-neutral-100 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10";
+    "flex h-40 w-44 flex-col justify-between rounded-xl border border-neutral-200/70 bg-neutral-50/70 p-4 transition-colors hover:border-neutral-300 hover:bg-neutral-100/80 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10";
   const body = (
     <>
       <span className="inset-shadow-sm inset-shadow-white flex size-9 items-center justify-center rounded-lg bg-white text-neutral-700 shadow-black/5 shadow-sm ring-1 ring-black/5 dark:inset-shadow-white/8 dark:bg-white/10 dark:text-neutral-200 dark:ring-white/10">
@@ -416,9 +418,11 @@ export function Navbar({ variant }: NavbarProps = {}) {
                     </span>
                   </span>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent
+                <GlassDropdownMenuContent
                   align="start"
-                  className="w-56"
+                  className="w-56 bg-white/60 dark:bg-neutral-950/60"
+                  glassVariant="liquid-refract"
+                  showBackdrop
                   side="bottom"
                 >
                   <DropdownMenuItem
@@ -434,7 +438,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
                     <HugeiconsIcon icon={DashboardSquare01Icon} />
                     Dashboard
                   </DropdownMenuItem>
-                </DropdownMenuContent>
+                </GlassDropdownMenuContent>
               </DropdownMenu>
 
               {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: onMouseLeave is a pointer-only convenience to dismiss the hover menu; the menu is fully operable via click, focus, and Escape */}
@@ -526,7 +530,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
                           width: activeSize?.width,
                           height: activeSize?.height,
                         }}
-                        className="relative inset-shadow-lg inset-shadow-white overflow-hidden rounded-2xl bg-white shadow-black/8 shadow-lg ring-1 ring-black/5 dark:inset-shadow-white/3 dark:bg-neutral-950 dark:shadow-black/50 dark:shadow-xl dark:ring-white/10"
+                        className="relative"
                         initial={{
                           width: activeSize?.width,
                           height: activeSize?.height,
@@ -536,24 +540,31 @@ export function Navbar({ variant }: NavbarProps = {}) {
                           height: morphTransition,
                         }}
                       >
-                        <AnimatePresence custom={direction} initial={false}>
-                          <m.div
-                            animate="center"
-                            className="absolute top-0 left-0 w-max"
-                            custom={direction}
-                            exit="exit"
-                            initial="enter"
-                            key={activeGroupData.label}
-                            role="menu"
-                            transition={contentTransition}
-                            variants={contentVariants}
-                          >
-                            <MegaPanel
-                              group={activeGroupData}
-                              onSelect={closePanel}
-                            />
-                          </m.div>
-                        </AnimatePresence>
+                        <LiquidGlass
+                          blur={5}
+                          className="h-full w-full rounded-2xl border-0 bg-transparent shadow-none"
+                        >
+                          <div className="relative inset-shadow-lg inset-shadow-white h-full w-full overflow-hidden rounded-2xl bg-white/70 shadow-black/8 shadow-lg ring-1 ring-black/5 dark:inset-shadow-white/3 dark:bg-neutral-950/70 dark:shadow-black/50 dark:shadow-xl dark:ring-white/10">
+                            <AnimatePresence custom={direction} initial={false}>
+                              <m.div
+                                animate="center"
+                                className="absolute top-0 left-0 w-max"
+                                custom={direction}
+                                exit="exit"
+                                initial="enter"
+                                key={activeGroupData.label}
+                                role="menu"
+                                transition={contentTransition}
+                                variants={contentVariants}
+                              >
+                                <MegaPanel
+                                  group={activeGroupData}
+                                  onSelect={closePanel}
+                                />
+                              </m.div>
+                            </AnimatePresence>
+                          </div>
+                        </LiquidGlass>
                       </m.div>
                     </m.div>
                   )}

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -24,6 +24,7 @@
     "@svgl": "https://svgl.app/r/{name}.json",
     "@diceui": "https://diceui.com/r/{name}.json",
     "@react-bits": "https://reactbits.dev/r/{name}.json",
-    "@kibo-ui": "https://www.kibo-ui.com/r/{name}.json"
+    "@kibo-ui": "https://www.kibo-ui.com/r/{name}.json",
+    "@glasscn": "https://glasscn-components.vercel.app/r/{name}.json"
   }
 }

--- a/packages/ui/src/components/ui/glasscn/glass-dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/glasscn/glass-dropdown-menu.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import type * as React from "react";
+import {
+  type FrostGlassVariantProp,
+  glassVariantStyles,
+} from "@notra/ui/lib/glass-variants";
+import { cn } from "@notra/ui/lib/utils";
+import { DropdownMenuContent } from "../dropdown-menu";
+import { LiquidGlass } from "./liquid-glass";
+
+type GlassDropdownMenuContentProps = React.ComponentProps<
+  typeof DropdownMenuContent
+> &
+  FrostGlassVariantProp;
+
+const menuStateStyles = [
+  "[&_[data-slot=dropdown-menu-item]:focus]:bg-white/70",
+  "[&_[data-slot=dropdown-menu-item]:focus]:text-black",
+  "dark:[&_[data-slot=dropdown-menu-item]:focus]:bg-white/12",
+  "dark:[&_[data-slot=dropdown-menu-item]:focus]:text-white",
+  "[&_[data-slot=dropdown-menu-checkbox-item]:focus]:bg-white/70",
+  "[&_[data-slot=dropdown-menu-checkbox-item]:focus]:text-black",
+  "dark:[&_[data-slot=dropdown-menu-checkbox-item]:focus]:bg-white/12",
+  "dark:[&_[data-slot=dropdown-menu-checkbox-item]:focus]:text-white",
+  "[&_[data-slot=dropdown-menu-sub-trigger]:focus]:bg-white/70",
+  "[&_[data-slot=dropdown-menu-sub-trigger]:focus]:text-black",
+  "dark:[&_[data-slot=dropdown-menu-sub-trigger]:focus]:bg-white/12",
+  "dark:[&_[data-slot=dropdown-menu-sub-trigger]:focus]:text-white",
+  "[&_[data-slot=dropdown-menu-separator]]:bg-white/25",
+  "dark:[&_[data-slot=dropdown-menu-separator]]:bg-white/10",
+].join(" ");
+
+function GlassDropdownMenuContent({
+  className,
+  glassVariant = "liquid-refract",
+  showBackdrop = false,
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: GlassDropdownMenuContentProps) {
+  if (glassVariant === "liquid-refract") {
+    return (
+      <MenuPrimitive.Portal>
+        {showBackdrop ? (
+          <MenuPrimitive.Backdrop
+            className="data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-40 bg-black/8 duration-100 dark:bg-black/30"
+            data-slot="dropdown-menu-backdrop"
+          />
+        ) : null}
+        <MenuPrimitive.Positioner
+          align={align}
+          alignOffset={alignOffset}
+          className="isolate z-50 outline-none"
+          side={side}
+          sideOffset={sideOffset}
+        >
+          <LiquidGlass className="rounded-lg">
+            <MenuPrimitive.Popup
+              className={cn(
+                "z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-transparent p-1 text-foreground shadow-none outline-none ring-0 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-closed:overflow-hidden",
+                menuStateStyles,
+                className
+              )}
+              data-glass-variant={glassVariant}
+              data-slot="glass-dropdown-menu-content"
+              {...props}
+            />
+          </LiquidGlass>
+        </MenuPrimitive.Positioner>
+      </MenuPrimitive.Portal>
+    );
+  }
+
+  return (
+    <DropdownMenuContent
+      align={align}
+      alignOffset={alignOffset}
+      className={cn(
+        glassVariantStyles[glassVariant],
+        "border border-white/30 bg-white/60 text-foreground shadow-2xl ring-1 ring-white/20 dark:border-white/10 dark:bg-black/55 dark:ring-white/10",
+        menuStateStyles,
+        className
+      )}
+      data-glass-variant={glassVariant}
+      data-slot="glass-dropdown-menu-content"
+      showBackdrop={showBackdrop}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  );
+}
+
+export { GlassDropdownMenuContent };

--- a/packages/ui/src/components/ui/glasscn/glass-dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/glasscn/glass-dropdown-menu.tsx
@@ -13,7 +13,9 @@ import { LiquidGlass } from "./liquid-glass";
 type GlassDropdownMenuContentProps = React.ComponentProps<
   typeof DropdownMenuContent
 > &
-  FrostGlassVariantProp;
+  FrostGlassVariantProp & {
+    glassClassName?: string;
+  };
 
 const menuStateStyles = [
   "[&_[data-slot=dropdown-menu-item]:focus]:bg-white/70",
@@ -34,6 +36,7 @@ const menuStateStyles = [
 
 function GlassDropdownMenuContent({
   className,
+  glassClassName,
   glassVariant = "liquid-refract",
   showBackdrop = false,
   align = "start",
@@ -58,7 +61,7 @@ function GlassDropdownMenuContent({
           side={side}
           sideOffset={sideOffset}
         >
-          <LiquidGlass className="rounded-lg">
+          <LiquidGlass className={cn("rounded-lg", glassClassName)}>
             <MenuPrimitive.Popup
               className={cn(
                 "z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-transparent p-1 text-foreground shadow-none outline-none ring-0 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-closed:overflow-hidden",

--- a/packages/ui/src/components/ui/glasscn/liquid-glass.tsx
+++ b/packages/ui/src/components/ui/glasscn/liquid-glass.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import {
+  type CSSProperties,
+  forwardRef,
+  type HTMLAttributes,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+import { cn } from "@notra/ui/lib/utils";
+
+export type LiquidGlassProps = HTMLAttributes<HTMLDivElement> & {
+  blur?: number;
+  refraction?: number;
+  mapSize?: number;
+  bezel?: number;
+};
+
+export const LiquidGlass = forwardRef<HTMLDivElement, LiquidGlassProps>(
+  function LiquidGlass(
+    {
+      blur = 2,
+      refraction = 15,
+      mapSize = 320,
+      bezel = 0.34,
+      className,
+      style,
+      children,
+      ...props
+    },
+    ref
+  ) {
+    const rawId = useId();
+    const filterId = useMemo(
+      () => `liquid-glass-${rawId.replace(/:/g, "")}`,
+      [rawId]
+    );
+    const [mapUrl, setMapUrl] = useState("");
+
+    useEffect(() => {
+      setMapUrl(createDisplacementMap(mapSize, bezel));
+    }, [bezel, mapSize]);
+
+    return (
+      <>
+        <div
+          className={cn(
+            "relative overflow-hidden rounded-full border border-black/10 bg-white/[0.08] shadow-[0_8px_32px_rgba(0,0,0,0.08),inset_0_1px_0_0_rgba(255,255,255,0.5),inset_0_-1px_0_0_rgba(0,0,0,0.05)] dark:border-white/20 dark:shadow-[0_18px_60px_rgba(0,0,0,0.36),inset_0_0_0_1px_rgba(255,255,255,0.035),inset_-9px_-7px_18px_rgba(0,0,0,0.48)]",
+            className
+          )}
+          ref={ref}
+          style={
+            {
+              ...style,
+              backdropFilter: `url(#${filterId}) blur(${blur}px) saturate(1.28)`,
+              WebkitBackdropFilter: `url(#${filterId}) blur(${blur}px) saturate(1.28)`,
+            } as CSSProperties
+          }
+          {...props}
+        >
+          {children}
+        </div>
+
+        <svg aria-hidden className="absolute size-0 overflow-hidden">
+          <filter
+            colorInterpolationFilters="sRGB"
+            height="100%"
+            id={filterId}
+            width="100%"
+            x="0"
+            y="0"
+          >
+            {mapUrl ? (
+              <feImage
+                height="100%"
+                href={mapUrl}
+                preserveAspectRatio="none"
+                result="displacementMap"
+                width="100%"
+                x="0"
+                y="0"
+              />
+            ) : null}
+            <feDisplacementMap
+              in="SourceGraphic"
+              in2="displacementMap"
+              result="displaced"
+              scale={refraction}
+              xChannelSelector="R"
+              yChannelSelector="G"
+            />
+            <feGaussianBlur in="displaced" stdDeviation="0.15" />
+          </filter>
+        </svg>
+      </>
+    );
+  }
+);
+
+function createDisplacementMap(size: number, bezel: number) {
+  const canvas = document.createElement("canvas");
+  canvas.height = size;
+  canvas.width = size;
+
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  if (!ctx) {
+    return "";
+  }
+
+  const image = ctx.createImageData(size, size);
+  const { data } = image;
+  const center = (size - 1) / 2;
+
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const nx = (x - center) / center;
+      const ny = (y - center) / center;
+      const radius = Math.hypot(nx, ny);
+      const index = (y * size + x) * 4;
+
+      if (radius > 1) {
+        data[index] = 128;
+        data[index + 1] = 128;
+        data[index + 2] = 128;
+        data[index + 3] = 255;
+        continue;
+      }
+
+      const edgeDistance = 1 - radius;
+      const bezelT = clamp(edgeDistance / bezel, 0, 1);
+      const surface = convexSquircle(bezelT);
+      const fadeToCenter = 1 - smootherstep(0.55, 1, edgeDistance);
+      const rimKick = Math.sin(bezelT * Math.PI) * 0.52;
+      const magnitude =
+        clamp((1 - surface) * 0.55 + rimKick, 0, 1) * fadeToCenter;
+      const direction =
+        radius === 0 ? { x: 0, y: 0 } : { x: nx / radius, y: ny / radius };
+
+      data[index] = Math.round(128 + direction.x * magnitude * 127);
+      data[index + 1] = Math.round(128 + direction.y * magnitude * 127);
+      data[index + 2] = 128;
+      data[index + 3] = 255;
+    }
+  }
+
+  ctx.putImageData(image, 0, 0);
+  return canvas.toDataURL("image/png");
+}
+
+function convexSquircle(x: number) {
+  return (1 - (1 - x) ** 4) ** 0.25;
+}
+
+function smootherstep(edge0: number, edge1: number, x: number) {
+  const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/packages/ui/src/components/ui/glasscn/liquid-glass.tsx
+++ b/packages/ui/src/components/ui/glasscn/liquid-glass.tsx
@@ -11,6 +11,12 @@ import {
 } from "react";
 import { cn } from "@notra/ui/lib/utils";
 
+const displacementMapCache = new Map<string, string>();
+
+function getDisplacementMapCacheKey(size: number, bezel: number) {
+  return `${size}:${bezel}`;
+}
+
 export type LiquidGlassProps = HTMLAttributes<HTMLDivElement> & {
   blur?: number;
   refraction?: number;
@@ -37,10 +43,21 @@ export const LiquidGlass = forwardRef<HTMLDivElement, LiquidGlassProps>(
       () => `liquid-glass-${rawId.replace(/:/g, "")}`,
       [rawId]
     );
-    const [mapUrl, setMapUrl] = useState("");
+    const [mapUrl, setMapUrl] = useState(() => {
+      if (typeof document === "undefined") {
+        return "";
+      }
+
+      return displacementMapCache.get(
+        getDisplacementMapCacheKey(mapSize, bezel)
+      ) ?? "";
+    });
 
     useEffect(() => {
-      setMapUrl(createDisplacementMap(mapSize, bezel));
+      const nextMapUrl = createDisplacementMap(mapSize, bezel);
+      setMapUrl((currentMapUrl) =>
+        currentMapUrl === nextMapUrl ? currentMapUrl : nextMapUrl
+      );
     }, [bezel, mapSize]);
 
     return (
@@ -100,6 +117,13 @@ export const LiquidGlass = forwardRef<HTMLDivElement, LiquidGlassProps>(
 );
 
 function createDisplacementMap(size: number, bezel: number) {
+  const cacheKey = getDisplacementMapCacheKey(size, bezel);
+  const cachedMap = displacementMapCache.get(cacheKey);
+
+  if (cachedMap !== undefined) {
+    return cachedMap;
+  }
+
   const canvas = document.createElement("canvas");
   canvas.height = size;
   canvas.width = size;
@@ -146,7 +170,10 @@ function createDisplacementMap(size: number, bezel: number) {
   }
 
   ctx.putImageData(image, 0, 0);
-  return canvas.toDataURL("image/png");
+  const mapUrl = canvas.toDataURL("image/png");
+  displacementMapCache.set(cacheKey, mapUrl);
+
+  return mapUrl;
 }
 
 function convexSquircle(x: number) {

--- a/packages/ui/src/lib/glass-variants.ts
+++ b/packages/ui/src/lib/glass-variants.ts
@@ -1,0 +1,28 @@
+export type FrostGlassVariant =
+  | "clear"
+  | "frosted"
+  | "subtle"
+  | "liquid-refract";
+export type FrostGlassVariantProp = { glassVariant?: FrostGlassVariant };
+
+export const glassVariantStyles: Record<FrostGlassVariant, string> = {
+  clear: [
+    "backdrop-blur-[2px] backdrop-saturate-[1.9]",
+    "bg-white/[0.25] dark:bg-black/[0.25]",
+    "border border-white/[0.5] dark:border-white/[0.12]",
+    "shadow-[0_1px_12px_rgba(0,0,0,0.05)] dark:shadow-[0_1px_12px_rgba(0,0,0,0.2)]",
+  ].join(" "),
+  frosted: [
+    "backdrop-blur-[16px] backdrop-saturate-[1.6]",
+    "bg-white/[0.55] dark:bg-black/[0.35]",
+    "border border-white/[0.4] dark:border-white/10",
+    "shadow-[0_2px_20px_rgba(0,0,0,0.06)] dark:shadow-[0_2px_20px_rgba(0,0,0,0.3)]",
+  ].join(" "),
+  subtle: [
+    "backdrop-blur-[4px] backdrop-saturate-[1.5]",
+    "bg-white/[0.3] dark:bg-white/[0.06]",
+    "border border-black/[0.05] dark:border-white/[0.08]",
+    "shadow-sm",
+  ].join(" "),
+  "liquid-refract": "",
+};


### PR DESCRIPTION
### Description

Adds GlassCN-based liquid glass treatment to the marketing navbar menus.

This updates the logo dropdown to use the new GlassDropdownMenuContent component and applies the same glass styling language to the custom Products/Resources mega menu using the shared LiquidGlass wrapper. The change also registers the local @glasscn registry in @notra/ui and adds the supporting glass UI primitives needed by the navbar.

AI assistance was used to help implement and review this change.

### Screenshot/Recording (if applicable)


https://github.com/user-attachments/assets/450feeed-e5ce-45f0-b435-4b1a78f22467






<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds liquid glass effects to the marketing navbar menus and fine-tunes the mega menu shell/dropdown backdrop for clearer depth and contrast. Caches refraction displacement maps for faster rendering.

- **New Features**
  - Added `GlassDropdownMenuContent` with `liquid-refract` styling, optional backdrop, and glass variant support, built on `LiquidGlass`.
  - Introduced `LiquidGlass` for SVG-based refraction/blur with cached displacement maps, plus a shared `glass-variants` utility.
  - Applied glass styling to the logo dropdown and the Products/Resources mega menu, wrapping the mega panel shell in `LiquidGlass` with tuned opacity/border for contrast.

- **Dependencies**
  - Registered the `@glasscn` component registry in `@notra/ui/components.json`.

<sup>Written for commit f01d1034ec001734343e4925e551ed511fde83b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

