### PR TITLE
Brand Identity sidebar group with selector + Company Info/References sub-entries

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -32,6 +32,11 @@ import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { getValidLanguage } from "@/schemas/brand";
+import {
+  findSelectedBrandIdentity,
+  readStoredBrandIdentityId,
+  writeStoredBrandIdentityId,
+} from "@/utils/brand-identity-selection";
 import { formatRelativeTime } from "@/utils/format";
 import {
   useAnalyzeBrand,
@@ -108,6 +113,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   );
   const [newIdentityParam, setNewIdentityParam] = useQueryState("new");
   const isAddIdentityOpen = addIdentityOpen || Boolean(newIdentityParam);
+  const [storedVoiceId, setStoredVoiceId] = useState<string | null>(null);
 
   const handleAddIdentityOpenChange = (open: boolean) => {
     setAddIdentityOpen(open);
@@ -115,6 +121,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
       setNewIdentityParam(null);
     }
   };
+
+  useEffect(() => {
+    if (organizationId) {
+      setStoredVoiceId(readStoredBrandIdentityId(organizationId));
+    }
+  }, [organizationId]);
 
   useHotkey(
     "C",
@@ -128,10 +140,17 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     { enabled: !(isAddIdentityOpen || addReferenceOpen) }
   );
 
-  const selectedVoice =
-    voices.find((v) => v.id === activeVoiceId) ??
-    voices.find((v) => v.isDefault) ??
-    voices[0];
+  const selectedVoice = findSelectedBrandIdentity(
+    voices,
+    activeVoiceId,
+    storedVoiceId
+  );
+
+  const handleSelectVoice = (voiceId: string) => {
+    writeStoredBrandIdentityId(organizationId, voiceId);
+    setStoredVoiceId(voiceId);
+    setActiveVoiceId(voiceId);
+  };
 
   const deleteTargetVoice = deleteTargetVoiceId
     ? voices.find((v) => v.id === deleteTargetVoiceId)
@@ -432,14 +451,14 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           }}
           onReanalyze={handleReanalyze}
           onRequestDelete={setDeleteTargetVoiceId}
-          onSelect={setActiveVoiceId}
+          onSelect={handleSelectVoice}
           onSetDefault={handleSetDefault}
           organizationId={organizationId}
           voices={voices}
         />
 
         <AddIdentityDialog
-          onCreated={(voice) => setActiveVoiceId(voice.id)}
+          onCreated={(voice) => handleSelectVoice(voice.id)}
           onOpenChange={handleAddIdentityOpenChange}
           open={isAddIdentityOpen}
           organizationId={organizationId}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -107,9 +107,6 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     parseAsStringLiteral(TAB_VALUES).withDefault("identity")
   );
   const [newIdentityParam, setNewIdentityParam] = useQueryState("new");
-  // Opening the create dialog from the sidebar/breadcrumb arrives as ?new=1.
-  // Derive the open state from the URL rather than syncing it into state via an
-  // effect, and clear the param when the dialog closes.
   const isAddIdentityOpen = addIdentityOpen || Boolean(newIdentityParam);
 
   const handleAddIdentityOpenChange = (open: boolean) => {

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -107,13 +107,17 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     parseAsStringLiteral(TAB_VALUES).withDefault("identity")
   );
   const [newIdentityParam, setNewIdentityParam] = useQueryState("new");
+  // Opening the create dialog from the sidebar/breadcrumb arrives as ?new=1.
+  // Derive the open state from the URL rather than syncing it into state via an
+  // effect, and clear the param when the dialog closes.
+  const isAddIdentityOpen = addIdentityOpen || Boolean(newIdentityParam);
 
-  useEffect(() => {
-    if (newIdentityParam) {
-      setAddIdentityOpen(true);
+  const handleAddIdentityOpenChange = (open: boolean) => {
+    setAddIdentityOpen(open);
+    if (!open && newIdentityParam) {
       setNewIdentityParam(null);
     }
-  }, [newIdentityParam, setNewIdentityParam]);
+  };
 
   useHotkey(
     "C",
@@ -124,7 +128,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         setAddReferenceOpen(true);
       }
     },
-    { enabled: !(addIdentityOpen || addReferenceOpen) }
+    { enabled: !(isAddIdentityOpen || addReferenceOpen) }
   );
 
   const selectedVoice =
@@ -439,8 +443,8 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
         <AddIdentityDialog
           onCreated={(voice) => setActiveVoiceId(voice.id)}
-          onOpenChange={setAddIdentityOpen}
-          open={addIdentityOpen}
+          onOpenChange={handleAddIdentityOpenChange}
+          open={isAddIdentityOpen}
           organizationId={organizationId}
           startPolling={startPolling}
         />

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -106,6 +106,14 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     "view",
     parseAsStringLiteral(TAB_VALUES).withDefault("identity")
   );
