### PR TITLE
fix: readable skills updated date and balanced description

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -188,11 +188,16 @@ export default function PageClient({ slug }: PageClientProps) {
                     <CardTitle className="font-mono text-base">
                       {skill.name}
                     </CardTitle>
-                    <CardDescription className="line-clamp-3">
+                    <CardDescription className="line-clamp-3 text-pretty">
                       {skill.description}
                     </CardDescription>
                     <p className="pt-1 text-muted-foreground text-xs">
-                      Updated {new Date(skill.updatedAt).toLocaleDateString()}
+                      Updated{" "}
+                      {new Date(skill.updatedAt).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
                     </p>
                   </CardHeader>
                 </Card>


### PR DESCRIPTION
### Description
On the skills page, the "Updated" label rendered a terse, locale-dependent date (e.g. `6/3/2026`). This formats it as a readable long form (e.g. `Updated June 3, 2026`) via `toLocaleDateString("en-US", { year, month: "long", day })`, and adds `text-pretty` to the skill card description for better line balancing.

### Screenshot/Recording (if applicable)
N/A — minor display change on the skills index cards.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/80217541-f15b-4f69-85b0-6754784549cf/pull/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a readable long date for the Skills page “Updated” label (e.g., “Updated June 3, 2026”) and improve description line breaks with balanced wrapping. This makes skill cards clearer and easier to scan.

<sup>Written for commit dd29b62518441907252284190a127094b10adcc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

