### PR TITLE
Add image export actions

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -2,7 +2,9 @@
 
 import { useChat } from "@ai-sdk/react";
 import {
+  ArrowDown01Icon,
   ArrowLeft02Icon,
+  Download01Icon,
   SentIcon,
   TextIcon,
 } from "@hugeicons/core-free-icons";
@@ -26,9 +28,7 @@ import {
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
 import { useSidebar } from "@notra/ui/components/ui/sidebar";
-import { Figma } from "@notra/ui/components/ui/svgs/figma";
 import { Linkedin } from "@notra/ui/components/ui/svgs/linkedin";
-import { Paper } from "@notra/ui/components/ui/svgs/paper";
 import { XTwitter } from "@notra/ui/components/ui/svgs/twitter";
 import {
   Tooltip,
@@ -37,7 +37,6 @@ import {
 } from "@notra/ui/components/ui/tooltip";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { DefaultChatTransport } from "ai";
-import { ChevronDownIcon, DownloadIcon, SparklesIcon } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import remend from "remend";
@@ -46,6 +45,7 @@ import ChatInput from "@/components/chat-input";
 import { getContentTypeLabel } from "@/components/content/content-card";
 import type { EditorRefHandle } from "@/components/content/editor/plugins/editor-ref-plugin";
 import { ContentEditorSwitch } from "@/components/content/editors";
+import { ImageExportTargetIcon } from "@/components/content/image-export-target-icon";
 import { RecommendationsSection } from "@/components/content/recommendations-section";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { CONTENT_TITLE_REGEX } from "@/constants/content-detail";
@@ -56,7 +56,7 @@ import { TWITTER_BRAND_COLOR } from "@/constants/twitter";
 import {
   copyImageAsFigma,
   copyImageAsPaper,
-  downloadImageAsPng,
+  downloadImage,
 } from "@/lib/content/image-export";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import { cn } from "@/lib/utils";
@@ -88,25 +88,6 @@ function formatDate(date: Date): string {
 function extractTitleFromMarkdown(markdown: string): string {
   const match = markdown.match(CONTENT_TITLE_REGEX);
   return match?.[1] ?? "Untitled";
-}
-
-function ImageExportTargetIcon({
-  target,
-  className,
-}: {
-  target: ImageExportTarget;
-  className?: string;
-}) {
-  switch (target) {
-    case "figma":
-      return <Figma className={className} />;
-    case "wonder":
-      return <SparklesIcon className={className} />;
-    case "paper":
-      return <Paper className={className} />;
-    default:
-      return <Paper className={className} />;
-  }
 }
 
 function formatLookbackWindow(window: string): string {
@@ -769,11 +750,6 @@ export default function PageClient({
       return;
     }
 
-    if (imageExportTarget === "wonder") {
-      toast.info("Wonder export is coming soon");
-      return;
-    }
-
     copyImageAsPaper(
       imageExportRef.current,
       title,
@@ -1004,12 +980,12 @@ export default function PageClient({
               {content.contentType === "image" && (
                 <>
                   <Button
-                    onClick={() => downloadImageAsPng(imageDownloadUrl, title)}
+                    onClick={() => downloadImage(imageDownloadUrl, title)}
                     size="sm"
                     variant="outline"
                   >
-                    <DownloadIcon className="size-4" />
-                    Download PNG
+                    <HugeiconsIcon className="size-4" icon={Download01Icon} />
+                    Download image
                   </Button>
                   <ButtonGroup>
                     <Button
@@ -1028,7 +1004,10 @@ export default function PageClient({
                         render={<Button size="icon-sm" variant="outline" />}
                       >
                         <span className="sr-only">Select export target</span>
-                        <ChevronDownIcon className="size-4" />
+                        <HugeiconsIcon
+                          className="size-4"
+                          icon={ArrowDown01Icon}
+                        />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-52">
                         <DropdownMenuLabel>Copy target</DropdownMenuLabel>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -15,6 +15,16 @@ import {
 } from "@notra/ui/components/ui/avatar";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { Button } from "@notra/ui/components/ui/button";
+import { ButtonGroup } from "@notra/ui/components/ui/button-group";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@notra/ui/components/ui/dropdown-menu";
 import { useSidebar } from "@notra/ui/components/ui/sidebar";
 import { Figma } from "@notra/ui/components/ui/svgs/figma";
 import { Linkedin } from "@notra/ui/components/ui/svgs/linkedin";
@@ -27,6 +37,7 @@ import {
 } from "@notra/ui/components/ui/tooltip";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { DefaultChatTransport } from "ai";
+import { ChevronDownIcon, DownloadIcon, SparklesIcon } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import remend from "remend";
@@ -37,22 +48,33 @@ import type { EditorRefHandle } from "@/components/content/editor/plugins/editor
 import { ContentEditorSwitch } from "@/components/content/editors";
 import { RecommendationsSection } from "@/components/content/recommendations-section";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { CONTENT_TITLE_REGEX } from "@/constants/content-detail";
+import { IMAGE_EXPORT_TARGETS } from "@/constants/image-export";
 import { LINKEDIN_BRAND_PRIMARY } from "@/constants/linkedin";
+import { localStorageKeys } from "@/constants/storage";
 import { TWITTER_BRAND_COLOR } from "@/constants/twitter";
-import { copyImageAsFigma, copyImageAsPaper } from "@/lib/content/image-export";
+import {
+  copyImageAsFigma,
+  copyImageAsPaper,
+  downloadImageAsPng,
+} from "@/lib/content/image-export";
 import { dashboardOrpc } from "@/lib/orpc/query";
+import { cn } from "@/lib/utils";
 import { sourceMetadataSchema } from "@/schemas/content";
 import type { ContentDetailPageClientProps } from "@/types/content/detail";
+import type { ImageExportTarget } from "@/types/content/image-export";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
 import { getBrandFaviconUrl } from "@/utils/brand";
 import { formatSnakeCaseLabel } from "@/utils/format";
-import { getImageExportHtml } from "@/utils/image-content";
+import { getImageExportHtml, isHttpImageContent } from "@/utils/image-content";
+import {
+  getImageExportTargetLabel,
+  isImageExportTarget,
+} from "@/utils/image-export";
 import { createLinkedInPostUrl } from "@/utils/linkedin";
 import { createTwitterPostUrl } from "@/utils/twitter";
 import { useContent } from "../../../../../lib/hooks/use-content";
 import { ContentDetailSkeleton } from "./skeleton";
-
-const TITLE_REGEX = /^#\s+(.+)$/m;
 
 function formatDate(date: Date): string {
   return new Intl.DateTimeFormat(undefined, {
@@ -64,8 +86,27 @@ function formatDate(date: Date): string {
 }
 
 function extractTitleFromMarkdown(markdown: string): string {
-  const match = markdown.match(TITLE_REGEX);
+  const match = markdown.match(CONTENT_TITLE_REGEX);
   return match?.[1] ?? "Untitled";
+}
+
+function ImageExportTargetIcon({
+  target,
+  className,
+}: {
+  target: ImageExportTarget;
+  className?: string;
+}) {
+  switch (target) {
+    case "figma":
+      return <Figma className={className} />;
+    case "wonder":
+      return <SparklesIcon className={className} />;
+    case "paper":
+      return <Paper className={className} />;
+    default:
+      return <Paper className={className} />;
+  }
 }
 
 function formatLookbackWindow(window: string): string {
@@ -121,6 +162,8 @@ export default function PageClient({
   const [editorKey, setEditorKey] = useState(0);
   const [context, setContext] = useState<ContextItem[]>([]);
   const [chatInputValue, setChatInputValue] = useState("");
+  const [imageExportTarget, setImageExportTarget] =
+    useState<ImageExportTarget>("paper");
 
   const saveToastIdRef = useRef<string | number | null>(null);
   const editorRef = useRef<EditorRefHandle | null>(null);
@@ -130,6 +173,28 @@ export default function PageClient({
   const needsNormalizationRef = useRef(false);
   const originalMarkdownRef = useRef("");
   const editedMarkdownRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const storedTarget = window.localStorage.getItem(
+      localStorageKeys.imageExportTarget
+    );
+    if (
+      storedTarget &&
+      isImageExportTarget(storedTarget) &&
+      storedTarget !== "wonder"
+    ) {
+      setImageExportTarget(storedTarget);
+    }
+  }, []);
+
+  const handleImageExportTargetChange = useCallback((value: string) => {
+    if (!isImageExportTarget(value) || value === "wonder") {
+      return;
+    }
+
+    setImageExportTarget(value);
+    window.localStorage.setItem(localStorageKeys.imageExportTarget, value);
+  }, []);
 
   useEffect(() => {
     if (data?.content && editedMarkdown === null) {
@@ -689,6 +754,33 @@ export default function PageClient({
     content.contentType === "image" ? getImageExportHtml(content) : null;
   const imageExportHtmlUrl =
     content.contentType === "image" ? content.htmlUrl : null;
+  const imageDownloadUrl =
+    content.contentType === "image" && isHttpImageContent(content.content)
+      ? content.content
+      : null;
+  const handleCopyImageExport = () => {
+    if (imageExportTarget === "figma") {
+      copyImageAsFigma(
+        imageExportRef.current,
+        title,
+        imageExportHtml,
+        imageExportHtmlUrl
+      );
+      return;
+    }
+
+    if (imageExportTarget === "wonder") {
+      toast.info("Wonder export is coming soon");
+      return;
+    }
+
+    copyImageAsPaper(
+      imageExportRef.current,
+      title,
+      imageExportHtml,
+      imageExportHtmlUrl
+    );
+  };
   const collection = data.collection;
   const backHref = collection
     ? `/${organizationSlug}/collection/${collection.id}`
@@ -912,35 +1004,76 @@ export default function PageClient({
               {content.contentType === "image" && (
                 <>
                   <Button
-                    onClick={() =>
-                      copyImageAsFigma(
-                        imageExportRef.current,
-                        title,
-                        imageExportHtml,
-                        imageExportHtmlUrl
-                      )
-                    }
+                    onClick={() => downloadImageAsPng(imageDownloadUrl, title)}
                     size="sm"
                     variant="outline"
                   >
-                    <Figma className="size-4" />
-                    Copy for Figma
+                    <DownloadIcon className="size-4" />
+                    Download PNG
                   </Button>
-                  <Button
-                    onClick={() =>
-                      copyImageAsPaper(
-                        imageExportRef.current,
-                        title,
-                        imageExportHtml,
-                        imageExportHtmlUrl
-                      )
-                    }
-                    size="sm"
-                    variant="outline"
-                  >
-                    <Paper className="size-4" />
-                    Copy for Paper
-                  </Button>
+                  <ButtonGroup>
+                    <Button
+                      onClick={handleCopyImageExport}
+                      size="sm"
+                      variant="outline"
+                    >
+                      <ImageExportTargetIcon
+                        className="size-4"
+                        target={imageExportTarget}
+                      />
+                      Copy for {getImageExportTargetLabel(imageExportTarget)}
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={<Button size="icon-sm" variant="outline" />}
+                      >
+                        <span className="sr-only">Select export target</span>
+                        <ChevronDownIcon className="size-4" />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-52">
+                        <DropdownMenuLabel>Copy target</DropdownMenuLabel>
+                        <DropdownMenuRadioGroup
+                          onValueChange={handleImageExportTargetChange}
+                          value={imageExportTarget}
+                        >
+                          {IMAGE_EXPORT_TARGETS.map((target) => {
+                            const isWonder = target === "wonder";
+
+                            return (
+                              <DropdownMenuRadioItem
+                                className={cn(
+                                  "gap-2",
+                                  isWonder && "items-start"
+                                )}
+                                disabled={isWonder}
+                                key={target}
+                                value={target}
+                              >
+                                <ImageExportTargetIcon
+                                  className="mt-0.5 size-4"
+                                  target={target}
+                                />
+                                <span className="flex flex-col">
+                                  <span>
+                                    {getImageExportTargetLabel(target)}
+                                  </span>
+                                  {isWonder && (
+                                    <span className="text-muted-foreground text-xs">
+                                      Coming soon
+                                    </span>
+                                  )}
+                                </span>
+                              </DropdownMenuRadioItem>
+                            );
+                          })}
+                        </DropdownMenuRadioGroup>
+                        <DropdownMenuSeparator />
+                        <div className="px-1.5 py-1 text-muted-foreground text-xs">
+                          Selection is saved on this device.
+                        </div>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </ButtonGroup>
                 </>
               )}
             </div>

--- a/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/constants.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/constants.ts
@@ -2,7 +2,6 @@ export const DATA_IMAGE_URL_REGEX = /^data:image\/[a-z0-9.+-]+;base64,/i;
 export const HTTP_URL_REGEX = /^https?:\/\//i;
 export const IMAGE_EXTENSION_REGEX =
   /\.(?:avif|gif|jpe?g|png|svg|webp)(?:[?#]|$)/i;
-export const FILENAME_EXTENSION_REGEX = /\.[a-z0-9]+$/i;
 export const LEADING_DOT_REGEX = /^[.]/;
 export const URL_SUFFIX_REGEX = /[?#].*$/;
 export const IMAGE_SPECIFIC_URL_KEYS = [

--- a/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/utils.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/tool-output-images/utils.ts
@@ -1,6 +1,11 @@
 import {
+  buildImageDownloadFilename,
+  downloadBlob,
+  imageExtensionFromMediaType,
+  sanitizeDownloadFilename,
+} from "@/utils/download";
+import {
   DATA_IMAGE_URL_REGEX,
-  FILENAME_EXTENSION_REGEX,
   GENERIC_URL_KEYS,
   HTTP_URL_REGEX,
   IMAGE_CONTAINER_KEYS,
@@ -12,46 +17,15 @@ import {
 } from "./constants";
 import type { ToolOutputImage } from "./types";
 
-function imageExtensionFromMediaType(mediaType: string) {
-  switch (mediaType.toLowerCase()) {
-    case "image/jpeg":
-      return "jpg";
-    case "image/svg+xml":
-      return "svg";
-    case "image/avif":
-      return "avif";
-    case "image/gif":
-      return "gif";
-    case "image/png":
-      return "png";
-    case "image/webp":
-      return "webp";
-    default:
-      return undefined;
-  }
-}
-
-function sanitizeDownloadFilename(filename: string) {
-  return filename
-    .trim()
-    .replace(/[^\w.-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 96);
-}
-
 function getImageDownloadFilename(image: ToolOutputImage, mediaType: string) {
-  const baseName = sanitizeDownloadFilename(
-    image.filename ?? "tool-output-image"
+  const baseName =
+    sanitizeDownloadFilename(image.filename ?? "tool-output-image") ||
+    "tool-output-image";
+  return buildImageDownloadFilename(
+    baseName,
+    mediaType,
+    imageExtensionFromMediaType(image.mediaType)
   );
-  const filename = baseName || "tool-output-image";
-  if (FILENAME_EXTENSION_REGEX.test(filename)) {
-    return filename;
-  }
-
-  const extension =
-    imageExtensionFromMediaType(mediaType) ??
-    imageExtensionFromMediaType(image.mediaType);
-  return extension ? `${filename}.${extension}` : filename;
 }
 
 export async function downloadToolOutputImage(image: ToolOutputImage) {
@@ -62,14 +36,7 @@ export async function downloadToolOutputImage(image: ToolOutputImage) {
     }
 
     const blob = await response.blob();
-    const objectUrl = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = objectUrl;
-    anchor.download = getImageDownloadFilename(image, blob.type);
-    document.body.append(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(objectUrl);
+    downloadBlob(blob, getImageDownloadFilename(image, blob.type));
   } catch {
     window.open(image.url, "_blank", "noopener,noreferrer");
   }

--- a/apps/dashboard/src/components/content/image-export-target-icon.tsx
+++ b/apps/dashboard/src/components/content/image-export-target-icon.tsx
@@ -1,0 +1,21 @@
+import { SparklesIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Figma } from "@notra/ui/components/ui/svgs/figma";
+import { Paper } from "@notra/ui/components/ui/svgs/paper";
+import type { ImageExportTargetIconProps } from "@/types/content/image-export";
+
+export function ImageExportTargetIcon({
+  target,
+  className,
+}: ImageExportTargetIconProps) {
+  switch (target) {
+    case "figma":
+      return <Figma className={className} />;
+    case "wonder":
+      return <HugeiconsIcon className={className} icon={SparklesIcon} />;
+    case "paper":
+      return <Paper className={className} />;
+    default:
+      return <Paper className={className} />;
+  }
+}

--- a/apps/dashboard/src/constants/content-detail.ts
+++ b/apps/dashboard/src/constants/content-detail.ts
@@ -1,0 +1,1 @@
+export const CONTENT_TITLE_REGEX = /^#\s+(.+)$/m;

--- a/apps/dashboard/src/constants/download.ts
+++ b/apps/dashboard/src/constants/download.ts
@@ -1,2 +1,3 @@
 export const DOWNLOAD_FILENAME_INVALID_CHARS_REGEX = /[^\w.-]+/g;
 export const DOWNLOAD_FILENAME_EDGE_DASHES_REGEX = /^-+|-+$/g;
+export const DOWNLOAD_FILENAME_EXTENSION_REGEX = /\.[a-z0-9]+$/i;

--- a/apps/dashboard/src/constants/download.ts
+++ b/apps/dashboard/src/constants/download.ts
@@ -1,0 +1,2 @@
+export const DOWNLOAD_FILENAME_INVALID_CHARS_REGEX = /[^\w.-]+/g;
+export const DOWNLOAD_FILENAME_EDGE_DASHES_REGEX = /^-+|-+$/g;

--- a/apps/dashboard/src/constants/image-export.ts
+++ b/apps/dashboard/src/constants/image-export.ts
@@ -1,1 +1,10 @@
 export const IMAGE_EXPORT_TARGETS = ["paper", "figma", "wonder"] as const;
+
+export const IMAGE_EXPORT_TARGET_LABELS: Record<
+  (typeof IMAGE_EXPORT_TARGETS)[number],
+  string
+> = {
+  paper: "Paper",
+  figma: "Figma",
+  wonder: "Wonder",
+};

--- a/apps/dashboard/src/constants/image-export.ts
+++ b/apps/dashboard/src/constants/image-export.ts
@@ -1,0 +1,1 @@
+export const IMAGE_EXPORT_TARGETS = ["paper", "figma", "wonder"] as const;

--- a/apps/dashboard/src/constants/storage.ts
+++ b/apps/dashboard/src/constants/storage.ts
@@ -3,6 +3,7 @@ const CHAT_PREFERENCES_STORAGE_VERSION = "v1";
 export const localStorageKeys = {
   chatPreferences: `notra_chat_preferences:${CHAT_PREFERENCES_STORAGE_VERSION}`,
   chatQueue: (chatId: string) => `chat-queue:${chatId}`,
+  imageExportTarget: "notra:image-export-target",
   contentView: "notra:content-view",
   sidebarOnboardingCollapsed: (organizationId?: string) =>
     organizationId

--- a/apps/dashboard/src/lib/content/image-export.ts
+++ b/apps/dashboard/src/lib/content/image-export.ts
@@ -1,6 +1,7 @@
 import { copyAsFigma } from "@notra/kiwi";
 import { copyAsPaper } from "@notra/kiwi/paper";
 import { toast } from "sonner";
+import { downloadBlob, sanitizeDownloadFilename } from "@/utils/download";
 
 function createExportElement(html: string): HTMLDivElement {
   const container = document.createElement("div");
@@ -103,5 +104,30 @@ export async function copyImageAsPaper(
   } catch (error) {
     console.error("Failed to copy image for Paper", error);
     toast.error("Failed to copy for Paper");
+  }
+}
+
+export async function downloadImageAsPng(
+  imageUrl: string | null | undefined,
+  label?: string
+): Promise<void> {
+  if (!imageUrl) {
+    toast.error("Image is not ready yet");
+    return;
+  }
+
+  const baseName = sanitizeDownloadFilename(label ?? "image") || "image";
+
+  try {
+    const response = await fetch(imageUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download image: ${response.status}`);
+    }
+
+    downloadBlob(await response.blob(), `${baseName}.png`);
+    toast.success("Downloaded PNG");
+  } catch (error) {
+    console.error("Failed to download image as PNG", error);
+    toast.error("Failed to download PNG");
   }
 }

--- a/apps/dashboard/src/lib/content/image-export.ts
+++ b/apps/dashboard/src/lib/content/image-export.ts
@@ -1,7 +1,11 @@
 import { copyAsFigma } from "@notra/kiwi";
 import { copyAsPaper } from "@notra/kiwi/paper";
 import { toast } from "sonner";
-import { downloadBlob, sanitizeDownloadFilename } from "@/utils/download";
+import {
+  buildImageDownloadFilename,
+  downloadBlob,
+  sanitizeDownloadFilename,
+} from "@/utils/download";
 
 function createExportElement(html: string): HTMLDivElement {
   const container = document.createElement("div");
@@ -107,7 +111,7 @@ export async function copyImageAsPaper(
   }
 }
 
-export async function downloadImageAsPng(
+export async function downloadImage(
   imageUrl: string | null | undefined,
   label?: string
 ): Promise<void> {
@@ -124,10 +128,11 @@ export async function downloadImageAsPng(
       throw new Error(`Failed to download image: ${response.status}`);
     }
 
-    downloadBlob(await response.blob(), `${baseName}.png`);
-    toast.success("Downloaded PNG");
+    const blob = await response.blob();
+    downloadBlob(blob, buildImageDownloadFilename(baseName, blob.type, "png"));
+    toast.success("Downloaded image");
   } catch (error) {
-    console.error("Failed to download image as PNG", error);
-    toast.error("Failed to download PNG");
+    console.error("Failed to download image", error);
+    toast.error("Failed to download image");
   }
 }

--- a/apps/dashboard/src/types/content/image-export.ts
+++ b/apps/dashboard/src/types/content/image-export.ts
@@ -1,3 +1,8 @@
 import type { IMAGE_EXPORT_TARGETS } from "@/constants/image-export";
 
 export type ImageExportTarget = (typeof IMAGE_EXPORT_TARGETS)[number];
+
+export interface ImageExportTargetIconProps {
+  target: ImageExportTarget;
+  className?: string;
+}

--- a/apps/dashboard/src/types/content/image-export.ts
+++ b/apps/dashboard/src/types/content/image-export.ts
@@ -1,0 +1,3 @@
+import type { IMAGE_EXPORT_TARGETS } from "@/constants/image-export";
+
+export type ImageExportTarget = (typeof IMAGE_EXPORT_TARGETS)[number];

--- a/apps/dashboard/src/utils/download.ts
+++ b/apps/dashboard/src/utils/download.ts
@@ -13,7 +13,8 @@ export function sanitizeDownloadFilename(filename: string) {
 }
 
 export function imageExtensionFromMediaType(mediaType: string) {
-  switch (mediaType.toLowerCase()) {
+  const [baseMediaType = ""] = mediaType.toLowerCase().split(";");
+  switch (baseMediaType.trim()) {
     case "image/jpeg":
       return "jpg";
     case "image/svg+xml":

--- a/apps/dashboard/src/utils/download.ts
+++ b/apps/dashboard/src/utils/download.ts
@@ -1,0 +1,23 @@
+import {
+  DOWNLOAD_FILENAME_EDGE_DASHES_REGEX,
+  DOWNLOAD_FILENAME_INVALID_CHARS_REGEX,
+} from "@/constants/download";
+
+export function sanitizeDownloadFilename(filename: string) {
+  return filename
+    .trim()
+    .replace(DOWNLOAD_FILENAME_INVALID_CHARS_REGEX, "-")
+    .replace(DOWNLOAD_FILENAME_EDGE_DASHES_REGEX, "")
+    .slice(0, 96);
+}
+
+export function downloadBlob(blob: Blob, filename: string) {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/apps/dashboard/src/utils/download.ts
+++ b/apps/dashboard/src/utils/download.ts
@@ -1,5 +1,6 @@
 import {
   DOWNLOAD_FILENAME_EDGE_DASHES_REGEX,
+  DOWNLOAD_FILENAME_EXTENSION_REGEX,
   DOWNLOAD_FILENAME_INVALID_CHARS_REGEX,
 } from "@/constants/download";
 
@@ -9,6 +10,38 @@ export function sanitizeDownloadFilename(filename: string) {
     .replace(DOWNLOAD_FILENAME_INVALID_CHARS_REGEX, "-")
     .replace(DOWNLOAD_FILENAME_EDGE_DASHES_REGEX, "")
     .slice(0, 96);
+}
+
+export function imageExtensionFromMediaType(mediaType: string) {
+  switch (mediaType.toLowerCase()) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/svg+xml":
+      return "svg";
+    case "image/avif":
+      return "avif";
+    case "image/gif":
+      return "gif";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    default:
+      return undefined;
+  }
+}
+
+export function buildImageDownloadFilename(
+  baseName: string,
+  mediaType: string,
+  fallbackExtension?: string
+) {
+  if (DOWNLOAD_FILENAME_EXTENSION_REGEX.test(baseName)) {
+    return baseName;
+  }
+
+  const extension = imageExtensionFromMediaType(mediaType) ?? fallbackExtension;
+  return extension ? `${baseName}.${extension}` : baseName;
 }
 
 export function downloadBlob(blob: Blob, filename: string) {

--- a/apps/dashboard/src/utils/image-export.ts
+++ b/apps/dashboard/src/utils/image-export.ts
@@ -1,0 +1,17 @@
+import { IMAGE_EXPORT_TARGETS } from "@/constants/image-export";
+import type { ImageExportTarget } from "@/types/content/image-export";
+
+export function isImageExportTarget(value: string): value is ImageExportTarget {
+  return IMAGE_EXPORT_TARGETS.includes(value as ImageExportTarget);
+}
+
+export function getImageExportTargetLabel(target: ImageExportTarget): string {
+  switch (target) {
+    case "figma":
+      return "Figma";
+    case "wonder":
+      return "Wonder";
+    case "paper":
+      return "Paper";
+  }
+}

--- a/apps/dashboard/src/utils/image-export.ts
+++ b/apps/dashboard/src/utils/image-export.ts
@@ -1,17 +1,13 @@
-import { IMAGE_EXPORT_TARGETS } from "@/constants/image-export";
+import {
+  IMAGE_EXPORT_TARGET_LABELS,
+  IMAGE_EXPORT_TARGETS,
+} from "@/constants/image-export";
 import type { ImageExportTarget } from "@/types/content/image-export";
 
 export function isImageExportTarget(value: string): value is ImageExportTarget {
-  return IMAGE_EXPORT_TARGETS.includes(value as ImageExportTarget);
+  return IMAGE_EXPORT_TARGETS.some((target) => target === value);
 }
 
 export function getImageExportTargetLabel(target: ImageExportTarget): string {
-  switch (target) {
-    case "figma":
-      return "Figma";
-    case "wonder":
-      return "Wonder";
-    case "paper":
-      return "Paper";
-  }
+  return IMAGE_EXPORT_TARGET_LABELS[target];
 }


### PR DESCRIPTION
## Summary
- add PNG download support for image content
- replace separate Figma/Paper buttons with a persisted export target button group
- add disabled Wonder export option marked coming soon
- move export targets, regexes, storage keys, types, and download helpers into constants/types/utils

## Test
- bun run check-types

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds image export actions: a single “Copy for …” with a saved target (Paper, Figma; Wonder coming soon) and a “Download image” action. Centralizes export logic and filename handling into shared utils, types, and constants.

- New Features
  - “Download image” saves with a sanitized name and the correct file extension.
  - “Copy for …” with a dropdown for Figma or Paper; choice is saved per device. Wonder is shown but disabled.

- Bug Fixes
  - Correctly resolves the download extension by stripping media-type parameters (e.g., “image/png; charset=utf-8”).

<sup>Written for commit e6307417617b28adae091a46e03fe0a1610d493a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

