### PR TITLE
fix: track repo image cache token costs

### DIFF
--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -35,6 +35,7 @@ import {
   injectBrandIdentitySkill,
   injectHumanizerSkill,
 } from "@notra/ai/utils/repo-image-skills";
+import { extractRepoImageUsage } from "@notra/ai/utils/repo-image-usage";
 import { withLongFetchTimeouts } from "@notra/ai/utils/undici-dispatcher";
 import { Agent, Box } from "@upstash/box";
 import { generateText, Output } from "ai";
@@ -588,44 +589,6 @@ function readSnapshotNumber(snapshot: unknown, key: string) {
   }
   const value = (snapshot as Record<string, unknown>)[key];
   return typeof value === "number" ? value : undefined;
-}
-
-function extractRepoImageUsage(
-  cost: unknown,
-  modelId: string
-): GenerateRepoImageResult["usage"] {
-  if (!cost || typeof cost !== "object") {
-    return undefined;
-  }
-
-  const inputTokens =
-    "inputTokens" in cost && typeof cost.inputTokens === "number"
-      ? cost.inputTokens
-      : 0;
-  const outputTokens =
-    "outputTokens" in cost && typeof cost.outputTokens === "number"
-      ? cost.outputTokens
-      : 0;
-  const computeMs =
-    "computeMs" in cost && typeof cost.computeMs === "number"
-      ? cost.computeMs
-      : undefined;
-  const totalUsd =
-    "totalUsd" in cost && typeof cost.totalUsd === "number"
-      ? cost.totalUsd
-      : undefined;
-
-  return {
-    inputTokens,
-    outputTokens,
-    totalTokens: inputTokens + outputTokens,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    modelId,
-    ...(computeMs === undefined ? {} : { computeMs }),
-    ...(totalUsd === undefined ? {} : { totalUsd }),
-    raw: cost,
-  };
 }
 
 function mergeRepoImageUsage(

--- a/packages/ai/src/schemas/repo-image.ts
+++ b/packages/ai/src/schemas/repo-image.ts
@@ -103,3 +103,45 @@ export const imageRevisionToolInputSchema = z.object({
 export const unavailableImageRevisionToolInputSchema = z.object({
   prompt: z.string().optional(),
 });
+
+const repoImageCostNumberSchema = z.number().finite().nonnegative();
+
+const repoImageCostInputTokenDetailsSchema = z
+  .object({
+    cacheReadTokens: repoImageCostNumberSchema.optional(),
+    cacheWriteTokens: repoImageCostNumberSchema.optional(),
+    cacheCreationInputTokens: repoImageCostNumberSchema.optional(),
+    cache_read_tokens: repoImageCostNumberSchema.optional(),
+    cache_write_tokens: repoImageCostNumberSchema.optional(),
+    cache_creation_input_tokens: repoImageCostNumberSchema.optional(),
+  })
+  .passthrough();
+
+export const repoImageCostSchema = z
+  .object({
+    inputTokens: repoImageCostNumberSchema.optional(),
+    input_tokens: repoImageCostNumberSchema.optional(),
+    input: repoImageCostNumberSchema.optional(),
+    outputTokens: repoImageCostNumberSchema.optional(),
+    output_tokens: repoImageCostNumberSchema.optional(),
+    output: repoImageCostNumberSchema.optional(),
+    cacheReadTokens: repoImageCostNumberSchema.optional(),
+    cacheReadInputTokens: repoImageCostNumberSchema.optional(),
+    cachedInputTokens: repoImageCostNumberSchema.optional(),
+    cache_read_tokens: repoImageCostNumberSchema.optional(),
+    cache_read_input_tokens: repoImageCostNumberSchema.optional(),
+    cached_input_tokens: repoImageCostNumberSchema.optional(),
+    cacheWriteTokens: repoImageCostNumberSchema.optional(),
+    cacheWriteInputTokens: repoImageCostNumberSchema.optional(),
+    cacheCreationInputTokens: repoImageCostNumberSchema.optional(),
+    cache_write_tokens: repoImageCostNumberSchema.optional(),
+    cache_write_input_tokens: repoImageCostNumberSchema.optional(),
+    cache_creation_input_tokens: repoImageCostNumberSchema.optional(),
+    inputTokenDetails: repoImageCostInputTokenDetailsSchema.optional(),
+    input_token_details: repoImageCostInputTokenDetailsSchema.optional(),
+    computeMs: repoImageCostNumberSchema.optional(),
+    compute_ms: repoImageCostNumberSchema.optional(),
+    totalUsd: repoImageCostNumberSchema.optional(),
+    total_usd: repoImageCostNumberSchema.optional(),
+  })
+  .passthrough();

--- a/packages/ai/src/utils/repo-image-usage.ts
+++ b/packages/ai/src/utils/repo-image-usage.ts
@@ -1,0 +1,81 @@
+import { repoImageCostSchema } from "@notra/ai/schemas/repo-image";
+import type { GenerateRepoImageResult } from "@notra/ai/types/repo-image";
+import type * as z from "zod";
+
+type RepoImageCost = z.infer<typeof repoImageCostSchema>;
+type RepoImageCostInputTokenDetails = NonNullable<
+  RepoImageCost["inputTokenDetails"]
+>;
+
+export function extractRepoImageUsage(
+  cost: unknown,
+  modelId: string
+): GenerateRepoImageResult["usage"] {
+  const parsed = repoImageCostSchema.safeParse(cost);
+  if (!parsed.success) {
+    return undefined;
+  }
+
+  const normalizedCost = parsed.data;
+  const inputTokens =
+    normalizedCost.inputTokens ??
+    normalizedCost.input_tokens ??
+    normalizedCost.input ??
+    0;
+  const outputTokens =
+    normalizedCost.outputTokens ??
+    normalizedCost.output_tokens ??
+    normalizedCost.output ??
+    0;
+  const cacheReadTokens =
+    normalizedCost.cacheReadTokens ??
+    normalizedCost.cacheReadInputTokens ??
+    normalizedCost.cachedInputTokens ??
+    normalizedCost.cache_read_tokens ??
+    normalizedCost.cache_read_input_tokens ??
+    normalizedCost.cached_input_tokens ??
+    readInputTokenDetailsCacheReadTokens(normalizedCost.inputTokenDetails) ??
+    readInputTokenDetailsCacheReadTokens(normalizedCost.input_token_details) ??
+    0;
+  const cacheWriteTokens =
+    normalizedCost.cacheWriteTokens ??
+    normalizedCost.cacheWriteInputTokens ??
+    normalizedCost.cacheCreationInputTokens ??
+    normalizedCost.cache_write_tokens ??
+    normalizedCost.cache_write_input_tokens ??
+    normalizedCost.cache_creation_input_tokens ??
+    readInputTokenDetailsCacheWriteTokens(normalizedCost.inputTokenDetails) ??
+    readInputTokenDetailsCacheWriteTokens(normalizedCost.input_token_details) ??
+    0;
+  const computeMs = normalizedCost.computeMs ?? normalizedCost.compute_ms;
+  const totalUsd = normalizedCost.totalUsd ?? normalizedCost.total_usd;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    modelId,
+    ...(computeMs === 0 ? {} : { computeMs }),
+    ...(totalUsd === 0 ? {} : { totalUsd }),
+    raw: cost,
+  };
+}
+
+function readInputTokenDetailsCacheReadTokens(
+  details?: RepoImageCostInputTokenDetails
+) {
+  return details?.cacheReadTokens ?? details?.cache_read_tokens;
+}
+
+function readInputTokenDetailsCacheWriteTokens(
+  details?: RepoImageCostInputTokenDetails
+) {
+  return (
+    details?.cacheWriteTokens ??
+    details?.cacheCreationInputTokens ??
+    details?.cache_write_tokens ??
+    details?.cache_creation_input_tokens
+  );
+}


### PR DESCRIPTION
### Description
Parse cache token usage from Upstash Box repo image generation cost payloads so Autumn AI credit deductions include cache reads and writes. The cost payload shape is defined with Zod in `packages/ai/src/schemas/repo-image.ts`, while the normalization helper stays in `packages/ai/src/utils/repo-image-usage.ts` and feeds the existing Autumn tracking path.

### Screenshot/Recording (if applicable)
Not applicable. Billing/accounting backend change only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

Disclosure: Codex was used to implement this change.

</details>

Validation:
- `bun run check packages/ai/src/schemas/repo-image.ts packages/ai/src/utils/repo-image-usage.ts packages/ai/src/agents/repo-image.ts`
- `bun run --filter=@notra/ai check-types`