### PR TITLE
feat: review generated image logos

### DIFF
--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -3,10 +3,12 @@ import {
   BOX_BASE_URL,
   IMAGE_GEN_AGENT_SKILLS_INSTALL_COMMAND,
   IMAGE_GEN_MODEL_ID,
+  IMAGE_REVIEW_MODEL_ID,
   RECOVERY_AGENT_TIMEOUT_MS,
   REPO_IMAGE_OUTPUT_HTML_PATH,
   TRAILING_SLASH_RE,
 } from "@notra/ai/constants/repo-image";
+import { gateway } from "@notra/ai/gateway";
 import {
   getDecryptedToken,
   getGitHubIntegrationById,
@@ -14,6 +16,7 @@ import {
 } from "@notra/ai/integrations/github";
 import {
   buildMarketingAssetExtractionPrompt,
+  buildMarketingAssetLogoReviewPrompt,
   buildMarketingAssetMissingOutputPrompt,
   buildMarketingAssetRevisionPrompt,
 } from "@notra/ai/prompts/marketing-assets";
@@ -28,6 +31,8 @@ import { shortSha } from "@notra/ai/utils/repo-image";
 import { renderHtmlToImages } from "@notra/ai/utils/repo-image-render";
 import { withLongFetchTimeouts } from "@notra/ai/utils/undici-dispatcher";
 import { Agent, Box } from "@upstash/box";
+import { generateText, Output } from "ai";
+import { z } from "zod";
 
 export class RepoImageError extends Error {
   readonly code: RepoImageErrorCode;
@@ -157,6 +162,44 @@ function sleep(ms: number) {
 }
 
 const MISSING_OUTPUT_RECOVERY_ATTEMPTS = 3;
+
+const repoImageLogoReviewSchema = z.object({
+  needsRevision: z.boolean(),
+  reason: z.string().min(1),
+  revisionPrompt: z.string().nullable(),
+});
+
+async function reviewRenderedRepoImageForLogoIssues(params: {
+  pngBase64: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  source: RepoImageSourceContext;
+}) {
+  const { output } = await generateText({
+    model: gateway(IMAGE_REVIEW_MODEL_ID),
+    output: Output.object({ schema: repoImageLogoReviewSchema }),
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: buildMarketingAssetLogoReviewPrompt(params),
+          },
+          {
+            type: "image",
+            image: params.pngBase64,
+            mediaType: "image/png",
+          },
+        ],
+      },
+    ],
+    maxOutputTokens: 700,
+  });
+
+  return output;
+}
 
 async function buildSourceContext(params: {
   mode: GenerateRepoImageInput["mode"];
@@ -337,6 +380,7 @@ export async function generateRepoImage(params: {
       : await withBoxRetry(() => Box.create(boxConfig));
 
     let html: string;
+    let rendered: Awaited<ReturnType<typeof renderHtmlToImages>>;
     let usage: GenerateRepoImageResult["usage"];
     let snapshot: Awaited<ReturnType<typeof box.snapshot>> | null = null;
 
@@ -416,6 +460,56 @@ export async function generateRepoImage(params: {
       html = await withBoxRetry(() =>
         box.files.read(REPO_IMAGE_OUTPUT_HTML_PATH)
       );
+      rendered = await renderHtmlToImages(html);
+
+      let review: z.infer<typeof repoImageLogoReviewSchema> | null = null;
+      try {
+        review = await reviewRenderedRepoImageForLogoIssues({
+          pngBase64: rendered.pngBase64,
+          owner: repository.owner,
+          repo: repository.repo,
+          branch: input.branch,
+          source,
+        });
+      } catch (error) {
+        console.warn("[repo-image] logo review skipped after error", error);
+      }
+
+      if (review?.needsRevision) {
+        const revisionPrompt =
+          review.revisionPrompt ??
+          "Review the rendered image for unofficial or fabricated company logos. Replace any questionable logos with official assets from the brand-logos skill or real repo assets, or remove them if no official source is available. Preserve the current layout as much as possible.";
+
+        console.log(
+          `[repo-image] logo review requested revision: ${review.reason}`
+        );
+
+        const reviewRevisionRun = await runRepoImageAgentStream({
+          box,
+          prompt: buildMarketingAssetRevisionPrompt({
+            prompt: revisionPrompt,
+          }),
+          timeout: RECOVERY_AGENT_TIMEOUT_MS,
+          label: "logo-review-revision",
+        });
+        usage = mergeRepoImageUsage(
+          usage,
+          extractRepoImageUsage(reviewRevisionRun.cost, IMAGE_GEN_MODEL_ID)
+        );
+
+        if (!(await hasRepoImageOutput(box))) {
+          throw new RepoImageError(
+            "agent_failed",
+            `Logo review revision removed ${REPO_IMAGE_OUTPUT_HTML_PATH}`
+          );
+        }
+
+        html = await withBoxRetry(() =>
+          box.files.read(REPO_IMAGE_OUTPUT_HTML_PATH)
+        );
+        rendered = await renderHtmlToImages(html);
+      }
+
       snapshot = await withBoxRetry(() =>
         box.snapshot({
           name:
@@ -429,11 +523,9 @@ export async function generateRepoImage(params: {
       });
     }
 
-    const { svg, pngBase64 } = await renderHtmlToImages(html);
-
     return {
-      pngBase64,
-      svg,
+      pngBase64: rendered.pngBase64,
+      svg: rendered.svg,
       html,
       sandbox: snapshot
         ? {

--- a/packages/ai/src/constants/repo-image.ts
+++ b/packages/ai/src/constants/repo-image.ts
@@ -7,6 +7,7 @@ export const REPO_IMAGE_OUTPUT_HTML_PATH = "output.html";
 export const IMAGE_GEN_AGENT_SKILLS_INSTALL_COMMAND =
   "npx skills add usenotra/skills --skill brand-logos --skill satori --skill marketing-image-generation --yes";
 export const IMAGE_GEN_MODEL_ID = OpenCodeModel.Claude_Opus_4_8;
+export const IMAGE_REVIEW_MODEL_ID = "anthropic/claude-sonnet-4.6";
 export const BOX_BASE_URL =
   process.env.UPSTASH_BOX_BASE_URL ?? "https://us-east-1.box.upstash.com";
 export const TRAILING_SLASH_RE = /\/$/;

--- a/packages/ai/src/prompts/marketing-assets.ts
+++ b/packages/ai/src/prompts/marketing-assets.ts
@@ -89,6 +89,8 @@ After research and before writing any HTML, write a short image plan that locks 
 - **Style notes:** Aesthetic and guardrails in 1-2 lines: the repo's globals.css tokens and one accent color, plus the avoid-list (no code snippets, no charts, no version or PR eyebrows, no generic SaaS illustration in place of a real component).
 
 Then execute this plan: every HTML decision must follow it, and the rendered image must look like a real screenshot of the anchor component. If you deviate while designing, update the plan first so it stays the source of truth.
+
+You may save the plan as a Markdown file such as image-plan.md in the current working directory for future context. This context file is optional and must not replace or delay the required ${REPO_IMAGE_OUTPUT_HTML_PATH} deliverable.
 </image-plan>
 
 <html-contract>
@@ -182,6 +184,31 @@ You MUST edit the file on disk. Use the Read tool or shell command to read ${REP
 <quality-loop>
 After editing, inspect the final HTML for broken layout, clipping, missing text, and accidental changes outside the requested edit. If the requested text appears in the existing design, replace it exactly. If the text is rendered through an image or SVG asset, recreate that part with normal HTML text or an SVG path-safe alternative so the requested wording is visible.
 </quality-loop>`;
+}
+
+export function buildMarketingAssetLogoReviewPrompt(params: {
+  owner: string;
+  repo: string;
+  branch: string;
+  source: RepoImageSourceContext;
+}) {
+  const sourceContext = describeSource(params.source);
+
+  return dedent`Review the attached rendered 1200x630 marketing image for unofficial or fabricated company, product, or vendor logos.
+
+Repository context: ${params.owner}/${params.repo}@${params.branch}
+
+Subject:
+${sourceContext}
+
+Rules:
+- Focus only on visible company/product/vendor logos and brand marks, including stylized wordmarks and app icons that imply a real organization.
+- Pass if the image uses the repo's own real logo, official brand assets, or no company logos.
+- Pass if the only marks are generic UI icons, abstract shapes, avatars, status dots, or decorative glyphs that do not claim to be a company logo.
+- Fail if any logo looks hand-drawn, approximated, fabricated, misspelled, or likely not the real official mark for the company/product it represents.
+- Fail if a recognizable vendor logo is used as the focal subject instead of a subordinate accent.
+
+If it fails, produce a concise revision prompt for the sandbox agent. The prompt must tell it exactly which logo issue to fix and instruct it to use official assets through the brand-logos skill, use real repo assets, or remove the questionable logo. Preserve the existing layout unless replacing/removing the logo requires a minor spacing adjustment.`;
 }
 
 export function buildMarketingAssetMissingOutputPrompt() {


### PR DESCRIPTION
### Description
Adds a post-render logo review pass for generated repo marketing images. After `output.html` exists, the pipeline renders the candidate PNG, sends the rendered image to a structured vision review prompt, and asks the sandbox agent to revise the HTML if the image appears to use fabricated or unofficial company logos. The final snapshot now captures the reviewed output.

Also updates the image-plan prompt to allow saving the plan as an optional Markdown context file such as `image-plan.md`, while keeping `output.html` as the required deliverable.

### Screenshot/Recording (if applicable)
Not applicable. Backend agent pipeline change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

AI-use disclosure: Codex assisted with this change.

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/80217541-f15b-4f69-85b0-6754784549cf/pull/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-render logo review step for generated repo marketing images to block fabricated or unofficial logos. We review the rendered PNG, auto-revise the HTML if needed, then snapshot and return the reviewed result.

- New Features
  - Structured vision check on the rendered PNG using `IMAGE_REVIEW_MODEL_ID` via `gateway` and `ai.generateText` (zod-typed) to detect unofficial logos.
  - If it fails, run a focused fix with `buildMarketingAssetRevisionPrompt`, re-render, and use the revised assets; review is best-effort and skips on errors.
  - Added `buildMarketingAssetLogoReviewPrompt` with clear logo rules; snapshots capture the reviewed output and the API returns the final `pngBase64`, `svg`, and `html`.
  - The image plan prompt allows saving an optional `image-plan.md`; `output.html` remains the required deliverable.

<sup>Written for commit 523f73da4effea0c82802d63d936f8c7d878d420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

