### PR TITLE
fix(dashboard): prevent dialog content overflow with long input text

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-identity-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-identity-dialog.tsx
@@ -95,7 +95,7 @@ export function AddIdentityDialog({
 
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
-      <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-md [&>*]:min-w-0">
+      <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-md [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Add Brand Identity</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-identity-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-identity-dialog.tsx
@@ -95,7 +95,7 @@ export function AddIdentityDialog({
 
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
-      <ResponsiveDialogContent className="sm:max-w-md">
+      <ResponsiveDialogContent className="overflow-hidden sm:max-w-md [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Add Brand Identity</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>
@@ -104,7 +104,7 @@ export function AddIdentityDialog({
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
         <form
-          className="space-y-4"
+          className="min-w-0 space-y-4"
           onSubmit={(e) => {
             e.preventDefault();
             handleSubmit();
@@ -122,7 +122,7 @@ export function AddIdentityDialog({
           </div>
           <div className="space-y-2">
             <Label htmlFor="voice-url">Website</Label>
-            <div className="flex w-full flex-row items-center rounded-md border border-border transition-colors focus-within:border-ring focus-within:ring-ring/50">
+            <div className="flex w-full min-w-0 flex-row items-center rounded-md border border-border transition-colors focus-within:border-ring focus-within:ring-ring/50">
               <label
                 className="border-border border-r px-2.5 py-1.5 text-muted-foreground text-sm transition-colors"
                 htmlFor="voice-url"
@@ -130,7 +130,7 @@ export function AddIdentityDialog({
                 https://
               </label>
               <input
-                className="flex-1 bg-transparent px-2.5 py-1.5 text-sm outline-none"
+                className="min-w-0 flex-1 bg-transparent px-2.5 py-1.5 text-sm outline-none"
                 id="voice-url"
                 onChange={(e) => setUrl(sanitizeBrandUrlInput(e.target.value))}
                 placeholder="example.com"

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-identity-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-identity-dialog.tsx
@@ -95,7 +95,7 @@ export function AddIdentityDialog({
 
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
-      <ResponsiveDialogContent className="overflow-hidden sm:max-w-md [&>*]:min-w-0">
+      <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-md [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Add Brand Identity</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-reference-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-reference-dialog.tsx
@@ -165,7 +165,7 @@ export function AddReferenceDialog({
 
   return (
     <ResponsiveDialog onOpenChange={handleClose} open={open}>
-      <ResponsiveDialogContent>
+      <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto [&>*]:min-w-0">
         {step === "source" && <SourceStep onSelect={setStep} />}
         {step === "tweet-url" && (
           <TweetUrlStep

--- a/apps/dashboard/src/components/dashboard/create-org-modal.tsx
+++ b/apps/dashboard/src/components/dashboard/create-org-modal.tsx
@@ -93,7 +93,7 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="overflow-hidden">
+      <DialogContent className="overflow-x-hidden">
         <DialogHeader>
           <DialogTitle>Create Organization</DialogTitle>
           <DialogDescription>

--- a/apps/dashboard/src/components/dashboard/create-org-modal.tsx
+++ b/apps/dashboard/src/components/dashboard/create-org-modal.tsx
@@ -93,7 +93,7 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent>
+      <DialogContent className="overflow-hidden">
         <DialogHeader>
           <DialogTitle>Create Organization</DialogTitle>
           <DialogDescription>
@@ -102,13 +102,14 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
         </DialogHeader>
 
         <form
+          className="min-w-0"
           onSubmit={(e) => {
             e.preventDefault();
             e.stopPropagation();
             form.handleSubmit();
           }}
         >
-          <div className="grid gap-4 py-4">
+          <div className="grid min-w-0 gap-4 py-4">
             <form.Field
               name="name"
               validators={{
@@ -118,7 +119,7 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
               }}
             >
               {(field) => (
-                <div className="grid gap-2">
+                <div className="grid min-w-0 gap-2">
                   <Label htmlFor="name">
                     Organization Name{" "}
                     <span className="text-destructive">*</span>
@@ -161,7 +162,7 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
               }}
             >
               {(field) => (
-                <div className="grid gap-2">
+                <div className="grid min-w-0 gap-2">
                   <Label htmlFor="slug">
                     Organization Slug{" "}
                     <span className="text-destructive">*</span>
@@ -182,7 +183,7 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
                       {field.state.meta.errors[0]}
                     </p>
                   ) : null}
-                  <p className="text-muted-foreground text-xs">
+                  <p className="break-all text-muted-foreground text-xs">
                     Used in URLs: app.usenotra.com/
                     {field.state.value || "your-slug"}
                   </p>
@@ -205,10 +206,10 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
               }}
             >
               {(field) => (
-                <div className="grid gap-2">
+                <div className="grid min-w-0 gap-2">
                   <Label htmlFor="website">Website (optional)</Label>
                   <div
-                    className={`flex w-full flex-row items-center rounded-md border transition-colors focus-within:border-ring focus-within:ring-ring/50 ${field.state.meta.errors.length > 0 ? "border-destructive" : "border-border"}`}
+                    className={`flex w-full min-w-0 flex-row items-center rounded-md border transition-colors focus-within:border-ring focus-within:ring-ring/50 ${field.state.meta.errors.length > 0 ? "border-destructive" : "border-border"}`}
                   >
                     <label
                       className="border-border border-r px-2.5 py-1.5 text-muted-foreground text-sm transition-colors"
@@ -217,7 +218,7 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
                       https://
                     </label>
                     <input
-                      className="flex-1 bg-transparent px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                      className="min-w-0 flex-1 bg-transparent px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
                       disabled={isCreating}
                       id="website"
                       onBlur={field.handleBlur}

--- a/apps/dashboard/src/components/dashboard/create-org-modal.tsx
+++ b/apps/dashboard/src/components/dashboard/create-org-modal.tsx
@@ -93,7 +93,7 @@ export function CreateOrgModal({ open, onOpenChange }: CreateOrgModalProps) {
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="overflow-x-hidden">
+      <DialogContent className="max-h-[85svh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create Organization</DialogTitle>
           <DialogDescription>

--- a/apps/dashboard/src/components/delete-integration-dialog.tsx
+++ b/apps/dashboard/src/components/delete-integration-dialog.tsx
@@ -51,7 +51,7 @@ export function DeleteIntegrationDialog({
 
   return (
     <ResponsiveAlertDialog onOpenChange={handleOpenChange} open={open}>
-      <ResponsiveAlertDialogContent className="overflow-hidden sm:max-w-[520px] [&>*]:min-w-0">
+      <ResponsiveAlertDialogContent className="overflow-x-hidden sm:max-w-[520px] [&>*]:min-w-0">
         <ResponsiveAlertDialogHeader>
           <ResponsiveAlertDialogTitle className="text-lg">
             Delete {integrationName}?

--- a/apps/dashboard/src/components/delete-integration-dialog.tsx
+++ b/apps/dashboard/src/components/delete-integration-dialog.tsx
@@ -51,7 +51,7 @@ export function DeleteIntegrationDialog({
 
   return (
     <ResponsiveAlertDialog onOpenChange={handleOpenChange} open={open}>
-      <ResponsiveAlertDialogContent className="sm:max-w-[520px]">
+      <ResponsiveAlertDialogContent className="overflow-hidden sm:max-w-[520px] [&>*]:min-w-0">
         <ResponsiveAlertDialogHeader>
           <ResponsiveAlertDialogTitle className="text-lg">
             Delete {integrationName}?

--- a/apps/dashboard/src/components/delete-integration-dialog.tsx
+++ b/apps/dashboard/src/components/delete-integration-dialog.tsx
@@ -51,7 +51,7 @@ export function DeleteIntegrationDialog({
 
   return (
     <ResponsiveAlertDialog onOpenChange={handleOpenChange} open={open}>
-      <ResponsiveAlertDialogContent className="overflow-x-hidden sm:max-w-[520px] [&>*]:min-w-0">
+      <ResponsiveAlertDialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-[520px] [&>*]:min-w-0">
         <ResponsiveAlertDialogHeader>
           <ResponsiveAlertDialogTitle className="text-lg">
             Delete {integrationName}?

--- a/apps/dashboard/src/components/integrations/add-mcp-server-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/add-mcp-server-dialog.tsx
@@ -222,7 +222,7 @@ export function AddMcpServerDialog({
       open={open}
     >
       {triggerElement}
-      <ResponsiveDialogContent className="sm:max-w-[32.5rem]">
+      <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-[32.5rem] [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <div className="flex items-start gap-3">
             <form.Subscribe selector={(state) => state.values.url}>
@@ -348,6 +348,7 @@ export function AddMcpServerDialog({
                     Use case description
                   </FieldLabel>
                   <Textarea
+                    className="max-h-[10rem] overflow-y-auto"
                     id="mcp-description"
                     onBlur={field.handleBlur}
                     onChange={(event) => field.handleChange(event.target.value)}

--- a/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
@@ -248,7 +248,7 @@ export function AddRepositoryDialog({
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
       {triggerElement}
-      <ResponsiveDialogContent className="overflow-x-hidden [&>*]:min-w-0">
+      <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Add Repository</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>

--- a/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
@@ -248,7 +248,7 @@ export function AddRepositoryDialog({
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
       {triggerElement}
-      <ResponsiveDialogContent className="overflow-hidden [&>*]:min-w-0">
+      <ResponsiveDialogContent className="overflow-x-hidden [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Add Repository</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>

--- a/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
@@ -248,7 +248,7 @@ export function AddRepositoryDialog({
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
       {triggerElement}
-      <ResponsiveDialogContent>
+      <ResponsiveDialogContent className="overflow-hidden [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Add Repository</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>

--- a/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
@@ -121,7 +121,7 @@ export function EditIntegrationDialog({
     <>
       {triggerElement}
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
-        <ResponsiveDialogContent className="sm:max-w-[500px]">
+        <ResponsiveDialogContent className="overflow-hidden sm:max-w-[500px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Edit Integration

--- a/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
@@ -121,7 +121,7 @@ export function EditIntegrationDialog({
     <>
       {triggerElement}
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
-        <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[500px] [&>*]:min-w-0">
+        <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-[500px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Edit Integration

--- a/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/edit-integration-dialog.tsx
@@ -121,7 +121,7 @@ export function EditIntegrationDialog({
     <>
       {triggerElement}
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
-        <ResponsiveDialogContent className="overflow-hidden sm:max-w-[500px] [&>*]:min-w-0">
+        <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[500px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Edit Integration

--- a/apps/dashboard/src/components/integrations/edit-linear-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/edit-linear-integration-dialog.tsx
@@ -85,7 +85,7 @@ export function EditLinearIntegrationDialog({
 
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
-      <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[500px] [&>*]:min-w-0">
+      <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-[500px] [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle className="text-2xl">
             Edit Integration

--- a/apps/dashboard/src/components/integrations/edit-linear-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/edit-linear-integration-dialog.tsx
@@ -85,7 +85,7 @@ export function EditLinearIntegrationDialog({
 
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
-      <ResponsiveDialogContent className="overflow-hidden sm:max-w-[500px] [&>*]:min-w-0">
+      <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[500px] [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle className="text-2xl">
             Edit Integration

--- a/apps/dashboard/src/components/integrations/edit-linear-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/edit-linear-integration-dialog.tsx
@@ -85,7 +85,7 @@ export function EditLinearIntegrationDialog({
 
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
-      <ResponsiveDialogContent className="sm:max-w-[500px]">
+      <ResponsiveDialogContent className="overflow-hidden sm:max-w-[500px] [&>*]:min-w-0">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle className="text-2xl">
             Edit Integration

--- a/apps/dashboard/src/components/integrations/legacy/add-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/legacy/add-integration-dialog.tsx
@@ -296,7 +296,7 @@ export function LegacyAddIntegrationDialog({
     <>
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
         {triggerElement}
-        <ResponsiveDialogContent className="sm:max-w-[520px]">
+        <ResponsiveDialogContent className="overflow-hidden sm:max-w-[520px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Add GitHub Integration

--- a/apps/dashboard/src/components/integrations/legacy/add-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/legacy/add-integration-dialog.tsx
@@ -296,7 +296,7 @@ export function LegacyAddIntegrationDialog({
     <>
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
         {triggerElement}
-        <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[520px] [&>*]:min-w-0">
+        <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-[520px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Add GitHub Integration

--- a/apps/dashboard/src/components/integrations/legacy/add-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/legacy/add-integration-dialog.tsx
@@ -296,7 +296,7 @@ export function LegacyAddIntegrationDialog({
     <>
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
         {triggerElement}
-        <ResponsiveDialogContent className="overflow-hidden sm:max-w-[520px] [&>*]:min-w-0">
+        <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[520px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Add GitHub Integration

--- a/apps/dashboard/src/components/integrations/legacy/edit-token-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/legacy/edit-token-dialog.tsx
@@ -89,7 +89,7 @@ export function LegacyEditTokenDialog({
     <>
       {triggerElement}
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
-        <ResponsiveDialogContent className="overflow-hidden sm:max-w-[500px] [&>*]:min-w-0">
+        <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[500px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Update Personal Access Token

--- a/apps/dashboard/src/components/integrations/legacy/edit-token-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/legacy/edit-token-dialog.tsx
@@ -89,7 +89,7 @@ export function LegacyEditTokenDialog({
     <>
       {triggerElement}
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
-        <ResponsiveDialogContent className="overflow-x-hidden sm:max-w-[500px] [&>*]:min-w-0">
+        <ResponsiveDialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-[500px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Update Personal Access Token

--- a/apps/dashboard/src/components/integrations/legacy/edit-token-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/legacy/edit-token-dialog.tsx
@@ -89,7 +89,7 @@ export function LegacyEditTokenDialog({
     <>
       {triggerElement}
       <ResponsiveDialog onOpenChange={setOpen} open={open}>
-        <ResponsiveDialogContent className="sm:max-w-[500px]">
+        <ResponsiveDialogContent className="overflow-hidden sm:max-w-[500px] [&>*]:min-w-0">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle className="text-2xl">
               Update Personal Access Token


### PR DESCRIPTION
### Description

Long text in dashboard dialogs could break their layout on desktop. Two root causes, both in the way the shared `DialogContent`/`Textarea` primitives behave (those primitives are not edited here; fixes are applied at the consuming dialogs):

- The base `Textarea` uses `field-sizing-content` with no max-height, so it auto-grows; inside a CSS-grid `DialogContent` (grid tracks default to `min-width: auto`) a long unbroken string or auto-growing textarea blows the dialog wider than the viewport.
- The desktop `DialogContent` has no `max-h`/`overflow` of its own, so tall content pushes the footer (and its action buttons) off-screen.

Fixes:

- **Create Organization** – `overflow-hidden` + `min-w-0` on the form/grid/website wrappers, `break-all` on the slug URL preview. Long name/slug/website values now scroll inside their inputs instead of running off-screen.
- **Add MCP Server** – dialog now `max-h-[85svh] overflow-y-auto` and the description textarea is capped (`max-h-[10rem] overflow-y-auto`). A long description no longer pushes the Add/Test Connection buttons off-screen.
- **Add Custom Reference** & **Add Brand Identity** – `[&>*]:min-w-0` / `overflow-hidden` so pasted URLs and long website values wrap/scroll within the dialog.
- **Integration dialogs** (add repository, edit GitHub/Linear, legacy add/edit-token, delete) – same defensive `overflow-hidden [&>*]:min-w-0` applied preemptively.

Verification: Create Organization and Add MCP Server were tested live in a headless browser (before/after); the data-gated dialogs were verified by reproducing the exact edited class strings. `tsc --noEmit` is clean for the dashboard app.

### Screenshot/Recording (if applicable)

After fix — long text now stays contained:

**Create Organization** (inputs scroll internally, slug preview wraps, footer visible):

![Create Organization after fix](https://raw.githubusercontent.com/usenotra/notra/pr-assets/dialog-overflow/shot-create-org-fixed.png)

**Add MCP Server** (description textarea capped + scrolls, footer reachable):

![Add MCP Server after fix](https://raw.githubusercontent.com/usenotra/notra/pr-assets/dialog-overflow/shot-mcp-fixed.png)

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

> Disclosure: implemented with AI assistance (Claude Code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dashboard dialog overflow on desktop with long strings or pasted URLs. Dialogs are height-capped with vertical scroll; fields wrap or scroll so footers stay reachable.

- **Bug Fixes**
  - Create Organization: `max-h-[85svh] overflow-y-auto` on dialog; `min-w-0` on form/grid/website wrappers; slug preview uses `break-all`.
  - Add MCP Server: dialog `max-h-[85svh] overflow-y-auto` + `[&>*]:min-w-0`; description textarea `max-h-[10rem] overflow-y-auto`.
  - Brand Identity / Custom Reference: both use `max-h-[85svh] overflow-y-auto` + `[&>*]:min-w-0`; Brand Identity adds `min-w-0` on form and input wrappers.
  - Integration dialogs (add repository, edit GitHub/Linear, legacy add/edit-token, delete): dialog content `max-h-[85svh] overflow-y-auto` + `[&>*]:min-w-0` to prevent width blowout and keep footers in view.

<sup>Written for commit fa0974234b96fc380ebf861591c9c54373a3da8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

