### PR TITLE
feat(web): add image gen announcement banner above landing nav

### DIFF
--- a/apps/web/src/components/landing-banner.tsx
+++ b/apps/web/src/components/landing-banner.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ArrowRight01Icon, SparklesIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LANDING_BANNER_HREF,
+  LANDING_BANNER_LINK_LABEL,
+  LANDING_BANNER_TEXT,
+} from "@/lib/landing-banner/constants";
+
+export function LandingBanner() {
+  const pathname = usePathname();
+
+  if (pathname !== "/") {
+    return null;
+  }
+
+  return (
+    <div className="sticky top-0 z-[60] mb-2 flex w-full justify-center">
+      <Link
+        className="group inset-shadow-sm inset-shadow-white flex w-full items-center justify-center gap-2 rounded-2xl bg-white px-4 py-2.5 text-center font-medium text-neutral-700 text-sm shadow-black/5 shadow-sm ring-1 ring-black/5 transition-colors duration-150 ease-out hover:bg-neutral-50 dark:inset-shadow-white/5 dark:bg-neutral-950 dark:text-neutral-200 dark:ring-white/10 dark:hover:bg-neutral-900"
+        href={LANDING_BANNER_HREF}
+      >
+        <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <HugeiconsIcon className="size-3.5" icon={SparklesIcon} />
+        </span>
+        <span>{LANDING_BANNER_TEXT}</span>
+        <span className="inline-flex items-center gap-1 text-primary">
+          {LANDING_BANNER_LINK_LABEL}
+          <HugeiconsIcon
+            className="size-4 transition-transform duration-150 ease-out group-hover:translate-x-0.5"
+            icon={ArrowRight01Icon}
+          />
+        </span>
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing-banner.tsx
+++ b/apps/web/src/components/landing-banner.tsx
@@ -5,6 +5,8 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
+  LANDING_BANNER_BADGE,
+  LANDING_BANNER_DETAIL,
   LANDING_BANNER_HREF,
   LANDING_BANNER_LINK_LABEL,
   LANDING_BANNER_TEXT,
@@ -18,28 +20,33 @@ export function LandingBanner() {
   }
 
   return (
-    <div className="sticky top-0 z-[60] mb-2 flex w-full justify-center">
-      <Link
-        className="group inset-shadow-sm inset-shadow-white flex w-full items-center justify-center gap-2 rounded-2xl bg-white px-4 py-2.5 text-center font-medium text-neutral-700 text-sm shadow-black/5 shadow-sm ring-1 ring-black/5 transition-colors duration-150 ease-out hover:bg-neutral-50 dark:inset-shadow-white/5 dark:bg-neutral-950 dark:text-neutral-200 dark:ring-white/10 dark:hover:bg-neutral-900"
-        href={LANDING_BANNER_HREF}
-      >
-        <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-          <HugeiconsIcon
-            aria-hidden={true}
-            className="size-3.5"
-            icon={SparklesIcon}
-          />
+    <Link
+      className="group sticky top-0 z-[70] flex w-full items-center justify-center gap-x-2 gap-y-1 bg-primary px-4 py-2.5 text-center font-medium text-primary-foreground text-sm transition-colors duration-150 ease-out hover:bg-primary-hover"
+      href={LANDING_BANNER_HREF}
+    >
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-white/15 px-2 py-0.5 font-semibold text-xs">
+        <HugeiconsIcon
+          aria-hidden={true}
+          className="size-3.5"
+          icon={SparklesIcon}
+        />
+        {LANDING_BANNER_BADGE}
+      </span>
+      <span>
+        <span className="font-semibold">{LANDING_BANNER_TEXT}</span>
+        <span className="hidden text-primary-foreground/85 sm:inline">
+          {" "}
+          {LANDING_BANNER_DETAIL}
         </span>
-        <span>{LANDING_BANNER_TEXT}</span>
-        <span className="inline-flex items-center gap-1 text-primary">
-          {LANDING_BANNER_LINK_LABEL}
-          <HugeiconsIcon
-            aria-hidden={true}
-            className="size-4 transition-transform duration-150 ease-out group-hover:translate-x-0.5"
-            icon={ArrowRight01Icon}
-          />
-        </span>
-      </Link>
-    </div>
+      </span>
+      <span className="inline-flex shrink-0 items-center gap-1 font-semibold underline decoration-primary-foreground/40 underline-offset-2">
+        {LANDING_BANNER_LINK_LABEL}
+        <HugeiconsIcon
+          aria-hidden={true}
+          className="size-4 transition-transform duration-150 ease-out group-hover:translate-x-0.5"
+          icon={ArrowRight01Icon}
+        />
+      </span>
+    </Link>
   );
 }

--- a/apps/web/src/components/landing-banner.tsx
+++ b/apps/web/src/components/landing-banner.tsx
@@ -24,12 +24,17 @@ export function LandingBanner() {
         href={LANDING_BANNER_HREF}
       >
         <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-          <HugeiconsIcon className="size-3.5" icon={SparklesIcon} />
+          <HugeiconsIcon
+            aria-hidden={true}
+            className="size-3.5"
+            icon={SparklesIcon}
+          />
         </span>
         <span>{LANDING_BANNER_TEXT}</span>
         <span className="inline-flex items-center gap-1 text-primary">
           {LANDING_BANNER_LINK_LABEL}
           <HugeiconsIcon
+            aria-hidden={true}
             className="size-4 transition-transform duration-150 ease-out group-hover:translate-x-0.5"
             icon={ArrowRight01Icon}
           />

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -236,6 +236,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
   const resolvedVariant = variant ?? getNavbarVariantForPath(pathname);
   const tracksScroll = resolvedVariant === "island";
   const isStatic = resolvedVariant === "static";
+  const hasBanner = pathname === "/";
 
   const [isOpen, setIsOpen] = useState(false);
   const [activeGroup, setActiveGroup] = useState<string | null>(null);
@@ -371,12 +372,14 @@ export function Navbar({ variant }: NavbarProps = {}) {
   const mutedNavClass = chrome
     ? "text-neutral-500 dark:text-neutral-400"
     : "text-neutral-700 dark:text-neutral-200";
+  const bannerStickyOffset = hasBanner ? "sticky top-14" : "sticky top-4";
+  const stickyClass = isStatic ? "" : bannerStickyOffset;
 
   return (
     <LazyMotion features={domAnimation} strict>
       <m.div
         animate={{ maxWidth: chrome ? "64rem" : "80rem" }}
-        className={`z-50 mx-auto w-full ${isStatic ? "" : "sticky top-4"}`}
+        className={`z-50 mx-auto w-full ${stickyClass}`}
         initial={false}
         transition={shellTransition}
       >

--- a/apps/web/src/components/site-shell.tsx
+++ b/apps/web/src/components/site-shell.tsx
@@ -7,6 +7,7 @@ import { Navbar } from "./navbar";
 export function SiteShell({ children }: SiteShellProps) {
   return (
     <div className="relative flex min-h-screen w-full flex-col items-center justify-start bg-background">
+      <LandingBanner />
       <div className="relative isolate flex w-full flex-col items-center justify-start">
         <HeroGradient />
         <div className="relative flex w-full max-w-none flex-col items-start justify-start px-4 sm:px-6 md:px-8 lg:max-w-7xl lg:px-0">
@@ -14,7 +15,6 @@ export function SiteShell({ children }: SiteShellProps) {
           <div className="absolute top-0 right-4 z-0 h-full w-px bg-border/60 [-webkit-mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] [mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] sm:right-6 md:right-8 lg:right-0" />
 
           <div className="relative z-10 flex flex-col items-center self-stretch pt-4 pb-8 md:pb-12">
-            <LandingBanner />
             <Navbar />
             {children}
             <div className="w-full">

--- a/apps/web/src/components/site-shell.tsx
+++ b/apps/web/src/components/site-shell.tsx
@@ -1,6 +1,7 @@
 import type { SiteShellProps } from "../types/site-shell";
 import FooterSection from "./footer-section";
 import { HeroGradient } from "./hero-gradient";
+import { LandingBanner } from "./landing-banner";
 import { Navbar } from "./navbar";
 
 export function SiteShell({ children }: SiteShellProps) {
@@ -13,6 +14,7 @@ export function SiteShell({ children }: SiteShellProps) {
           <div className="absolute top-0 right-4 z-0 h-full w-px bg-border/60 [-webkit-mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] [mask-image:linear-gradient(to_bottom,transparent,#fff_40vh)] sm:right-6 md:right-8 lg:right-0" />
 
           <div className="relative z-10 flex flex-col items-center self-stretch pt-4 pb-8 md:pb-12">
+            <LandingBanner />
             <Navbar />
             {children}
             <div className="w-full">

--- a/apps/web/src/lib/landing-banner/constants.ts
+++ b/apps/web/src/lib/landing-banner/constants.ts
@@ -1,3 +1,6 @@
-export const LANDING_BANNER_TEXT = "Image gen is live";
+export const LANDING_BANNER_BADGE = "New";
+export const LANDING_BANNER_TEXT = "Image generation is live.";
+export const LANDING_BANNER_DETAIL =
+  "Turn shipped work into editable marketing visuals in seconds.";
 export const LANDING_BANNER_LINK_LABEL = "Try it now";
 export const LANDING_BANNER_HREF = "/features/marketing/assets";

--- a/apps/web/src/lib/landing-banner/constants.ts
+++ b/apps/web/src/lib/landing-banner/constants.ts
@@ -1,0 +1,3 @@
+export const LANDING_BANNER_TEXT = "Image gen is live";
+export const LANDING_BANNER_LINK_LABEL = "Try it now";
+export const LANDING_BANNER_HREF = "/features/marketing/assets";


### PR DESCRIPTION
### Description
Adds a non-scrolling announcement banner pinned above the landing page navigation that promotes the new image generation feature and links to it.

- New `LandingBanner` client component, rendered at the very top of `SiteShell` (above `Navbar`) and scoped to the landing page (`/`) only.
- Full-bleed bar, `sticky top-0` so it stays pinned while scrolling; the navbar's sticky offset bumps to `top-14` on the landing page so the island nav clears the banner once scrolled.
- Copy reads "Image generation is live. Turn shipped work into editable marketing visuals in seconds." with a "Try it now" link to `/features/marketing/assets`.
- Text, link label, and href are centralized in `@/lib/landing-banner/constants`; decorative icons are marked `aria-hidden` (addresses the cubic review).

> Note: this PR was written with AI assistance (Claude Code).

### Screenshot/Recording (if applicable)
**Banner pinned above the nav (landing page):**

![Image gen banner pinned above the landing nav](https://raw.githubusercontent.com/usenotra/notra/assets/pr-landing-banner/pr/banner-above-nav.png)

**In context:**

![Landing page with the announcement banner](https://raw.githubusercontent.com/usenotra/notra/assets/pr-landing-banner/pr/landing-full.png)

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full-width, sticky announcement banner above the landing navbar to promote image generation and link to it. Updates navbar offset to keep the layout consistent when the banner is present.

- New Features
  - New `LandingBanner` on `/`; full-width sticky top bar (`z-[70]`) linking to `/features/marketing/assets` (“Try it now”).
  - Integrated in `SiteShell` above `Navbar`; navbar sticky offset adapts (`top-14` on `/`, `top-4` elsewhere).
  - Copy centralized in `@/lib/landing-banner/constants` (badge “New”, headline + detail, link label); icons from `@hugeicons/core-free-icons`/`@hugeicons/react`, marked `aria-hidden`.

<sup>Written for commit 4be3e9936717e4be205892c82747e577ad5362a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