+  const [newIdentityParam, setNewIdentityParam] = useQueryState("new");
+
+  useEffect(() => {
+    if (newIdentityParam) {
+      setAddIdentityOpen(true);
+      setNewIdentityParam(null);
+    }
+  }, [newIdentityParam, setNewIdentityParam]);
 
   useHotkey(
     "C",
@@ -377,7 +385,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         <div className="flex items-start justify-between">
           <div className="space-y-1">
             <h1 className="font-bold text-3xl tracking-tight">
-              {activeTab === "identity" ? "Brand Identity" : "References"}
+              {activeTab === "identity" ? "Company Info" : "References"}
             </h1>
             <p className="text-muted-foreground">
               {activeTab === "identity"
@@ -463,7 +471,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         >
           <div className="flex items-center justify-between">
             <TabsList variant="line">
-              <TabsTrigger value="identity">Identity</TabsTrigger>
+              <TabsTrigger value="identity">Company Info</TabsTrigger>
               <TabsTrigger value="references">
                 References
                 {referenceCount > 0 && (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
-  title: "Identity & References",
+  title: "Brand Identity",
 };
 
 async function Page({

--- a/apps/dashboard/src/components/command-palette/registry.ts
+++ b/apps/dashboard/src/components/command-palette/registry.ts
@@ -1,6 +1,7 @@
 import {
   AnalyticsUpIcon,
   Calendar03Icon,
+  Comment01Icon,
   CorporateIcon,
   CreditCardIcon,
   Home01Icon,
@@ -50,12 +51,20 @@ export const COMMAND_ROUTES: CommandRoute[] = [
     path: (slug) => `/${slug}/content`,
   },
   {
-    id: "brand-identity",
-    label: "Identity & References",
-    keywords: ["brand", "voice", "tone", "references"],
+    id: "brand-company-info",
+    label: "Company Info",
+    keywords: ["brand", "identity", "voice", "tone", "company"],
     icon: CorporateIcon,
     section: "Workspace",
     path: (slug) => `/${slug}/brand/identity`,
+  },
+  {
+    id: "brand-references",
+    label: "References",
+    keywords: ["brand", "identity", "references", "examples", "posts"],
+    icon: Comment01Icon,
+    section: "Workspace",
+    path: (slug) => `/${slug}/brand/identity?view=references`,
   },
   {
     id: "automation-schedules",

--- a/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
@@ -18,8 +18,14 @@ import {
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
+import {
+  findSelectedBrandIdentity,
+  readStoredBrandIdentityId,
+  writeStoredBrandIdentityId,
+} from "@/utils/brand-identity-selection";
 
 export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
   const { activeOrganization } = useOrganizationsContext();
@@ -31,19 +37,33 @@ export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
   const voices = data?.voices ?? [];
   const voiceParam = searchParams.get("voice");
   const isReferencesView = searchParams.get("view") === "references";
+  const [storedVoiceId, setStoredVoiceId] = useState<string | null>(null);
 
-  const activeVoice =
-    (voiceParam ? voices.find((v) => v.id === voiceParam) : undefined) ??
-    voices.find((v) => v.isDefault) ??
-    voices[0];
+  useEffect(() => {
+    if (organizationId) {
+      setStoredVoiceId(readStoredBrandIdentityId(organizationId));
+    }
+  }, [organizationId]);
+
+  const activeVoice = findSelectedBrandIdentity(
+    voices,
+    voiceParam,
+    storedVoiceId
+  );
 
   const brandBasePath = `/${slug}/brand/identity`;
   const viewSuffix = isReferencesView ? "&view=references" : "";
 
+  function handleSelectVoice(voiceId: string) {
+    writeStoredBrandIdentityId(organizationId, voiceId);
+    setStoredVoiceId(voiceId);
+    router.push(`${brandBasePath}?voice=${voiceId}${viewSuffix}`);
+  }
+
   if (voices.length === 0 || !activeVoice) {
     return (
       <BreadcrumbPage className="block min-w-0 truncate">
-        Brand Identity
+        Company Info
       </BreadcrumbPage>
     );
   }
@@ -75,9 +95,7 @@ export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
             <DropdownMenuItem
               className="cursor-pointer gap-2 pr-8"
               key={voice.id}
-              onClick={() =>
-                router.push(`${brandBasePath}?voice=${voice.id}${viewSuffix}`)
-              }
+              onClick={() => handleSelectVoice(voice.id)}
             >
               <span className="min-w-0 flex-1 truncate">{voice.name}</span>
               {voice.isDefault ? (

--- a/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
@@ -6,6 +6,11 @@ import {
   Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { BreadcrumbPage } from "@notra/ui/components/ui/breadcrumb";
 import {
@@ -21,11 +26,29 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
+import { getBrandFaviconUrl } from "@/utils/brand";
 import {
   findSelectedBrandIdentity,
   readStoredBrandIdentityId,
   writeStoredBrandIdentityId,
 } from "@/utils/brand-identity-selection";
+
+function BrandIdentityAvatar({
+  name,
+  websiteUrl,
+}: {
+  name: string;
+  websiteUrl: string | null;
+}) {
+  return (
+    <Avatar className="size-4 after:rounded-full" size="sm">
+      <AvatarImage src={getBrandFaviconUrl(websiteUrl)} />
+      <AvatarFallback className="text-[9px]">
+        {name.slice(0, 2).toUpperCase()}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
 
 export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
   const { activeOrganization } = useOrganizationsContext();
@@ -73,9 +96,13 @@ export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
       <DropdownMenuTrigger
         render={
           <button
-            className="-mx-1.5 flex min-w-0 cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 font-normal text-foreground outline-none transition-colors hover:bg-accent data-popup-open:bg-accent"
+            className="-mx-1.5 flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 font-normal text-foreground outline-none transition-colors hover:bg-accent data-popup-open:bg-accent"
             type="button"
           >
+            <BrandIdentityAvatar
+              name={activeVoice.name}
+              websiteUrl={activeVoice.websiteUrl}
+            />
             <span className="truncate">{activeVoice.name}</span>
             <HugeiconsIcon
               className="size-3.5 shrink-0 text-muted-foreground"
@@ -97,6 +124,10 @@ export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
               key={voice.id}
               onClick={() => handleSelectVoice(voice.id)}
             >
+              <BrandIdentityAvatar
+                name={voice.name}
+                websiteUrl={voice.websiteUrl}
+              />
               <span className="min-w-0 flex-1 truncate">{voice.name}</span>
               {voice.isDefault ? (
                 <Badge

--- a/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+  ArrowDown01Icon,
+  PlusSignIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Badge } from "@notra/ui/components/ui/badge";
+import { BreadcrumbPage } from "@notra/ui/components/ui/breadcrumb";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@notra/ui/components/ui/dropdown-menu";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
+
+export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
+  const { activeOrganization } = useOrganizationsContext();
+  const organizationId = activeOrganization?.id ?? "";
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const { data } = useBrandSettings(organizationId);
+  const voices = data?.voices ?? [];
+  const voiceParam = searchParams.get("voice");
+  const isReferencesView = searchParams.get("view") === "references";
+
+  const activeVoice =
+    (voiceParam ? voices.find((v) => v.id === voiceParam) : undefined) ??
+    voices.find((v) => v.isDefault) ??
+    voices[0];
+
+  const brandBasePath = `/${slug}/brand/identity`;
+  const viewSuffix = isReferencesView ? "&view=references" : "";
+
+  if (voices.length === 0 || !activeVoice) {
+    return (
+      <BreadcrumbPage className="block min-w-0 truncate">
+        Brand Identity
+      </BreadcrumbPage>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            className="-mx-1.5 flex min-w-0 cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 font-normal text-foreground outline-none transition-colors hover:bg-accent data-popup-open:bg-accent"
+            type="button"
+          >
+            <span className="truncate">{activeVoice.name}</span>
+            <HugeiconsIcon
+              className="size-3.5 shrink-0 text-muted-foreground"
+              icon={ArrowDown01Icon}
+            />
+          </button>
+        }
+      />
+      <DropdownMenuContent
+        align="start"
+        className="min-w-52 rounded-lg"
+        sideOffset={8}
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Brand identities</DropdownMenuLabel>
+          {voices.map((voice) => (
+            <DropdownMenuItem
+              className="cursor-pointer gap-2 pr-8"
+              key={voice.id}
+              onClick={() =>
+                router.push(`${brandBasePath}?voice=${voice.id}${viewSuffix}`)
+              }
+            >
+              <span className="min-w-0 flex-1 truncate">{voice.name}</span>
+              {voice.isDefault ? (
+                <Badge
+                  className="shrink-0 px-1.5 py-0 font-medium text-[10px]"
+                  variant="secondary"
+                >
+                  Default
+                </Badge>
+              ) : null}
+              {activeVoice.id === voice.id ? (
+                <HugeiconsIcon
+                  className="absolute right-2 size-4 text-muted-foreground"
+                  icon={Tick02Icon}
+                />
+              ) : null}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="cursor-pointer gap-2"
+          onClick={() => router.push(`${brandBasePath}?new=1`)}
+        >
+          <HugeiconsIcon icon={PlusSignIcon} />
+          Create identity
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
+++ b/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
@@ -16,11 +16,6 @@ import {
 import type * as React from "react";
 import { useState } from "react";
 
-/**
- * A sidebar group whose label acts as a collapse/expand toggle. When the
- * sidebar itself is collapsed to icons, the group is forced open so the item
- * icons stay reachable.
- */
 export function CollapsibleSidebarGroup({
   label,
   defaultOpen = true,

--- a/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
+++ b/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
@@ -42,7 +42,7 @@ export function CollapsibleSidebarGroup({
             <CollapsibleTrigger className="w-full cursor-pointer hover:text-sidebar-foreground [&[data-panel-open]>svg]:rotate-0">
               {label}
               <HugeiconsIcon
-                className="-rotate-90 ml-auto text-sidebar-foreground/50 transition-transform"
+                className="-rotate-90 ml-1 size-3.5! text-sidebar-foreground/50 transition-transform"
                 icon={ArrowDown01Icon}
               />
             </CollapsibleTrigger>

--- a/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
+++ b/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@notra/ui/components/ui/collapsible";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  useSidebar,
+} from "@notra/ui/components/ui/sidebar";
+import type * as React from "react";
+import { useState } from "react";
+
+/**
+ * A sidebar group whose label acts as a collapse/expand toggle. When the
+ * sidebar itself is collapsed to icons, the group is forced open so the item
+ * icons stay reachable.
+ */
+export function CollapsibleSidebarGroup({
+  label,
+  defaultOpen = true,
+  children,
+}: {
+  label: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const { state, isMobile } = useSidebar();
+  const isIconMode = state === "collapsed" && !isMobile;
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <Collapsible onOpenChange={setOpen} open={isIconMode ? true : open}>
+      <SidebarGroup>
+        <SidebarGroupLabel
+          render={
+            <CollapsibleTrigger className="w-full cursor-pointer hover:text-sidebar-foreground [&[data-panel-open]>svg]:rotate-0">
+              {label}
+              <HugeiconsIcon
+                className="-rotate-90 ml-auto text-sidebar-foreground/50 transition-transform"
+                icon={ArrowDown01Icon}
+              />
+            </CollapsibleTrigger>
+          }
+        />
+        <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 ease-out data-[ending-style]:h-0 data-[starting-style]:h-0">
+          <SidebarGroupContent>{children}</SidebarGroupContent>
+        </CollapsibleContent>
+      </SidebarGroup>
+    </Collapsible>
+  );
+}

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -56,7 +56,7 @@ const SEGMENT_CONFIG: Record<string, { label?: string; href?: null }> = {
   automation: { href: null },
   brand: { href: null },
   "api-keys": { label: "API Keys" },
-  identity: { label: "Identity & References" },
+  identity: { label: "Brand Identity" },
   schedules: { label: "Schedules" },
 };
 

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -40,6 +40,7 @@ import {
   CreditBalanceButton,
   CreditBalanceMenuItem,
 } from "@/components/billing/credit-balance-button";
+import { BrandTopbarIdentitySelector } from "@/components/dashboard/brand-topbar-identity-selector";
 import { ChatTopbarTitle } from "@/components/dashboard/chat-topbar-title";
 import { ContentTopbarTitle } from "@/components/dashboard/content-topbar-title";
 import { useFeedback } from "@/components/dashboard/feedback-context";
@@ -147,80 +148,111 @@ export function SiteHeader() {
     breadcrumbSegments[0] === "content" &&
     breadcrumbSegments.length >= 2;
   const contentDetailId = isContentDetail ? breadcrumbSegments[1] : null;
+  const isBrandIdentity =
+    !isNonOrgPath &&
+    breadcrumbSegments[0] === "brand" &&
+    breadcrumbSegments[1] === "identity";
 
   const displayBreadcrumbSegments = isCollectionDetail
     ? ["content", "collection"]
     : breadcrumbSegments;
 
-  const breadcrumbs = displayBreadcrumbSegments.flatMap((segment, index) => {
-    const href = (() => {
-      if (isCollectionDetail && segment === "content") {
-        return `/${slug}/content`;
-      }
-      if (isCollectionDetail && segment === "collection") {
-        return `/${slug}/content`;
-      }
-      return isNonOrgPath
-        ? `/${segments.slice(0, index + 1).join("/")}`
-        : `/${segments.slice(0, index + 2).join("/")}`;
-    })();
-    const isLast = index === displayBreadcrumbSegments.length - 1;
-    const config = SEGMENT_CONFIG[segment];
-    const label =
-      config?.label ??
-      segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, " ");
-    const isClickable = config?.href !== null;
-    const isChatDetailLast = isChatDetail && isLast && chatDetailId;
-    const isContentDetailLast = isContentDetail && isLast && contentDetailId;
-    const content = (() => {
-      if (isChatDetailLast) {
-        return <ChatTopbarTitle chatId={chatDetailId} />;
-      }
+  const brandIdentityBreadcrumbs = [
+    <BreadcrumbItem
+      className="hover:underline"
+      key={`${id}-brand-identity-link`}
+    >
+      <BreadcrumbLink
+        render={<Link href={`/${slug}/brand/identity`}>Brand Identity</Link>}
+      />
+    </BreadcrumbItem>,
+    <BreadcrumbSeparator key={`${id}-brand-identity-sep`}>
+      <HugeiconsIcon icon={ArrowRight01Icon} />
+    </BreadcrumbSeparator>,
+    <BreadcrumbItem className="min-w-0" key={`${id}-brand-identity-selector`}>
+      <BrandTopbarIdentitySelector slug={slug ?? ""} />
+    </BreadcrumbItem>,
+  ];
 
-      if (isContentDetailLast) {
-        return <ContentTopbarTitle contentId={contentDetailId} />;
-      }
+  const genericBreadcrumbs = displayBreadcrumbSegments.flatMap(
+    (segment, index) => {
+      const href = (() => {
+        if (isCollectionDetail && segment === "content") {
+          return `/${slug}/content`;
+        }
+        if (isCollectionDetail && segment === "collection") {
+          return `/${slug}/content`;
+        }
+        return isNonOrgPath
+          ? `/${segments.slice(0, index + 1).join("/")}`
+          : `/${segments.slice(0, index + 2).join("/")}`;
+      })();
+      const isLast = index === displayBreadcrumbSegments.length - 1;
+      const config = SEGMENT_CONFIG[segment];
+      const label =
+        config?.label ??
+        segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, " ");
+      const isClickable = config?.href !== null;
+      const isChatDetailLast = isChatDetail && isLast && chatDetailId;
+      const isContentDetailLast = isContentDetail && isLast && contentDetailId;
+      const content = (() => {
+        if (isChatDetailLast) {
+          return <ChatTopbarTitle chatId={chatDetailId} />;
+        }
 
-      if (isCollectionDetail && isLast) {
-        return <BreadcrumbPage>{label}</BreadcrumbPage>;
-      }
+        if (isContentDetailLast) {
+          return <ContentTopbarTitle contentId={contentDetailId} />;
+        }
 
-      if (isClickable) {
-        return <BreadcrumbLink render={<Link href={href}>{label}</Link>} />;
-      }
+        if (isCollectionDetail && isLast) {
+          return <BreadcrumbPage>{label}</BreadcrumbPage>;
+        }
+
+        if (isClickable) {
+          return <BreadcrumbLink render={<Link href={href}>{label}</Link>} />;
+        }
+
+        if (isLast) {
+          return <BreadcrumbPage>{label}</BreadcrumbPage>;
+        }
+
+        return <span>{label}</span>;
+      })();
+
+      const item = (
+        <BreadcrumbItem
+          className={cn(
+            (isChatDetailLast || isContentDetailLast) && "min-w-0",
+            isClickable &&
+              !(
+                isChatDetailLast ||
+                isCollectionDetail ||
+                isContentDetailLast
+              ) &&
+              "hover:underline"
+          )}
+          key={`${id}-item-${segment}`}
+        >
+          {content}
+        </BreadcrumbItem>
+      );
 
       if (isLast) {
-        return <BreadcrumbPage>{label}</BreadcrumbPage>;
+        return [item];
       }
 
-      return <span>{label}</span>;
-    })();
-
-    const item = (
-      <BreadcrumbItem
-        className={cn(
-          (isChatDetailLast || isContentDetailLast) && "min-w-0",
-          isClickable &&
-            !(isChatDetailLast || isCollectionDetail || isContentDetailLast) &&
-            "hover:underline"
-        )}
-        key={`${id}-item-${segment}`}
-      >
-        {content}
-      </BreadcrumbItem>
-    );
-
-    if (isLast) {
-      return [item];
+      return [
+        item,
+        <BreadcrumbSeparator key={`${id}-separator-${segment}`}>
+          <HugeiconsIcon icon={ArrowRight01Icon} />
+        </BreadcrumbSeparator>,
+      ];
     }
+  );
 
-    return [
-      item,
-      <BreadcrumbSeparator key={`${id}-separator-${segment}`}>
-        <HugeiconsIcon icon={ArrowRight01Icon} />
-      </BreadcrumbSeparator>,
-    ];
-  });
+  const breadcrumbs = isBrandIdentity
+    ? brandIdentityBreadcrumbs
+    : genericBreadcrumbs;
 
   return (
     <header className="relative flex h-12 shrink-0 items-center gap-2 border-b border-dashed transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -14,8 +14,8 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import { useReferences } from "@/lib/hooks/use-brand-references";
 import {
+  findSelectedBrandIdentity,
   readStoredBrandIdentityId,
-  writeStoredBrandIdentityId,
 } from "@/utils/brand-identity-selection";
 import { CollapsibleSidebarGroup } from "./collapsible-nav-group";
 
@@ -41,24 +41,12 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
     }
   }, [organizationId]);
 
-  const activeVoice =
-    (voiceParam ? voices.find((v) => v.id === voiceParam) : undefined) ??
-    (storedVoiceId ? voices.find((v) => v.id === storedVoiceId) : undefined) ??
-    voices.find((v) => v.isDefault) ??
-    voices[0];
+  const activeVoice = findSelectedBrandIdentity(
+    voices,
+    voiceParam,
+    storedVoiceId
+  );
   const activeVoiceId = activeVoice?.id;
-
-  useEffect(() => {
-    if (
-      organizationId &&
-      isOnBrandPage &&
-      voiceParam &&
-      voices.some((v) => v.id === voiceParam)
-    ) {
-      writeStoredBrandIdentityId(organizationId, voiceParam);
-      setStoredVoiceId(voiceParam);
-    }
-  }, [organizationId, isOnBrandPage, voiceParam, voices]);
 
   const { data: referencesData } = useReferences(
     organizationId,

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import {
+  ArrowDown01Icon,
+  Comment01Icon,
+  CorporateIcon,
+  PlusSignIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Badge } from "@notra/ui/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@notra/ui/components/ui/dropdown-menu";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  useSidebar,
+} from "@notra/ui/components/ui/sidebar";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
+import { useReferences } from "@/lib/hooks/use-brand-references";
+import { cn } from "@/lib/utils";
+
+const STORAGE_VERSION = "v1";
+
+function storageKey(organizationId: string) {
+  return `notra:brand-identity:${STORAGE_VERSION}:${organizationId}`;
+}
+
+function readStoredVoiceId(organizationId: string) {
+  try {
+    return localStorage.getItem(storageKey(organizationId));
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredVoiceId(organizationId: string, voiceId: string) {
+  try {
+    localStorage.setItem(storageKey(organizationId), voiceId);
+  } catch {
+    // Ignore storage failures (private mode, quota, disabled).
+  }
+}
+
+export function NavBrandIdentity({ slug }: { slug: string }) {
+  const { activeOrganization } = useOrganizationsContext();
+  const organizationId = activeOrganization?.id ?? "";
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { state, isMobile } = useSidebar();
+  const isCollapsed = state === "collapsed" && !isMobile;
+
+  const { data, isPending } = useBrandSettings(organizationId);
+  const voices = data?.voices ?? [];
+
+  const brandBasePath = `/${slug}/brand/identity`;
+  const isOnBrandPage = pathname === brandBasePath;
+  const voiceParam = searchParams.get("voice");
+  const isReferencesView =
+    isOnBrandPage && searchParams.get("view") === "references";
+
+  const [storedVoiceId, setStoredVoiceId] = useState<string | null>(null);
+  useEffect(() => {
+    if (organizationId) {
+      setStoredVoiceId(readStoredVoiceId(organizationId));
+    }
+  }, [organizationId]);
+
+  const activeVoice =
+    (voiceParam ? voices.find((v) => v.id === voiceParam) : undefined) ??
+    (storedVoiceId ? voices.find((v) => v.id === storedVoiceId) : undefined) ??
+    voices.find((v) => v.isDefault) ??
+    voices[0];
+  const activeVoiceId = activeVoice?.id;
+
+  // Keep the persisted identity in sync when it changes via the page URL.
+  useEffect(() => {
+    if (
+      organizationId &&
+      isOnBrandPage &&
+      voiceParam &&
+      voices.some((v) => v.id === voiceParam)
+    ) {
+      writeStoredVoiceId(organizationId, voiceParam);
+      setStoredVoiceId(voiceParam);
+    }
+  }, [organizationId, isOnBrandPage, voiceParam, voices]);
+
+  const { data: referencesData } = useReferences(
+    organizationId,
+    activeVoiceId ?? ""
+  );
+  const referenceCount = referencesData?.references.length ?? 0;
+
+  if (!organizationId) {
+    return null;
+  }
+
+  const companyInfoHref = activeVoiceId
+    ? `${brandBasePath}?voice=${activeVoiceId}`
+    : brandBasePath;
+  const referencesHref = activeVoiceId
+    ? `${brandBasePath}?voice=${activeVoiceId}&view=references`
+    : `${brandBasePath}?view=references`;
+
+  function handleSelectVoice(voiceId: string) {
+    writeStoredVoiceId(organizationId, voiceId);
+    setStoredVoiceId(voiceId);
+    const viewSuffix = isReferencesView ? "&view=references" : "";
+    router.push(`${brandBasePath}?voice=${voiceId}${viewSuffix}`);
+  }
+
+  // Icon-collapsed sidebar: show a single entry that links to the page.
+  if (isCollapsed) {
+    return (
+      <SidebarGroup>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                isActive={isOnBrandPage}
+                render={
+                  <Link href={companyInfoHref}>
+                    <HugeiconsIcon icon={CorporateIcon} />
+                    <span>Brand Identity</span>
+                  </Link>
+                }
+                tooltip="Brand Identity"
+              />
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    );
+  }
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Brand Identity</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            {voices.length === 0 ? (
+              isPending && !data ? (
+                <div className="flex h-8 items-center gap-2 rounded-md px-2">
+                  <Skeleton className="size-4 rounded-md" />
+                  <Skeleton className="h-4 flex-1" />
+                </div>
+              ) : (
+                <SidebarMenuButton
+                  isActive={isOnBrandPage}
+                  render={
+                    <Link href={brandBasePath}>
+                      <HugeiconsIcon icon={CorporateIcon} />
+                      <span>Set up brand identity</span>
+                    </Link>
+                  }
+                />
+              )
+            ) : (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <SidebarMenuButton className="cursor-pointer data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground">
+                      <HugeiconsIcon icon={CorporateIcon} />
+                      <span className="truncate font-medium">
+                        {activeVoice?.name}
+                      </span>
+                      <HugeiconsIcon
+                        className="ml-auto text-muted-foreground"
+                        icon={ArrowDown01Icon}
+                      />
+                    </SidebarMenuButton>
+                  }
+                />
+                <DropdownMenuContent
+                  align="start"
+                  className="min-w-56 rounded-lg"
+                  side="bottom"
+                  sideOffset={4}
+                >
+                  <DropdownMenuLabel>Brand identities</DropdownMenuLabel>
+                  <DropdownMenuGroup>
+                    {voices.map((voice) => (
+                      <DropdownMenuItem
+                        className="cursor-pointer gap-2 pr-8"
+                        key={voice.id}
+                        onClick={() => handleSelectVoice(voice.id)}
+                      >
+                        <HugeiconsIcon
+                          className="size-4 text-muted-foreground"
+                          icon={CorporateIcon}
+                        />
+                        <span className="min-w-0 flex-1 truncate">
+                          {voice.name}
+                        </span>
+                        {voice.isDefault ? (
+                          <Badge
+                            className="shrink-0 px-1.5 py-0 font-medium text-[10px]"
+                            variant="secondary"
+                          >
+                            Default
+                          </Badge>
+                        ) : null}
+                        {activeVoiceId === voice.id ? (
+                          <HugeiconsIcon
+                            className="absolute right-2 size-4 text-muted-foreground"
+                            icon={Tick02Icon}
+                          />
+                        ) : null}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-2"
+                    onClick={() => router.push(`${brandBasePath}?new=1`)}
+                  >
+                    <HugeiconsIcon icon={PlusSignIcon} />
+                    Create identity
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+
+            {voices.length > 0 ? (
+              <SidebarMenuSub>
+                <SidebarMenuSubItem>
+                  <SidebarMenuSubButton
+                    isActive={isOnBrandPage && !isReferencesView}
+                    render={
+                      <Link href={companyInfoHref}>
+                        <HugeiconsIcon icon={CorporateIcon} />
+                        <span>Company Info</span>
+                      </Link>
+                    }
+                  />
+                </SidebarMenuSubItem>
+                <SidebarMenuSubItem>
+                  <SidebarMenuSubButton
+                    isActive={isReferencesView}
+                    render={
+                      <Link href={referencesHref}>
+                        <HugeiconsIcon icon={Comment01Icon} />
+                        <span>References</span>
+                        {referenceCount > 0 ? (
+                          <span
+                            className={cn(
+                              "ml-auto text-muted-foreground text-xs tabular-nums"
+                            )}
+                          >
+                            {referenceCount}
+                          </span>
+                        ) : null}
+                      </Link>
+                    }
+                  />
+                </SidebarMenuSubItem>
+              </SidebarMenuSub>
+            ) : null}
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -1,43 +1,19 @@
 "use client";
 
-import {
-  ArrowDown01Icon,
-  Comment01Icon,
-  CorporateIcon,
-  PlusSignIcon,
-  Tick02Icon,
-} from "@hugeicons/core-free-icons";
+import { Comment01Icon, CorporateIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Badge } from "@notra/ui/components/ui/badge";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@notra/ui/components/ui/dropdown-menu";
-import {
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
-  useSidebar,
 } from "@notra/ui/components/ui/sidebar";
-import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import { useReferences } from "@/lib/hooks/use-brand-references";
-import { cn } from "@/lib/utils";
+import { CollapsibleSidebarGroup } from "./collapsible-nav-group";
 
 const STORAGE_VERSION = "v1";
 
@@ -65,12 +41,9 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
   const { activeOrganization } = useOrganizationsContext();
   const organizationId = activeOrganization?.id ?? "";
   const pathname = usePathname();
-  const router = useRouter();
   const searchParams = useSearchParams();
-  const { state, isMobile } = useSidebar();
-  const isCollapsed = state === "collapsed" && !isMobile;
 
-  const { data, isPending } = useBrandSettings(organizationId);
+  const { data } = useBrandSettings(organizationId);
   const voices = data?.voices ?? [];
 
   const brandBasePath = `/${slug}/brand/identity`;
@@ -86,6 +59,8 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
     }
   }, [organizationId]);
 
+  // The active identity is selected on the page; the sidebar only mirrors it so
+  // the Company Info / References links and reference count stay scoped to it.
   const activeVoice =
     (voiceParam ? voices.find((v) => v.id === voiceParam) : undefined) ??
     (storedVoiceId ? voices.find((v) => v.id === storedVoiceId) : undefined) ??
@@ -93,7 +68,6 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
     voices[0];
   const activeVoiceId = activeVoice?.id;
 
-  // Keep the persisted identity in sync when it changes via the page URL.
   useEffect(() => {
     if (
       organizationId &&
@@ -123,164 +97,39 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
     ? `${brandBasePath}?voice=${activeVoiceId}&view=references`
     : `${brandBasePath}?view=references`;
 
-  function handleSelectVoice(voiceId: string) {
-    writeStoredVoiceId(organizationId, voiceId);
-    setStoredVoiceId(voiceId);
-    const viewSuffix = isReferencesView ? "&view=references" : "";
-    router.push(`${brandBasePath}?voice=${voiceId}${viewSuffix}`);
-  }
-
-  // Icon-collapsed sidebar: show a single entry that links to the page.
-  if (isCollapsed) {
-    return (
-      <SidebarGroup>
-        <SidebarGroupContent>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                isActive={isOnBrandPage}
-                render={
-                  <Link href={companyInfoHref}>
-                    <HugeiconsIcon icon={CorporateIcon} />
-                    <span>Brand Identity</span>
-                  </Link>
-                }
-                tooltip="Brand Identity"
-              />
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarGroupContent>
-      </SidebarGroup>
-    );
-  }
-
   return (
-    <SidebarGroup>
-      <SidebarGroupLabel>Brand Identity</SidebarGroupLabel>
-      <SidebarGroupContent>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            {voices.length === 0 ? (
-              isPending && !data ? (
-                <div className="flex h-8 items-center gap-2 rounded-md px-2">
-                  <Skeleton className="size-4 rounded-md" />
-                  <Skeleton className="h-4 flex-1" />
-                </div>
-              ) : (
-                <SidebarMenuButton
-                  isActive={isOnBrandPage}
-                  render={
-                    <Link href={brandBasePath}>
-                      <HugeiconsIcon icon={CorporateIcon} />
-                      <span>Set up brand identity</span>
-                    </Link>
-                  }
-                />
-              )
-            ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <SidebarMenuButton className="cursor-pointer data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground">
-                      <HugeiconsIcon icon={CorporateIcon} />
-                      <span className="truncate font-medium">
-                        {activeVoice?.name}
-                      </span>
-                      <HugeiconsIcon
-                        className="ml-auto text-muted-foreground"
-                        icon={ArrowDown01Icon}
-                      />
-                    </SidebarMenuButton>
-                  }
-                />
-                <DropdownMenuContent
-                  align="start"
-                  className="min-w-56 rounded-lg"
-                  side="bottom"
-                  sideOffset={4}
-                >
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel>Brand identities</DropdownMenuLabel>
-                    {voices.map((voice) => (
-                      <DropdownMenuItem
-                        className="cursor-pointer gap-2 pr-8"
-                        key={voice.id}
-                        onClick={() => handleSelectVoice(voice.id)}
-                      >
-                        <HugeiconsIcon
-                          className="size-4 text-muted-foreground"
-                          icon={CorporateIcon}
-                        />
-                        <span className="min-w-0 flex-1 truncate">
-                          {voice.name}
-                        </span>
-                        {voice.isDefault ? (
-                          <Badge
-                            className="shrink-0 px-1.5 py-0 font-medium text-[10px]"
-                            variant="secondary"
-                          >
-                            Default
-                          </Badge>
-                        ) : null}
-                        {activeVoiceId === voice.id ? (
-                          <HugeiconsIcon
-                            className="absolute right-2 size-4 text-muted-foreground"
-                            icon={Tick02Icon}
-                          />
-                        ) : null}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    className="cursor-pointer gap-2"
-                    onClick={() => router.push(`${brandBasePath}?new=1`)}
-                  >
-                    <HugeiconsIcon icon={PlusSignIcon} />
-                    Create identity
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-
-            {voices.length > 0 ? (
-              <SidebarMenuSub>
-                <SidebarMenuSubItem>
-                  <SidebarMenuSubButton
-                    isActive={isOnBrandPage && !isReferencesView}
-                    render={
-                      <Link href={companyInfoHref}>
-                        <HugeiconsIcon icon={CorporateIcon} />
-                        <span>Company Info</span>
-                      </Link>
-                    }
-                  />
-                </SidebarMenuSubItem>
-                <SidebarMenuSubItem>
-                  <SidebarMenuSubButton
-                    isActive={isReferencesView}
-                    render={
-                      <Link href={referencesHref}>
-                        <HugeiconsIcon icon={Comment01Icon} />
-                        <span>References</span>
-                        {referenceCount > 0 ? (
-                          <span
-                            className={cn(
-                              "ml-auto text-muted-foreground text-xs tabular-nums"
-                            )}
-                          >
-                            {referenceCount}
-                          </span>
-                        ) : null}
-                      </Link>
-                    }
-                  />
-                </SidebarMenuSubItem>
-              </SidebarMenuSub>
-            ) : null}
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarGroup>
+    <CollapsibleSidebarGroup label="Brand Identity">
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={isOnBrandPage && !isReferencesView}
+            render={
+              <Link href={companyInfoHref}>
+                <HugeiconsIcon icon={CorporateIcon} />
+                <span>Company Info</span>
+              </Link>
+            }
+            tooltip="Company Info"
+          />
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={isReferencesView}
+            render={
+              <Link href={referencesHref}>
+                <HugeiconsIcon icon={Comment01Icon} />
+                <span>References</span>
+                {referenceCount > 0 ? (
+                  <span className="ml-auto text-muted-foreground text-xs tabular-nums group-data-[collapsible=icon]:hidden">
+                    {referenceCount}
+                  </span>
+                ) : null}
+              </Link>
+            }
+            tooltip="References"
+          />
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </CollapsibleSidebarGroup>
   );
 }

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -199,8 +199,8 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
                   side="bottom"
                   sideOffset={4}
                 >
-                  <DropdownMenuLabel>Brand identities</DropdownMenuLabel>
                   <DropdownMenuGroup>
+                    <DropdownMenuLabel>Brand identities</DropdownMenuLabel>
                     {voices.map((voice) => (
                       <DropdownMenuItem
                         className="cursor-pointer gap-2 pr-8"

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -13,29 +13,11 @@ import { useEffect, useState } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import { useReferences } from "@/lib/hooks/use-brand-references";
+import {
+  readStoredBrandIdentityId,
+  writeStoredBrandIdentityId,
+} from "@/utils/brand-identity-selection";
 import { CollapsibleSidebarGroup } from "./collapsible-nav-group";
-
-const STORAGE_VERSION = "v1";
-
-function storageKey(organizationId: string) {
-  return `notra:brand-identity:${STORAGE_VERSION}:${organizationId}`;
-}
-
-function readStoredVoiceId(organizationId: string) {
-  try {
-    return localStorage.getItem(storageKey(organizationId));
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredVoiceId(organizationId: string, voiceId: string) {
-  try {
-    localStorage.setItem(storageKey(organizationId), voiceId);
-  } catch {
-    // Ignore storage failures (private mode, quota, disabled).
-  }
-}
 
 export function NavBrandIdentity({ slug }: { slug: string }) {
   const { activeOrganization } = useOrganizationsContext();
@@ -55,12 +37,10 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
   const [storedVoiceId, setStoredVoiceId] = useState<string | null>(null);
   useEffect(() => {
     if (organizationId) {
-      setStoredVoiceId(readStoredVoiceId(organizationId));
+      setStoredVoiceId(readStoredBrandIdentityId(organizationId));
     }
   }, [organizationId]);
 
-  // The active identity is selected on the page; the sidebar only mirrors it so
-  // the Company Info / References links and reference count stay scoped to it.
   const activeVoice =
     (voiceParam ? voices.find((v) => v.id === voiceParam) : undefined) ??
     (storedVoiceId ? voices.find((v) => v.id === storedVoiceId) : undefined) ??
@@ -75,7 +55,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
       voiceParam &&
       voices.some((v) => v.id === voiceParam)
     ) {
-      writeStoredVoiceId(organizationId, voiceParam);
+      writeStoredBrandIdentityId(organizationId, voiceParam);
       setStoredVoiceId(voiceParam);
     }
   }, [organizationId, isOnBrandPage, voiceParam, voices]);

--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -2,7 +2,6 @@
 import {
   AnalyticsUpIcon,
   Calendar03Icon,
-  CorporateIcon,
   Home01Icon,
   Key01Icon,
   MagicWand01Icon,
@@ -26,10 +25,11 @@ import {
 import { useIsApplePlatform } from "@notra/ui/hooks/use-is-apple-platform";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { memo } from "react";
+import { Fragment, memo } from "react";
 import { useCommandPalette } from "@/components/command-palette/command-palette-context";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import type { NavMainCategory, NavMainItem } from "@/types/components/nav";
+import { NavBrandIdentity } from "./nav-brand-identity";
 
 const categoryLabels: Record<Exclude<NavMainCategory, "none">, string> = {
   workspace: "Workspace",
@@ -55,12 +55,6 @@ const navMainItems: NavMainItem[] = [
     link: "/content",
     icon: NoteIcon,
     label: "Content",
-    category: "workspace",
-  },
-  {
-    link: "/brand/identity",
-    icon: CorporateIcon,
-    label: "Identity & References",
     category: "workspace",
   },
   {
@@ -209,13 +203,15 @@ export function NavMain() {
       </SidebarGroup>
       <NavGroup items={rootItems} pathname={pathname} slug={slug} />
       {categories.map((category) => (
-        <NavGroup
-          items={itemsByCategory[category]}
-          key={category}
-          label={categoryLabels[category]}
-          pathname={pathname}
-          slug={slug}
-        />
+        <Fragment key={category}>
+          <NavGroup
+            items={itemsByCategory[category]}
+            label={categoryLabels[category]}
+            pathname={pathname}
+            slug={slug}
+          />
+          {category === "workspace" && <NavBrandIdentity slug={slug} />}
+        </Fragment>
       ))}
     </>
   );

--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -17,7 +17,6 @@ import { Kbd, KbdGroup } from "@notra/ui/components/ui/kbd";
 import {
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -29,6 +28,7 @@ import { Fragment, memo } from "react";
 import { useCommandPalette } from "@/components/command-palette/command-palette-context";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import type { NavMainCategory, NavMainItem } from "@/types/components/nav";
+import { CollapsibleSidebarGroup } from "./collapsible-nav-group";
 import { NavBrandIdentity } from "./nav-brand-identity";
 
 const categoryLabels: Record<Exclude<NavMainCategory, "none">, string> = {
@@ -120,42 +120,49 @@ const NavGroup = memo(function NavGroup({
     return null;
   }
 
+  const menu = (
+    <SidebarMenu>
+      {items.map((item) => {
+        const href = `/${slug}${item.link}`;
+        const isActive =
+          item.link === ""
+            ? pathname === `/${slug}` || pathname === `/${slug}/`
+            : pathname.startsWith(href);
+        return (
+          <SidebarMenuItem key={item.link}>
+            <SidebarMenuButton
+              isActive={isActive}
+              render={
+                <Link href={href}>
+                  <HugeiconsIcon icon={item.icon} />
+                  <span>{item.label}</span>
+                  {item.badge && (
+                    <Badge
+                      className="ml-auto h-[1.125rem] px-[0.375rem] text-[0.625rem] text-muted-foreground"
+                      variant="secondary"
+                    >
+                      {item.badge}
+                    </Badge>
+                  )}
+                </Link>
+              }
+              tooltip={item.label}
+            />
+          </SidebarMenuItem>
+        );
+      })}
+    </SidebarMenu>
+  );
+
+  if (label) {
+    return (
+      <CollapsibleSidebarGroup label={label}>{menu}</CollapsibleSidebarGroup>
+    );
+  }
+
   return (
     <SidebarGroup>
-      {label && <SidebarGroupLabel>{label}</SidebarGroupLabel>}
-      <SidebarGroupContent>
-        <SidebarMenu>
-          {items.map((item) => {
-            const href = `/${slug}${item.link}`;
-            const isActive =
-              item.link === ""
-                ? pathname === `/${slug}` || pathname === `/${slug}/`
-                : pathname.startsWith(href);
-            return (
-              <SidebarMenuItem key={item.link}>
-                <SidebarMenuButton
-                  isActive={isActive}
-                  render={
-                    <Link href={href}>
-                      <HugeiconsIcon icon={item.icon} />
-                      <span>{item.label}</span>
-                      {item.badge && (
-                        <Badge
-                          className="ml-auto h-[1.125rem] px-[0.375rem] text-[0.625rem] text-muted-foreground"
-                          variant="secondary"
-                        >
-                          {item.badge}
-                        </Badge>
-                      )}
-                    </Link>
-                  }
-                  tooltip={item.label}
-                />
-              </SidebarMenuItem>
-            );
-          })}
-        </SidebarMenu>
-      </SidebarGroupContent>
+      <SidebarGroupContent>{menu}</SidebarGroupContent>
     </SidebarGroup>
   );
 });

--- a/apps/dashboard/src/constants/storage.ts
+++ b/apps/dashboard/src/constants/storage.ts
@@ -9,6 +9,8 @@ export const localStorageKeys = {
     organizationId
       ? `onboarding-collapsed:${organizationId}`
       : "onboarding-collapsed",
+  brandIdentity: (organizationId: string) =>
+    `notra:brand-identity:v1:${organizationId}`,
 } as const;
 
 export const sessionStorageKeys = {

--- a/apps/dashboard/src/utils/brand-identity-selection.ts
+++ b/apps/dashboard/src/utils/brand-identity-selection.ts
@@ -1,6 +1,22 @@
 "use client";
 
 import { localStorageKeys } from "@/constants/storage";
+import type { BrandSettings } from "@/types/hooks/brand-analysis";
+
+export function findSelectedBrandIdentity(
+  voices: BrandSettings[],
+  voiceId: string | null,
+  storedVoiceId: string | null
+): BrandSettings | undefined {
+  return (
+    (voiceId ? voices.find((voice) => voice.id === voiceId) : undefined) ??
+    (storedVoiceId
+      ? voices.find((voice) => voice.id === storedVoiceId)
+      : undefined) ??
+    voices.find((voice) => voice.isDefault) ??
+    voices[0]
+  );
+}
 
 export function readStoredBrandIdentityId(
   organizationId: string

--- a/apps/dashboard/src/utils/brand-identity-selection.ts
+++ b/apps/dashboard/src/utils/brand-identity-selection.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { localStorageKeys } from "@/constants/storage";
+
+export function readStoredBrandIdentityId(
+  organizationId: string
+): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(
+      localStorageKeys.brandIdentity(organizationId)
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredBrandIdentityId(
+  organizationId: string,
+  voiceId: string
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      localStorageKeys.brandIdentity(organizationId),
+      voiceId
+    );
+  } catch {
+    return;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restructures the dashboard sidebar so brand identity is its own section, makes every labeled sidebar group collapsible, and adds a brand‑identity selector to the top breadcrumb.

- **Brand Identity** is a sidebar group heading (plain text, not an identity name) with two nested entries: **Company Info** and **References**. Both are scoped to the active identity via `?voice=`; References resolves per‑identity and shows a live count badge.
- **All labeled sidebar groups** (Workspace, Brand Identity, Automation, Manage) are now collapsible. The collapse/expand caret sits **directly next to the heading text**. When the sidebar is icon‑collapsed, groups are forced open so the icons stay reachable.
- The **identity selector lives on the page** (existing on‑page `VoiceSelector`) and is **also available in the top breadcrumb**: on the brand pages the breadcrumb reads `Brand Identity > <identity> ▾`, and the dropdown switches the active identity (updates the page, breadcrumb label, sidebar count, and `?voice=` URL). It also offers `Create identity`.
- Page tabs/H1, breadcrumb label, command palette, and metadata were aligned to the `Company Info` / `References` naming. The selector's `Create identity` opens the create dialog via `?new=1`.

## Changes
- `components/dashboard/nav-brand-identity.tsx` (new): Brand Identity collapsible group with Company Info / References entries, scoped to the active identity (localStorage + URL).
- `components/dashboard/collapsible-nav-group.tsx` (new): reusable collapsible sidebar group (label-as-trigger with caret next to text).
- `components/dashboard/brand-topbar-identity-selector.tsx` (new): breadcrumb identity dropdown.
- `components/dashboard/nav-main.tsx`: labeled groups use the collapsible group; old combined item removed.
- `components/dashboard/header.tsx`: breadcrumb special‑case for the brand identity page.
- `app/(dashboard)/[slug]/brand/identity/page-client.tsx`: `Company Info` naming + `?new=1` create dialog.
- `components/command-palette/registry.ts`, `brand/identity/page.tsx`: naming alignment.

## Testing
- `bun run check-types --filter=dashboard`
- `bunx biome check` on changed files
- Manual end‑to‑end walkthrough (collapsible groups, breadcrumb identity switching, per‑identity references). See attached video + screenshots.

[brand_identity_sidebar_and_breadcrumb_selector.mp4](https://cursor.com/agents/bc-c36e734d-1a2c-4df8-87c8-d8fb6c50855c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrand_identity_sidebar_and_breadcrumb_selector.mp4)
[Breadcrumb identity selector open](https://cursor.com/agents/bc-c36e734d-1a2c-4df8-87c8-d8fb6c50855c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreadcrumb_identity_selector.webp)
[Collapsible sidebar groups with caret next to text](https://cursor.com/agents/bc-c36e734d-1a2c-4df8-87c8-d8fb6c50855c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_collapsible_groups.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c36e734d-1a2c-4df8-87c8-d8fb6c50855c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c36e734d-1a2c-4df8-87c8-d8fb6c50855c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds collapsible sidebar groups and a dedicated Brand Identity section with Company Info/References. Adds a breadcrumb identity dropdown with avatars and per‑org persistence synced via `?voice=`.

- **New Features**
  - All labeled sidebar groups are collapsible; caret next to label; groups stay open in icon mode.
  - New Brand Identity group under Workspace with Company Info and References; links scoped to the active identity; References shows a live count badge.
  - Breadcrumb shows “Brand Identity > <identity>” with a dropdown; shows favicon/initials avatar; lists all identities, marks default/active, supports “Create identity” via `?new=1`, and clears the param on close.
  - Active identity persists per org (localStorage) and syncs with `?voice=` across breadcrumb, page, and sidebar links.
  - Command palette split into “Company Info” and “References”; page H1/tab/metadata updated to “Brand Identity” / “Company Info”.
  - Removed the old “Identity & References” nav item.

- **Refactors**
  - Extracted identity storage/helpers to `constants/storage` and `utils/brand-identity-selection` with key `notra:brand-identity:v1:<orgId>`.
  - Introduced `CollapsibleSidebarGroup` for reusable labeled group behavior.

<sup>Written for commit 9f56117818cdc7b73693eb93330db892637a95c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

