### PR TITLE
fix(ai): run opencode cleanup after clone

### DIFF
--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -388,6 +388,12 @@ export async function generateRepoImage(params: {
       }
       await withBoxRetry(() => box.cd(repository.repo));
 
+      try {
+        await cleanupRepoImageSandbox({ box });
+      } catch (error) {
+        console.warn("[repo-image] sandbox cleanup skipped after error", error);
+      }
+
       if (!restoreSnapshotId) {
         await installImageGenAgentSkills({ box });
       }
@@ -513,12 +519,6 @@ export async function generateRepoImage(params: {
           box.files.read(REPO_IMAGE_OUTPUT_HTML_PATH)
         );
         rendered = await renderHtmlToImages(html);
-      }
-
-      try {
-        await cleanupRepoImageSandbox({ box });
-      } catch (error) {
-        console.warn("[repo-image] sandbox cleanup skipped after error", error);
       }
 
       snapshot = await withBoxRetry(() =>

--- a/packages/ai/src/utils/repo-image-sandbox-cleanup.ts
+++ b/packages/ai/src/utils/repo-image-sandbox-cleanup.ts
@@ -4,22 +4,11 @@ import { withBoxRetry } from "./repo-image-box";
 type RepoImageBox = Awaited<ReturnType<typeof Box.create>>;
 
 const OPENCODE_SANDBOX_CLEANUP_COMMAND = [
-  "{",
   "find . \\(",
   "-type d -name .opencode -prune -exec rm -rf {} +",
   "\\) -o \\(",
   "-type f \\( -name opencode.json -o -name opencode.jsonc \\) -delete",
-  "\\);",
-  '[ -z "$HOME" ] || rm -rf "$HOME/.config/opencode"',
-  '"$HOME/.local/share/opencode"',
-  '"$HOME/.cache/opencode";',
-  "rm -rf",
-  "/workspace/home/.config/opencode",
-  "/workspace/home/.local/share/opencode",
-  "/workspace/home/.cache/opencode;",
-  '[ -z "$OPENCODE_CONFIG" ] || rm -f "$OPENCODE_CONFIG";',
-  '[ -z "$OPENCODE_CONFIG_DIR" ] || rm -rf "$OPENCODE_CONFIG_DIR";',
-  "} >/dev/null 2>&1 || true",
+  "\\) >/dev/null 2>&1 || true",
 ].join(" ");
 
 export async function cleanupRepoImageSandbox(params: { box: RepoImageBox }) {


### PR DESCRIPTION
### Description
Moves the repo image OpenCode cleanup to run immediately after the repository is cloned/restored and `cd`'d into, before skill installation or agent execution.

This also narrows the cleanup to repo-local OpenCode artifacts only: `.opencode`, `opencode.json`, and `opencode.jsonc`. It leaves OpenCode home/runtime state intact so restored snapshots can still run the OpenCode harness for image revisions.

Follow-up to #420.

AI assistance was used to implement this PR.

### Screenshot/Recording (if applicable)
N/A - backend sandbox cleanup change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run OpenCode cleanup immediately after cloning/restoring the repo so runs start with a clean repo directory. Limit the cleanup to repo-local files and keep OpenCode home/runtime state intact for restored snapshots.

- **Bug Fixes**
  - Run cleanup right after `cd` into the repo, before skill install or agent execution.
  - Only remove `.opencode`, `opencode.json`, and `opencode.jsonc`; leave `$HOME` and `/workspace/home` OpenCode dirs untouched.

<sup>Written for commit f661c11067a12fc3d050654f37f86bcc1f4ad9f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

