### PR TITLE
fix: gate workflow generation by ai credits

### DIFF
--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -1,9 +1,6 @@
 import { autumn } from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
-import {
-  calculateTokenCostCents,
-  shouldApplyMarkup,
-} from "@notra/ai/billing/token-pricing";
+import { calculateTokenCostCents } from "@notra/ai/billing/token-pricing";
 import { getGitHubToolRepositoryContextByIntegrationId } from "@notra/ai/integrations/github";
 import { getBaseUrl } from "@notra/ai/qstash/triggers";
 import { getValidToneProfile } from "@notra/ai/schemas/tone";
@@ -24,9 +21,9 @@ import { getResend } from "@notra/email/utils/resend";
 import type { WorkflowContext } from "@upstash/workflow";
 import { WorkflowAbort } from "@upstash/workflow";
 import { serve } from "@upstash/workflow/nextjs";
-import type { CheckResponse } from "autumn-js";
 import { and, eq } from "drizzle-orm";
 import { checkLogRetention } from "@/lib/billing/check-log-retention";
+import { checkWorkflowAiCredits } from "@/lib/billing/workflow-ai-credits";
 import {
   trackScheduledContentCreated,
   trackScheduledContentFailed,
@@ -40,6 +37,7 @@ import {
 } from "@/lib/generations/tracking";
 import { appendWebhookLog } from "@/lib/webhooks/logging";
 import { generateEventBasedContent } from "@/lib/workflows/event/handlers";
+import { sendAiCreditsDepletedEmails } from "@/lib/workflows/shared/ai-credit-notifications";
 import {
   parseLookbackWindow,
   parseTriggerOutputConfig,
@@ -102,6 +100,37 @@ export const { POST } = serve<EventWorkflowPayload>(
 
     if (!trigger.enabled) {
       console.log(`[Event] Trigger ${triggerId} is disabled, canceling`);
+      await context.cancel();
+      return;
+    }
+
+    const aiCreditReservation = await context.run(
+      "check-ai-credit-balance",
+      async () => checkWorkflowAiCredits(trigger.organizationId)
+    );
+
+    if (!aiCreditReservation.allowed) {
+      if (aiCreditReservation.reason === "no_active_paid_plan") {
+        console.warn(
+          `[Event] No active paid plan for org ${trigger.organizationId}, canceling trigger ${triggerId} without notification`
+        );
+      }
+
+      if (aiCreditReservation.shouldNotify) {
+        await context.run("send-ai-credits-depleted-emails", () =>
+          sendAiCreditsDepletedEmails({
+            organizationId: trigger.organizationId,
+            automationName: trigger.name.trim() || `${eventType} event`,
+            logPrefix: "Event",
+          })
+        );
+
+        console.warn(
+          `[Event] AI credits depleted for paid org ${trigger.organizationId}, canceling trigger ${triggerId}`,
+          { balanceRemaining: aiCreditReservation.balanceRemaining }
+        );
+      }
+
       await context.cancel();
       return;
     }
@@ -192,44 +221,6 @@ export const { POST } = serve<EventWorkflowPayload>(
         };
       }
     );
-
-    const aiCreditReservation = await context.run<{
-      canceled: boolean;
-      reserved: boolean;
-      useMarkup: boolean;
-    }>("reserve-ai-credit", async () => {
-      if (!autumn) {
-        return { canceled: false, reserved: false, useMarkup: false };
-      }
-
-      let data: CheckResponse | null = null;
-      try {
-        data = await autumn.check({
-          customerId: trigger.organizationId,
-          featureId: FEATURES.AI_CREDITS,
-          requiredBalance: 1,
-        });
-      } catch (error) {
-        throw new Error(`Autumn check failed: ${String(error)}`);
-      }
-
-      if (!data?.allowed) {
-        console.warn(
-          `[Event] AI credit limit reached for org ${trigger.organizationId}, canceling trigger ${triggerId}`,
-          { balance: data?.balance ?? 0 }
-        );
-        await context.cancel();
-        return { canceled: true, reserved: false, useMarkup: false };
-      }
-
-      const useMarkup = shouldApplyMarkup(data?.balance ?? null);
-
-      return { canceled: false, reserved: true, useMarkup };
-    });
-
-    if (aiCreditReservation.canceled) {
-      return;
-    }
 
     const logRetentionDays = await context.run<LogRetentionDays>(
       "fetch-retention",

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -1,9 +1,6 @@
 import { autumn } from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
-import {
-  calculateTokenCostCents,
-  shouldApplyMarkup,
-} from "@notra/ai/billing/token-pricing";
+import { calculateTokenCostCents } from "@notra/ai/billing/token-pricing";
 import { getGitHubToolRepositoryContextByIntegrationId } from "@notra/ai/integrations/github";
 import { getLinearToolContextByIntegrationId } from "@notra/ai/integrations/linear";
 import { getBaseUrl, triggerScheduleNow } from "@notra/ai/qstash/triggers";
@@ -26,10 +23,10 @@ import { getResend } from "@notra/email/utils/resend";
 import type { WorkflowContext } from "@upstash/workflow";
 import { WorkflowAbort } from "@upstash/workflow";
 import { serve } from "@upstash/workflow/nextjs";
-import type { CheckResponse } from "autumn-js";
 import { and, eq, inArray } from "drizzle-orm";
 import { createRequestLogger } from "evlog";
 import { GITHUB_RATE_LIMIT_RETRY_DELAY } from "@/constants/workflows";
+import { checkWorkflowAiCredits } from "@/lib/billing/workflow-ai-credits";
 import {
   trackScheduledContentCreated,
   trackScheduledContentFailed,
@@ -49,6 +46,7 @@ import { appendWebhookLog } from "@/lib/webhooks/logging";
 import { buildDataPointRestrictionInstructions } from "@/lib/workflows/on-demand/helpers";
 import { generateScheduledContent } from "@/lib/workflows/schedule/handlers";
 import type { ContentGenerationResult } from "@/lib/workflows/schedule/types";
+import { sendAiCreditsDepletedEmails } from "@/lib/workflows/shared/ai-credit-notifications";
 import {
   formatUtcTodayContext,
   resolveLookbackRange,
@@ -149,6 +147,37 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
 
     if (!trigger.enabled) {
       console.log(`[Schedule] Trigger ${triggerId} is disabled, canceling`);
+      await context.cancel();
+      return;
+    }
+
+    const aiCreditReservation = await context.run(
+      "check-ai-credit-balance",
+      async () => checkWorkflowAiCredits(trigger.organizationId)
+    );
+
+    if (!aiCreditReservation.allowed) {
+      if (aiCreditReservation.reason === "no_active_paid_plan") {
+        console.warn(
+          `[Schedule] No active paid plan for org ${trigger.organizationId}, canceling trigger ${triggerId} without notification`
+        );
+      }
+
+      if (aiCreditReservation.shouldNotify) {
+        await context.run("send-ai-credits-depleted-emails", () =>
+          sendAiCreditsDepletedEmails({
+            organizationId: trigger.organizationId,
+            automationName: trigger.name.trim() || trigger.outputType,
+            logPrefix: "Schedule",
+          })
+        );
+
+        console.warn(
+          `[Schedule] AI credits depleted for paid org ${trigger.organizationId}, canceling trigger ${triggerId}`,
+          { balanceRemaining: aiCreditReservation.balanceRemaining }
+        );
+      }
+
       await context.cancel();
       return;
     }
@@ -255,46 +284,6 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
         };
       }
     );
-
-    const aiCreditReservation = await context.run<{
-      canceled: boolean;
-      reserved: boolean;
-      useMarkup: boolean;
-    }>("reserve-ai-credit", async () => {
-      if (!autumn) {
-        return { canceled: false, reserved: false, useMarkup: false };
-      }
-
-      let data: CheckResponse | null = null;
-      try {
-        data = await autumn.check({
-          customerId: trigger.organizationId,
-          featureId: FEATURES.AI_CREDITS,
-          requiredBalance: 1,
-        });
-      } catch (error) {
-        throw new Error(`Autumn check failed: ${String(error)}`);
-      }
-
-      if (!data?.allowed) {
-        console.warn(
-          `[Schedule] AI credit limit reached for org ${trigger.organizationId}, canceling trigger ${triggerId}`,
-          {
-            balance: data?.balance ?? 0,
-          }
-        );
-        await context.cancel();
-        return { canceled: true, reserved: false, useMarkup: false };
-      }
-
-      const useMarkup = shouldApplyMarkup(data?.balance ?? null);
-
-      return { canceled: false, reserved: true, useMarkup };
-    });
-
-    if (aiCreditReservation.canceled) {
-      return;
-    }
 
     const runId = await context.run("generate-run-id", () =>
       generateRunId(triggerId)

--- a/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
+++ b/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
@@ -1,0 +1,62 @@
+import { autumn } from "@notra/ai/billing/autumn";
+import { ACTIVE_PAID_PLAN_IDS, FEATURES } from "@notra/ai/billing/features";
+import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
+import type { CheckResponse } from "autumn-js";
+import type { WorkflowAiCreditGateResult } from "@/types/billing/workflow-ai-credits";
+
+export async function checkWorkflowAiCredits(
+  organizationId: string
+): Promise<WorkflowAiCreditGateResult> {
+  if (!autumn) {
+    return { allowed: true, reserved: false, useMarkup: false };
+  }
+
+  const customer = await autumn.customers.getOrCreate({
+    customerId: organizationId,
+  });
+
+  const hasActivePaidPlan = customer.subscriptions.some(
+    (subscription) =>
+      !subscription.addOn &&
+      subscription.status === "active" &&
+      ACTIVE_PAID_PLAN_IDS.has(subscription.planId)
+  );
+
+  if (!hasActivePaidPlan) {
+    return {
+      allowed: false,
+      reason: "no_active_paid_plan",
+      shouldNotify: false,
+      balanceRemaining: null,
+    };
+  }
+
+  let data: CheckResponse | null = null;
+  try {
+    data = await autumn.check({
+      customerId: organizationId,
+      featureId: FEATURES.AI_CREDITS,
+      requiredBalance: 1,
+    });
+  } catch (error) {
+    throw new Error(`Autumn check failed: ${String(error)}`);
+  }
+
+  const balanceRemaining =
+    typeof data?.balance?.remaining === "number" ? data.balance.remaining : 0;
+
+  if (!data?.allowed || balanceRemaining <= 0) {
+    return {
+      allowed: false,
+      reason: "insufficient_ai_credits",
+      shouldNotify: true,
+      balanceRemaining,
+    };
+  }
+
+  return {
+    allowed: true,
+    reserved: true,
+    useMarkup: shouldApplyMarkup(data.balance ?? null),
+  };
+}

--- a/apps/dashboard/src/lib/email/send.ts
+++ b/apps/dashboard/src/lib/email/send.ts
@@ -312,7 +312,12 @@ export async function sendAiCreditsDepletedEmail(
 ) {
   const appUrl = process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
   const creditsLink = `${appUrl}/${organizationSlug}/settings/credits`;
-  const today = new Date().toISOString().slice(0, 10);
+  const idempotencyKey = createHash("sha256")
+    .update(
+      `${recipientEmail}:${organizationSlug}:${automationName}:${Date.now()}`
+    )
+    .digest("hex")
+    .slice(0, 32);
 
   return sendWithRetry(
     resend,
@@ -329,7 +334,7 @@ export async function sendAiCreditsDepletedEmail(
       }),
       tags: [{ name: "category", value: "ai-credits-depleted" }],
     },
-    `notra:ai-credits-depleted:${recipientEmail}:${organizationSlug}:${automationName}:${today}`
+    idempotencyKey
   );
 }
 

