### PR TITLE
feat(image): pass cherry-picked context into marketing image generation

### DIFF
--- a/apps/dashboard/src/lib/workflows/schedule/handlers/image.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/image.ts
@@ -102,10 +102,57 @@ export async function handleImage(
   }
 }
 
+function buildSelectedItemsContext(ctx: ContentGenerationContext): string {
+  const filters = ctx.selectionFilters;
+
+  if (!filters) {
+    return "";
+  }
+
+  const lines: string[] = [];
+
+  const commitShas = filters.allowedCommitShas ?? [];
+  if (commitShas.length > 0) {
+    lines.push(
+      `Commits: ${commitShas.join(", ")}. Read each one with \`git show <sha>\` to see exactly what code changed.`
+    );
+  }
+
+  const prNumbers = Object.values(
+    filters.allowedPullRequestNumbersByIntegrationId ?? {}
+  ).flat();
+  if (prNumbers.length > 0) {
+    lines.push(
+      `Pull requests: ${prNumbers.map((number) => `#${number}`).join(", ")}. Read each diff with \`gh pr diff <number>\` (or \`git show\` on its merge commit) to see exactly what code changed.`
+    );
+  }
+
+  const releaseTags = [
+    ...(filters.allowedReleaseTagsGlobal ?? []),
+    ...Object.values(filters.allowedReleaseTagsByIntegrationId ?? {}).flat(),
+  ];
+  if (releaseTags.length > 0) {
+    lines.push(
+      `Releases: ${releaseTags.join(", ")}. Inspect the code these tags introduced.`
+    );
+  }
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  return [
+    "This image must be about ONLY these specific items the user cherry-picked. Open the code they changed, understand what the change does for the user, and design the image around that outcome. Do not depict any other repository activity.",
+    ...lines,
+  ].join("\n");
+}
+
 function buildImagePrompt(ctx: ContentGenerationContext) {
+  const selectedItemsContext = buildSelectedItemsContext(ctx);
   const promptParts = [
     `Create a polished 1200x630 marketing asset for: ${ctx.promptInput.sourceTargets}.`,
-    `Use repository activity from ${ctx.promptInput.lookbackLabel} (${ctx.promptInput.lookbackStartIso} to ${ctx.promptInput.lookbackEndIso}).`,
+    selectedItemsContext ||
+      `Use repository activity from ${ctx.promptInput.lookbackLabel} (${ctx.promptInput.lookbackStartIso} to ${ctx.promptInput.lookbackEndIso}).`,
     ctx.promptInput.companyName
       ? `Company name: ${ctx.promptInput.companyName}.`
       : "",

--- a/packages/ai/src/prompts/marketing-assets.ts
+++ b/packages/ai/src/prompts/marketing-assets.ts
@@ -10,7 +10,7 @@ function describeSource(source: RepoImageSourceContext): string {
     return [
       "<source-type>prompt</source-type>",
       `<user-prompt>${source.prompt}</user-prompt>`,
-      `<guidance>If the prompt names a feature, page, route, or component (e.g. "chat", "billing", "editor"), find that feature in the repo and copy its visual style. Otherwise use the landing page.</guidance>`,
+      `<guidance>If the prompt names specific commits, pull requests, or releases, read the actual code they changed (\`git show <sha>\`, \`gh pr diff <number>\`) and design the image around what that change does for the user. If it names a feature, page, route, or component (e.g. "chat", "billing", "editor"), find that feature in the repo and copy its visual style. Otherwise use the landing page.</guidance>`,
     ].join("\n");
   }
   if (source.mode === "pr") {
@@ -20,7 +20,7 @@ function describeSource(source: RepoImageSourceContext): string {
       `<pr-title>${source.title}</pr-title>`,
       `<pr-body>${source.body.slice(0, 240)}</pr-body>`,
       `<top-files>${source.topFiles.slice(0, 6).join(", ")}</top-files>`,
-      `<guidance>Open the changed files. Use those components' visual style.</guidance>`,
+      `<guidance>This image is about pull request #${source.prNumber}. Read its actual diff with \`gh pr diff ${source.prNumber}\` or \`git show\` / \`git diff\` on the listed files, and open the changed files. Understand what the change does for the user, then design from those components' visual style.</guidance>`,
     ].join("\n");
   }
   return [
@@ -28,7 +28,7 @@ function describeSource(source: RepoImageSourceContext): string {
     `<commit-sha>${source.shortSha}</commit-sha>`,
     `<commit-message>${source.message.slice(0, 240)}</commit-message>`,
     `<top-files>${source.topFiles.slice(0, 6).join(", ")}</top-files>`,
-    `<guidance>Open the changed files. Use those components' visual style.</guidance>`,
+    `<guidance>This image is about commit ${source.shortSha}. Read its actual diff with \`git show ${source.shortSha}\`, and open the changed files. Understand what the change does for the user, then design from those components' visual style.</guidance>`,
   ].join("\n");
 }
 
@@ -78,6 +78,18 @@ Gather source material before designing. Skipping this step produces generic out
 5. Component translation: When the feature is built in JSX, TSX, or Vue, manually translate the real component markup into static HTML. Match components as they are actually composed in the app, not their isolated primitive definitions. Inspect the route or parent that uses them, then preserve the real visual hierarchy, labels, spacing, colors, surfaces, button variants, input/table/card states, and radius values as closely as possible. Convert class-based styles and design tokens into inline styles. You may scale components up to make the 1200x630 image stronger, but scaling must preserve proportions and spacing. Do not invent a generic marketing layout when a real component exists.
 </research>
 
+<image-plan>
+After research and before writing any HTML, write a short image plan that locks in the visual angle for this specific change. The plan is your own design brief; do not write it to ${REPO_IMAGE_OUTPUT_HTML_PATH}. Base it on what the changed code actually does for the user, not on the raw diff. Use exactly these five bolded sections, each one or a few short lines:
+
+- **Approach:** One sentence naming the visual strategy (e.g. "Outcome/benefit visual") and a because-clause justifying it from the nature of the change. Most backend, runtime, API, performance, and docs changes should show the user-felt outcome, not code or dashboards.
+- **Concept:** One sentence describing the single image idea, its focal subject, and what it implies.
+- **Layout:** Composition in 2-3 lines: the focal element and where it sits, what is cropped out (no full browser chrome or dashboard), the background treatment, and any subordinate supporting elements.
+- **Content:** The concrete elements to depict in 2-3 lines: real component, labels, rows, chips, status cues, and recognizable vendor or brand icons the change implies. Keep on-image text minimal.
+- **Style notes:** Aesthetic and guardrails in 1-2 lines: the repo's tokens and one accent color, plus the avoid-list (no code snippets, no charts, no version or PR eyebrows baked into the image).
+
+Then execute this plan: every HTML decision must follow it. If you deviate while designing, update the plan first so it stays the source of truth.
+</image-plan>
+
 <html-contract>
 The loaded satori and marketing-image-generation skills contain the general renderer rules, marketing workflow, anti-slop patterns, and quality checks. Follow them. These additional constraints are specific to this repo-image pipeline:
 
@@ -113,14 +125,15 @@ The HTML follows this shape (this is structure only; replace the content with ma
 </output-format>
 
 <the-ask>
-1. Run the research steps to gather tokens, brand assets, and the real component to translate.
-2. Design the 1200x630 image as inline-styled HTML following every rule in <html-contract>.
-3. Run the <quality-loop> on a draft until it would pass at Fortune 500 standards.
-4. Use the Write tool to create ${REPO_IMAGE_OUTPUT_HTML_PATH} with the final HTML. Stop after the file exists.
+1. Read the diff of the commit, PR, or release this image is about and run the research steps to gather tokens, brand assets, and the real component to translate.
+2. Write the <image-plan> for this specific change.
+3. Execute the plan: design the 1200x630 image as inline-styled HTML following the plan and every rule in <html-contract>.
+4. Run the <quality-loop> on a draft until it would pass at Fortune 500 standards and still matches the plan.
+5. Use the Write tool to create ${REPO_IMAGE_OUTPUT_HTML_PATH} with the final HTML. Stop after the file exists.
 </the-ask>
 
 <thinking-instructions>
-Before writing HTML, decide which real component or page in this repo best matches the subject and which globals.css tokens you will use. Plan the layout math (widths + padding + gaps for each row and column) so you know the design will fit 1200x630 with safe margins. Only then draft the HTML and run the quality loop.
+First read what the named commit, PR, or release actually changed and what it does for the user. Then decide which real component or page in this repo best matches the subject and which globals.css tokens you will use, and commit to that in the <image-plan>. Plan the layout math (widths + padding + gaps for each row and column) so you know the design will fit 1200x630 with safe margins. Only then draft the HTML and run the quality loop.
 </thinking-instructions>`;
 }
 

--- a/packages/ai/src/prompts/marketing-assets.ts
+++ b/packages/ai/src/prompts/marketing-assets.ts
@@ -79,15 +79,16 @@ Gather source material before designing. Skipping this step produces generic out
 </research>
 
 <image-plan>
-After research and before writing any HTML, write a short image plan that locks in the visual angle for this specific change. The plan is your own design brief; do not write it to ${REPO_IMAGE_OUTPUT_HTML_PATH}. Base it on what the changed code actually does for the user, not on the raw diff. Use exactly these five bolded sections, each one or a few short lines:
+After research and before writing any HTML, write a short image plan that locks in the visual angle for this specific change. The plan is your own design brief; do not write it to ${REPO_IMAGE_OUTPUT_HTML_PATH}. Base it on what the changed code actually does for the user, not on the raw diff. Use exactly these six bolded sections, each one or a few short lines:
 
-- **Approach:** One sentence naming the visual strategy (e.g. "Outcome/benefit visual") and a because-clause justifying it from the nature of the change. Most backend, runtime, API, performance, and docs changes should show the user-felt outcome, not code or dashboards.
+- **Approach:** One sentence naming the visual strategy (e.g. "Outcome/benefit visual") and a because-clause justifying it from the nature of the change. Most backend, runtime, API, performance, and docs changes should show the user-felt outcome rather than code or dashboards — but the outcome must still be depicted with the repo's real product UI, not abstract illustration.
 - **Concept:** One sentence describing the single image idea, its focal subject, and what it implies.
-- **Layout:** Composition in 2-3 lines: the focal element and where it sits, what is cropped out (no full browser chrome or dashboard), the background treatment, and any subordinate supporting elements.
-- **Content:** The concrete elements to depict in 2-3 lines: real component, labels, rows, chips, status cues, and recognizable vendor or brand icons the change implies. Keep on-image text minimal.
-- **Style notes:** Aesthetic and guardrails in 1-2 lines: the repo's tokens and one accent color, plus the avoid-list (no code snippets, no charts, no version or PR eyebrows baked into the image).
+- **Anchor component:** Name the exact real component or page from this repo that is the focal subject, with the file path you found during research. Every plan must have one. If the change is backend-only, pick the real surface a user touches that this change improves. Never make the focal subject a generic illustration, abstract icon cluster, or invented mockup.
+- **Layout:** Composition in 2-3 lines: where the anchor component sits, what is cropped out (no full browser chrome or dashboard), the background treatment, and any subordinate supporting elements.
+- **Content:** The concrete elements to depict in 2-3 lines, drawn from the anchor component's actual markup: its real labels, rows, chips, surfaces, button variants, and status cues. Recognizable vendor or brand icons may appear only as subordinate accents, never as the focal subject. Keep on-image text minimal.
+- **Style notes:** Aesthetic and guardrails in 1-2 lines: the repo's globals.css tokens and one accent color, plus the avoid-list (no code snippets, no charts, no version or PR eyebrows, no generic SaaS illustration in place of a real component).
 
-Then execute this plan: every HTML decision must follow it. If you deviate while designing, update the plan first so it stays the source of truth.
+Then execute this plan: every HTML decision must follow it, and the rendered image must look like a real screenshot of the anchor component. If you deviate while designing, update the plan first so it stays the source of truth.
 </image-plan>
 
 <html-contract>


### PR DESCRIPTION
### Description
The schedule/manual image generation flow always runs `generateRepoImage` in `prompt` mode, but `buildImagePrompt` only emitted the lookback window and silently dropped `ctx.selectionFilters`. As a result, cherry-picked commits/PRs/releases from manual content generation never reached the image agent, so those images had no idea which change they were supposed to be about.

This wires the cherry-picked context into the image prompt:

- `buildImagePrompt` now adds a selected-items block (commit SHAs, PR numbers, release tags) pulled from `ctx.selectionFilters` when present, instructing the agent to read the actual code changed (`git show <sha>`, `gh pr diff <number>`) and design around what the change does for the user. Schedule mode (no selection) keeps the lookback-window behavior.
- Prompt-mode guidance in `marketing-assets.ts` now tells the agent to read diffs when the prompt names specific commits/PRs/releases.

The `pr`/`commit` modes used by the chat-based image tool are unchanged.

### Screenshot/Recording (if applicable)
N/A — backend prompt construction only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/80217541-f15b-4f69-85b0-6754784549cf/pull/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass cherry-picked commits, PRs, and releases into marketing image generation so manual/scheduled runs create images about the selected change. Add an image plan that names a real repo component (with path) as the focal subject and tighten guidance to read diffs and design around user impact.

- **Bug Fixes**
  - `buildImagePrompt` now emits the selected commits/PRs/releases from `ctx.selectionFilters`; falls back to the lookback window when none are provided.
  - `packages/ai/src/prompts/marketing-assets.ts` adds an `<image-plan>` that requires a named anchor component (with file path) and updates prompt/PR/commit guidance to read actual diffs and design around the user-facing outcome.

<sup>Written for commit 4d22723f41330c83c64dd2b1272947c0a3fc22e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

