### PR TITLE
fix: harden repo image stream timeouts

### DIFF
--- a/apps/web/src/lib/sanitize-html-links/constants.ts
+++ b/apps/web/src/lib/sanitize-html-links/constants.ts
@@ -1,11 +1,11 @@
-export const EXTERNAL_HREF_REGEX = /^(https?:)?\/\//;
+export const EXTERNAL_HREF_REGEX = /^(https?:)?\/\//i;
 export const ANCHOR_TAG_REGEX = /<a\s([^>]*)>/gi;
-export const HREF_ATTR_REGEX = /href=["']([^"']*)["']/;
-export const HREF_ATTR_REPLACE_REGEX = /href=["'][^"']*["']/;
-export const REL_ATTR_MATCH_REGEX = /rel=["']([^"']*)["']/;
+export const HREF_ATTR_REGEX = /(?:^|\s)href=["']([^"']*)["']/i;
+export const HREF_ATTR_REPLACE_REGEX = /(^|\s)href=["'][^"']*["']/i;
+export const REL_ATTR_MATCH_REGEX = /(?:^|\s)rel=["']([^"']*)["']/i;
 export const REL_SPLIT_REGEX = /\s+/;
-export const REL_ATTR_REPLACE_REGEX = /rel=["'][^"']*["']/;
-export const TARGET_ATTR_REGEX = /target=["'][^"']*["']/;
+export const REL_ATTR_REPLACE_REGEX = /(^|\s)rel=["'][^"']*["']/i;
+export const TARGET_ATTR_REGEX = /(^|\s)target=["'][^"']*["']/i;
 
 export const HEX_ENTITY_REGEX = /&#x([0-9a-f]+);?/gi;
 export const DECIMAL_ENTITY_REGEX = /&#(\d+);?/g;

--- a/apps/web/src/lib/sanitize-html-links/constants.ts
+++ b/apps/web/src/lib/sanitize-html-links/constants.ts
@@ -1,0 +1,21 @@
+export const EXTERNAL_HREF_REGEX = /^(https?:)?\/\//;
+export const ANCHOR_TAG_REGEX = /<a\s([^>]*)>/gi;
+export const HREF_ATTR_REGEX = /href=["']([^"']*)["']/;
+export const HREF_ATTR_REPLACE_REGEX = /href=["'][^"']*["']/;
+export const REL_ATTR_MATCH_REGEX = /rel=["']([^"']*)["']/;
+export const REL_SPLIT_REGEX = /\s+/;
+export const REL_ATTR_REPLACE_REGEX = /rel=["'][^"']*["']/;
+export const TARGET_ATTR_REGEX = /target=["'][^"']*["']/;
+
+export const HEX_ENTITY_REGEX = /&#x([0-9a-f]+);?/gi;
+export const DECIMAL_ENTITY_REGEX = /&#(\d+);?/g;
+export const STRIPPED_URL_CHARS_REGEX = /[\t\n\r]/g;
+export const URL_SCHEME_REGEX = /^([a-z][a-z0-9+.-]*):/;
+export const MAX_CODE_POINT = 0x10_ff_ff;
+export const SAFE_SCHEMES = new Set(["http", "https", "mailto", "tel"]);
+
+export const FIGCAPTION_REGEX = /<figcaption([^>]*)>([\s\S]*?)<\/figcaption>/gi;
+export const ENCODED_ANCHOR_REGEX =
+  /&lt;a\b([\s\S]*?)&gt;([\s\S]*?)&lt;\/a&gt;/gi;
+export const ENCODED_QUOTE_REGEX = /&quot;/g;
+export const ENCODED_APOS_REGEX = /&#39;/g;

