### PR TITLE
feat: surface annual billing discount on pricing page

### DIFF
--- a/apps/web/src/components/pricing-section.tsx
+++ b/apps/web/src/components/pricing-section.tsx
@@ -6,7 +6,7 @@ import { Button } from "@notra/ui/components/ui/button";
 import { Card } from "@notra/ui/components/ui/card";
 import Link from "next/link";
 import { useState } from "react";
-import { PRICING_PLANS } from "../utils/constants";
+import { ANNUAL_FREE_MONTHS, PRICING_PLANS } from "../utils/constants";
 import { HatchPattern } from "./hatch-pattern";
 import { TrackedSignupLink } from "./tracked-signup-link";
 
@@ -176,6 +176,15 @@ export function PricingCards() {
                 }`}
               >
                 Annually
+              </span>
+              <span
+                className={`ml-1 font-medium font-sans text-[11px] leading-5 transition-colors duration-300 ${
+                  billingPeriod === "annually"
+                    ? "text-primary/70"
+                    : "text-muted-foreground/70"
+                }`}
+              >
+                {ANNUAL_FREE_MONTHS} months free
               </span>
             </button>
           </div>

--- a/apps/web/src/components/pricing-section.tsx
+++ b/apps/web/src/components/pricing-section.tsx
@@ -20,6 +20,7 @@ function PricingCard({
   features,
   variant = "default",
   signupSource,
+  badge,
 }: {
   name: string;
   description: string;
@@ -28,6 +29,7 @@ function PricingCard({
   features: readonly (string | { label: string; subtitle: string })[];
   signupSource: string;
   variant?: "default" | "featured";
+  badge?: string | null;
 }) {
   const isFeatured = variant === "featured";
   const ctaLink =
@@ -46,12 +48,25 @@ function PricingCard({
       }`}
     >
       <div className="flex flex-col items-start justify-start gap-2">
-        <div
-          className={`font-medium font-sans text-lg leading-7 ${
-            isFeatured ? "text-primary-foreground" : "text-primary/90"
-          }`}
-        >
-          {name}
+        <div className="flex w-full items-center justify-between gap-2">
+          <div
+            className={`font-medium font-sans text-lg leading-7 ${
+              isFeatured ? "text-primary-foreground" : "text-primary/90"
+            }`}
+          >
+            {name}
+          </div>
+          {badge && (
+            <div
+              className={`rounded-full border px-2.5 py-0.5 font-medium font-sans text-[11px] leading-4 ${
+                isFeatured
+                  ? "border-white/20 bg-white/10 text-primary-foreground"
+                  : "border-primary/10 bg-primary/5 text-primary/80"
+              }`}
+            >
+              {badge}
+            </div>
+          )}
         </div>
         <div
           className={`w-full max-w-[242px] font-normal font-sans text-sm leading-5 ${
@@ -131,6 +146,8 @@ export function PricingCards() {
   const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
 
   const { basic, pro, enterprise } = PRICING_PLANS;
+  const annualBadge =
+    billingPeriod === "annually" ? `${ANNUAL_FREE_MONTHS} months free` : null;
 
   return (
     <>
@@ -177,15 +194,6 @@ export function PricingCards() {
               >
                 Annually
               </span>
-              <span
-                className={`ml-1 font-medium font-sans text-[11px] leading-5 transition-colors duration-300 ${
-                  billingPeriod === "annually"
-                    ? "text-primary/70"
-                    : "text-muted-foreground/70"
-                }`}
-              >
-                {ANNUAL_FREE_MONTHS} months free
-              </span>
             </button>
           </div>
 
@@ -202,6 +210,7 @@ export function PricingCards() {
 
           <div className="grid flex-1 grid-cols-1 gap-y-12 py-12 md:grid-cols-[1fr_auto_1fr_auto_1fr] md:grid-rows-[auto_auto_auto_1fr] md:gap-y-0 md:py-0">
             <PricingCard
+              badge={annualBadge}
               cta={basic.cta}
               description={basic.description}
               features={basic.features}
@@ -225,6 +234,7 @@ export function PricingCards() {
             <HatchPattern className="hidden w-6 self-stretch md:row-span-4 md:block lg:w-8" />
 
             <PricingCard
+              badge={annualBadge}
               cta={pro.cta}
               description={pro.description}
               features={pro.features}

--- a/apps/web/src/utils/constants.ts
+++ b/apps/web/src/utils/constants.ts
@@ -68,6 +68,10 @@ export const HTML_ENTITY_MAP: Record<string, string> = {
   nbsp: " ",
 };
 
+export const ANNUAL_DISCOUNT_PERCENT = 17;
+
+export const ANNUAL_FREE_MONTHS = 2;
+
 export const PRICING_PLANS = {
   basic: {
     name: "Basic",

--- a/apps/web/src/utils/site-markdown.ts
+++ b/apps/web/src/utils/site-markdown.ts
@@ -1,5 +1,7 @@
 import { BRAND_ASSETS, BRAND_COLORS, BRAND_FONTS } from "@/lib/brand/constants";
 import {
+  ANNUAL_DISCOUNT_PERCENT,
+  ANNUAL_FREE_MONTHS,
   COMPARISON_FEATURES,
   PRICING_PLANS,
   SOCIAL_PROOF_LOGOS,
@@ -54,8 +56,12 @@ function renderPlanPrice(
   }
 
   const price = plan.pricing[billingPeriod];
-  const unit = billingPeriod === "monthly" ? "month" : "year";
-  return `$${price}/${unit}`;
+
+  if (billingPeriod === "annually") {
+    return `$${price}/year (save ${ANNUAL_DISCOUNT_PERCENT}% vs monthly billing)`;
+  }
+
+  return `$${price}/month`;
 }
 
 function renderPlanFeatures(
@@ -153,6 +159,8 @@ export function buildPricingMarkdown() {
     "Choose the right Notra plan for your team.",
     "",
     "Start with a 7-day free trial. Upgrade when you need more integrations, posts, or team seats.",
+    "",
+    `Annual billing saves ${ANNUAL_DISCOUNT_PERCENT}% compared to monthly billing (${ANNUAL_FREE_MONTHS} months free).`,
     "",
     planSections,
     "## Feature Comparison",


### PR DESCRIPTION
### Description
Adds the annual billing discount to the pricing page in both the HTML and the dualmark (`/pricing.md`) versions, so agents reading the markdown twin see the same numbers humans see.

- Humans (HTML): the Basic and Pro cards show a "2 months free" badge in the top right when annual billing is selected ($200/yr vs $240, $500/yr vs $600).
- Agents (dualmark): `/pricing.md` states "Annual billing saves 17% compared to monthly billing (2 months free)." and each plan renders `Annual: $200/year (save 17% vs monthly billing)`.
- Both are driven by shared constants (`ANNUAL_DISCOUNT_PERCENT`, `ANNUAL_FREE_MONTHS`) in `apps/web/src/utils/constants.ts` so the two versions cannot drift apart.

### Screenshot/Recording (if applicable)
![Pricing page with annual billing selected showing the 2 months free badge on the Basic and Pro cards](https://raw.githubusercontent.com/usenotra/notra/assets/pricing-annual-discount/pricing-annual-discount.png)

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did: written with Claude Code

</details>
