### PR TITLE
feat(web): add prev/next pagination to blog posts

### DIFF
--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -6,10 +6,12 @@ import { notFound } from "next/navigation";
 import { ViewTransition } from "react";
 import { BlogArticle } from "@/components/blog-article";
 import { BlogCopyArticle } from "@/components/blog-copy-article";
+import { BlogPostPagination } from "@/components/blog-post-pagination";
 import { BlogPostSidebar } from "@/components/blog-post-sidebar";
 import {
   formatBlogDate,
   getNotraBlogPostBySlug,
+  getNotraBlogPostPagination,
   listNotraBlogPosts,
 } from "@/utils/blog";
 import {
@@ -81,6 +83,7 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
   const { html: htmlWithIds, toc } = extractBlogToc(post.content);
   const content = await highlightCodeBlocks(htmlWithIds);
   const readingMinutes = getReadingTimeMinutes(post.markdown);
+  const { previous, next } = await getNotraBlogPostPagination(slug);
   const articleJsonLd = buildBlogArticleJsonLd({ post, url, imageUrl });
   const faqJsonLd = buildBlogFaqJsonLd(post);
   const breadcrumbJsonLd = buildBreadcrumbJsonLd([
@@ -148,6 +151,8 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
           </div>
 
           <BlogArticle html={content} />
+
+          <BlogPostPagination next={next} previous={previous} />
         </article>
 
         <BlogPostSidebar authors={post.authors} toc={toc} />

--- a/apps/web/src/app/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(blog)/blog/[slug]/page.tsx
@@ -81,9 +81,11 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
   const markdownUrl = `${SITE_URL}/blog/${slug}.md`;
   const imageUrl = `${SITE_URL}${DEFAULT_SOCIAL_IMAGE.url}`;
   const { html: htmlWithIds, toc } = extractBlogToc(post.content);
-  const content = await highlightCodeBlocks(htmlWithIds);
   const readingMinutes = getReadingTimeMinutes(post.markdown);
-  const { previous, next } = await getNotraBlogPostPagination(slug);
+  const [content, { previous, next }] = await Promise.all([
+    highlightCodeBlocks(htmlWithIds),
+    getNotraBlogPostPagination(slug),
+  ]);
   const articleJsonLd = buildBlogArticleJsonLd({ post, url, imageUrl });
   const faqJsonLd = buildBlogFaqJsonLd(post);
   const breadcrumbJsonLd = buildBreadcrumbJsonLd([

--- a/apps/web/src/components/blog-pagination-card.tsx
+++ b/apps/web/src/components/blog-pagination-card.tsx
@@ -1,0 +1,69 @@
+import { ArrowLeft02Icon, ArrowRight02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
+import Link from "next/link";
+import type { BlogPaginationCardProps } from "~types/blog";
+
+export function BlogPaginationCard({
+  link,
+  direction,
+}: BlogPaginationCardProps) {
+  const isPrevious = direction === "previous";
+  const label = isPrevious ? "Previous" : "Next";
+  const icon = isPrevious ? ArrowLeft02Icon : ArrowRight02Icon;
+  const containerAlignment = isPrevious
+    ? "items-start text-left"
+    : "items-end text-right";
+  const authorRowDirection = isPrevious ? "flex-row" : "flex-row-reverse";
+
+  return (
+    <Link
+      className={`group flex h-full flex-col gap-3 rounded-xl border border-border bg-card p-5 transition-colors hover:border-foreground/20 hover:bg-neutral-50 dark:hover:bg-white/5 ${containerAlignment}`}
+      href={link.href}
+    >
+      <span className="flex items-center gap-1 font-mono text-neutral-500 text-xs dark:text-neutral-400">
+        {isPrevious ? (
+          <>
+            <HugeiconsIcon
+              className="group-hover:-translate-x-0.5 size-3.5 transition-transform"
+              icon={icon}
+              strokeWidth={2}
+            />
+            {label}
+          </>
+        ) : (
+          <>
+            {label}
+            <HugeiconsIcon
+              className="size-3.5 transition-transform group-hover:translate-x-0.5"
+              icon={icon}
+              strokeWidth={2}
+            />
+          </>
+        )}
+      </span>
+      <h3 className="line-clamp-2 font-sans font-semibold text-base text-foreground leading-snug transition-colors group-hover:text-primary">
+        {link.title}
+      </h3>
+      {link.author ? (
+        <div
+          className={`mt-auto flex items-center gap-2 font-sans text-muted-foreground text-sm ${authorRowDirection}`}
+        >
+          <Avatar className="size-6" size="sm">
+            {link.author.image ? (
+              <AvatarImage alt={link.author.name} src={link.author.image} />
+            ) : null}
+            <AvatarFallback className="text-xs">
+              {link.author.name.charAt(0)}
+            </AvatarFallback>
+          </Avatar>
+          <span>{link.author.name}</span>
+        </div>
+      ) : null}
+    </Link>
+  );
+}

--- a/apps/web/src/components/blog-post-pagination.tsx
+++ b/apps/web/src/components/blog-post-pagination.tsx
@@ -1,0 +1,29 @@
+import { BlogPaginationCard } from "@/components/blog-pagination-card";
+import type { BlogPostPaginationProps } from "~types/blog";
+
+export function BlogPostPagination({
+  previous,
+  next,
+}: BlogPostPaginationProps) {
+  if (!(previous || next)) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Blog post navigation"
+      className="mt-16 grid gap-4 border-border border-t pt-8 sm:grid-cols-2"
+    >
+      {previous ? (
+        <BlogPaginationCard direction="previous" link={previous} />
+      ) : (
+        <div aria-hidden="true" className="hidden sm:block" />
+      )}
+      {next ? (
+        <BlogPaginationCard direction="next" link={next} />
+      ) : (
+        <div aria-hidden="true" className="hidden sm:block" />
+      )}
+    </nav>
+  );
+}

--- a/apps/web/src/utils/blog.ts
+++ b/apps/web/src/utils/blog.ts
@@ -12,7 +12,12 @@ import {
   listMarblePublishedPosts,
   type MarblePublishedPost,
 } from "@/utils/marble";
-import type { BlogCardItem, NotraBlogAuthor, NotraBlogPost } from "~types/blog";
+import type {
+  BlogCardItem,
+  BlogPaginationLink,
+  NotraBlogAuthor,
+  NotraBlogPost,
+} from "~types/blog";
 
 const BLOG_CONTENT_TYPE = "blog_post";
 const FALLBACK_EXCERPT_MAX_LENGTH = 160;
@@ -180,4 +185,39 @@ export function buildBlogCardItems(posts: NotraBlogPost[]): BlogCardItem[] {
         : null,
     };
   });
+}
+
+function buildBlogPaginationLink(post: NotraBlogPost): BlogPaginationLink {
+  const [primaryAuthor] = post.authors;
+
+  return {
+    slug: post.slug,
+    href: getBlogPostHref(post.slug),
+    title: post.title,
+    author: primaryAuthor
+      ? {
+          name: primaryAuthor.name,
+          image: primaryAuthor.image,
+          slug: primaryAuthor.slug,
+          href: getAuthorHref(primaryAuthor.slug),
+        }
+      : null,
+  };
+}
+
+export async function getNotraBlogPostPagination(slug: string) {
+  const posts = await listNotraBlogPosts();
+  const index = posts.findIndex((post) => post.slug === slug);
+
+  if (index === -1) {
+    return { previous: null, next: null };
+  }
+
+  const olderPost = posts[index + 1] ?? null;
+  const newerPost = posts[index - 1] ?? null;
+
+  return {
+    previous: olderPost ? buildBlogPaginationLink(olderPost) : null,
+    next: newerPost ? buildBlogPaginationLink(newerPost) : null,
+  };
 }

--- a/apps/web/src/utils/blog.ts
+++ b/apps/web/src/utils/blog.ts
@@ -13,6 +13,7 @@ import {
   type MarblePublishedPost,
 } from "@/utils/marble";
 import type {
+  BlogCardAuthor,
   BlogCardItem,
   BlogPaginationLink,
   NotraBlogAuthor,
@@ -164,44 +165,39 @@ export async function getNotraBlogPostBySlug(slug: string) {
   return posts.find((post) => post.slug === slug) ?? null;
 }
 
-export function buildBlogCardItems(posts: NotraBlogPost[]): BlogCardItem[] {
-  return posts.map((post) => {
-    const [primaryAuthor] = post.authors;
+function toBlogCardAuthor(
+  author: NotraBlogAuthor | undefined
+): BlogCardAuthor | null {
+  if (!author) {
+    return null;
+  }
 
-    return {
-      id: post.id,
-      slug: post.slug,
-      title: post.title,
-      description: post.excerpt,
-      href: getBlogPostHref(post.slug),
-      date: post.createdAt,
-      author: primaryAuthor
-        ? {
-            name: primaryAuthor.name,
-            image: primaryAuthor.image,
-            slug: primaryAuthor.slug,
-            href: getAuthorHref(primaryAuthor.slug),
-          }
-        : null,
-    };
-  });
+  return {
+    name: author.name,
+    image: author.image,
+    slug: author.slug,
+    href: getAuthorHref(author.slug),
+  };
+}
+
+export function buildBlogCardItems(posts: NotraBlogPost[]): BlogCardItem[] {
+  return posts.map((post) => ({
+    id: post.id,
+    slug: post.slug,
+    title: post.title,
+    description: post.excerpt,
+    href: getBlogPostHref(post.slug),
+    date: post.createdAt,
+    author: toBlogCardAuthor(post.authors[0]),
+  }));
 }
 
 function buildBlogPaginationLink(post: NotraBlogPost): BlogPaginationLink {
-  const [primaryAuthor] = post.authors;
-
   return {
     slug: post.slug,
     href: getBlogPostHref(post.slug),
     title: post.title,
-    author: primaryAuthor
-      ? {
-          name: primaryAuthor.name,
-          image: primaryAuthor.image,
-          slug: primaryAuthor.slug,
-          href: getAuthorHref(primaryAuthor.slug),
-        }
-      : null,
+    author: toBlogCardAuthor(post.authors[0]),
   };
 }
 

--- a/apps/web/types/blog.ts
+++ b/apps/web/types/blog.ts
@@ -67,7 +67,7 @@ interface BlogTimelineItem {
   date: string;
 }
 
-interface BlogCardAuthor {
+export interface BlogCardAuthor {
   name: string;
   image: string | null;
   slug: string;

--- a/apps/web/types/blog.ts
+++ b/apps/web/types/blog.ts
@@ -74,6 +74,23 @@ interface BlogCardAuthor {
   href: string;
 }
 
+export interface BlogPaginationLink {
+  slug: string;
+  href: string;
+  title: string;
+  author: BlogCardAuthor | null;
+}
+
+export interface BlogPostPaginationProps {
+  previous: BlogPaginationLink | null;
+  next: BlogPaginationLink | null;
+}
+
+export interface BlogPaginationCardProps {
+  link: BlogPaginationLink;
+  direction: "previous" | "next";
+}
+
 export interface BlogCardItem {
   id: string;
   slug: string;


### PR DESCRIPTION
### Description
Adds chronological prev/next navigation between blog posts, modeled after the docs.json-style cards but extended with the post's author avatar and name on each card. Previous links to the older post, Next links to the newer one. Lives below the article body inside the reading column so the sticky TOC sidebar stays untouched.

Organization:
- Types (`BlogPaginationLink`, `BlogPostPaginationProps`, `BlogPaginationCardProps`) in `apps/web/types/blog.ts`
- `getNotraBlogPostPagination` helper in `apps/web/src/utils/blog.ts` (reuses the existing cached post list)
- `BlogPaginationCard` and `BlogPostPagination` split into their own component files under `apps/web/src/components/`

Edge cases handled: first/last posts render only one card with a placeholder on the empty side, posts without an author hide the avatar row.

### Screenshot/Recording (if applicable)
n/a — see the file changes; matches existing blog card styling (rounded-xl, border-border, hover state).

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds previous/next navigation to blog posts with author avatar and name, placed below the article without touching the sticky TOC. Also refactors author mapping and parallelizes post page work to reduce render time.

- **New Features**
  - Added `getNotraBlogPostPagination` to fetch previous/next posts from the cached list.
  - Introduced `BlogPostPagination` and `BlogPaginationCard` to render directional cards with arrows.
  - Integrated into `apps/web/src/app/(blog)/blog/[slug]/page.tsx` after `BlogArticle`.
  - Handles edges (single card with placeholder) and hides the author row when missing.

- **Refactors**
  - Added `toBlogCardAuthor` to reuse author mapping in `buildBlogCardItems` and pagination links.
  - Parallelized `highlightCodeBlocks` and `getNotraBlogPostPagination` via `Promise.all` in the post page.

<sup>Written for commit 00a09abd69a97dcc0b380192d3b1198ba07a4817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

