### PR TITLE
feat(web): add sidebar with sticky toc to blog posts

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     turbopackFileSystemCacheForDev: false,
+    viewTransition: true,
   },
   transpilePackages: ["@notra/ui"],
   rewrites: async () => {

--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,5 +1,9 @@
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
+import { ViewTransition } from "react";
 import { BlogArticle } from "@/components/blog-article";
 import { BlogCopyArticle } from "@/components/blog-copy-article";
 import { BlogPostSidebar } from "@/components/blog-post-sidebar";
@@ -13,6 +17,7 @@ import {
   buildBlogFaqJsonLd,
 } from "@/utils/blog-jsonld";
 import { extractBlogToc } from "@/utils/blog-toc";
+import { blogPostTitleTransitionName } from "@/utils/blog-view-transitions";
 import { highlightCodeBlocks } from "@/utils/highlight-code";
 import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
@@ -106,13 +111,29 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 
       <div className="grid w-full grid-cols-1 gap-x-16 gap-y-12 lg:grid-cols-[minmax(0,1fr)_16rem]">
         <article className="min-w-0 [&_h2]:scroll-mt-24 [&_h3]:scroll-mt-24 [&_h4]:scroll-mt-24">
+          <ViewTransition name="blog-back-button">
+            <Link
+              className="group mb-6 inline-flex items-center gap-2 font-mono text-neutral-500 text-sm transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-50"
+              href="/blog"
+            >
+              <HugeiconsIcon
+                className="group-hover:-translate-x-0.5 size-4 transition-transform"
+                icon={ArrowLeft02Icon}
+                strokeWidth={2}
+              />
+              Back to blog
+            </Link>
+          </ViewTransition>
+
           <time className="block font-mono text-neutral-700 text-sm dark:text-neutral-200">
             Published {formatBlogDate(post.createdAt)}
           </time>
 
-          <h1 className="mt-6 max-w-3xl text-balance font-sans font-semibold text-4xl leading-[1.05] tracking-tight sm:text-5xl">
-            {post.title}
-          </h1>
+          <ViewTransition name={blogPostTitleTransitionName(slug)}>
+            <h1 className="mt-6 max-w-3xl text-balance font-sans font-semibold text-4xl leading-[1.05] tracking-tight sm:text-5xl">
+              {post.title}
+            </h1>
+          </ViewTransition>
 
           <div className="mt-6 flex flex-wrap items-center justify-between gap-4 border-border border-b pb-6">
             <span className="font-mono text-neutral-700 text-sm dark:text-neutral-200">

--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,14 +1,8 @@
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@notra/ui/components/ui/avatar";
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BlogArticle } from "@/components/blog-article";
 import { BlogCopyArticle } from "@/components/blog-copy-article";
