### PR TITLE
fix: send markdown attachments as text documents

### DIFF
--- a/packages/ai/src/constants/media-types.ts
+++ b/packages/ai/src/constants/media-types.ts
@@ -1,0 +1,2 @@
+export const MARKDOWN_MEDIA_TYPE = "text/markdown";
+export const PLAIN_TEXT_MEDIA_TYPE = "text/plain";

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -18,6 +18,7 @@ import type {
   StandaloneChatDeps,
   StandaloneChatInput,
 } from "@notra/ai/types/standalone-chat";
+import { normalizeMarkdownFileAttachments } from "@notra/ai/utils/message-attachments";
 import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
 import {
   convertToModelMessages,
@@ -218,7 +219,9 @@ export async function orchestrateStandaloneChat(
     { modelId: routingDecision.model }
   );
 
-  const messagesForModel = stripIncompleteToolParts(messages);
+  const messagesForModel = normalizeMarkdownFileAttachments(
+    stripIncompleteToolParts(messages)
+  );
 
   const modelMessages = await convertToModelMessages(messagesForModel, {
     ignoreIncompleteToolCalls: true,

--- a/packages/ai/src/orchestration/orchestrate.ts
+++ b/packages/ai/src/orchestration/orchestrate.ts
@@ -6,6 +6,7 @@ import type {
   OrchestrateInput,
   OrchestrateResult,
 } from "@notra/ai/types/orchestration";
+import { normalizeMarkdownFileAttachments } from "@notra/ai/utils/message-attachments";
 import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
 import {
   convertToModelMessages,
@@ -113,10 +114,12 @@ export async function orchestrateChat(
     timezone,
   });
 
+  const messagesForModel = normalizeMarkdownFileAttachments(messages);
+
   const stream = streamText({
     model: modelWithMemory,
     system: systemPrompt,
-    messages: await convertToModelMessages(messages, {
+    messages: await convertToModelMessages(messagesForModel, {
       ignoreIncompleteToolCalls: true,
     }),
     tools,

--- a/packages/ai/src/utils/message-attachments.ts
+++ b/packages/ai/src/utils/message-attachments.ts
@@ -1,0 +1,35 @@
+import {
+  MARKDOWN_MEDIA_TYPE,
+  PLAIN_TEXT_MEDIA_TYPE,
+} from "@notra/ai/constants/media-types";
+import type { UIMessage } from "ai";
+
+type MessagePart = UIMessage["parts"][number];
+
+function normalizeFilePartMediaType(part: MessagePart): MessagePart {
+  if (
+    part.type === "file" &&
+    typeof part.mediaType === "string" &&
+    part.mediaType.toLowerCase() === MARKDOWN_MEDIA_TYPE
+  ) {
+    // Anthropic's "File types and content blocks" section only maps plain text
+    // (`text/plain`) to document blocks, so Markdown files are sent as plain
+    // text documents while preserving the attachment/document-block flow.
+    // https://platform.claude.com/docs/en/build-with-claude/files#file-types-and-content-blocks
+    return {
+      ...part,
+      mediaType: PLAIN_TEXT_MEDIA_TYPE,
+    };
+  }
+
+  return part;
+}
+
+export function normalizeMarkdownFileAttachments<TMessage extends UIMessage>(
+  messages: TMessage[]
+): TMessage[] {
+  return messages.map((message) => ({
+    ...message,
+    parts: message.parts.map(normalizeFilePartMediaType),
+  }));
+}


### PR DESCRIPTION
### Description
Normalize Markdown chat attachments from `text/markdown` to `text/plain` before AI SDK message conversion so Anthropic receives them as supported document blocks. The normalization is applied in both content-editor and standalone chat orchestration paths, with MIME constants centralized under `packages/ai/src/constants`.

This is needed because Anthropic documents only map plain text (`text/plain`) and PDFs to document blocks; Markdown uploads otherwise fail with unsupported media type errors.

AI assistance disclosure: Codex was used to implement and verify this change.

### Screenshot/Recording (if applicable)
Not applicable; backend message normalization only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Validation:
- `bun run --cwd packages/ai check-types`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send Markdown attachments as plain-text documents so Anthropic accepts them as document blocks. Fixes unsupported media type errors for .md uploads in content-editor and standalone chat.

- **Bug Fixes**
  - Normalize `text/markdown` to `text/plain` before model conversion in both orchestration paths.
  - Add `normalizeMarkdownFileAttachments` and centralize media type constants under `@notra/ai/constants/media-types`.

<sup>Written for commit 2075b010cac39541ef766e86dcc5ef6deb0ad16c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