--- a/apps/dashboard/src/lib/email/send.ts
+++ b/apps/dashboard/src/lib/email/send.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { AiCreditsDepletedEmail } from "@notra/email/emails/ai-credits-depleted";
 import { FeedbackEmail } from "@notra/email/emails/feedback";
 import { InviteUserEmail } from "@notra/email/emails/invite";
 import { ResetPasswordEmail } from "@notra/email/emails/reset";
@@ -12,6 +13,7 @@ import { FEEDBACK_SENTIMENT_META } from "@notra/email/utils/feedback";
 import type { Resend } from "resend";
 import type {
   EmailResult,
+  SendAiCreditsDepletedEmailProps,
   SendFeedbackEmailProps,
   SendInviteEmailProps,
   SendScheduledContentCreatedEmailProps,
@@ -295,6 +297,39 @@ export async function sendScheduledContentSkippedEmail(
       tags: [{ name: "category", value: "schedule-content-skipped" }],
     },
     `notra:schedule-content-skipped:${recipientEmail}:${scheduleName}:${Date.now()}`
+  );
+}
+
+export async function sendAiCreditsDepletedEmail(
+  resend: Resend,
+  {
+    recipientEmail,
+    organizationName,
+    automationName,
+    organizationSlug,
+    subject,
+  }: SendAiCreditsDepletedEmailProps
+) {
+  const appUrl = process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
+  const creditsLink = `${appUrl}/${organizationSlug}/settings/credits`;
+  const today = new Date().toISOString().slice(0, 10);
+
+  return sendWithRetry(
+    resend,
+    {
+      from: EMAIL_CONFIG.from,
+      replyTo: EMAIL_CONFIG.replyTo,
+      to: recipientEmail,
+      subject: subject ?? "Your Notra AI credits are depleted",
+      react: AiCreditsDepletedEmail({
+        organizationName,
+        organizationSlug,
+        automationName,
+        creditsLink,
+      }),
+      tags: [{ name: "category", value: "ai-credits-depleted" }],
+    },
+    `notra:ai-credits-depleted:${recipientEmail}:${organizationSlug}:${automationName}:${today}`
   );
 }
 

