### PR TITLE
fix(ai): scrub opencode state before sandbox snapshots

### DIFF
--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -31,6 +31,7 @@ import { createOctokit } from "@notra/ai/utils/octokit";
 import { shortSha } from "@notra/ai/utils/repo-image";
 import { withBoxRetry } from "@notra/ai/utils/repo-image-box";
 import { renderHtmlToImages } from "@notra/ai/utils/repo-image-render";
+import { cleanupRepoImageSandbox } from "@notra/ai/utils/repo-image-sandbox-cleanup";
 import {
   injectBrandIdentitySkill,
   injectHumanizerSkill,
@@ -512,6 +513,12 @@ export async function generateRepoImage(params: {
           box.files.read(REPO_IMAGE_OUTPUT_HTML_PATH)
         );
         rendered = await renderHtmlToImages(html);
+      }
+
+      try {
+        await cleanupRepoImageSandbox({ box });
+      } catch (error) {
+        console.warn("[repo-image] sandbox cleanup skipped after error", error);
       }
 
       snapshot = await withBoxRetry(() =>

--- a/packages/ai/src/utils/repo-image-sandbox-cleanup.ts
+++ b/packages/ai/src/utils/repo-image-sandbox-cleanup.ts
@@ -1,0 +1,29 @@
+import type { Box } from "@upstash/box";
+import { withBoxRetry } from "./repo-image-box";
+
+type RepoImageBox = Awaited<ReturnType<typeof Box.create>>;
+
+const OPENCODE_SANDBOX_CLEANUP_COMMAND = [
+  "{",
+  "find . \\(",
+  "-type d -name .opencode -prune -exec rm -rf {} +",
+  "\\) -o \\(",
+  "-type f \\( -name opencode.json -o -name opencode.jsonc \\) -delete",
+  "\\);",
+  '[ -z "$HOME" ] || rm -rf "$HOME/.config/opencode"',
+  '"$HOME/.local/share/opencode"',
+  '"$HOME/.cache/opencode";',
+  "rm -rf",
+  "/workspace/home/.config/opencode",
+  "/workspace/home/.local/share/opencode",
+  "/workspace/home/.cache/opencode;",
+  '[ -z "$OPENCODE_CONFIG" ] || rm -f "$OPENCODE_CONFIG";',
+  '[ -z "$OPENCODE_CONFIG_DIR" ] || rm -rf "$OPENCODE_CONFIG_DIR";',
+  "} >/dev/null 2>&1 || true",
+].join(" ");
+
+export async function cleanupRepoImageSandbox(params: { box: RepoImageBox }) {
+  await withBoxRetry(() =>
+    params.box.exec.command(OPENCODE_SANDBOX_CLEANUP_COMMAND)
+  );
+}


### PR DESCRIPTION
### Description
Scrubs OpenCode project config and home state from repo image Upstash sandboxes before snapshots are persisted.

This removes project-local `.opencode`, `opencode.json`, and `opencode.jsonc` files, plus OpenCode config/data/cache directories under `$HOME` and `/workspace/home`. Cleanup is best-effort so a cleanup failure cannot discard an already generated and rendered image.

AI assistance was used to implement this PR.

### Screenshot/Recording (if applicable)
N/A - backend sandbox cleanup change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs OpenCode state from repo-image sandboxes before snapshotting to prevent leaking project or user config. Cleanup runs after rendering and won’t block snapshots if it fails.

- **Bug Fixes**
  - Remove `.opencode` dirs and `opencode.json`/`opencode.jsonc` from the repo.
  - Purge OpenCode config/data/cache under `$HOME` and `/workspace/home`; respect `OPENCODE_CONFIG*` paths.
  - Execute via `withBoxRetry` and `box.exec` on `@upstash/box`; on error, skip and log a warning.

<sup>Written for commit fbaf15bc9f998f38d7d22896cf1d666216681816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