--- a/apps/web/src/utils/sanitize-html-links.ts
+++ b/apps/web/src/utils/sanitize-html-links.ts
@@ -1,23 +1,23 @@
-const EXTERNAL_HREF_REGEX = /^(https?:)?\/\//;
-const ANCHOR_TAG_REGEX = /<a\s([^>]*)>/gi;
-const HREF_ATTR_REGEX = /href=["']([^"']*)["']/;
-const HREF_ATTR_REPLACE_REGEX = /href=["'][^"']*["']/;
-const REL_ATTR_MATCH_REGEX = /rel=["']([^"']*)["']/;
-const REL_SPLIT_REGEX = /\s+/;
-const REL_ATTR_REPLACE_REGEX = /rel=["'][^"']*["']/;
-const TARGET_ATTR_REGEX = /target=["'][^"']*["']/;
-
-const HEX_ENTITY_REGEX = /&#x([0-9a-f]+);?/gi;
-const DECIMAL_ENTITY_REGEX = /&#(\d+);?/g;
-const STRIPPED_URL_CHARS_REGEX = /[\t\n\r]/g;
-const URL_SCHEME_REGEX = /^([a-z][a-z0-9+.-]*):/;
-const MAX_CODE_POINT = 0x10_ff_ff;
-const SAFE_SCHEMES = new Set(["http", "https", "mailto", "tel"]);
-
-const FIGCAPTION_REGEX = /<figcaption([^>]*)>([\s\S]*?)<\/figcaption>/gi;
-const ENCODED_ANCHOR_REGEX = /&lt;a\b([\s\S]*?)&gt;([\s\S]*?)&lt;\/a&gt;/gi;
-const ENCODED_QUOTE_REGEX = /&quot;/g;
-const ENCODED_APOS_REGEX = /&#39;/g;
+import {
+  ANCHOR_TAG_REGEX,
+  DECIMAL_ENTITY_REGEX,
+  ENCODED_ANCHOR_REGEX,
+  ENCODED_APOS_REGEX,
+  ENCODED_QUOTE_REGEX,
+  EXTERNAL_HREF_REGEX,
+  FIGCAPTION_REGEX,
+  HEX_ENTITY_REGEX,
+  HREF_ATTR_REGEX,
+  HREF_ATTR_REPLACE_REGEX,
+  MAX_CODE_POINT,
+  REL_ATTR_MATCH_REGEX,
+  REL_ATTR_REPLACE_REGEX,
+  REL_SPLIT_REGEX,
+  SAFE_SCHEMES,
+  STRIPPED_URL_CHARS_REGEX,
+  TARGET_ATTR_REGEX,
+  URL_SCHEME_REGEX,
+} from "@/lib/sanitize-html-links/constants";
 
 function decodeCodePoint(code: number): string {
   if (Number.isNaN(code) || code < 0 || code > MAX_CODE_POINT) {

--- a/apps/web/src/utils/sanitize-html-links.ts
+++ b/apps/web/src/utils/sanitize-html-links.ts
@@ -56,7 +56,7 @@ export function addExternalLinkAttrs(html: string): string {
     if (href && !isSafeHref(href)) {
       const neutralizedAttrs = attrs.replace(
         HREF_ATTR_REPLACE_REGEX,
-        'href="#"'
+        '$1href="#"'
       );
 
       return `<a ${neutralizedAttrs}>`;
@@ -79,14 +79,17 @@ export function addExternalLinkAttrs(html: string): string {
     if (relMatch) {
       updatedAttrs = updatedAttrs.replace(
         REL_ATTR_REPLACE_REGEX,
-        `rel="${relValue}"`
+        `$1rel="${relValue}"`
       );
     } else {
       updatedAttrs += ` rel="${relValue}"`;
     }
 
     if (TARGET_ATTR_REGEX.test(updatedAttrs)) {
-      updatedAttrs = updatedAttrs.replace(TARGET_ATTR_REGEX, 'target="_blank"');
+      updatedAttrs = updatedAttrs.replace(
+        TARGET_ATTR_REGEX,
+        '$1target="_blank"'
+      );
     } else {
       updatedAttrs += ' target="_blank"';
     }

--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -53,6 +53,7 @@ async function runRepoImageAgentStream(params: {
   timeout: number;
   label: string;
 }) {
+  const startedAt = Date.now();
   const stream = await params.box.agent.stream({
     prompt: params.prompt,
     timeout: params.timeout,
@@ -64,12 +65,33 @@ async function runRepoImageAgentStream(params: {
     }
   }
 
+  console.log(
+    `[repo-image] ${params.label} stream completed in ${Date.now() - startedAt}ms`
+  );
+
   return {
     cost:
       typeof stream === "object" && stream !== null && "cost" in stream
         ? (stream.cost as unknown)
         : undefined,
   };
+}
+
+async function runRepoImageAgentStreamAllowTimeout(
+  params: Parameters<typeof runRepoImageAgentStream>[0]
+) {
+  try {
+    return await runRepoImageAgentStream(params);
+  } catch (error) {
+    if (!isAgentTimeoutError(error)) {
+      throw error;
+    }
+
+    console.warn(
+      `[repo-image] ${params.label} stream timed out after ${params.timeout}ms; checking for ${REPO_IMAGE_OUTPUT_HTML_PATH}`
+    );
+    return null;
+  }
 }
 
 async function hasRepoImageOutput(box: Awaited<ReturnType<typeof Box.create>>) {
@@ -115,6 +137,17 @@ function isTransientBoxError(error: unknown) {
     error.message.includes("fetch failed") ||
     error.message.includes("ECONNRESET") ||
     error.message.includes("UND_ERR")
+  );
+}
+
+function isAgentTimeoutError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("stream timed out") || message.includes("run timed out")
   );
 }
 
@@ -329,7 +362,7 @@ export async function generateRepoImage(params: {
         await installImageGenAgentSkills({ box });
       }
 
-      const initialRun = await runRepoImageAgentStream({
+      const initialRun = await runRepoImageAgentStreamAllowTimeout({
         box,
         prompt: restoreSnapshotId
           ? buildRevisionPrompt({ prompt: input.prompt ?? "" })
@@ -342,13 +375,13 @@ export async function generateRepoImage(params: {
         timeout: AGENT_TIMEOUT_MS,
         label: restoreSnapshotId ? "revision" : "initial",
       });
-      usage = extractRepoImageUsage(initialRun.cost, IMAGE_GEN_MODEL_ID);
+      usage = extractRepoImageUsage(initialRun?.cost, IMAGE_GEN_MODEL_ID);
 
       if (!(await hasRepoImageOutput(box))) {
         console.warn(
           `[repo-image] missing ${REPO_IMAGE_OUTPUT_HTML_PATH}; asking agent to recover`
         );
-        const recoveryRun = await runRepoImageAgentStream({
+        const recoveryRun = await runRepoImageAgentStreamAllowTimeout({
           box,
           prompt: buildMissingOutputRecoveryPrompt(),
           timeout: RECOVERY_AGENT_TIMEOUT_MS,
@@ -356,7 +389,7 @@ export async function generateRepoImage(params: {
         });
         usage = mergeRepoImageUsage(
           usage,
-          extractRepoImageUsage(recoveryRun.cost, IMAGE_GEN_MODEL_ID)
+          extractRepoImageUsage(recoveryRun?.cost, IMAGE_GEN_MODEL_ID)
         );
       }
 

--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -362,7 +362,10 @@ export async function generateRepoImage(params: {
         await installImageGenAgentSkills({ box });
       }
 
-      const initialRun = await runRepoImageAgentStreamAllowTimeout({
+      const runInitialRepoImageAgent = restoreSnapshotId
+        ? runRepoImageAgentStream
+        : runRepoImageAgentStreamAllowTimeout;
+      const initialRun = await runInitialRepoImageAgent({
         box,
         prompt: restoreSnapshotId
           ? buildRevisionPrompt({ prompt: input.prompt ?? "" })

--- a/packages/ai/src/constants/repo-image.ts
+++ b/packages/ai/src/constants/repo-image.ts
@@ -1,7 +1,7 @@
 import type { FontSpec } from "@notra/ai/types/repo-image";
 import { OpenCodeModel } from "@upstash/box";
 
-export const AGENT_TIMEOUT_MS = 480_000;
+export const AGENT_TIMEOUT_MS = 960_000;
 export const RECOVERY_AGENT_TIMEOUT_MS = 180_000;
 export const REPO_IMAGE_OUTPUT_HTML_PATH = "/workspace/home/output.html";
 export const IMAGE_GEN_AGENT_SKILLS_INSTALL_COMMAND =
@@ -34,4 +34,4 @@ export const STYLE_ATTR_RE = /style\s*=\s*(['"])([\s\S]*?)\1/i;
 export const DISPLAY_STYLE_RE = /(^|;)\s*display\s*:/i;
 export const LEADING_STYLE_SEPARATOR_RE = /^\s*;?/;
 
-export const TEN_MINUTES_MS = 600_000;
+export const LONG_FETCH_TIMEOUT_MS = 1_080_000;

--- a/packages/ai/src/utils/undici-dispatcher.ts
+++ b/packages/ai/src/utils/undici-dispatcher.ts
@@ -1,11 +1,11 @@
-import { TEN_MINUTES_MS } from "@notra/ai/constants/repo-image";
+import { LONG_FETCH_TIMEOUT_MS } from "@notra/ai/constants/repo-image";
 import { Agent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
 
 export async function withLongFetchTimeouts<T>(callback: () => Promise<T>) {
   const previousDispatcher = getGlobalDispatcher();
   const dispatcher = new Agent({
-    headersTimeout: TEN_MINUTES_MS,
-    bodyTimeout: TEN_MINUTES_MS,
+    headersTimeout: LONG_FETCH_TIMEOUT_MS,
+    bodyTimeout: LONG_FETCH_TIMEOUT_MS,
     keepAliveTimeout: 60_000,
   });
 


### PR DESCRIPTION
### Description
Harden repo image generation against intermittent Upstash Box stream timeouts.

This doubles the main Box agent timeout, raises the long fetch timeout above it, and treats `Stream timed out` / `Run timed out` as recoverable when the agent already wrote `/workspace/home/output.html`. If the artifact is still missing, the existing recovery prompt is attempted instead of failing immediately.

### Screenshot/Recording (if applicable)
N/A. Backend reliability fix.

### Verification
- `bun run --filter=@notra/ai check-types`
- `bunx ultracite check packages/ai/src/constants/repo-image.ts packages/ai/src/utils/undici-dispatcher.ts packages/ai/src/agents/repo-image.ts`
- Commit hook ran `ultracite fix`, `knip`, and `commitlint`; `ultracite` reported existing warnings outside this change but did not fail.

AI assistance disclosure: Codex was used to investigate and draft this change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened repo image generation against intermittent `@upstash/box` stream timeouts to improve reliability without changing behavior or UI.

- **Bug Fixes**
  - Doubled agent timeout to 960,000 ms.
  - Longer fetch timeouts via `LONG_FETCH_TIMEOUT_MS` (1,080,000 ms) in `undici` dispatcher.
  - Treat “Stream timed out” / “Run timed out” as recoverable: check `/workspace/home/output.html`; if missing, run recovery prompt. Only the initial run may allow timeout; revision runs require completion. Added stream timing logs and safe handling when a timed-out run returns no cost.
  - Fixed `sanitize-html-links` replacements to preserve spacing and prefixes when overriding `href`, `rel`, and `target`.

- **Refactors**
  - Moved sanitize HTML link regex constants to `apps/web/src/lib/sanitize-html-links/constants.ts` and updated imports.

<sup>Written for commit 15a2a0063502d621cf897574e197e58edec21c10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