--- a/apps/dashboard/src/lib/workflows/shared/ai-credit-notifications.ts
+++ b/apps/dashboard/src/lib/workflows/shared/ai-credit-notifications.ts
@@ -1,0 +1,59 @@
+import { db } from "@notra/db/drizzle";
+import { members, organizations } from "@notra/db/schema";
+import { getResend } from "@notra/email/utils/resend";
+import { and, eq } from "drizzle-orm";
+import { sendAiCreditsDepletedEmail } from "@/lib/email/send";
+import type { SendAiCreditsDepletedEmailsParams } from "@/types/workflows/ai-credit-notifications";
+
+export async function sendAiCreditsDepletedEmails({
+  organizationId,
+  automationName,
+  logPrefix,
+}: SendAiCreditsDepletedEmailsParams) {
+  const resend = getResend();
+  if (!resend) {
+    console.warn(
+      `[${logPrefix}] Resend API key not configured, skipping AI credits depleted emails`
+    );
+    return;
+  }
+
+  const org = await db.query.organizations.findFirst({
+    where: eq(organizations.id, organizationId),
+    columns: { name: true, slug: true },
+  });
+
+  const ownerMemberships = await db.query.members.findMany({
+    where: and(
+      eq(members.organizationId, organizationId),
+      eq(members.role, "owner")
+    ),
+    with: { users: { columns: { email: true } } },
+  });
+
+  const ownerEmails = ownerMemberships.map((m) => m.users.email);
+  if (ownerEmails.length === 0) {
+    return;
+  }
+
+  const organizationName = org?.name ?? "Your organization";
+  const organizationSlug = org?.slug ?? "";
+
+  await Promise.allSettled(
+    ownerEmails.map((email) =>
+      sendAiCreditsDepletedEmail(resend, {
+        recipientEmail: email,
+        organizationName,
+        organizationSlug,
+        automationName,
+      }).then((result) => {
+        if (result.error) {
+          console.warn(
+            `[${logPrefix}] Failed to send AI credits depleted notification to ${email}:`,
+            result.error
+          );
+        }
+      })
+    )
+  );
+}

