### PR TITLE
fix(brand): cap reference note and content textarea height

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-reference-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-reference-dialog.tsx
@@ -665,6 +665,7 @@ function CustomTextStep({
         <div className="space-y-2">
           <Label htmlFor="custom-content">Content</Label>
           <Textarea
+            className="max-h-[15rem] overflow-y-auto"
             id="custom-content"
             onChange={(e) => setContent(e.target.value)}
             placeholder="Paste or write text that represents your writing style..."
@@ -696,6 +697,7 @@ function CustomTextStep({
         <div className="space-y-2">
           <Label htmlFor="custom-note">Note (optional)</Label>
           <Textarea
+            className="max-h-[7.5rem] overflow-y-auto"
             id="custom-note"
             onChange={(e) => setNote(e.target.value)}
             placeholder="When should the AI use this as reference?"


### PR DESCRIPTION
### Description
When adding a reference via the brand identity dialog (custom text / blog), the Content and Note textareas used `field-sizing-content` auto-grow with no max-height cap. A large note expanded the dialog until the Save button was pushed below the viewport, so the reference could no longer be saved. This caps both textareas with a max-height and `overflow-y-auto` so they scroll instead of growing unbounded.

### Screenshot/Recording (if applicable)
N/A

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap the Content and Note textareas in the Brand Identity “Add reference” dialog to stop the modal from expanding off-screen and keep the Save button accessible.

- **Bug Fixes**
  - Set Content max height to 15rem and Note to 7.5rem.
  - Added overflow-y-auto so long input scrolls instead of growing the dialog.

<sup>Written for commit cd054a7c5d4bd197dec2d848db4c086999bfb43f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

