### PR TITLE
chore: remove stale bun release exception

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 # Only install package versions published at least 7 days ago
 minimumReleaseAge = 604800
-minimumReleaseAgeExcludes = ["@bydefault/vercel", "@upstash/box", "cnfast"]
+minimumReleaseAgeExcludes = ["@bydefault/vercel", "cnfast"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Remove `@upstash/box` from `minimumReleaseAgeExcludes` because the locked `0.5.0` release is now older than the 7-day release window. Keep `@bydefault/vercel` and `cnfast` excluded because their locked versions are still within the window.

### Validation
- `npm exec --yes bun@1.3.9 -- install --frozen-lockfile`

### Screenshot/Recording (if applicable)
Not applicable.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bc58123-8fa6-4911-99b4-10ea1213e164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bc58123-8fa6-4911-99b4-10ea1213e164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `@upstash/box` from `minimumReleaseAgeExcludes` in `bunfig.toml` since its `0.5.0` release is now older than the 7-day window. This re-enables the 7-day minimum release age check for that package; `@bydefault/vercel` and `cnfast` stay excluded.

<sup>Written for commit 70c1d62ec9e39c142a30e3ac2e6b42e9cd803e91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