--- a/apps/dashboard/src/types/billing/workflow-ai-credits.ts
+++ b/apps/dashboard/src/types/billing/workflow-ai-credits.ts
@@ -1,0 +1,12 @@
+export type WorkflowAiCreditGateResult =
+  | {
+      allowed: true;
+      reserved: boolean;
+      useMarkup: boolean;
+    }
+  | {
+      allowed: false;
+      reason: "no_active_paid_plan" | "insufficient_ai_credits";
+      shouldNotify: boolean;
+      balanceRemaining: number | null;
+    };

--- a/apps/dashboard/src/types/email/send.ts
+++ b/apps/dashboard/src/types/email/send.ts
@@ -44,6 +44,14 @@ export interface SendScheduledContentSkippedEmailProps {
   subject?: string;
 }
 
+export interface SendAiCreditsDepletedEmailProps {
+  recipientEmail: string;
+  organizationName: string;
+  organizationSlug: string;
+  automationName: string;
+  subject?: string;
+}
+
 export interface ScheduledCreatedContentItem {
   title: string;
   contentLink: string;

--- a/apps/dashboard/src/types/workflows/ai-credit-notifications.ts
+++ b/apps/dashboard/src/types/workflows/ai-credit-notifications.ts
@@ -1,0 +1,5 @@
+export interface SendAiCreditsDepletedEmailsParams {
+  organizationId: string;
+  automationName: string;
+  logPrefix: string;
+}

--- a/packages/ai/src/billing/features.ts
+++ b/packages/ai/src/billing/features.ts
@@ -25,6 +25,13 @@ export const PAID_OR_LEGACY_PLAN_IDS: Set<string> = new Set([
   PLANS.PRO_YEARLY,
 ]);
 
+export const ACTIVE_PAID_PLAN_IDS: Set<string> = new Set([
+  PLANS.BASIC,
+  PLANS.BASIC_YEARLY,
+  PLANS.PRO,
+  PLANS.PRO_YEARLY,
+]);
+
 export const ADDONS = {
   AI_CREDITS_TOPUP: "ai_credits_top_up",
 } as const;

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "exports": {
     "./emails/feedback": "./src/emails/feedback.tsx",
+    "./emails/ai-credits-depleted": "./src/emails/ai-credits-depleted.tsx",
     "./emails/invite": "./src/emails/invite.tsx",
     "./emails/reset": "./src/emails/reset.tsx",
     "./emails/schedule-content-created": "./src/emails/schedule-content-created.tsx",
@@ -10,6 +11,7 @@
     "./emails/schedule-content-skipped": "./src/emails/schedule-content-skipped.tsx",
     "./emails/verify": "./src/emails/verify.tsx",
     "./emails/welcome": "./src/emails/welcome.tsx",
+    "./types/ai-credits-depleted": "./src/types/ai-credits-depleted.ts",
     "./types/feedback": "./src/types/feedback.ts",
     "./utils/config": "./src/utils/config.ts",
     "./utils/dev": "./src/utils/dev.ts",

--- a/packages/email/src/emails/ai-credits-depleted.tsx
+++ b/packages/email/src/emails/ai-credits-depleted.tsx
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+import { EmailButton } from "../components/button";
+import { EmailFooter } from "../components/footer";
+import type { AiCreditsDepletedEmailProps } from "../types/ai-credits-depleted";
+import { EMAIL_CONFIG } from "../utils/config";
+
+export const AiCreditsDepletedEmail = ({
+  organizationName = "Acme Inc",
+  organizationSlug = "acme",
+  automationName = "Weekly Product Updates",
+  creditsLink = `${EMAIL_CONFIG.getAppUrl()}/${organizationSlug}/settings/credits`,
+}: AiCreditsDepletedEmailProps) => {
+  const logoUrl = EMAIL_CONFIG.getLogoUrl();
+
+  return (
+    <Html>
+      <Head />
+      <Preview>Your Notra AI credits are depleted</Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white px-2 font-sans">
+          <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
+            <Section className="mt-[32px]">
+              <Img
+                alt="Notra Logo"
+                className="mx-auto"
+                height="40"
+                src={logoUrl}
+                width="40"
+              />
+            </Section>
+
+            <Heading className="my-6 text-center font-medium text-2xl text-black">
+              AI credits are depleted
+            </Heading>
+
+            <Text className="text-center text-[#737373] text-base leading-relaxed">
+              Your <strong>{automationName}</strong> automation in{" "}
+              <strong>{organizationName}</strong> did not run because your AI
+              credit balance is empty.
+            </Text>
+
+            <Section className="my-8 text-center">
+              <EmailButton href={creditsLink}>Add AI Credits</EmailButton>
+            </Section>
+
+            <Text className="text-[14px] text-black leading-[24px]">
+              If the button does not work, copy and paste this URL into your
+              browser: <Link href={creditsLink}>{creditsLink}</Link>
+            </Text>
+
+            <EmailFooter />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};

--- a/packages/email/src/types/ai-credits-depleted.ts
+++ b/packages/email/src/types/ai-credits-depleted.ts
@@ -1,0 +1,6 @@
+export interface AiCreditsDepletedEmailProps {
+  organizationName: string;
+  organizationSlug: string;
+  automationName: string;
+  creditsLink: string;
+}


### PR DESCRIPTION
### Description
Require automated content workflow runs to pass a billing gate before any generation starts. Schedule and event workflows now require an active paid plan and a positive AI credit balance. Orgs without an active paid plan are canceled silently, while paid orgs with depleted AI credits get an owner email with a link to top up credits.

This also adds shared workflow billing/notification helpers, a dedicated AI credits depleted email, and separates related types into `types/` files.

AI assistance was used to write code in this PR.

### Screenshot/Recording (if applicable)
N/A - backend workflow and email notification change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Checks run:
- `bunx ultracite check apps/dashboard/src/app/api/workflows/schedule/route.ts apps/dashboard/src/app/api/workflows/event/route.ts apps/dashboard/src/lib/billing/workflow-ai-credits.ts apps/dashboard/src/lib/workflows/shared/ai-credit-notifications.ts apps/dashboard/src/types/billing/workflow-ai-credits.ts apps/dashboard/src/types/workflows/ai-credit-notifications.ts apps/dashboard/src/lib/email/send.ts apps/dashboard/src/types/email/send.ts packages/ai/src/billing/features.ts packages/email/src/emails/ai-credits-depleted.tsx packages/email/src/types/ai-credits-depleted.ts packages/email/package.json`
- `bun run --filter=dashboard check-types`
- `bun run check-types`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/80217541-f15b-4f69-85b0-6754784549cf/pull/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate scheduled and event workflow runs behind billing: only orgs on an active paid plan with positive AI credits can generate content. Free orgs are canceled silently; paid orgs with depleted credits get an owner email to top up.

- **New Features**
  - Central credit gate via `checkWorkflowAiCredits` (verifies active paid plan, checks/reserves AI credits, returns `useMarkup`).
  - Owner notifications when credits are depleted using `sendAiCreditsDepletedEmails` and new `AiCreditsDepletedEmail` in `@notra/email` (links to credits page).
  - Replaced inline checks in schedule/event routes with a shared helper; added `ACTIVE_PAID_PLAN_IDS` in `@notra/ai` and exported new email/types from `packages/email`.

- **Bug Fixes**
  - Use a unique idempotency key in `sendAiCreditsDepletedEmail` to avoid suppressing repeated depletion emails.

<sup>Written for commit 3bf04bda66c45109011db0c2d74174e3dfeceea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

