### PR TITLE
fix: harden ai gateway workflow failures

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.35.8",
     "@upstash/workflow": "^1.1.0",
-    "ai": "6.0.190",
+    "ai": "6.0.193",
     "autumn-js": "^1.2.5",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.0",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -14,7 +14,7 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
-    "@ai-sdk/react": "3.0.192",
+    "@ai-sdk/react": "3.0.195",
     "@aws-sdk/client-s3": "^3.990.0",
     "@aws-sdk/s3-request-presigner": "^3.990.0",
     "@c15t/nextjs": "^2.0.4",
@@ -60,7 +60,7 @@
     "@upstash/workflow": "^1.1.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/otel": "^2.1.2",
-    "ai": "6.0.190",
+    "ai": "6.0.193",
     "autumn-js": "^1.2.7",
     "better-auth": "^1.5.5",
     "clsx": "^2.1.1",

--- a/apps/dashboard/src/app/api/command-palette/navigate/route.ts
+++ b/apps/dashboard/src/app/api/command-palette/navigate/route.ts
@@ -294,7 +294,9 @@ export async function POST(request: NextRequest) {
           : "No matching entities found.",
         `User query: ${query}`,
       ].join("\n"),
-      providerOptions: withGatewayAutomaticCaching(),
+      providerOptions: withGatewayAutomaticCaching(undefined, {
+        modelId: "anthropic/claude-sonnet-4.6",
+      }),
       abortSignal: request.signal,
       experimental_telemetry: buildExperimentalTelemetry({
         feature: "command_palette",

--- a/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts
+++ b/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts
@@ -194,7 +194,9 @@ Extract the following information:
 4. audience: A description of their target audience (1-2 sentences)
 5. language: The primary language of the website content. Must be one of: ${SUPPORTED_LANGUAGES.join(", ")}`,
               system: `You are a brand analyst expert. Your job is to analyze website content and extract key brand identity information. Be thorough but concise. Focus on understanding the company's essence, values, and how they communicate.`,
-              providerOptions: withGatewayAutomaticCaching(),
+              providerOptions: withGatewayAutomaticCaching(undefined, {
+                modelId: "anthropic/claude-sonnet-4.6",
+              }),
               experimental_telemetry: buildExperimentalTelemetry({
                 feature: "brand_analysis",
                 jobId,

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.35.8",
         "@upstash/workflow": "^1.1.0",
-        "ai": "6.0.190",
+        "ai": "6.0.193",
         "autumn-js": "^1.2.5",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.0",
@@ -54,7 +54,7 @@
       "name": "dashboard",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/react": "3.0.192",
+        "@ai-sdk/react": "3.0.195",
         "@aws-sdk/client-s3": "^3.990.0",
         "@aws-sdk/s3-request-presigner": "^3.990.0",
         "@c15t/nextjs": "^2.0.4",
@@ -100,7 +100,7 @@
         "@upstash/workflow": "^1.1.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/otel": "^2.1.2",
-        "ai": "6.0.190",
+        "ai": "6.0.193",
         "autumn-js": "^1.2.7",
         "better-auth": "^1.5.5",
         "clsx": "^2.1.1",
@@ -210,8 +210,8 @@
       "name": "@notra/ai",
       "version": "0.0.1",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.119",
-        "@ai-sdk/mcp": "1.0.43",
+        "@ai-sdk/gateway": "3.0.121",
+        "@ai-sdk/mcp": "1.0.45",
         "@aws-sdk/client-s3": "^3.990.0",
         "@linear/sdk": "^80.0.0",
         "@mendable/firecrawl-js": "^4.10.0",
@@ -226,7 +226,7 @@
         "@upstash/realtime": "^1.0.3",
         "@upstash/redis": "^1.35.8",
         "@upstash/workflow": "^1.1.0",
-        "ai": "6.0.190",
+        "ai": "6.0.193",
         "autumn-js": "^1.2.7",
         "dedent": "^1.7.1",
         "drizzle-orm": "^0.45.2",
@@ -323,7 +323,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@toolwind/corner-shape": "^0.0.8-3",
         "@xyflow/react": "^12.10.0",
-        "ai": "6.0.190",
+        "ai": "6.0.193",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -376,9 +376,9 @@
 
     "@ai-sdk/devtools": ["@ai-sdk/devtools@0.0.18", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@hono/node-server": "^1.13.7", "hono": "^4.6.14" }, "bin": { "devtools": "bin/cli.js" } }, "sha512-0J25Q7occrkMJM1MrP0KeR8XNdGGKNgzxhOLfxBe/qZBQP6yXgV4H5Gf2DnDC3UgXDBJBskH9nh23doCo2Pebw=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.119", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VAhfRWC+JexZakkVfmjaJKaTj00x7/UHdE8kMWL3NhuQAlf8oXtg9r4dfvFZrByXxchGRBvYE3biEUyibkg0xg=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.121", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uY248djJRxa5W68MHiyqO8WLdOeKQoRClGg7PVX/VPhVW8SJNM7/l5DcrA5WAM3YfQrLyNkgZa2VOu8T0t8LUw=="],
 
-    "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.43", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HdDMeyCcfIn5tW/P1kJ+BmYP8vfY8vppRn7swbVNRcLeFz/cpwik+B+C49Up4u5scRAcATtRJywOa7/rA4BmIA=="],
+    "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.45", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-0J+pVPu5IlBGVirY2nnLlHPuSEqnN0kd7zefL6zfBkezs6x93t0ET8OKgpGaCzEHrj/W+d7TvZ9AhwywWP7wnQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@2.0.106", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ=="],
 
@@ -386,7 +386,7 @@
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.192", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.190", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-QB7ViYcM1o2zN6Zo1nVD1FqAkiivCPOi1vmT/OmWAxctmXUGTdWOL7MBs9q3zuzPbZpkty4xDERwemWYoZx6Kw=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.195", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.193", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-+yIH84d4bBNzLKfaDDf4EocEH0XQKKNwNShxbrz5xAiJMNIPnWVWT9cyrSerYaGH3iNVS/g2io42PE4HNbc4RA=="],
 
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
@@ -1818,7 +1818,7 @@
 
     "aggregate-error": ["aggregate-error@4.0.1", "", { "dependencies": { "clean-stack": "^4.0.0", "indent-string": "^5.0.0" } }, "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w=="],
 
-    "ai": ["ai@6.0.190", "", { "dependencies": { "@ai-sdk/gateway": "3.0.119", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T+ixHbWZ6jmHRREpVVJTkFyWJeCekCdzLPan7lp1F32jG5OUw4+odlVYjtMRXVzogU+pWzpMmXdRiHUmdL/q0w=="],
+    "ai": ["ai@6.0.193", "", { "dependencies": { "@ai-sdk/gateway": "3.0.121", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VQOTOse8+X8kMtg61DNSXlYJzwOW4NjMLDJNk/qxClWsFe4oiyFJDHGGG1oezfGcFzuYuQe/8Z7r4kwiZWh2YQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -34,8 +34,8 @@
     "./crypto/*": "./src/crypto/*.ts"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "3.0.119",
-    "@ai-sdk/mcp": "1.0.43",
+    "@ai-sdk/gateway": "3.0.121",
+    "@ai-sdk/mcp": "1.0.45",
     "@aws-sdk/client-s3": "^3.990.0",
     "@linear/sdk": "^80.0.0",
     "@mendable/firecrawl-js": "^4.10.0",
@@ -50,7 +50,7 @@
     "@upstash/realtime": "^1.0.3",
     "@upstash/redis": "^1.35.8",
     "@upstash/workflow": "^1.1.0",
-    "ai": "6.0.190",
+    "ai": "6.0.193",
     "autumn-js": "^1.2.7",
     "dedent": "^1.7.1",
     "drizzle-orm": "^0.45.2",

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -1,6 +1,8 @@
 import { AGENT_DEFAULT_MODEL } from "@notra/ai/constants/models";
+import { assertGatewayHasCredits } from "@notra/ai/gateway";
 import { createModel } from "@notra/ai/model";
 import { getUserPrompt } from "@notra/ai/prompts/user";
+import { withGatewayDefaults } from "@notra/ai/provider-options";
 import {
   createGetBrandReferencesTool,
   createSearchBrandReferencesTool,
@@ -103,6 +105,8 @@ export async function runBackgroundGen(
     primarySkillName: skillName,
   });
 
+  await assertGatewayHasCredits();
+
   const model = createModel(
     organizationId,
     AGENT_DEFAULT_MODEL,
@@ -152,11 +156,14 @@ export async function runBackgroundGen(
 
   const agent = new ToolLoopAgent({
     model,
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 4096 },
+    providerOptions: withGatewayDefaults(
+      {
+        anthropic: {
+          thinking: { type: "enabled", budgetTokens: 4096 },
+        },
       },
-    },
+      { modelId: AGENT_DEFAULT_MODEL }
+    ),
     tools: {
       ...brandReferenceTools,
       ...buildGitHubDataTools({

--- a/packages/ai/src/agents/chat.ts
+++ b/packages/ai/src/agents/chat.ts
@@ -80,7 +80,7 @@ export async function createChatAgent(
 
   const agent = new ToolLoopAgent({
     model: modelWithMemory,
-    providerOptions: withGatewayAutomaticCaching(),
+    providerOptions: withGatewayAutomaticCaching(undefined, { modelId: model }),
     tools: lazyMcpRuntime
       ? { ...baseTools, ...lazyMcpRuntime.tools }
       : baseTools,

--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -20,6 +20,7 @@ import {
   buildMarketingAssetMissingOutputPrompt,
   buildMarketingAssetRevisionPrompt,
 } from "@notra/ai/prompts/marketing-assets";
+import { withGatewayDefaults } from "@notra/ai/provider-options";
 import type {
   GenerateRepoImageInput,
   GenerateRepoImageResult,
@@ -199,6 +200,9 @@ async function reviewRenderedRepoImageForLogoIssues(params: {
       },
     ],
     maxOutputTokens: 700,
+    providerOptions: withGatewayDefaults(undefined, {
+      modelId: IMAGE_REVIEW_MODEL_ID,
+    }),
   });
 
   return output;

--- a/packages/ai/src/billing/token-pricing.ts
+++ b/packages/ai/src/billing/token-pricing.ts
@@ -18,7 +18,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     cacheReadPerMillionTokens: 0.08,
     cacheWritePerMillionTokens: 1.0,
   },
-  "openai/gpt-5.1-instant": {
+  "openai/gpt-5.4-mini": {
     inputPerMillionTokens: 0.1,
     outputPerMillionTokens: 0.4,
     cacheReadPerMillionTokens: 0.05,

--- a/packages/ai/src/chat/history.ts
+++ b/packages/ai/src/chat/history.ts
@@ -733,7 +733,9 @@ export async function generateAndSetChatTitle(
       system: `Generate a short, descriptive title (max 50 chars) for a chat conversation based on the user's first message. Return ONLY the title text, nothing else. No quotes, no prefix. Be specific and concise.`,
       prompt: userMessage,
       maxOutputTokens: 30,
-      providerOptions: withGatewayAutomaticCaching(),
+      providerOptions: withGatewayAutomaticCaching(undefined, {
+        modelId: "openai/gpt-5.4-nano",
+      }),
       experimental_telemetry: buildExperimentalTelemetry({
         chatId,
         feature: "chat_title",

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -11,6 +11,23 @@ const headers = {
 };
 
 let gatewayClient: GatewayClient | null = null;
+let lastCreditCheck:
+  | {
+      checkedAt: number;
+      balance: number;
+    }
+  | undefined;
+
+const CREDIT_CHECK_TTL_MS = 30_000;
+
+export class GatewayCreditBalanceError extends Error {
+  constructor(balance: number) {
+    super(
+      `AI Gateway credit balance is ${balance}. Add credits before running AI workflows.`
+    );
+    this.name = "GatewayCreditBalanceError";
+  }
+}
 
 function getGatewayClient(): GatewayClient {
   if (gatewayClient) {
@@ -25,3 +42,33 @@ export const gateway = (...args: GatewayArgs): GatewayResult => {
   const client = getGatewayClient();
   return client(...args);
 };
+
+export async function assertGatewayHasCredits() {
+  const now = Date.now();
+  if (
+    lastCreditCheck &&
+    now - lastCreditCheck.checkedAt < CREDIT_CHECK_TTL_MS
+  ) {
+    if (lastCreditCheck.balance <= 0) {
+      throw new GatewayCreditBalanceError(lastCreditCheck.balance);
+    }
+    return;
+  }
+
+  const client = getGatewayClient();
+  const credits = await client.getCredits();
+  const balance =
+    typeof credits.balance === "number"
+      ? credits.balance
+      : Number(credits.balance);
+
+  if (!Number.isFinite(balance)) {
+    return;
+  }
+
+  lastCreditCheck = { checkedAt: now, balance };
+
+  if (balance <= 0) {
+    throw new GatewayCreditBalanceError(balance);
+  }
+}

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -18,7 +18,8 @@ let lastCreditCheck:
     }
   | undefined;
 
-const CREDIT_CHECK_TTL_MS = 30_000;
+const POSITIVE_CREDIT_CHECK_TTL_MS = 5_000;
+const NEGATIVE_CREDIT_CHECK_TTL_MS = 30_000;
 
 export class GatewayCreditBalanceError extends Error {
   constructor(balance: number) {
@@ -45,12 +46,20 @@ export const gateway = (...args: GatewayArgs): GatewayResult => {
 
 export async function assertGatewayHasCredits() {
   const now = Date.now();
-  if (
-    lastCreditCheck &&
-    now - lastCreditCheck.checkedAt < CREDIT_CHECK_TTL_MS &&
-    lastCreditCheck.balance <= 0
-  ) {
-    throw new GatewayCreditBalanceError(lastCreditCheck.balance);
+  if (lastCreditCheck) {
+    const ageMs = now - lastCreditCheck.checkedAt;
+    if (
+      lastCreditCheck.balance > 0 &&
+      ageMs < POSITIVE_CREDIT_CHECK_TTL_MS
+    ) {
+      return;
+    }
+    if (
+      lastCreditCheck.balance <= 0 &&
+      ageMs < NEGATIVE_CREDIT_CHECK_TTL_MS
+    ) {
+      throw new GatewayCreditBalanceError(lastCreditCheck.balance);
+    }
   }
 
   const client = getGatewayClient();

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -18,7 +18,7 @@ let lastCreditCheck:
     }
   | undefined;
 
-const POSITIVE_CREDIT_CHECK_TTL_MS = 5000;
+const POSITIVE_CREDIT_CHECK_TTL_MS = 30_000;
 const NEGATIVE_CREDIT_CHECK_TTL_MS = 30_000;
 
 export class GatewayCreditBalanceError extends Error {

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -47,12 +47,10 @@ export async function assertGatewayHasCredits() {
   const now = Date.now();
   if (
     lastCreditCheck &&
-    now - lastCreditCheck.checkedAt < CREDIT_CHECK_TTL_MS
+    now - lastCreditCheck.checkedAt < CREDIT_CHECK_TTL_MS &&
+    lastCreditCheck.balance <= 0
   ) {
-    if (lastCreditCheck.balance <= 0) {
-      throw new GatewayCreditBalanceError(lastCreditCheck.balance);
-    }
-    return;
+    throw new GatewayCreditBalanceError(lastCreditCheck.balance);
   }
 
   const client = getGatewayClient();

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -18,7 +18,7 @@ let lastCreditCheck:
     }
   | undefined;
 
-const POSITIVE_CREDIT_CHECK_TTL_MS = 5_000;
+const POSITIVE_CREDIT_CHECK_TTL_MS = 5000;
 const NEGATIVE_CREDIT_CHECK_TTL_MS = 30_000;
 
 export class GatewayCreditBalanceError extends Error {
@@ -48,16 +48,10 @@ export async function assertGatewayHasCredits() {
   const now = Date.now();
   if (lastCreditCheck) {
     const ageMs = now - lastCreditCheck.checkedAt;
-    if (
-      lastCreditCheck.balance > 0 &&
-      ageMs < POSITIVE_CREDIT_CHECK_TTL_MS
-    ) {
+    if (lastCreditCheck.balance > 0 && ageMs < POSITIVE_CREDIT_CHECK_TTL_MS) {
       return;
     }
-    if (
-      lastCreditCheck.balance <= 0 &&
-      ageMs < NEGATIVE_CREDIT_CHECK_TTL_MS
-    ) {
+    if (lastCreditCheck.balance <= 0 && ageMs < NEGATIVE_CREDIT_CHECK_TTL_MS) {
       throw new GatewayCreditBalanceError(lastCreditCheck.balance);
     }
   }

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -1,6 +1,7 @@
 import { getEnabledMcpServerCount } from "@notra/ai/integrations/mcp-tool-index";
 import { createModel } from "@notra/ai/model";
 import { getStandaloneChatPrompt } from "@notra/ai/prompts/standalone-chat";
+import { withGatewayDefaults } from "@notra/ai/provider-options";
 import { STANDALONE_SKILL_CATALOG_LIMIT } from "@notra/ai/skills/constants";
 import { listSkillSummaries } from "@notra/ai/skills/functions/service";
 import { createLazyMcpRuntime } from "@notra/ai/tools/mcp-lazy";
@@ -208,10 +209,13 @@ export async function orchestrateStandaloneChat(
   const effectiveEnableThinking =
     enableThinking && (autoThinkingLevel ? autoThinkingLevel !== "off" : true);
 
-  const providerOptions = getThinkingProviderOptions(
-    routingDecision.model,
-    effectiveEnableThinking,
-    effectiveThinkingLevel
+  const providerOptions = withGatewayDefaults(
+    getThinkingProviderOptions(
+      routingDecision.model,
+      effectiveEnableThinking,
+      effectiveThinkingLevel
+    ),
+    { modelId: routingDecision.model }
   );
 
   const messagesForModel = stripIncompleteToolParts(messages);

--- a/packages/ai/src/orchestration/orchestrate.ts
+++ b/packages/ai/src/orchestration/orchestrate.ts
@@ -1,5 +1,6 @@
 import { createModel } from "@notra/ai/model";
 import { getContentEditorChatPrompt } from "@notra/ai/prompts/content-editor";
+import { withGatewayDefaults } from "@notra/ai/provider-options";
 import type {
   OrchestrateDeps,
   OrchestrateInput,
@@ -120,6 +121,9 @@ export async function orchestrateChat(
     }),
     tools,
     stopWhen: stepCountIs(maxSteps),
+    providerOptions: withGatewayDefaults(undefined, {
+      modelId: routingDecision.model,
+    }),
     experimental_telemetry: buildExperimentalTelemetry(telemetryMetadata),
     async onFinish({ totalUsage }) {
       await deps?.onUsage?.(totalUsage, routingDecision.model);

--- a/packages/ai/src/orchestration/router.ts
+++ b/packages/ai/src/orchestration/router.ts
@@ -19,7 +19,7 @@ import { generateText, Output } from "ai";
 
 const MODELS = {
   router: "openai/gpt-oss-120b",
-  simple: "openai/gpt-5.1-instant",
+  simple: "openai/gpt-5.4-mini",
   complex: "anthropic/claude-sonnet-4.6",
 } as const;
 
@@ -126,7 +126,9 @@ export async function routeMessage(
     prompt: `Classify this user message:
 
 "${userMessage}"${contextHint}`,
-    providerOptions: withGatewayAutomaticCaching(),
+    providerOptions: withGatewayAutomaticCaching(undefined, {
+      modelId: MODELS.router,
+    }),
     experimental_telemetry: buildExperimentalTelemetry(telemetryMetadata),
   });
 

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -24,7 +24,9 @@ export function getGatewayFallbackModels(modelId?: string): string[] {
   }
 
   if (modelId.startsWith("openai/")) {
-    return ["openai/gpt-5.4-mini"];
+    return modelId === "openai/gpt-5.4-mini"
+      ? ["openai/gpt-5.4-nano"]
+      : ["openai/gpt-5.4-mini"];
   }
 
   return DEFAULT_GATEWAY_FALLBACK_MODELS.filter((model) => model !== modelId);

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -1,17 +1,61 @@
+import {
+  type GatewayOptions,
+  gatewayOptionsSchema,
+} from "@notra/ai/schemas/provider-options";
 import type { generateText } from "ai";
 
 type ProviderOptions = NonNullable<
   Parameters<typeof generateText>[0]["providerOptions"]
 >;
 
-export function withGatewayAutomaticCaching(
-  providerOptions?: ProviderOptions
+const DEFAULT_GATEWAY_FALLBACK_MODELS = ["anthropic/claude-sonnet-4.6"];
+
+export function getGatewayFallbackModels(modelId?: string): string[] {
+  if (!modelId) {
+    return [...DEFAULT_GATEWAY_FALLBACK_MODELS];
+  }
+
+  if (modelId.startsWith("anthropic/claude-opus-")) {
+    return ["anthropic/claude-sonnet-4.6"];
+  }
+
+  if (modelId.startsWith("anthropic/")) {
+    return ["anthropic/claude-haiku-4.5"];
+  }
+
+  if (modelId.startsWith("openai/")) {
+    return ["openai/gpt-5.4-mini"];
+  }
+
+  return DEFAULT_GATEWAY_FALLBACK_MODELS.filter((model) => model !== modelId);
+}
+
+export function withGatewayDefaults(
+  providerOptions?: ProviderOptions,
+  options?: { modelId?: string; fallbackModels?: string[] }
 ): ProviderOptions {
+  const parsedGatewayOptions = gatewayOptionsSchema.safeParse(
+    providerOptions?.gateway
+  );
+  const existingGatewayOptions = parsedGatewayOptions.success
+    ? parsedGatewayOptions.data
+    : undefined;
+  const existingModels = existingGatewayOptions?.models;
+  const fallbackModels =
+    options?.fallbackModels ?? getGatewayFallbackModels(options?.modelId);
+  const gatewayOptions = {
+    ...existingGatewayOptions,
+    caching: "auto",
+    models:
+      existingModels && existingModels.length > 0
+        ? existingModels
+        : fallbackModels,
+  } satisfies GatewayOptions;
+
   return {
     ...providerOptions,
-    gateway: {
-      ...providerOptions?.gateway,
-      caching: "auto",
-    },
+    gateway: gatewayOptions,
   };
 }
+
+export const withGatewayAutomaticCaching = withGatewayDefaults;

--- a/packages/ai/src/schemas/provider-options.ts
+++ b/packages/ai/src/schemas/provider-options.ts
@@ -1,0 +1,13 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+export const gatewayOptionsSchema = z
+  .object({
+    models: z.array(z.string()).optional(),
+  })
+  .catchall(z.json());
+
+export type GatewayOptions = z.infer<typeof gatewayOptionsSchema> & {
+  caching: "auto";
+  models: string[];
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@toolwind/corner-shape": "^0.0.8-3",
     "@xyflow/react": "^12.10.0",
-    "ai": "6.0.190",
+    "ai": "6.0.193",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
### Description
Hardens AI workflow generation against recent production failures seen in Context telemetry.

- Adds an AI Gateway credit preflight for background generation so scheduled jobs fail before spending time on GitHub/Linear source tools when the Gateway balance is not positive.
- Adds shared AI Gateway provider defaults that preserve existing provider options, keep automatic caching, and configure same-provider fallback models.
- Moves Gateway provider option parsing into a zod schema under `packages/ai/src/schemas`.
- Updates the simple/router OpenAI model and pricing entry to `openai/gpt-5.4-mini`.
- Upgrades AI SDK packages to the newest patch versions allowed by the repo's release-age policy.

### Screenshot/Recording (if applicable)
Not applicable. Backend workflow/provider behavior only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Checks run:

- `bun run --filter=@notra/ai check-types`
- `bun run --filter=dashboard check-types`
- `bun run --filter=api check-types`
- `bun run --filter=@notra/ui check-types`
- Pre-commit hook: `ultracite fix` ran and reported existing unrelated warnings, `knip` passed, commitlint passed.

Disclosure: AI assistance was used to prepare this change.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/80217541-f15b-4f69-85b0-6754784549cf/pull/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens AI workflows by adding a Gateway credit preflight and shared provider defaults with auto caching and smart same‑provider fallbacks. Sets credit check cache to 30s for both positive and zero/negative balances, switches the simple model to `openai/gpt-5.4-mini`, and updates SDK packages.

- **Bug Fixes**
  - Add credit preflight before background jobs; throw `GatewayCreditBalanceError` when balance ≤ 0; cache credit checks for 30s.
  - Standardize provider options with `withGatewayDefaults` and a `zod` schema. Enable auto caching and model‑aware fallbacks using `modelId` hints across agents, orchestration, and API routes.
  - Update simple router model and pricing to `openai/gpt-5.4-mini`.

- **Dependencies**
  - Bump `ai` to `6.0.193`, `@ai-sdk/react` to `3.0.195`, `@ai-sdk/gateway` to `3.0.121`, `@ai-sdk/mcp` to `1.0.45`.

<sup>Written for commit b64ec736ce6e25a9ec065c71dbec35c4fb65b8c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

