### PR TITLE
perf(web): fix top react doctor warnings

### DIFF
--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -19,16 +19,20 @@ function isExternalHref(href?: string) {
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...components,
-    a: ({ href, rel, target, ...props }) =>
+    a: ({ children, href, rel, target, ...props }) =>
       isExternalHref(href) ? (
         <a
           {...props}
           href={href}
           rel={withSafeExternalRel(rel)}
           target="_blank"
-        />
+        >
+          {children}
+        </a>
       ) : (
-        <a {...props} href={href} rel={rel} target={target} />
+        <a {...props} href={href} rel={rel} target={target}>
+          {children}
+        </a>
       ),
   };
 }

--- a/apps/web/src/app/(changelog)/changelog/[name]/[slug]/page.tsx
+++ b/apps/web/src/app/(changelog)/changelog/[name]/[slug]/page.tsx
@@ -22,12 +22,16 @@ import type { ShowcaseEntryPageProps } from "~types/showcase";
 
 export function generateStaticParams() {
   return SHOWCASE_COMPANIES.flatMap((company) =>
-    changelog
-      .filter((entry) => entry.info.path.startsWith(`${company.slug}/`))
-      .map((entry) => ({
-        name: company.slug,
-        slug: getShowcaseEntrySlug(entry.info.path),
-      }))
+    changelog.flatMap((entry) =>
+      entry.info.path.startsWith(`${company.slug}/`)
+        ? [
+            {
+              name: company.slug,
+              slug: getShowcaseEntrySlug(entry.info.path),
+            },
+          ]
+        : []
+    )
   );
 }
 

--- a/apps/web/src/app/(changelog)/changelog/page.tsx
+++ b/apps/web/src/app/(changelog)/changelog/page.tsx
@@ -45,7 +45,7 @@ export default async function ChangelogHubPage() {
     ])
   );
 
