### PR TITLE
feat: support MCP image output in standalone chat

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { ArrowDown01Icon, X } from "@hugeicons/core-free-icons";
+import { AiBrain01Icon, ArrowDown01Icon, X } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   chatErrorPayloadSchema,
@@ -178,7 +178,7 @@ function ChatReasoningBlock({
         {isStreaming ? (
           <Loader2Icon className="size-4 animate-spin" />
         ) : (
-          <span className="size-4" />
+          <HugeiconsIcon className="size-4" icon={AiBrain01Icon} />
         )}
         <span>{statusLabel}</span>
         <HugeiconsIcon
@@ -1926,6 +1926,7 @@ function StandaloneChatPageClient({
         !lastMessage.parts.some(
           (p) =>
             (p.type === "text" && p.text.trim()) ||
+            p.type === "file" ||
             p.type === "reasoning" ||
             isToolUIPart(p)
         )));

--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -3,6 +3,7 @@
 import { ArrowDown01Icon, CpuIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Shimmer } from "@notra/ui/components/ai-elements/shimmer";
+import { ImageZoom } from "@notra/ui/components/kibo-ui/image-zoom";
 import {
   Avatar,
   AvatarFallback,
@@ -15,8 +16,10 @@ import {
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
 import { cn } from "@notra/ui/lib/utils";
-import { CheckIcon, XIcon } from "lucide-react";
+import { CheckIcon, DownloadIcon, XIcon } from "lucide-react";
+import Image from "next/image";
 import { type ReactNode, useEffect, useState } from "react";
+import { getMcpFaviconUrl } from "@/lib/integrations/mcp";
 import {
   commitsByTimeframeInputSchema,
   type MemoryToolInput,
@@ -509,12 +512,25 @@ const TOOL_COPY: Record<string, ToolCopy> = {
 
 const MCP_TOOL_NAME_REGEX = /^mcp_/;
 const UNDERSCORE_REGEX = /_+/g;
+const NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX = /[^a-zA-Z0-9]+/g;
+
+function formatToolDisplayName(value: string): string {
+  return value
+    .replace(NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX, " ")
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
 
 function formatMcpToolName(toolName: string): string {
   const label = toolName
     .replace(MCP_TOOL_NAME_REGEX, "")
-    .replace(UNDERSCORE_REGEX, " ")
-    .trim();
+    .replace(UNDERSCORE_REGEX, " ");
+  const displayName = formatToolDisplayName(label);
+  return displayName || "MCP Tool";
+}
+
+function formatMcpToolLabelPart(value: string): string {
+  const label = formatToolDisplayName(value);
   return label || "MCP tool";
 }
 
@@ -522,14 +538,20 @@ function getMcpToolLabel(toolName: string, toolMetadata: unknown) {
   const parsed = mcpToolMetadataSchema.safeParse(toolMetadata);
   const notraMetadata = parsed.success ? parsed.data.notra : undefined;
   if (notraMetadata?.label) {
-    return notraMetadata.label;
+    return formatMcpToolLabelPart(notraMetadata.label);
   }
 
   if (notraMetadata?.serverName && notraMetadata.toolName) {
-    return `${notraMetadata.serverName} - ${notraMetadata.toolName}`;
+    return `${notraMetadata.serverName} - ${formatMcpToolLabelPart(notraMetadata.toolName)}`;
   }
 
   return formatMcpToolName(toolName);
+}
+
+function getMcpToolIconUrl(toolMetadata: unknown) {
+  const parsed = mcpToolMetadataSchema.safeParse(toolMetadata);
+  const notraMetadata = parsed.success ? parsed.data.notra : undefined;
+  return getMcpFaviconUrl(notraMetadata?.serverUrl);
 }
 
 function getSubtitle({
@@ -588,6 +610,207 @@ function getSubtitle({
 const JSON_TOKEN_RE =
   /"(?:\\.|[^"\\])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g;
 const MAX_JSON_RENDER_CHARS = 20_000;
+const DATA_IMAGE_URL_REGEX = /^data:image\/[a-z0-9.+-]+;base64,/i;
+const HTTP_URL_REGEX = /^https?:\/\//i;
+const IMAGE_EXTENSION_REGEX = /\.(?:avif|gif|jpe?g|png|svg|webp)(?:[?#]|$)/i;
+const FILENAME_EXTENSION_REGEX = /\.[a-z0-9]+$/i;
+const LEADING_DOT_REGEX = /^[.]/;
+const URL_SUFFIX_REGEX = /[?#].*$/;
+const IMAGE_SPECIFIC_URL_KEYS = [
+  "image_url",
+  "imageUrl",
+  "thumbnail_url",
+  "thumbnailUrl",
+  "src",
+  "image",
+] as const;
+const GENERIC_URL_KEYS = ["url", "uri", "href"] as const;
+const IMAGE_DATA_KEYS = ["data", "blob", "base64", "image"] as const;
+const IMAGE_CONTAINER_KEYS = [
+  "content",
+  "contents",
+  "structuredContent",
+  "images",
+  "files",
+  "artifacts",
+  "result",
+  "results",
+] as const;
+
+interface ToolOutputImage {
+  url: string;
+  mediaType: string;
+  filename?: string;
+}
+
+function imageExtensionFromMediaType(mediaType: string) {
+  switch (mediaType.toLowerCase()) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/svg+xml":
+      return "svg";
+    case "image/avif":
+      return "avif";
+    case "image/gif":
+      return "gif";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    default:
+      return undefined;
+  }
+}
+
+function sanitizeDownloadFilename(filename: string) {
+  return filename
+    .trim()
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 96);
+}
+
+function getImageDownloadFilename(image: ToolOutputImage, mediaType: string) {
+  const baseName = sanitizeDownloadFilename(
+    image.filename ?? "tool-output-image"
+  );
+  const filename = baseName || "tool-output-image";
+  if (FILENAME_EXTENSION_REGEX.test(filename)) {
+    return filename;
+  }
+
+  const extension =
+    imageExtensionFromMediaType(mediaType) ??
+    imageExtensionFromMediaType(image.mediaType);
+  return extension ? `${filename}.${extension}` : filename;
+}
+
+async function downloadToolOutputImage(image: ToolOutputImage) {
+  try {
+    const response = await fetch(image.url);
+    if (!response.ok) {
+      throw new Error(`Failed to download image: ${response.status}`);
+    }
+
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = getImageDownloadFilename(image, blob.type);
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(objectUrl);
+  } catch {
+    window.open(image.url, "_blank", "noopener,noreferrer");
+  }
+}
+
+function isImageMediaType(value: unknown): value is string {
+  return typeof value === "string" && value.toLowerCase().startsWith("image/");
+}
+
+function getStringField(
+  record: Record<string, unknown>,
+  keys: readonly string[]
+) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function toImageUrl(value: string, mediaType?: string) {
+  if (DATA_IMAGE_URL_REGEX.test(value)) {
+    return value;
+  }
+  if (HTTP_URL_REGEX.test(value)) {
+    return value;
+  }
+  if (mediaType && isImageMediaType(mediaType)) {
+    return `data:${mediaType};base64,${value}`;
+  }
+  return undefined;
+}
+
+function inferImageMediaType(url: string) {
+  const match = url.match(IMAGE_EXTENSION_REGEX);
+  if (!match) {
+    return undefined;
+  }
+
+  const extension = match[0]
+    .replace(LEADING_DOT_REGEX, "")
+    .replace(URL_SUFFIX_REGEX, "");
+  if (extension === "jpg") {
+    return "image/jpeg";
+  }
+  if (extension === "svg") {
+    return "image/svg+xml";
+  }
+  return `image/${extension}`;
+}
+
+function collectToolOutputImages(
+  value: unknown,
+  images: ToolOutputImage[] = [],
+  seen = new Set<string>(),
+  depth = 0
+): ToolOutputImage[] {
+  if (value == null || depth > 5) {
+    return images;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectToolOutputImages(item, images, seen, depth + 1);
+    }
+    return images;
+  }
+
+  if (typeof value !== "object") {
+    return images;
+  }
+
+  const record = value as Record<string, unknown>;
+  const mediaType = getStringField(record, ["mediaType", "mimeType"]);
+  const filename = getStringField(record, ["filename", "name", "title"]);
+  const imageSpecificUrl = getStringField(record, IMAGE_SPECIFIC_URL_KEYS);
+  const genericUrl = getStringField(record, GENERIC_URL_KEYS);
+  const rawUrl = imageSpecificUrl ?? genericUrl;
+  const rawData = getStringField(record, IMAGE_DATA_KEYS);
+  const url =
+    (rawUrl ? toImageUrl(rawUrl, mediaType) : undefined) ??
+    (rawData ? toImageUrl(rawData, mediaType) : undefined);
+  const inferredMediaType =
+    mediaType ?? (url ? inferImageMediaType(url) : undefined);
+
+  if (
+    url &&
+    (Boolean(imageSpecificUrl) ||
+      isImageMediaType(inferredMediaType) ||
+      DATA_IMAGE_URL_REGEX.test(url))
+  ) {
+    const key = `${inferredMediaType ?? "image"}:${url}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      images.push({
+        url,
+        mediaType: inferredMediaType ?? "image/*",
+        filename,
+      });
+    }
+  }
+
+  for (const key of IMAGE_CONTAINER_KEYS) {
+    collectToolOutputImages(record[key], images, seen, depth + 1);
+  }
+
+  return images;
+}
 
 function stringifyForDisplay(value: unknown): string | undefined {
   try {
@@ -672,6 +895,48 @@ function ToolDataSection({ label, value }: { label: string; value: unknown }) {
   );
 }
 
+function ToolOutputImages({ images }: { images: ToolOutputImage[] }) {
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      {images.map((image, index) => (
+        <div
+          className="group/image relative w-fit max-w-full overflow-hidden rounded-lg border border-border bg-muted/20"
+          key={`${image.url}-${index}`}
+        >
+          <ImageZoom
+            className="block max-w-full transition-opacity group-hover/image:opacity-90"
+            zoomMargin={24}
+          >
+            <Image
+              alt={image.filename ?? "tool output image"}
+              className="block h-auto max-h-64 w-auto max-w-full cursor-pointer"
+              height={512}
+              src={image.url}
+              unoptimized
+              width={768}
+            />
+          </ImageZoom>
+          <button
+            aria-label="Download image"
+            className="absolute top-2 right-2 inline-flex size-8 cursor-pointer items-center justify-center rounded-md border border-border bg-background/90 text-foreground opacity-0 shadow-sm backdrop-blur transition-opacity hover:bg-muted focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/image:opacity-100"
+            onClick={() => {
+              downloadToolOutputImage(image);
+            }}
+            title="Download image"
+            type="button"
+          >
+            <DownloadIcon aria-hidden="true" className="size-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 interface ChatToolBlockProps {
   toolName: string;
   state: string;
@@ -720,22 +985,23 @@ export function ChatToolBlock({
   const hasOutput = output != null;
   const hasApprovalActions = isAwaitingApproval && (onApprove || onDeny);
   const hasDetails = hasInput || hasOutput || hasApprovalActions;
+  const outputImages =
+    hasOutput && !isError && !isStreaming
+      ? collectToolOutputImages(output)
+      : [];
   let toolIcon: ReactNode = null;
 
-  if (iconUrl) {
+  const resolvedIconUrl =
+    iconUrl ?? (isMcp ? getMcpToolIconUrl(toolMetadata) : undefined);
+
+  if (resolvedIconUrl || isMcp) {
     toolIcon = (
       <Avatar className="size-4 shrink-0 rounded-sm after:hidden">
-        <AvatarImage className="rounded-sm" src={iconUrl} />
+        <AvatarImage className="rounded-sm" src={resolvedIconUrl} />
         <AvatarFallback className="rounded-sm bg-transparent">
           <HugeiconsIcon className="size-3" icon={CpuIcon} />
         </AvatarFallback>
       </Avatar>
-    );
-  } else if (isMcp) {
-    toolIcon = (
-      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-medium text-[0.625rem] text-muted-foreground uppercase tracking-wide">
-        MCP
-      </span>
     );
   }
 
@@ -772,6 +1038,7 @@ export function ChatToolBlock({
           icon={ArrowDown01Icon}
         />
       </CollapsibleTrigger>
+      <ToolOutputImages images={outputImages} />
       <CollapsibleContent className="h-[var(--collapsible-panel-height)] overflow-hidden outline-none transition-[height,opacity] duration-300 ease-out data-[ending-style]:h-0 data-[starting-style]:h-0 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
         <div className="mt-3 space-y-4">
           {hasInput ? <ToolDataSection label="Input" value={input} /> : null}

--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -3,7 +3,6 @@
 import { ArrowDown01Icon, CpuIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Shimmer } from "@notra/ui/components/ai-elements/shimmer";
-import { ImageZoom } from "@notra/ui/components/kibo-ui/image-zoom";
 import {
   Avatar,
   AvatarFallback,
@@ -16,14 +15,11 @@ import {
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
 import { cn } from "@notra/ui/lib/utils";
-import { CheckIcon, DownloadIcon, XIcon } from "lucide-react";
-import Image from "next/image";
+import { CheckIcon, XIcon } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
-import { getMcpFaviconUrl } from "@/lib/integrations/mcp";
 import {
   commitsByTimeframeInputSchema,
   type MemoryToolInput,
-  mcpToolMetadataSchema,
   memoryIdentifierInputSchema,
   memoryIdentifierOutputSchema,
   memoryToolInputSchema,
@@ -36,18 +32,14 @@ import {
   webSearchInputSchema,
   webSearchOutputSchema,
 } from "@/schemas/ai/chat-tool-block";
-
-interface ToolCopy {
-  verbs: readonly [present: string, past: string];
-  noun: string;
-  subtitle?: (params: {
-    input: unknown;
-    output: unknown;
-    isStreaming: boolean;
-    isError: boolean;
-  }) => string | undefined;
-  suffix?: (input: unknown, output: unknown) => string | undefined;
-}
+import {
+  getMcpToolIconUrl,
+  getMcpToolLabel,
+  isMcpToolName,
+} from "./chat-tool-block/mcp";
+import { ToolOutputImages } from "./chat-tool-block/tool-output-images";
+import { collectToolOutputImages } from "./chat-tool-block/tool-output-images/utils";
+import type { ChatToolBlockProps, ToolCopy } from "./chat-tool-block/types";
 
 function firstStringValue<T extends object>(
   values: T,
@@ -510,50 +502,6 @@ const TOOL_COPY: Record<string, ToolCopy> = {
   },
 };
 
-const MCP_TOOL_NAME_REGEX = /^mcp_/;
-const UNDERSCORE_REGEX = /_+/g;
-const NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX = /[^a-zA-Z0-9]+/g;
-
-function formatToolDisplayName(value: string): string {
-  return value
-    .replace(NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX, " ")
-    .trim()
-    .replace(/\b\w/g, (match) => match.toUpperCase());
-}
-
-function formatMcpToolName(toolName: string): string {
-  const label = toolName
-    .replace(MCP_TOOL_NAME_REGEX, "")
-    .replace(UNDERSCORE_REGEX, " ");
-  const displayName = formatToolDisplayName(label);
-  return displayName || "MCP Tool";
-}
-
-function formatMcpToolLabelPart(value: string): string {
-  const label = formatToolDisplayName(value);
-  return label || "MCP tool";
-}
-
-function getMcpToolLabel(toolName: string, toolMetadata: unknown) {
-  const parsed = mcpToolMetadataSchema.safeParse(toolMetadata);
-  const notraMetadata = parsed.success ? parsed.data.notra : undefined;
-  if (notraMetadata?.label) {
-    return formatMcpToolLabelPart(notraMetadata.label);
-  }
-
-  if (notraMetadata?.serverName && notraMetadata.toolName) {
-    return `${notraMetadata.serverName} - ${formatMcpToolLabelPart(notraMetadata.toolName)}`;
-  }
-
-  return formatMcpToolName(toolName);
-}
-
-function getMcpToolIconUrl(toolMetadata: unknown) {
-  const parsed = mcpToolMetadataSchema.safeParse(toolMetadata);
-  const notraMetadata = parsed.success ? parsed.data.notra : undefined;
-  return getMcpFaviconUrl(notraMetadata?.serverUrl);
-}
-
 function getSubtitle({
   toolName,
   input,
@@ -574,7 +522,7 @@ function getSubtitle({
   const copy = TOOL_COPY[toolName];
   const failurePrefix = isError ? "Failed to call" : undefined;
   if (!copy) {
-    if (MCP_TOOL_NAME_REGEX.test(toolName)) {
+    if (isMcpToolName(toolName)) {
       const label = getMcpToolLabel(toolName, toolMetadata);
       if (isAwaitingApproval) {
         return `Approve ${label}`;
@@ -610,207 +558,6 @@ function getSubtitle({
 const JSON_TOKEN_RE =
   /"(?:\\.|[^"\\])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g;
 const MAX_JSON_RENDER_CHARS = 20_000;
-const DATA_IMAGE_URL_REGEX = /^data:image\/[a-z0-9.+-]+;base64,/i;
-const HTTP_URL_REGEX = /^https?:\/\//i;
-const IMAGE_EXTENSION_REGEX = /\.(?:avif|gif|jpe?g|png|svg|webp)(?:[?#]|$)/i;
-const FILENAME_EXTENSION_REGEX = /\.[a-z0-9]+$/i;
-const LEADING_DOT_REGEX = /^[.]/;
-const URL_SUFFIX_REGEX = /[?#].*$/;
-const IMAGE_SPECIFIC_URL_KEYS = [
-  "image_url",
-  "imageUrl",
-  "thumbnail_url",
-  "thumbnailUrl",
-  "src",
-  "image",
-] as const;
-const GENERIC_URL_KEYS = ["url", "uri", "href"] as const;
-const IMAGE_DATA_KEYS = ["data", "blob", "base64", "image"] as const;
-const IMAGE_CONTAINER_KEYS = [
-  "content",
-  "contents",
-  "structuredContent",
-  "images",
-  "files",
-  "artifacts",
-  "result",
-  "results",
-] as const;
-
-interface ToolOutputImage {
-  url: string;
-  mediaType: string;
-  filename?: string;
-}
-
-function imageExtensionFromMediaType(mediaType: string) {
-  switch (mediaType.toLowerCase()) {
-    case "image/jpeg":
-      return "jpg";
-    case "image/svg+xml":
-      return "svg";
-    case "image/avif":
-      return "avif";
-    case "image/gif":
-      return "gif";
-    case "image/png":
-      return "png";
-    case "image/webp":
-      return "webp";
-    default:
-      return undefined;
-  }
-}
-
-function sanitizeDownloadFilename(filename: string) {
-  return filename
-    .trim()
-    .replace(/[^\w.-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 96);
-}
-
-function getImageDownloadFilename(image: ToolOutputImage, mediaType: string) {
-  const baseName = sanitizeDownloadFilename(
-    image.filename ?? "tool-output-image"
-  );
-  const filename = baseName || "tool-output-image";
-  if (FILENAME_EXTENSION_REGEX.test(filename)) {
-    return filename;
-  }
-
-  const extension =
-    imageExtensionFromMediaType(mediaType) ??
-    imageExtensionFromMediaType(image.mediaType);
-  return extension ? `${filename}.${extension}` : filename;
-}
-
-async function downloadToolOutputImage(image: ToolOutputImage) {
-  try {
-    const response = await fetch(image.url);
-    if (!response.ok) {
-      throw new Error(`Failed to download image: ${response.status}`);
-    }
-
-    const blob = await response.blob();
-    const objectUrl = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = objectUrl;
-    anchor.download = getImageDownloadFilename(image, blob.type);
-    document.body.append(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(objectUrl);
-  } catch {
-    window.open(image.url, "_blank", "noopener,noreferrer");
-  }
-}
-
-function isImageMediaType(value: unknown): value is string {
-  return typeof value === "string" && value.toLowerCase().startsWith("image/");
-}
-
-function getStringField(
-  record: Record<string, unknown>,
-  keys: readonly string[]
-) {
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "string" && value.length > 0) {
-      return value;
-    }
-  }
-  return undefined;
-}
-
-function toImageUrl(value: string, mediaType?: string) {
-  if (DATA_IMAGE_URL_REGEX.test(value)) {
-    return value;
-  }
-  if (HTTP_URL_REGEX.test(value)) {
-    return value;
-  }
-  if (mediaType && isImageMediaType(mediaType)) {
-    return `data:${mediaType};base64,${value}`;
-  }
-  return undefined;
-}
-
-function inferImageMediaType(url: string) {
-  const match = url.match(IMAGE_EXTENSION_REGEX);
-  if (!match) {
-    return undefined;
-  }
-
-  const extension = match[0]
-    .replace(LEADING_DOT_REGEX, "")
-    .replace(URL_SUFFIX_REGEX, "");
-  if (extension === "jpg") {
-    return "image/jpeg";
-  }
-  if (extension === "svg") {
-    return "image/svg+xml";
-  }
-  return `image/${extension}`;
-}
-
-function collectToolOutputImages(
-  value: unknown,
-  images: ToolOutputImage[] = [],
-  seen = new Set<string>(),
-  depth = 0
-): ToolOutputImage[] {
-  if (value == null || depth > 5) {
-    return images;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectToolOutputImages(item, images, seen, depth + 1);
-    }
-    return images;
-  }
-
-  if (typeof value !== "object") {
-    return images;
-  }
-
-  const record = value as Record<string, unknown>;
-  const mediaType = getStringField(record, ["mediaType", "mimeType"]);
-  const filename = getStringField(record, ["filename", "name", "title"]);
-  const imageSpecificUrl = getStringField(record, IMAGE_SPECIFIC_URL_KEYS);
-  const genericUrl = getStringField(record, GENERIC_URL_KEYS);
-  const rawUrl = imageSpecificUrl ?? genericUrl;
-  const rawData = getStringField(record, IMAGE_DATA_KEYS);
-  const url =
-    (rawUrl ? toImageUrl(rawUrl, mediaType) : undefined) ??
-    (rawData ? toImageUrl(rawData, mediaType) : undefined);
-  const inferredMediaType =
-    mediaType ?? (url ? inferImageMediaType(url) : undefined);
-
-  if (
-    url &&
-    (Boolean(imageSpecificUrl) ||
-      isImageMediaType(inferredMediaType) ||
-      DATA_IMAGE_URL_REGEX.test(url))
-  ) {
-    const key = `${inferredMediaType ?? "image"}:${url}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      images.push({
-        url,
-        mediaType: inferredMediaType ?? "image/*",
-        filename,
-      });
-    }
-  }
-
-  for (const key of IMAGE_CONTAINER_KEYS) {
-    collectToolOutputImages(record[key], images, seen, depth + 1);
-  }
-
-  return images;
-}
 
 function stringifyForDisplay(value: unknown): string | undefined {
   try {
@@ -893,60 +640,6 @@ function ToolDataSection({ label, value }: { label: string; value: unknown }) {
       <JsonView value={value} />
     </div>
   );
-}
-
-function ToolOutputImages({ images }: { images: ToolOutputImage[] }) {
-  if (images.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="mt-3 flex flex-col gap-2">
-      {images.map((image, index) => (
-        <div
-          className="group/image relative w-fit max-w-full overflow-hidden rounded-lg border border-border bg-muted/20"
-          key={`${image.url}-${index}`}
-        >
-          <ImageZoom
-            className="block max-w-full transition-opacity group-hover/image:opacity-90"
-            zoomMargin={24}
-          >
-            <Image
-              alt={image.filename ?? "tool output image"}
-              className="block h-auto max-h-64 w-auto max-w-full cursor-pointer"
-              height={512}
-              src={image.url}
-              unoptimized
-              width={768}
-            />
-          </ImageZoom>
-          <button
-            aria-label="Download image"
-            className="absolute top-2 right-2 inline-flex size-8 cursor-pointer items-center justify-center rounded-md border border-border bg-background/90 text-foreground opacity-0 shadow-sm backdrop-blur transition-opacity hover:bg-muted focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/image:opacity-100"
-            onClick={() => {
-              downloadToolOutputImage(image);
-            }}
-            title="Download image"
-            type="button"
-          >
-            <DownloadIcon aria-hidden="true" className="size-4" />
-          </button>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-interface ChatToolBlockProps {
-  toolName: string;
-  state: string;
-  input?: unknown;
-  output?: unknown;
-  onApprove?: () => void;
-  onDeny?: () => void;
-  isMcp?: boolean;
-  iconUrl?: string;
-  toolMetadata?: unknown;
 }
 
 export function ChatToolBlock({

--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -36,7 +36,7 @@ import {
   getMcpToolIconUrl,
   getMcpToolLabel,
   isMcpToolName,
-} from "./chat-tool-block/mcp";
+} from "./chat-tool-block/mcp/utils";
 import { ToolOutputImages } from "./chat-tool-block/tool-output-images";
 import { collectToolOutputImages } from "./chat-tool-block/tool-output-images/utils";
 import type { ChatToolBlockProps, ToolCopy } from "./chat-tool-block/types";

--- a/apps/dashboard/src/components/ai/chat-tool-block/mcp/constants.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/mcp/constants.ts
@@ -1,0 +1,4 @@
+export const MCP_TOOL_NAME_REGEX = /^mcp_/;
+export const UNDERSCORE_REGEX = /_+/g;
+export const NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX = /[^a-zA-Z0-9]+/g;
+export const TITLE_CASE_WORD_REGEX = /\b\w/g;

--- a/apps/dashboard/src/components/ai/chat-tool-block/mcp/index.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/mcp/index.ts
@@ -1,0 +1,56 @@
+import { getMcpFaviconUrl } from "@/lib/integrations/mcp";
+import { mcpToolMetadataSchema } from "@/schemas/ai/chat-tool-block";
+import {
+  MCP_TOOL_NAME_REGEX,
+  NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX,
+  TITLE_CASE_WORD_REGEX,
+  UNDERSCORE_REGEX,
+} from "./constants";
+
+export function isMcpToolName(toolName: string) {
+  return MCP_TOOL_NAME_REGEX.test(toolName);
+}
+
+function formatToolDisplayName(value: string): string {
+  return value
+    .replace(NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX, " ")
+    .trim()
+    .replace(TITLE_CASE_WORD_REGEX, (match) => match.toUpperCase());
+}
+
+function formatMcpToolName(toolName: string): string {
+  const label = toolName
+    .replace(MCP_TOOL_NAME_REGEX, "")
+    .replace(UNDERSCORE_REGEX, " ");
+  const displayName = formatToolDisplayName(label);
+  return displayName || "MCP Tool";
+}
+
+function formatMcpToolLabelPart(value: string): string {
+  const label = formatToolDisplayName(value);
+  return label || "MCP tool";
+}
+
+function getNotraMcpMetadata(toolMetadata: unknown) {
+  const parsed = mcpToolMetadataSchema.safeParse(toolMetadata);
+  return parsed.success ? parsed.data.notra : undefined;
+}
+
+export function getMcpToolLabel(toolName: string, toolMetadata: unknown) {
+  const notraMetadata = getNotraMcpMetadata(toolMetadata);
+
+  if (notraMetadata?.serverName && notraMetadata.toolName) {
+    return `${notraMetadata.serverName} - ${formatMcpToolLabelPart(notraMetadata.toolName)}`;
+  }
+
+  if (notraMetadata?.label) {
+    return formatMcpToolLabelPart(notraMetadata.label);
+  }
+
+  return formatMcpToolName(toolName);
+}
+
+export function getMcpToolIconUrl(toolMetadata: unknown) {
+  const notraMetadata = getNotraMcpMetadata(toolMetadata);
+  return getMcpFaviconUrl(notraMetadata?.serverUrl);
+}

--- a/apps/dashboard/src/components/ai/chat-tool-block/mcp/utils.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/mcp/utils.ts
@@ -31,6 +31,11 @@ function formatMcpToolLabelPart(value: string): string {
   return label || "MCP tool";
 }
 
+function formatMcpServerName(value: string): string | undefined {
+  const serverName = value.trim();
+  return serverName || undefined;
+}
+
 function getNotraMcpMetadata(toolMetadata: unknown) {
   const parsed = mcpToolMetadataSchema.safeParse(toolMetadata);
   return parsed.success ? parsed.data.notra : undefined;
@@ -38,9 +43,15 @@ function getNotraMcpMetadata(toolMetadata: unknown) {
 
 export function getMcpToolLabel(toolName: string, toolMetadata: unknown) {
   const notraMetadata = getNotraMcpMetadata(toolMetadata);
+  const serverName = notraMetadata?.serverName
+    ? formatMcpServerName(notraMetadata.serverName)
+    : undefined;
+  const metadataToolName = notraMetadata?.toolName
+    ? formatMcpToolLabelPart(notraMetadata.toolName)
+    : undefined;
 
-  if (notraMetadata?.serverName && notraMetadata.toolName) {
-    return `${notraMetadata.serverName} - ${formatMcpToolLabelPart(notraMetadata.toolName)}`;
+  if (serverName && metadataToolName) {
+    return `${serverName} - ${metadataToolName}`;
   }
 
   if (notraMetadata?.label) {

--- a/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/constants.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/constants.ts
@@ -1,0 +1,27 @@
+export const DATA_IMAGE_URL_REGEX = /^data:image\/[a-z0-9.+-]+;base64,/i;
+export const HTTP_URL_REGEX = /^https?:\/\//i;
+export const IMAGE_EXTENSION_REGEX =
+  /\.(?:avif|gif|jpe?g|png|svg|webp)(?:[?#]|$)/i;
+export const FILENAME_EXTENSION_REGEX = /\.[a-z0-9]+$/i;
+export const LEADING_DOT_REGEX = /^[.]/;
+export const URL_SUFFIX_REGEX = /[?#].*$/;
+export const IMAGE_SPECIFIC_URL_KEYS = [
+  "image_url",
+  "imageUrl",
+  "thumbnail_url",
+  "thumbnailUrl",
+  "src",
+  "image",
+] as const;
+export const GENERIC_URL_KEYS = ["url", "uri", "href"] as const;
+export const IMAGE_DATA_KEYS = ["data", "blob", "base64", "image"] as const;
+export const IMAGE_CONTAINER_KEYS = [
+  "content",
+  "contents",
+  "structuredContent",
+  "images",
+  "files",
+  "artifacts",
+  "result",
+  "results",
+] as const;

--- a/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/index.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/index.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { ImageZoom } from "@notra/ui/components/kibo-ui/image-zoom";
+import { DownloadIcon } from "lucide-react";
+import Image from "next/image";
+import type { ToolOutputImage } from "./types";
+import { downloadToolOutputImage } from "./utils";
+
+export function ToolOutputImages({ images }: { images: ToolOutputImage[] }) {
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      {images.map((image, index) => (
+        <div
+          className="group/image relative w-fit max-w-full overflow-hidden rounded-lg border border-border bg-muted/20"
+          key={`${image.url}-${index}`}
+        >
+          <ImageZoom
+            className="block max-w-full transition-opacity group-hover/image:opacity-90"
+            zoomMargin={24}
+          >
+            <Image
+              alt={image.filename ?? "tool output image"}
+              className="block h-auto max-h-64 w-auto max-w-full cursor-pointer"
+              height={512}
+              src={image.url}
+              unoptimized
+              width={768}
+            />
+          </ImageZoom>
+          <button
+            aria-label="Download image"
+            className="absolute top-2 right-2 inline-flex size-8 cursor-pointer items-center justify-center rounded-md border border-border bg-background/90 text-foreground opacity-0 shadow-sm backdrop-blur transition-opacity hover:bg-muted focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/image:opacity-100"
+            onClick={() => {
+              downloadToolOutputImage(image);
+            }}
+            title="Download image"
+            type="button"
+          >
+            <DownloadIcon aria-hidden="true" className="size-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/types.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/types.ts
@@ -1,0 +1,5 @@
+export interface ToolOutputImage {
+  url: string;
+  mediaType: string;
+  filename?: string;
+}

--- a/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/utils.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/utils.ts
@@ -1,0 +1,182 @@
+import {
+  DATA_IMAGE_URL_REGEX,
+  FILENAME_EXTENSION_REGEX,
+  GENERIC_URL_KEYS,
+  HTTP_URL_REGEX,
+  IMAGE_CONTAINER_KEYS,
+  IMAGE_DATA_KEYS,
+  IMAGE_EXTENSION_REGEX,
+  IMAGE_SPECIFIC_URL_KEYS,
+  LEADING_DOT_REGEX,
+  URL_SUFFIX_REGEX,
+} from "./constants";
+import type { ToolOutputImage } from "./types";
+
+function imageExtensionFromMediaType(mediaType: string) {
+  switch (mediaType.toLowerCase()) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/svg+xml":
+      return "svg";
+    case "image/avif":
+      return "avif";
+    case "image/gif":
+      return "gif";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    default:
+      return undefined;
+  }
+}
+
+function sanitizeDownloadFilename(filename: string) {
+  return filename
+    .trim()
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 96);
+}
+
+function getImageDownloadFilename(image: ToolOutputImage, mediaType: string) {
+  const baseName = sanitizeDownloadFilename(
+    image.filename ?? "tool-output-image"
+  );
+  const filename = baseName || "tool-output-image";
+  if (FILENAME_EXTENSION_REGEX.test(filename)) {
+    return filename;
+  }
+
+  const extension =
+    imageExtensionFromMediaType(mediaType) ??
+    imageExtensionFromMediaType(image.mediaType);
+  return extension ? `${filename}.${extension}` : filename;
+}
+
+export async function downloadToolOutputImage(image: ToolOutputImage) {
+  try {
+    const response = await fetch(image.url);
+    if (!response.ok) {
+      throw new Error(`Failed to download image: ${response.status}`);
+    }
+
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = getImageDownloadFilename(image, blob.type);
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(objectUrl);
+  } catch {
+    window.open(image.url, "_blank", "noopener,noreferrer");
+  }
+}
+
+function isImageMediaType(value: unknown): value is string {
+  return typeof value === "string" && value.toLowerCase().startsWith("image/");
+}
+
+function getStringField(
+  record: Record<string, unknown>,
+  keys: readonly string[]
+) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function toImageUrl(value: string, mediaType?: string) {
+  if (DATA_IMAGE_URL_REGEX.test(value)) {
+    return value;
+  }
+  if (HTTP_URL_REGEX.test(value)) {
+    return value;
+  }
+  if (mediaType && isImageMediaType(mediaType)) {
+    return `data:${mediaType};base64,${value}`;
+  }
+  return undefined;
+}
+
+function inferImageMediaType(url: string) {
+  const match = url.match(IMAGE_EXTENSION_REGEX);
+  if (!match) {
+    return undefined;
+  }
+
+  const extension = match[0]
+    .replace(LEADING_DOT_REGEX, "")
+    .replace(URL_SUFFIX_REGEX, "");
+  if (extension === "jpg") {
+    return "image/jpeg";
+  }
+  if (extension === "svg") {
+    return "image/svg+xml";
+  }
+  return `image/${extension}`;
+}
+
+export function collectToolOutputImages(
+  value: unknown,
+  images: ToolOutputImage[] = [],
+  seen = new Set<string>(),
+  depth = 0
+): ToolOutputImage[] {
+  if (value == null || depth > 5) {
+    return images;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectToolOutputImages(item, images, seen, depth + 1);
+    }
+    return images;
+  }
+
+  if (typeof value !== "object") {
+    return images;
+  }
+
+  const record = value as Record<string, unknown>;
+  const mediaType = getStringField(record, ["mediaType", "mimeType"]);
+  const filename = getStringField(record, ["filename", "name", "title"]);
+  const imageSpecificUrl = getStringField(record, IMAGE_SPECIFIC_URL_KEYS);
+  const genericUrl = getStringField(record, GENERIC_URL_KEYS);
+  const rawUrl = imageSpecificUrl ?? genericUrl;
+  const rawData = getStringField(record, IMAGE_DATA_KEYS);
+  const url =
+    (rawUrl ? toImageUrl(rawUrl, mediaType) : undefined) ??
+    (rawData ? toImageUrl(rawData, mediaType) : undefined);
+  const inferredMediaType =
+    mediaType ?? (url ? inferImageMediaType(url) : undefined);
+
+  if (
+    url &&
+    (Boolean(imageSpecificUrl) ||
+      isImageMediaType(inferredMediaType) ||
+      DATA_IMAGE_URL_REGEX.test(url))
+  ) {
+    const key = `${inferredMediaType ?? "image"}:${url}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      images.push({
+        url,
+        mediaType: inferredMediaType ?? "image/*",
+        filename,
+      });
+    }
+  }
+
+  for (const key of IMAGE_CONTAINER_KEYS) {
+    collectToolOutputImages(record[key], images, seen, depth + 1);
+  }
+
+  return images;
+}

--- a/apps/dashboard/src/components/ai/chat-tool-block/types.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/types.ts
@@ -1,0 +1,23 @@
+export interface ToolCopy {
+  verbs: readonly [present: string, past: string];
+  noun: string;
+  subtitle?: (params: {
+    input: unknown;
+    output: unknown;
+    isStreaming: boolean;
+    isError: boolean;
+  }) => string | undefined;
+  suffix?: (input: unknown, output: unknown) => string | undefined;
+}
+
+export interface ChatToolBlockProps {
+  toolName: string;
+  state: string;
+  input?: unknown;
+  output?: unknown;
+  onApprove?: () => void;
+  onDeny?: () => void;
+  isMcp?: boolean;
+  iconUrl?: string;
+  toolMetadata?: unknown;
+}

--- a/apps/dashboard/src/components/integrations/add-mcp-server-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/add-mcp-server-dialog.tsx
@@ -20,6 +20,11 @@ import {
   ResponsiveDialogTrigger,
 } from "@notra/ui/components/shared/responsive-dialog";
 import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -41,6 +46,7 @@ import { Button } from "@/components/button";
 import {
   buildMcpHeaders,
   buildMcpUrl,
+  getMcpFaviconUrl,
   getMcpFormErrorMessage,
 } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
@@ -219,9 +225,19 @@ export function AddMcpServerDialog({
       <ResponsiveDialogContent className="sm:max-w-[32.5rem]">
         <ResponsiveDialogHeader>
           <div className="flex items-start gap-3">
-            <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
-              <HugeiconsIcon className="size-5" icon={CpuIcon} />
-            </span>
+            <form.Subscribe selector={(state) => state.values.url}>
+              {(url) => (
+                <Avatar className="size-9 shrink-0 rounded-lg bg-muted after:hidden">
+                  <AvatarImage
+                    className="rounded-lg"
+                    src={getMcpFaviconUrl(buildMcpUrl(url))}
+                  />
+                  <AvatarFallback className="rounded-lg bg-transparent text-foreground">
+                    <HugeiconsIcon className="size-5" icon={CpuIcon} />
+                  </AvatarFallback>
+                </Avatar>
+              )}
+            </form.Subscribe>
             <div>
               <ResponsiveDialogTitle className="text-xl">
                 Add MCP Server
@@ -252,7 +268,9 @@ export function AddMcpServerDialog({
             >
               {(field) => (
                 <Field>
-                  <FieldLabel htmlFor="mcp-name">Name</FieldLabel>
+                  <FieldLabel htmlFor="mcp-name">
+                    Name <span className="-ml-1 text-destructive">*</span>
+                  </FieldLabel>
                   <Input
                     autoComplete="off"
                     id="mcp-name"
@@ -280,7 +298,9 @@ export function AddMcpServerDialog({
             >
               {(field) => (
                 <Field>
-                  <FieldLabel htmlFor="mcp-url">Server URL</FieldLabel>
+                  <FieldLabel htmlFor="mcp-url">
+                    Server URL <span className="-ml-1 text-destructive">*</span>
+                  </FieldLabel>
                   <div
                     className={`flex w-full flex-row items-center rounded-md border transition-colors focus-within:border-ring focus-within:ring-ring/50 ${field.state.meta.errors.length > 0 ? "border-destructive" : "border-border"}`}
                   >
@@ -454,7 +474,7 @@ export function AddMcpServerDialog({
                               );
                               invalidateTestResult();
                             }}
-                            size="icon"
+                            size="icon-sm"
                             type="button"
                             variant="outline"
                           >

--- a/apps/dashboard/src/schemas/ai/chat-tool-block.ts
+++ b/apps/dashboard/src/schemas/ai/chat-tool-block.ts
@@ -180,6 +180,7 @@ export const mcpToolMetadataSchema = z
         .object({
           label: optionalStringSchema,
           serverName: optionalStringSchema,
+          serverUrl: optionalStringSchema,
           toolName: optionalStringSchema,
         })
         .passthrough()

--- a/bun.lock
+++ b/bun.lock
@@ -337,6 +337,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-icons": "^5.5.0",
+        "react-medium-image-zoom": "^5.4.5",
         "recharts": "2.15.4",
         "shadcn": "^3.6.2",
         "shiki": "^3.21.0",
@@ -3425,6 +3426,8 @@
     "react-icons": ["react-icons@5.6.0", "", { "peerDependencies": { "react": "*" } }, "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "react-medium-image-zoom": ["react-medium-image-zoom@5.4.5", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-58QSIRK6X3uw2fSTejJRnH0JuKTZl7ZJYX+sAMaYx4YTEm33gsNdnP5RuQSCnBiAvisQeErqZWAT31bR89WB6g=="],
 
     "react-reconciler": ["react-reconciler@0.32.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ=="],
 

--- a/packages/ai/src/integrations/mcp.ts
+++ b/packages/ai/src/integrations/mcp.ts
@@ -252,17 +252,27 @@ export async function testMcpServerConnection(input: {
       signal: AbortSignal.timeout(timeoutMs),
       timeout: timeoutMs,
     });
+    const definitions = await client.listTools(
+      {},
+      {
+        signal: AbortSignal.timeout(timeoutMs),
+        timeout: timeoutMs,
+      }
+    );
+    const toolCount = definitions.tools.length;
 
     return {
       success: true,
       status: null,
-      message: "MCP connection successful",
+      message: `MCP connection successful. Discovered ${toolCount} ${toolCount === 1 ? "tool" : "tools"}.`,
+      toolCount,
     };
   } catch (error) {
     return {
       success: false,
       status: null,
       message: "Could not reach the MCP server. Check the URL and headers.",
+      toolCount: 0,
     };
   } finally {
     await client.close().catch(() => undefined);

--- a/packages/ai/src/tools/mcp-lazy.ts
+++ b/packages/ai/src/tools/mcp-lazy.ts
@@ -370,6 +370,7 @@ function createRuntimeMcpTool({
         type: "mcp",
         serverId: indexedTool.serverIntegrationId,
         serverName: indexedTool.serverName,
+        serverUrl: indexedTool.serverUrl,
         toolName: indexedTool.serverToolName,
         runtimeToolName: indexedTool.runtimeToolName,
       },

--- a/packages/ai/src/tools/mcp.ts
+++ b/packages/ai/src/tools/mcp.ts
@@ -83,6 +83,7 @@ export async function createMcpRuntimeToolSet(
               type: "mcp",
               serverId: integration.id,
               serverName: integration.name,
+              serverUrl: integration.url,
               toolName,
               label: `${integration.name} - ${displayName}`,
             },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-icons": "^5.5.0",
+    "react-medium-image-zoom": "^5.4.5",
     "recharts": "2.15.4",
     "shadcn": "^3.6.2",
     "shiki": "^3.21.0",

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -672,7 +672,35 @@ function MessageTableCell({
   );
 }
 
+function MessageLink({
+  children,
+  className,
+  href,
+  node: _node,
+  rel,
+  target,
+  ...props
+}: ComponentProps<"a"> & { node?: unknown }) {
+  const isExternal = typeof href === "string" && /^https?:\/\//i.test(href);
+
+  return (
+    <a
+      className={cn(
+        "font-medium text-foreground underline underline-offset-3 transition-colors hover:text-foreground/80",
+        className
+      )}
+      href={href}
+      rel={rel ?? (isExternal ? "noopener noreferrer" : undefined)}
+      target={target ?? (isExternal ? "_blank" : undefined)}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}
+
 const messageResponseComponents = {
+  a: MessageLink,
   table: MessageMarkdownTable,
   thead: MessageTableHead,
   tbody: MessageTableBody,

--- a/packages/ui/src/components/kibo-ui/image-zoom/index.tsx
+++ b/packages/ui/src/components/kibo-ui/image-zoom/index.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Zoom, {
+  type ControlledProps,
+  type UncontrolledProps,
+} from "react-medium-image-zoom";
+import { cn } from "@notra/ui/lib/utils";
+
+export type ImageZoomProps = UncontrolledProps & {
+  isZoomed?: ControlledProps["isZoomed"];
+  onZoomChange?: ControlledProps["onZoomChange"];
+  className?: string;
+  backdropClassName?: string;
+};
+
+export const ImageZoom = ({
+  className,
+  backdropClassName,
+  ...props
+}: ImageZoomProps) => (
+  <div
+    className={cn(
+      "relative",
+      "[&_[data-rmiz-ghost]]:pointer-events-none [&_[data-rmiz-ghost]]:absolute",
+      "[&_[data-rmiz-btn-zoom]]:m-0 [&_[data-rmiz-btn-zoom]]:size-10 [&_[data-rmiz-btn-zoom]]:touch-manipulation [&_[data-rmiz-btn-zoom]]:appearance-none [&_[data-rmiz-btn-zoom]]:rounded-[50%] [&_[data-rmiz-btn-zoom]]:border-none [&_[data-rmiz-btn-zoom]]:bg-foreground/70 [&_[data-rmiz-btn-zoom]]:p-2 [&_[data-rmiz-btn-zoom]]:text-background [&_[data-rmiz-btn-zoom]]:outline-offset-2",
+      "[&_[data-rmiz-btn-unzoom]]:m-0 [&_[data-rmiz-btn-unzoom]]:size-10 [&_[data-rmiz-btn-unzoom]]:touch-manipulation [&_[data-rmiz-btn-unzoom]]:appearance-none [&_[data-rmiz-btn-unzoom]]:rounded-[50%] [&_[data-rmiz-btn-unzoom]]:border-none [&_[data-rmiz-btn-unzoom]]:bg-foreground/70 [&_[data-rmiz-btn-unzoom]]:p-2 [&_[data-rmiz-btn-unzoom]]:text-background [&_[data-rmiz-btn-unzoom]]:outline-offset-2",
+      "[&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:pointer-events-none [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:absolute [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:size-px [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:overflow-hidden [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:whitespace-nowrap [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:[clip-path:inset(50%)] [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:[clip:rect(0_0_0_0)]",
+      "[&_[data-rmiz-btn-zoom]]:absolute [&_[data-rmiz-btn-zoom]]:top-2.5 [&_[data-rmiz-btn-zoom]]:right-2.5 [&_[data-rmiz-btn-zoom]]:bottom-auto [&_[data-rmiz-btn-zoom]]:left-auto [&_[data-rmiz-btn-zoom]]:cursor-zoom-in",
+      "[&_[data-rmiz-btn-unzoom]]:absolute [&_[data-rmiz-btn-unzoom]]:top-5 [&_[data-rmiz-btn-unzoom]]:right-5 [&_[data-rmiz-btn-unzoom]]:bottom-auto [&_[data-rmiz-btn-unzoom]]:left-auto [&_[data-rmiz-btn-unzoom]]:z-[1] [&_[data-rmiz-btn-unzoom]]:cursor-zoom-out",
+      '[&_[data-rmiz-content="found"]_img]:cursor-zoom-in',
+      '[&_[data-rmiz-content="found"]_svg]:cursor-zoom-in',
+      '[&_[data-rmiz-content="found"]_[role="img"]]:cursor-zoom-in',
+      '[&_[data-rmiz-content="found"]_[data-zoom]]:cursor-zoom-in',
+      className
+    )}
+  >
+    <Zoom
+      classDialog={cn(
+        "[&::backdrop]:hidden",
+        "[&[open]]:fixed [&[open]]:m-0 [&[open]]:h-dvh [&[open]]:max-h-none [&[open]]:w-dvw [&[open]]:max-w-none [&[open]]:overflow-hidden [&[open]]:border-0 [&[open]]:bg-transparent [&[open]]:p-0",
+        "[&_[data-rmiz-modal-overlay]]:absolute [&_[data-rmiz-modal-overlay]]:inset-0 [&_[data-rmiz-modal-overlay]]:transition-all",
+        '[&_[data-rmiz-modal-overlay="hidden"]]:bg-transparent',
+        '[&_[data-rmiz-modal-overlay="visible"]]:bg-background/80 [&_[data-rmiz-modal-overlay="visible"]]:backdrop-blur-md',
+        "[&_[data-rmiz-modal-content]]:relative [&_[data-rmiz-modal-content]]:size-full",
+        "[&_[data-rmiz-modal-img]]:absolute [&_[data-rmiz-modal-img]]:origin-top-left [&_[data-rmiz-modal-img]]:cursor-zoom-out [&_[data-rmiz-modal-img]]:transition-transform",
+        "motion-reduce:[&_[data-rmiz-modal-img]]:transition-none motion-reduce:[&_[data-rmiz-modal-overlay]]:transition-none",
+        backdropClassName
+      )}
+      {...props}
+    />
+  </div>
+);


### PR DESCRIPTION
### Description
Adds standalone chat support for image outputs returned by MCP tools, including structured Bloom image responses. Tool output images now render inline with zoom and download controls, MCP tool rows use server favicons and normalized tool labels, and MCP connection tests report discovered tool counts.

Also fixes Streamdown link rendering in message responses to avoid invalid interactive markup inside paragraphs.

AI assistance used: Codex.

### Screenshot/Recording (if applicable)
Not attached. Tested locally against the Bloom MCP flow.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/80217541-f15b-4f69-85b0-6754784549cf/pull/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds standalone chat support for MCP tool image outputs and refactors helper logic for reuse. Images render inline with zoom/download, MCP labels are normalized with favicons, and connection tests now report discovered tools.

- **New Features**
  - Render MCP tool images inline with zoom and download; supports HTTP URLs and base64 data from structured outputs.
  - Normalize MCP tool labels (title case; serverName - toolName) and show server favicons via `serverUrl`; the Add MCP Server dialog previews the favicon.
  - Show image previews above tool details in tool blocks.
  - Add `ImageZoom` component powered by `react-medium-image-zoom`.
  - MCP connection test now returns the number of discovered tools.

- **Bug Fixes**
  - Fix link rendering in message responses to avoid invalid interactive markup; open external links safely.

<sup>Written for commit 83ab0acb5a6757d867d238eec65b29411c880a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

