### PR TITLE
chore: upgrade upstash box

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -220,7 +220,7 @@
         "@octokit/core": "^7.0.6",
         "@resvg/resvg-js": "^2.6.2",
         "@supermemory/tools": "^1.3.64",
-        "@upstash/box": "^0.4.5",
+        "@upstash/box": "^0.5.0",
         "@upstash/qstash": "2.9.0-rc",
         "@upstash/realtime": "^1.0.3",
         "@upstash/redis": "^1.35.8",
@@ -1768,7 +1768,7 @@
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
-    "@upstash/box": ["@upstash/box@0.4.5", "", { "dependencies": { "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-BOR0EPqIhxLguBsojZH5cBqI1Ax6fng2ob8vnVAXrdEcWLm4dJEsVsK/RqzxJ09MsEvQ4Vv46X0yLf6UIHEoDA=="],
+    "@upstash/box": ["@upstash/box@0.5.0", "", { "dependencies": { "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-0Cm1xU0390zHdbhjjw09jXxAz7bEwf66FYVimBqa0ZgeENyT3+TMal7zeatu9VANq1DJ9PJZl4LJMvHN+GKXiQ=="],
 
     "@upstash/core-analytics": ["@upstash/core-analytics@0.0.10", "", { "dependencies": { "@upstash/redis": "^1.28.3" } }, "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ=="],
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -45,7 +45,7 @@
     "@octokit/core": "^7.0.6",
     "@resvg/resvg-js": "^2.6.2",
     "@supermemory/tools": "^1.3.64",
-    "@upstash/box": "^0.4.5",
+    "@upstash/box": "^0.5.0",
     "@upstash/qstash": "2.9.0-rc",
     "@upstash/realtime": "^1.0.3",
     "@upstash/redis": "^1.35.8",


### PR DESCRIPTION
### Description
Upgrade `@upstash/box` in `@notra/ai` from `^0.4.5` to `^0.5.0` and refresh `bun.lock`.

`@upstash/box` is already included in `bunfig.toml` under `minimumReleaseAgeExcludes`, so the Bun minimum release age bypass is in place for this package.

### Screenshot/Recording (if applicable)
N/A - dependency-only change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Verification:
- `bun run check-types`
- Commit hook ran `ultracite fix`, `turbo run knip --filter=web --filter=dashboard --filter=api`, and `commitlint`. `ultracite fix` reported existing unrelated warnings about array index keys in dashboard skeleton files; it did not fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `@upstash/box` to `^0.5.0` in `@notra/ai` and refreshes `bun.lock` to pick up the latest fixes. The Bun minimum release age bypass for this package is already set in `bunfig.toml`.

<sup>Written for commit 4d519095c9e9f76a3a7b58b16fb811d2707706b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

