### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a Bun + Turborepo monorepo (product: **Notra**, an AI content-generation
+platform). See `README.md` and `CONTRIBUTING.md` for the standard workflow and
+`package.json` scripts for the canonical commands. The notes below only cover
+non-obvious, durable gotchas for working in the Cursor Cloud environment.
+
+### Toolchain
+- Runtime/package manager is **Bun `1.3.9`** (installed at `~/.bun`); tooling uses
+  **Node `24.11.1`** (installed via `nvm`, set as the default alias). Both are baked
+  into the VM snapshot and on `PATH` in a login shell. `bun install` is the startup
+  update script — do not run it manually unless deps changed.
+- Quality gates (run from repo root): lint `bun run check`, types `bun run check-types`,
+  build `bun run build` (use `--filter=dashboard` to scope). Husky `pre-commit` runs
+  `bun format` + `bun knip`.
+
+### Environment variables
+- Scripts wrap commands in `dotenv --`, so a **root `.env` is required** (it is
+  git-ignored and lives in the snapshot). If it is missing, copy `.env.example` to
+  `.env` and set at minimum: `DATABASE_URL` (local Postgres, below),
+  `BETTER_AUTH_SECRET` (`openssl rand -base64 32`), a base64-encoded **32-byte**
+  `INTEGRATION_ENCRYPTION_KEY` (`openssl rand -base64 32`), and the
+  `BETTER_AUTH_URL` / `NEXT_PUBLIC_SITE_URL` / `NEXT_PUBLIC_APP_URL` = `http://localhost:3000`.
+- Most third-party keys are optional and degrade gracefully (Autumn billing, Resend,
+  Redis, R2, integrations). Content/chat **generation** needs a real
+  `AI_GATEWAY_API_KEY` or `OPENROUTER_API_KEY`; background jobs/schedules need Upstash
+  Redis + QStash. `turbo.json` uses `envMode: "strict"`, so new env vars must be added
+  to its `globalEnv` list to be visible to tasks.
+
+### Local Postgres (required for the dashboard)
+- A local PostgreSQL 16 cluster is installed. Start it with:
+  `sudo pg_ctlcluster 16 main start`. The `notra` database and `postgres:postgres`
+  superuser are already provisioned; `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/notra`.
+
+### Database schema init gotcha (important)
+- `bun run db:migrate` does **not** work on a fresh DB: the committed migration chain
+  starts at `0001` and assumes base tables (e.g. `organizations`) already exist — no
+  migration creates them.
+- `bun run db:push` also fails on a fresh DB due to a drizzle-kit ordering bug: it emits
+  composite foreign keys (e.g. `mcpSessionToolActivations_org_tool_fk` →
+  `mcp_tool_index(organization_id, id)`) *before* creating the unique index they
+  reference, producing `there is no unique constraint matching given keys`.
+- Working approach (already applied in the snapshot; only redo if the DB is wiped):
+  export the schema DDL, reorder so all `CREATE [UNIQUE] INDEX` run before
+  `ALTER TABLE ... ADD ... FOREIGN KEY`, then apply with psql:
+  ```bash
+  bunx drizzle-kit export --config packages/db/drizzle.config.ts > /tmp/schema_init.sql
+  # reorder: emit CREATE TABLE/types, then all indexes, then FK ALTERs, then:
+  PGPASSWORD=postgres psql -h localhost -U postgres -d notra -v ON_ERROR_STOP=1 -f /tmp/schema_ordered.sql
+  ```
+  After this, `db:push` will still report a (harmless) diff because of the same
+  ordering bug — that is expected and does not mean the schema is incomplete.
+
+### Services (dev)
+- `apps/dashboard` — **core product**, `next dev` on **port 3000**; self-contained
+  (its own oRPC `/rpc`, Better Auth `/api/auth`, chat). Run with
+  `bun run dev --filter=dashboard`. This is the app to exercise end-to-end.
+- `apps/web` (port 3001), `apps/docs` (Mintlify, port 3005), `apps/api` (Hono;
+  defaults to port 3000 so set `PORT` to avoid clashing with the dashboard),
+  `packages/email` preview (`bun run email:dev`, port 3002) — all optional for the
+  core flow.
+
+### Auth note
+- Email/password sign-up works without OAuth/email providers and does not require email
+  verification. The `haveIBeenPwned` plugin rejects breached passwords, so use a strong
+  unique password when signing up during tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Notra monorepo in Cursor Cloud and documents durable, non-obvious setup gotchas for future agents in a new `AGENTS.md`.

This PR only adds `AGENTS.md` — no application code or schema is modified. The runtime setup (Bun/Node, dependencies, local Postgres, `.env`) lives in the VM snapshot + startup update script (`bun install`).

## What was set up
- **Toolchain:** Bun `1.3.9` and Node `24.11.1` (via nvm).
- **Dependencies:** `bun install` (3859 packages).
- **Database:** local PostgreSQL 16 cluster with a `notra` database; schema initialized from `schema.ts`.
- **Env:** git-ignored root `.env` with a local `DATABASE_URL`, generated `BETTER_AUTH_SECRET`, and a base64 32-byte `INTEGRATION_ENCRYPTION_KEY`.

## Notable gotcha documented
Neither `db:migrate` (migration chain starts at `0001` and never creates base tables like `organizations`) nor `db:push` (drizzle-kit emits composite FKs before the unique indexes they reference) works on a fresh DB. `AGENTS.md` documents the working export-and-reorder init approach.

## Verification
- ✅ `bun run check` (lint) — passed (pre-existing warnings only)
- ✅ `bun run check-types` — 8/8 packages passed
- ✅ `bun run build --filter=dashboard` — succeeded
- ✅ `bun run dev --filter=dashboard` — dashboard runs on port 3000; signed up a new user and created a workspace, with `users` / `organizations` / `members` rows persisted in Postgres.

[notra_signup_create_workspace.mp4](https://cursor.com/agents/bc-ed1e28e2-77c1-42b3-846e-542add3a1d44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnotra_signup_create_workspace.mp4)

[Dashboard after creating workspace](https://cursor.com/agents/bc-ed1e28e2-77c1-42b3-846e-542add3a1d44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnotra_dashboard_landed.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed1e28e2-77c1-42b3-846e-542add3a1d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed1e28e2-77c1-42b3-846e-542add3a1d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AGENTS.md with Cursor Cloud dev environment setup for the Notra monorepo. It covers the toolchain (`bun` 1.3.9, Node 24.11.1), required root `.env`, local Postgres 16 and `DATABASE_URL`, a reliable initial schema workaround for `drizzle-kit` FK/index ordering, and how to run the dashboard on port 3000; no app or schema changes.

<sup>Written for commit ffc093d4bc60117b63e05ffc025648e0b8ef15f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