-import { getAuthorHref } from "@/utils/authors";
+import { BlogPostSidebar } from "@/components/blog-post-sidebar";
 import {
   formatBlogDate,
   getNotraBlogPostBySlug,
@@ -18,6 +12,7 @@ import {
   buildBlogArticleJsonLd,
   buildBlogFaqJsonLd,
 } from "@/utils/blog-jsonld";
+import { extractBlogToc } from "@/utils/blog-toc";
 import { highlightCodeBlocks } from "@/utils/highlight-code";
 import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
@@ -78,9 +73,9 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
   const url = `${SITE_URL}/blog/${slug}`;
   const markdownUrl = `${SITE_URL}/blog/${slug}.md`;
   const imageUrl = `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`;
-  const content = await highlightCodeBlocks(post.content);
+  const { html: htmlWithIds, toc } = extractBlogToc(post.content);
+  const content = await highlightCodeBlocks(htmlWithIds);
   const readingMinutes = getReadingTimeMinutes(post.markdown);
-  const author = post.authors.at(0) ?? null;
   const articleJsonLd = buildBlogArticleJsonLd({ post, url, imageUrl });
   const faqJsonLd = buildBlogFaqJsonLd(post);
   const breadcrumbJsonLd = buildBreadcrumbJsonLd([
@@ -109,44 +104,33 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
         />
       ) : null}
 
-      <time className="block font-mono text-foreground/40 text-sm">
-        Published {formatBlogDate(post.createdAt)}
-      </time>
+      <div className="grid w-full grid-cols-1 gap-x-16 gap-y-12 lg:grid-cols-[minmax(0,1fr)_16rem]">
+        <article className="min-w-0 [&_h2]:scroll-mt-24 [&_h3]:scroll-mt-24 [&_h4]:scroll-mt-24">
+          <time className="block font-mono text-neutral-700 text-sm dark:text-neutral-200">
+            Published {formatBlogDate(post.createdAt)}
+          </time>
 
-      <h1 className="mt-6 max-w-3xl text-balance font-sans font-semibold text-4xl leading-[1.05] tracking-tight sm:text-5xl">
-        {post.title}
-      </h1>
+          <h1 className="mt-6 max-w-3xl text-balance font-sans font-semibold text-4xl leading-[1.05] tracking-tight sm:text-5xl">
+            {post.title}
+          </h1>
 
-      <div className="mt-6 flex flex-wrap items-center justify-between gap-4 border-border border-b pb-6">
-        <div className="flex items-center gap-3 font-mono text-foreground/50 text-sm">
-          <span>{readingMinutes} min read</span>
-          {author ? (
-            <>
-              <span aria-hidden="true">&middot;</span>
-              <Link
-                className="inline-flex items-center gap-2 transition-colors hover:text-foreground"
-                href={getAuthorHref(author.slug)}
-              >
-                <Avatar size="sm">
-                  {author.image ? (
-                    <AvatarImage alt={author.name} src={author.image} />
-                  ) : null}
-                  <AvatarFallback>{author.name.charAt(0)}</AvatarFallback>
-                </Avatar>
-                <span>{author.name}</span>
-              </Link>
-            </>
-          ) : null}
-        </div>
+          <div className="mt-6 flex flex-wrap items-center justify-between gap-4 border-border border-b pb-6">
+            <span className="font-mono text-neutral-700 text-sm dark:text-neutral-200">
+              {readingMinutes} min read
+            </span>
 
-        <BlogCopyArticle
-          markdown={post.markdown}
-          markdownUrl={markdownUrl}
-          title={post.title}
-        />
+            <BlogCopyArticle
+              markdown={post.markdown}
+              markdownUrl={markdownUrl}
+              title={post.title}
+            />
+          </div>
+
+          <BlogArticle html={content} />
+        </article>
+
+        <BlogPostSidebar authors={post.authors} toc={toc} />
       </div>
-
-      <BlogArticle html={content} />
     </>
   );
 }