-  const companies = SHOWCASE_COMPANIES.toSorted((left, right) => {
+  const companies = SHOWCASE_COMPANIES.slice().sort((left, right) => {
     const countDifference =
       (postCounts.get(right.slug) ?? 0) - (postCounts.get(left.slug) ?? 0);
 

--- a/apps/web/src/app/(changelog)/changelog/page.tsx
+++ b/apps/web/src/app/(changelog)/changelog/page.tsx
@@ -45,17 +45,16 @@ export default async function ChangelogHubPage() {
     ])
   );
 
-  const companies = [...SHOWCASE_COMPANIES]
-    .sort((left, right) => {
-      const countDifference =
-        (postCounts.get(right.slug) ?? 0) - (postCounts.get(left.slug) ?? 0);
+  const companies = SHOWCASE_COMPANIES.toSorted((left, right) => {
+    const countDifference =
+      (postCounts.get(right.slug) ?? 0) - (postCounts.get(left.slug) ?? 0);
 
-      if (countDifference !== 0) {
-        return countDifference;
-      }
+    if (countDifference !== 0) {
+      return countDifference;
+    }
 
-      return left.name.localeCompare(right.name);
-    })
+    return left.name.localeCompare(right.name);
+  })
     .map((company) => ({
       ...company,
       entryCount: postCounts.get(company.slug) ?? 0,

--- a/apps/web/src/app/(changelog)/changelog/page.tsx
+++ b/apps/web/src/app/(changelog)/changelog/page.tsx
@@ -45,16 +45,17 @@ export default async function ChangelogHubPage() {
     ])
   );
 
-  const companies = SHOWCASE_COMPANIES.slice().sort((left, right) => {
-    const countDifference =
-      (postCounts.get(right.slug) ?? 0) - (postCounts.get(left.slug) ?? 0);
+  const companies = SHOWCASE_COMPANIES.slice()
+    .sort((left, right) => {
+      const countDifference =
+        (postCounts.get(right.slug) ?? 0) - (postCounts.get(left.slug) ?? 0);
 
-    if (countDifference !== 0) {
-      return countDifference;
-    }
+      if (countDifference !== 0) {
+        return countDifference;
+      }
 
-    return left.name.localeCompare(right.name);
-  })
+      return left.name.localeCompare(right.name);
+    })
     .map((company) => ({
       ...company,
       entryCount: postCounts.get(company.slug) ?? 0,

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -14,12 +14,16 @@ const STATIC_PAGE_LAST_MODIFIED = new Date("2026-04-24");
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const showcaseEntries = SHOWCASE_COMPANIES.flatMap((company) =>
-    changelog
-      .filter((entry) => entry.info.path.startsWith(`${company.slug}/`))
-      .map((entry) => ({
-        url: `${SITE_URL}/changelog/${company.slug}/${getShowcaseEntrySlug(entry.info.path)}`,
-        lastModified: new Date(entry.date),
-      }))
+    changelog.flatMap((entry) =>
+      entry.info.path.startsWith(`${company.slug}/`)
+        ? [
+            {
+              url: `${SITE_URL}/changelog/${company.slug}/${getShowcaseEntrySlug(entry.info.path)}`,
+              lastModified: new Date(entry.date),
+            },
+          ]
+        : []
+    )
   );
 
   const notraChangelogEntries = (await listNotraChangelogPosts()).map(
@@ -64,12 +68,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const latestShowcaseByCompany = new Map<string, Date>();
   for (const company of SHOWCASE_COMPANIES) {
-    const latest = changelog
-      .filter((entry) => entry.info.path.startsWith(`${company.slug}/`))
-      .reduce<Date>((acc, entry) => {
-        const entryDate = new Date(entry.date);
-        return entryDate > acc ? entryDate : acc;
-      }, STATIC_PAGE_LAST_MODIFIED);
+    const latest = changelog.reduce<Date>((acc, entry) => {
+      if (!entry.info.path.startsWith(`${company.slug}/`)) {
+        return acc;
+      }
+
+      const entryDate = new Date(entry.date);
+      return entryDate > acc ? entryDate : acc;
+    }, STATIC_PAGE_LAST_MODIFIED);
     latestShowcaseByCompany.set(company.slug, latest);
   }
 

--- a/apps/web/src/utils/blog-jsonld.ts
+++ b/apps/web/src/utils/blog-jsonld.ts
@@ -121,15 +121,22 @@ function extractBlogFaqEntries(html: string): BlogFaqEntry[] {
 }
 
 function extractBlogAboutEntities(html: string) {
-  return extractHeadings(html)
-    .filter(
-      (heading) =>
-        heading.level === 2 && !BLOG_FAQ_HEADING_REGEX.test(heading.text)
-    )
-    .map((heading) =>
-      heading.text.replace(BLOG_NUMBERED_HEADING_PREFIX_REGEX, "")
-    )
-    .filter((text, index, list) => list.indexOf(text) === index);
+  const seen = new Set<string>();
+  const entities: string[] = [];
+
+  for (const heading of extractHeadings(html)) {
+    if (heading.level !== 2 || BLOG_FAQ_HEADING_REGEX.test(heading.text)) {
+      continue;
+    }
+
+    const text = heading.text.replace(BLOG_NUMBERED_HEADING_PREFIX_REGEX, "");
+    if (!seen.has(text)) {
+      seen.add(text);
+      entities.push(text);
+    }
+  }
+
+  return entities;
 }
 
 export function buildBlogArticleJsonLd({

--- a/apps/web/src/utils/github.ts
+++ b/apps/web/src/utils/github.ts
@@ -81,8 +81,9 @@ export async function fetchContributorsData(): Promise<ContributorsData> {
     return EMPTY_DATA;
   }
 
-  const contributors = (contributorsRaw ?? [])
-    .filter((c) => c.type === "User" && !c.login.endsWith("[bot]"));
+  const contributors = (contributorsRaw ?? []).filter(
+    (c) => c.type === "User" && !c.login.endsWith("[bot]")
+  );
 
   const issues = (issuesRaw ?? [])
     .filter((issue) => !issue.pull_request)

--- a/apps/web/src/utils/github.ts
+++ b/apps/web/src/utils/github.ts
@@ -82,8 +82,7 @@ export async function fetchContributorsData(): Promise<ContributorsData> {
   }
 
   const contributors = (contributorsRaw ?? [])
-    .filter((c) => c.type === "User")
-    .filter((c) => !c.login.endsWith("[bot]"));
+    .filter((c) => c.type === "User" && !c.login.endsWith("[bot]"));
 
   const issues = (issuesRaw ?? [])
     .filter((issue) => !issue.pull_request)

--- a/apps/web/src/utils/highlight-code.ts
+++ b/apps/web/src/utils/highlight-code.ts
@@ -49,14 +49,17 @@ function iconToSvg(icon: typeof Copy01Icon, className: string) {
   const children = icon
     .map(([tag, attributes]) => {
       const serializedAttributes = Object.entries(attributes)
-        .filter(([attributeName]) => attributeName !== "key")
-        .map(
-          ([attributeName, value]) =>
-            `${attributeName.replace(
-              SVG_ATTRIBUTE_CASE_REGEX,
-              (char) => `-${char.toLowerCase()}`
-            )}="${value}"`
-        )
+        .reduce<string[]>((acc, [attributeName, value]) => {
+          if (attributeName !== "key") {
+            acc.push(
+              `${attributeName.replace(
+                SVG_ATTRIBUTE_CASE_REGEX,
+                (char) => `-${char.toLowerCase()}`
+              )}="${value}"`
+            );
+          }
+          return acc;
+        }, [])
         .join(" ");
 
       return `<${tag} ${serializedAttributes} />`;

--- a/apps/web/src/utils/llms.ts
+++ b/apps/web/src/utils/llms.ts
@@ -27,7 +27,7 @@ function formatLink(title: string, path: string, description?: string) {
 }
 
 function sortShowcaseEntries() {
-  return [...changelog].sort(
+  return changelog.toSorted(
     (left, right) =>
       new Date(right.date).getTime() - new Date(left.date).getTime()
   );

--- a/apps/web/src/utils/llms.ts
+++ b/apps/web/src/utils/llms.ts
@@ -27,10 +27,12 @@ function formatLink(title: string, path: string, description?: string) {
 }
 
 function sortShowcaseEntries() {
-  return changelog.slice().sort(
-    (left, right) =>
-      new Date(right.date).getTime() - new Date(left.date).getTime()
-  );
+  return changelog
+    .slice()
+    .sort(
+      (left, right) =>
+        new Date(right.date).getTime() - new Date(left.date).getTime()
+    );
 }
 
 async function buildShowcaseEntrySections() {

--- a/apps/web/src/utils/llms.ts
+++ b/apps/web/src/utils/llms.ts
@@ -27,7 +27,7 @@ function formatLink(title: string, path: string, description?: string) {
 }
 
 function sortShowcaseEntries() {
-  return changelog.toSorted(
+  return changelog.slice().sort(
     (left, right) =>
       new Date(right.date).getTime() - new Date(left.date).getTime()
   );

--- a/apps/web/src/utils/marble.ts
+++ b/apps/web/src/utils/marble.ts
@@ -37,7 +37,7 @@ function createMarbleClient(apiKey: string) {
 function sortMarblePostsByPublishedAt<T extends Pick<Post, "publishedAt">>(
   posts: T[]
 ) {
-  return [...posts].sort(
+  return posts.toSorted(
     (firstPost, secondPost) =>
       secondPost.publishedAt.getTime() - firstPost.publishedAt.getTime()
   );

--- a/apps/web/src/utils/marble.ts
+++ b/apps/web/src/utils/marble.ts
@@ -37,7 +37,7 @@ function createMarbleClient(apiKey: string) {
 function sortMarblePostsByPublishedAt<T extends Pick<Post, "publishedAt">>(
   posts: T[]
 ) {
-  return posts.toSorted(
+  return posts.slice().sort(
     (firstPost, secondPost) =>
       secondPost.publishedAt.getTime() - firstPost.publishedAt.getTime()
   );

--- a/apps/web/src/utils/marble.ts
+++ b/apps/web/src/utils/marble.ts
@@ -37,10 +37,12 @@ function createMarbleClient(apiKey: string) {
 function sortMarblePostsByPublishedAt<T extends Pick<Post, "publishedAt">>(
   posts: T[]
 ) {
-  return posts.slice().sort(
-    (firstPost, secondPost) =>
-      secondPost.publishedAt.getTime() - firstPost.publishedAt.getTime()
-  );
+  return posts
+    .slice()
+    .sort(
+      (firstPost, secondPost) =>
+        secondPost.publishedAt.getTime() - firstPost.publishedAt.getTime()
+    );
 }
 
 async function listPostsByFormat(


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes top React Doctor warnings by removing extra allocations and keeping sorts non-mutating without relying on ES2023. Also fixes MDX links to render their children for both internal and external anchors.

- **Bug Fixes**
  - MDX `a` component now renders `children` for internal/external links.

- **Refactors**
  - Replace filter/map chains with `flatMap`, loops, or `reduce` in changelog pages, `sitemap`, and code highlighting to avoid intermediate arrays.
  - Use `slice().sort()` in the changelog hub, `llms`, and `marble` utils to avoid ES2023 `toSorted` types.
  - Optimize blog JSON-LD “About” entity parsing with a single pass and `Set`-based dedupe.
  - Serialize SVG icon attributes in one `reduce` pass.
  - Merge contributor filters in `github.ts` into a single predicate.

<sup>Written for commit 8a1c4a5f9736016032f4b30979f0933a8fa8c99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