--- a/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
 import { buttonVariants } from "@notra/ui/components/ui/button";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { ViewTransition } from "react";
 import { BlogPostCard } from "@/components/blog-post-card";
 import { resolveSocialLink } from "@/utils/author-socials";
 import {
@@ -15,6 +16,10 @@ import {
   listNotraAuthors,
 } from "@/utils/authors";
 import { buildBlogCardItems, listNotraBlogPosts } from "@/utils/blog";
+import {
+  blogAuthorAvatarTransitionName,
+  blogAuthorNameTransitionName,
+} from "@/utils/blog-view-transitions";
 import { TWITTER_HANDLE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";
 import type { BlogAuthorPageProps } from "~types/blog";
@@ -82,19 +87,23 @@ export default async function BlogAuthorPage({ params }: BlogAuthorPageProps) {
   return (
     <div className="mx-auto w-full max-w-220">
       <div className="flex flex-col items-start gap-5">
-        <Avatar className="size-20" size="default">
-          {author.image ? (
-            <AvatarImage alt={author.name} src={author.image} />
-          ) : null}
-          <AvatarFallback className="text-2xl">
-            {author.name.charAt(0)}
-          </AvatarFallback>
-        </Avatar>
+        <ViewTransition name={blogAuthorAvatarTransitionName(author.slug)}>
+          <Avatar className="size-20" size="default">
+            {author.image ? (
+              <AvatarImage alt={author.name} src={author.image} />
+            ) : null}
+            <AvatarFallback className="text-2xl">
+              {author.name.charAt(0)}
+            </AvatarFallback>
+          </Avatar>
+        </ViewTransition>
 
         <div className="flex flex-col gap-1">
-          <h1 className="font-sans font-semibold text-4xl tracking-tight">
-            {author.name}
-          </h1>
+          <ViewTransition name={blogAuthorNameTransitionName(author.slug)}>
+            <h1 className="font-sans font-semibold text-4xl tracking-tight">
+              {author.name}
+            </h1>
+          </ViewTransition>
           {author.role ? (
             <p className="font-mono text-foreground/50 text-sm">
               {author.role}

--- a/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/author/[slug]/page.tsx
@@ -80,7 +80,7 @@ export default async function BlogAuthorPage({ params }: BlogAuthorPageProps) {
   const postLabel = authorPosts.length === 1 ? "post" : "posts";
 
   return (
-    <>
+    <div className="mx-auto w-full max-w-220">
       <div className="flex flex-col items-start gap-5">
         <Avatar className="size-20" size="default">
           {author.image ? (
@@ -103,24 +103,28 @@ export default async function BlogAuthorPage({ params }: BlogAuthorPageProps) {
         </div>
 
         {socials.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
+          <ul className="flex flex-wrap gap-2">
             {socials.map((social) => (
-              <a
-                aria-label={social.displayUrl}
-                className={buttonVariants({ size: "icon", variant: "outline" })}
-                href={social.url}
-                key={social.url}
-                rel="noopener"
-                target="_blank"
-              >
-                <HugeiconsIcon
-                  className="size-4"
-                  icon={social.icon}
-                  strokeWidth={2}
-                />
-              </a>
+              <li key={social.url}>
+                <a
+                  aria-label={social.displayUrl}
+                  className={buttonVariants({
+                    size: "icon",
+                    variant: "outline",
+                  })}
+                  href={social.url}
+                  rel="noopener"
+                  target="_blank"
+                >
+                  <HugeiconsIcon
+                    className="size-4"
+                    icon={social.icon}
+                    strokeWidth={2}
+                  />
+                </a>
+              </li>
             ))}
-          </div>
+          </ul>
         ) : null}
       </div>
 
@@ -130,17 +134,19 @@ export default async function BlogAuthorPage({ params }: BlogAuthorPageProps) {
         </h2>
 
         {cardItems.length > 0 ? (
-          <div className="mt-6 grid w-full grid-cols-1 gap-x-8 gap-y-12 sm:grid-cols-2">
+          <ul className="mt-6 grid w-full grid-cols-1 gap-x-8 gap-y-12 sm:grid-cols-2">
             {cardItems.map((item) => (
-              <BlogPostCard item={item} key={item.id} />
+              <li className="h-full" key={item.id}>
+                <BlogPostCard item={item} />
+              </li>
             ))}
-          </div>
+          </ul>
         ) : (
           <p className="mt-4 font-sans text-muted-foreground text-sm leading-6">
             No posts published yet.
           </p>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/app/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(blog)/blog/page.tsx
@@ -36,7 +36,7 @@ export default async function BlogPage() {
   const cardItems = buildBlogCardItems(posts);
 
   return (
-    <>
+    <div className="mx-auto w-full max-w-220">
       <div className="flex w-full flex-col items-start gap-4">
         <h1 className="text-balance font-sans font-semibold text-4xl text-foreground leading-tight tracking-tight md:text-6xl">
           The Notra <span className="text-primary">Blog</span>
@@ -58,12 +58,14 @@ export default async function BlogPage() {
           </div>
         </div>
       ) : (
-        <div className="mt-14 grid w-full grid-cols-1 gap-x-8 gap-y-12 sm:grid-cols-2">
+        <ul className="mt-14 grid w-full grid-cols-1 gap-x-8 gap-y-12 sm:grid-cols-2">
           {cardItems.map((item) => (
-            <BlogPostCard item={item} key={item.id} />
+            <li className="h-full" key={item.id}>
+              <BlogPostCard item={item} />
+            </li>
           ))}
-        </div>
+        </ul>
       )}
-    </>
+    </div>
   );
 }

--- a/apps/web/src/app/(blog)/layout.tsx
+++ b/apps/web/src/app/(blog)/layout.tsx
@@ -5,7 +5,7 @@ export default function BlogLayout({
 }) {
   return (
     <>
-      <div className="mx-auto flex w-full max-w-220 flex-col items-stretch px-4 pt-24 pb-16 sm:px-6 sm:pt-28 md:px-8 md:pt-32 lg:px-0">
+      <div className="mx-auto flex w-full max-w-7xl flex-col items-stretch px-4 pt-24 pb-16 sm:px-6 sm:pt-28 md:px-8 md:pt-32 lg:px-12">
         {children}
       </div>
       <div className="w-full border-border border-t" />

--- a/apps/web/src/components/blog-post-author-card.tsx
+++ b/apps/web/src/components/blog-post-author-card.tsx
@@ -4,7 +4,12 @@ import {
   AvatarImage,
 } from "@notra/ui/components/ui/avatar";
 import Link from "next/link";
+import { ViewTransition } from "react";
 import { getAuthorHref } from "@/utils/authors";
+import {
+  blogAuthorAvatarTransitionName,
+  blogAuthorNameTransitionName,
+} from "@/utils/blog-view-transitions";
 import type { BlogPostAuthorCardProps } from "~types/blog";
 
 export function BlogPostAuthorCard({ authors }: BlogPostAuthorCardProps) {
@@ -24,16 +29,24 @@ export function BlogPostAuthorCard({ authors }: BlogPostAuthorCardProps) {
               className="group flex items-center gap-3"
               href={getAuthorHref(author.slug)}
             >
-              <Avatar size="sm">
-                {author.image ? (
-                  <AvatarImage alt={author.name} src={author.image} />
-                ) : null}
-                <AvatarFallback>{author.name.charAt(0)}</AvatarFallback>
-              </Avatar>
+              <ViewTransition
+                name={blogAuthorAvatarTransitionName(author.slug)}
+              >
+                <Avatar size="sm">
+                  {author.image ? (
+                    <AvatarImage alt={author.name} src={author.image} />
+                  ) : null}
+                  <AvatarFallback>{author.name.charAt(0)}</AvatarFallback>
+                </Avatar>
+              </ViewTransition>
               <span className="flex flex-col">
-                <span className="font-medium font-sans text-neutral-700 text-sm leading-tight transition-colors group-hover:text-foreground dark:text-neutral-200">
-                  {author.name}
-                </span>
+                <ViewTransition
+                  name={blogAuthorNameTransitionName(author.slug)}
+                >
+                  <span className="font-medium font-sans text-neutral-700 text-sm leading-tight transition-colors group-hover:text-foreground dark:text-neutral-200">
+                    {author.name}
+                  </span>
+                </ViewTransition>
                 {author.role ? (
                   <span className="mt-0.5 font-sans text-neutral-500 text-xs leading-tight dark:text-neutral-400">
                     {author.role}

--- a/apps/web/src/components/blog-post-author-card.tsx
+++ b/apps/web/src/components/blog-post-author-card.tsx
@@ -1,0 +1,49 @@
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
+import Link from "next/link";
+import { getAuthorHref } from "@/utils/authors";
+import type { BlogPostAuthorCardProps } from "~types/blog";
+
+export function BlogPostAuthorCard({ authors }: BlogPostAuthorCardProps) {
+  if (authors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <p className="mb-3 font-medium font-sans text-foreground text-sm">
+        Written by
+      </p>
+      <ul className="flex flex-col gap-3">
+        {authors.map((author) => (
+          <li key={author.id}>
+            <Link
+              className="group flex items-center gap-3"
+              href={getAuthorHref(author.slug)}
+            >
+              <Avatar size="sm">
+                {author.image ? (
+                  <AvatarImage alt={author.name} src={author.image} />
+                ) : null}
+                <AvatarFallback>{author.name.charAt(0)}</AvatarFallback>
+              </Avatar>
+              <span className="flex flex-col">
+                <span className="font-medium font-sans text-neutral-700 text-sm leading-tight transition-colors group-hover:text-foreground dark:text-neutral-200">
+                  {author.name}
+                </span>
+                {author.role ? (
+                  <span className="mt-0.5 font-sans text-neutral-500 text-xs leading-tight dark:text-neutral-400">
+                    {author.role}
+                  </span>
+                ) : null}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/blog-post-card.tsx
+++ b/apps/web/src/components/blog-post-card.tsx
@@ -4,16 +4,20 @@ import {
   AvatarImage,
 } from "@notra/ui/components/ui/avatar";
 import Link from "next/link";
+import { ViewTransition } from "react";
 import { formatBlogDate } from "@/utils/blog";
+import { blogPostTitleTransitionName } from "@/utils/blog-view-transitions";
 import type { BlogPostCardProps } from "~types/blog";
 
 export function BlogPostCard({ item }: BlogPostCardProps) {
   return (
     <article className="group flex h-full flex-col">
       <Link className="flex flex-col gap-3" href={item.href}>
-        <h2 className="font-sans font-semibold text-foreground text-xl tracking-tight transition-colors group-hover:text-primary sm:text-2xl">
-          {item.title}
-        </h2>
+        <ViewTransition name={blogPostTitleTransitionName(item.slug)}>
+          <h2 className="font-sans font-semibold text-foreground text-xl tracking-tight transition-colors group-hover:text-primary sm:text-2xl">
+            {item.title}
+          </h2>
+        </ViewTransition>
         <p className="line-clamp-3 font-sans text-base text-muted-foreground leading-7">
           {item.description}
         </p>

--- a/apps/web/src/components/blog-post-sidebar.tsx
+++ b/apps/web/src/components/blog-post-sidebar.tsx
@@ -1,0 +1,14 @@
+import { BlogPostAuthorCard } from "@/components/blog-post-author-card";
+import { BlogPostToc } from "@/components/blog-post-toc";
+import type { BlogPostSidebarProps } from "~types/blog";
+
+export function BlogPostSidebar({ authors, toc }: BlogPostSidebarProps) {
+  return (
+    <aside className="hidden lg:block">
+      <BlogPostAuthorCard authors={authors} />
+      <div className="sticky top-8 mt-8">
+        <BlogPostToc toc={toc} />
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/blog-post-toc.tsx
+++ b/apps/web/src/components/blog-post-toc.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import type { TOCItemType } from "fumadocs-core/toc";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { BlogPostTocProps } from "~types/blog";
+
+const TOC_DEPTHS = [2, 3] as const;
+const SCROLL_OFFSET_PX = 48;
+const PATH_TRACK_WIDTH = 20;
+const X_BY_DEPTH: Record<number, number> = {
+  2: 1,
+  3: 13,
+};
+const FALLBACK_X = 1;
+const TRANSITION_INSET = 5;
+const SCROLL_LOCK_FALLBACK_MS = 900;
+
+interface TocPosition {
+  id: string;
+  depth: number;
+  top: number;
+  height: number;
+}
+
+function getHeadingId(item: TOCItemType) {
+  return item.url.startsWith("#") ? item.url.slice(1) : item.url;
+}
+
+function scrollToHeading(id: string) {
+  const target = document.getElementById(id);
+  if (!target) {
+    return;
+  }
+  const rect = target.getBoundingClientRect();
+  const top = rect.top + window.scrollY - SCROLL_OFFSET_PX;
+  window.scrollTo({ top, behavior: "smooth" });
+  if (typeof history !== "undefined") {
+    history.replaceState(null, "", `#${id}`);
+  }
+}
+
+function buildPath(positions: TocPosition[]) {
+  if (positions.length === 0) {
+    return "";
+  }
+
+  const segments = positions.map((position, index) => {
+    const x = X_BY_DEPTH[position.depth] ?? FALLBACK_X;
+    const prev = positions[index - 1];
+    const next = positions[index + 1];
+    const prevX = prev ? (X_BY_DEPTH[prev.depth] ?? FALLBACK_X) : x;
+    const nextX = next ? (X_BY_DEPTH[next.depth] ?? FALLBACK_X) : x;
+    const startY =
+      prev && prevX !== x ? position.top + TRANSITION_INSET : position.top;
+    const endY =
+      next && nextX !== x
+        ? position.top + position.height - TRANSITION_INSET
+        : position.top + position.height;
+    return { x, startY, endY };
+  });
+
+  const first = segments[0];
+  if (!first) {
+    return "";
+  }
+
+  let d = `M ${first.x} ${first.startY}`;
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    if (!segment) {
+      continue;
+    }
+    d += ` L ${segment.x} ${segment.endY}`;
+    const next = segments[i + 1];
+    if (next) {
+      d += ` L ${next.x} ${next.startY}`;
+    }
+  }
+
+  return d;
+}
+
+export function BlogPostToc({ toc }: BlogPostTocProps) {
+  const items = useMemo(
+    () =>
+      toc.filter((item) =>
+        (TOC_DEPTHS as readonly number[]).includes(item.depth)
+      ),
+    [toc]
+  );
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [positions, setPositions] = useState<TocPosition[]>([]);
+  const listRef = useRef<HTMLUListElement>(null);
+  const linkRefs = useRef(new Map<string, HTMLAnchorElement>());
+  const scrollLockRef = useRef(false);
+  const scrollLockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function lockScrollSpy() {
+    scrollLockRef.current = true;
+    if (scrollLockTimerRef.current) {
+      clearTimeout(scrollLockTimerRef.current);
+    }
+    scrollLockTimerRef.current = setTimeout(() => {
+      scrollLockRef.current = false;
+    }, SCROLL_LOCK_FALLBACK_MS);
+  }
+
+  useEffect(() => {
+    function handleScrollEnd() {
+      scrollLockRef.current = false;
+      if (scrollLockTimerRef.current) {
+        clearTimeout(scrollLockTimerRef.current);
+        scrollLockTimerRef.current = null;
+      }
+    }
+    if (!("onscrollend" in window)) {
+      return;
+    }
+    window.addEventListener("scrollend", handleScrollEnd);
+    return () => window.removeEventListener("scrollend", handleScrollEnd);
+  }, []);
+
+  useLayoutEffect(() => {
+    function measure() {
+      const next: TocPosition[] = [];
+      for (const item of items) {
+        const id = getHeadingId(item);
+        const link = linkRefs.current.get(id);
+        if (!link) {
+          continue;
+        }
+        next.push({
+          id,
+          depth: item.depth,
+          top: link.offsetTop,
+          height: link.offsetHeight,
+        });
+      }
+      setPositions(next);
+    }
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    const list = listRef.current;
+    if (list) {
+      observer.observe(list);
+    }
+    window.addEventListener("resize", measure);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [items]);
+
+  useEffect(() => {
+    if (items.length === 0) {
+      return;
+    }
+    const headings = items
+      .map((item) => document.getElementById(getHeadingId(item)))
+      .filter((element): element is HTMLElement => element !== null);
+
+    if (headings.length === 0) {
+      return;
+    }
+
+    function update() {
+      if (scrollLockRef.current) {
+        return;
+      }
+      const scrollY = window.scrollY + SCROLL_OFFSET_PX + 8;
+      let current: string | null = headings[0]?.id ?? null;
+      for (const heading of headings) {
+        if (heading.offsetTop <= scrollY) {
+          current = heading.id;
+        } else {
+          break;
+        }
+      }
+      setActiveId(current);
+    }
+
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [items]);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const lastPosition = positions.at(-1);
+  const containerHeight = lastPosition
+    ? lastPosition.top + lastPosition.height
+    : 0;
+  const pathD = buildPath(positions);
+  const activePos = activeId
+    ? (positions.find((p) => p.id === activeId) ?? null)
+    : null;
+  const clipPath = activePos
+    ? `inset(${activePos.top}px 0px ${Math.max(
+        0,
+        containerHeight - activePos.top - activePos.height
+      )}px 0px)`
+    : "inset(100% 0px 0px 0px)";
+
+  return (
+    <nav aria-label="On this page" className="not-prose">
+      <p className="mb-3 font-medium font-sans text-foreground text-sm">
+        On this page
+      </p>
+      <div className="relative">
+        {positions.length > 0 && containerHeight > 0 ? (
+          <>
+            <svg
+              aria-hidden="true"
+              className="pointer-events-none absolute top-0 left-0 text-border"
+              height={containerHeight}
+              preserveAspectRatio="none"
+              viewBox={`0 0 ${PATH_TRACK_WIDTH} ${containerHeight}`}
+              width={PATH_TRACK_WIDTH}
+            >
+              <path
+                d={pathD}
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              className="pointer-events-none absolute top-0 left-0 text-foreground transition-[clip-path] duration-300 ease-out"
+              height={containerHeight}
+              preserveAspectRatio="none"
+              style={{ clipPath }}
+              viewBox={`0 0 ${PATH_TRACK_WIDTH} ${containerHeight}`}
+              width={PATH_TRACK_WIDTH}
+            >
+              <path
+                d={pathD}
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+              />
+            </svg>
+          </>
+        ) : null}
+        <ul className="flex flex-col" ref={listRef}>
+          {items.map((item) => {
+            const id = getHeadingId(item);
+            const isActive = id === activeId;
+            const indent = item.depth === 3 ? "pl-7" : "pl-4";
+            return (
+              <li key={item.url}>
+                <a
+                  className={`block py-1.5 font-sans text-sm leading-snug transition-colors ${indent} ${
+                    isActive
+                      ? "text-foreground"
+                      : "text-neutral-500 hover:text-foreground dark:text-neutral-400"
+                  }`}
+                  href={item.url}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    lockScrollSpy();
+                    setActiveId(id);
+                    scrollToHeading(id);
+                  }}
+                  ref={(node) => {
+                    if (node) {
+                      linkRefs.current.set(id, node);
+                    } else {
+                      linkRefs.current.delete(id);
+                    }
+                  }}
+                >
+                  {item.title}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/site-shell.tsx
+++ b/apps/web/src/components/site-shell.tsx
@@ -12,7 +12,7 @@ export function SiteShell({ children }: SiteShellProps) {
           <div className="absolute top-0 left-4 z-0 h-full w-px bg-border/60 [-webkit-mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] [mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] sm:left-6 md:left-8 lg:left-0" />
           <div className="absolute top-0 right-4 z-0 h-full w-px bg-border/60 [-webkit-mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] [mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] sm:right-6 md:right-8 lg:right-0" />
 
-          <div className="relative z-10 flex flex-col items-center self-stretch pt-2.25 pb-8 md:pb-12">
+          <div className="relative z-10 flex flex-col items-center self-stretch pt-4 pb-8 md:pb-12">
             <Navbar />
             {children}
             <div className="w-full">

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -379,6 +379,17 @@
   }
 }
 
+::view-transition-group(*) {
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -387,5 +398,11 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
   }
 }

--- a/apps/web/src/utils/blog-toc.ts
+++ b/apps/web/src/utils/blog-toc.ts
@@ -74,11 +74,15 @@ export function extractBlogToc(html: string): {
         depth: Number(levelGroup),
       });
 
-      if (existingId) {
+      if (existingId === id) {
         return match;
       }
 
-      return `<h${levelGroup}${attributes} id="${id}">${content}</h${levelGroup}>`;
+      const attributesWithoutId = existingId
+        ? attributes.replace(ID_ATTRIBUTE_REGEX, "")
+        : attributes;
+
+      return `<h${levelGroup}${attributesWithoutId} id="${id}">${content}</h${levelGroup}>`;
     }
   );
 

--- a/apps/web/src/utils/blog-toc.ts
+++ b/apps/web/src/utils/blog-toc.ts
@@ -1,0 +1,86 @@
+import type { TOCItemType } from "fumadocs-core/toc";
+import { HTML_ENTITY_MAP, HTML_ENTITY_REGEX } from "@/utils/constants";
+
+const HEADING_WITH_TAG_REGEX = /<h([2-4])([^>]*)>([\s\S]*?)<\/h\1>/gi;
+const HTML_TAG_REGEX = /<[^>]+>/g;
+const WHITESPACE_REGEX = /\s+/g;
+const ID_ATTRIBUTE_REGEX = /\sid\s*=\s*["']([^"']+)["']/i;
+const DIACRITICS_REGEX = /[̀-ͯ]/g;
+const NON_ALPHANUM_REGEX = /[^a-z0-9]+/g;
+const TRIM_DASHES_REGEX = /^-+|-+$/g;
+const SLUG_FALLBACK = "section";
+
+function decodeHtmlEntities(value: string) {
+  return value.replace(
+    HTML_ENTITY_REGEX,
+    (match, entity: string) => HTML_ENTITY_MAP[entity] ?? match
+  );
+}
+
+function stripHtml(value: string) {
+  return decodeHtmlEntities(value.replace(HTML_TAG_REGEX, ""))
+    .replace(WHITESPACE_REGEX, " ")
+    .trim();
+}
+
+function slugify(value: string) {
+  const slug = value
+    .normalize("NFKD")
+    .replace(DIACRITICS_REGEX, "")
+    .toLowerCase()
+    .replace(NON_ALPHANUM_REGEX, "-")
+    .replace(TRIM_DASHES_REGEX, "");
+  return slug || SLUG_FALLBACK;
+}
+
+function ensureUnique(base: string, used: Set<string>) {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  let suffix = 2;
+  let candidate = `${base}-${suffix}`;
+  while (used.has(candidate)) {
+    suffix += 1;
+    candidate = `${base}-${suffix}`;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+export function extractBlogToc(html: string): {
+  html: string;
+  toc: TOCItemType[];
+} {
+  const toc: TOCItemType[] = [];
+  const used = new Set<string>();
+
+  const transformed = html.replace(
+    HEADING_WITH_TAG_REGEX,
+    (match, levelGroup: string, attributes: string, content: string) => {
+      const text = stripHtml(content);
+      if (text.length === 0) {
+        return match;
+      }
+
+      const existingId = attributes.match(ID_ATTRIBUTE_REGEX)?.[1];
+      const id = existingId
+        ? ensureUnique(existingId, used)
+        : ensureUnique(slugify(text), used);
+
+      toc.push({
+        title: text,
+        url: `#${id}`,
+        depth: Number(levelGroup),
+      });
+
+      if (existingId) {
+        return match;
+      }
+
+      return `<h${levelGroup}${attributes} id="${id}">${content}</h${levelGroup}>`;
+    }
+  );
+
+  return { html: transformed, toc };
+}

--- a/apps/web/src/utils/blog-view-transitions.ts
+++ b/apps/web/src/utils/blog-view-transitions.ts
@@ -1,0 +1,8 @@
+export const blogPostTitleTransitionName = (slug: string) =>
+  `blog-post-title-${slug}`;
+
+export const blogAuthorAvatarTransitionName = (slug: string) =>
+  `blog-author-avatar-${slug}`;
+
+export const blogAuthorNameTransitionName = (slug: string) =>
+  `blog-author-name-${slug}`;

--- a/apps/web/src/utils/blog.ts
+++ b/apps/web/src/utils/blog.ts
@@ -165,6 +165,7 @@ export function buildBlogCardItems(posts: NotraBlogPost[]): BlogCardItem[] {
 
     return {
       id: post.id,
+      slug: post.slug,
       title: post.title,
       description: post.excerpt,
       href: getBlogPostHref(post.slug),

--- a/apps/web/types/blog.ts
+++ b/apps/web/types/blog.ts
@@ -76,6 +76,7 @@ interface BlogCardAuthor {
 
 export interface BlogCardItem {
   id: string;
+  slug: string;
   title: string;
   description: string;
   href: string;

--- a/apps/web/types/blog.ts
+++ b/apps/web/types/blog.ts
@@ -1,4 +1,5 @@
 import type { IconSvgElement } from "@hugeicons/react";
+import type { TOCItemType } from "fumadocs-core/toc";
 import type { ReactNode } from "react";
 
 export interface NotraAuthorSocial {
@@ -113,6 +114,19 @@ export interface BlogJsonLdInput {
 
 export interface BlogArticleProps {
   html: string;
+}
+
+export interface BlogPostAuthorCardProps {
+  authors: NotraBlogAuthor[];
+}
+
+export interface BlogPostTocProps {
+  toc: TOCItemType[];
+}
+
+export interface BlogPostSidebarProps {
+  authors: NotraBlogAuthor[];
+  toc: TOCItemType[];
 }
 
 export interface ResolvedSocialLink {

--- a/apps/web/types/react.d.ts
+++ b/apps/web/types/react.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react/canary" />


### PR DESCRIPTION
### Description
Restructures blog post pages with a two-column layout — article on the left, sidebar on the right containing the author block and a scroll-spy table of contents that pins as you scroll.

Implementation notes:
- New `blog-toc.ts` util walks the Marble HTML for `<h2>`–`<h4>`, injects unique slug IDs, and returns a `TOCItemType[]` list compatible with the existing `TableOfContents` component shape
- `BlogPostToc` renders the active-section indicator as an SVG path that bends through depth changes (h2 at `x=1`, h3 at `x=13`) with a 5px chamfered diagonal at each transition. A second SVG with `clip-path: inset(...)` is layered over the first to reveal only the active heading's segment
- Scroll-spy is locked during click-driven scrolls (via `scrollend` event with a 900ms fallback) so the indicator slides once to the destination instead of bouncing through every heading along the way
- Blog post card grids and the author social row are now `<ul>`/`<li>` for semantics
- Layout container widened to `max-w-7xl` to fit the new sidebar column; index and author pages wrap their content in an inner `max-w-220` to preserve their existing narrow look

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a right-hand sidebar with a sticky, scroll-spy TOC to blog posts and smooth shared-element view transitions across blog, post, and author pages. Introduces a two-column layout with an author card and aligns the navbar across pages.

- **New Features**
  - Extracts h2–h4 headings, injects unique IDs (rewrites duplicates), and builds the TOC via a new util.
  - Adds a scroll-spy TOC with an SVG path indicator that bends by depth and highlights the active section.
  - Locks the indicator during smooth-scroll clicks (uses `scrollend` with a fallback) to avoid bouncing.
  - New components: BlogPostToc, BlogPostSidebar, BlogPostAuthorCard.
  - Adds shared-element view transitions for blog titles and author avatar/name, plus a back link lane; enables Next.js `experimental.viewTransition` and tunes global timing with a reduced-motion fallback.

- **Refactors**
  - Switches blog cards and author social links to semantic `<ul>/<li>`.
  - Widens the blog layout to `max-w-7xl`; index and author pages are wrapped in `max-w-220` to preserve their narrow look.
  - Aligns the navbar y-position across pages by matching wrapper padding to the sticky offset.

<sup>Written for commit 88a7bda69fb8953e957e827879c93db16861ca1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

