### PR TITLE
refactor(dashboard): address top react doctor issues

### DIFF
--- a/.agents/skills/react-doctor/SKILL.md
+++ b/.agents/skills/react-doctor/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: react-doctor
+description: Use when finishing a feature, fixing a bug, before committing React code, or when the user types `/doctor`, asks to scan, triage, or clean up React diagnostics. Covers lint, accessibility, bundle size, architecture. Includes a regression check and a full local-triage workflow that fetches the canonical playbook.
+version: "1.2.0"
+---
+
+# React Doctor
+
+Scans React codebases for security, performance, correctness, and architecture issues. Outputs a 0–100 health score.
+
+## After making React code changes:
+
+Run `npx react-doctor@latest --verbose --scope changed` and check the score did not regress.
+
+If the score dropped, fix the regressions before committing.
+
+## For general cleanup or code improvement:
+
+Run `npx react-doctor@latest --verbose` (the default `--scope full`) to scan the full codebase. Fix issues by severity — errors first, then warnings.
+
+## /doctor — full local triage workflow
+
+When the user types `/doctor`, says "run react doctor", or asks for a full triage / cleanup pass (not just a regression check), fetch the canonical local-triage playbook and follow every step in it:
+
+```bash
+curl --fail --silent --show-error \
+  --header 'Cache-Control: no-cache' \
+  https://www.react.doctor/prompts/react-doctor-agent.md
+```
+
+The playbook is the single source of truth — a scan → filter → triage → fix → validate loop that edits the working tree directly (never commits, never opens PRs). Updating the prompt at its source updates every agent on its next fetch — no skill reinstall needed.
+
+Pair it with the matching per-rule prompts at `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md` (fetched on demand inside the playbook) so each fix uses the canonical, reviewer-tested recipe.
+
+## Configuring or explaining rules
+
+When the user wants to understand a rule, disagrees with one, or wants to disable / tune which rules run (not fix code), read [references/explain.md](references/explain.md) and follow it. Start with `npx react-doctor@latest rules explain <rule>`, then apply the narrowest control via `npx react-doctor@latest rules disable|set|category|ignore-tag …`, which edits your `doctor.config.*` (or `package.json#reactDoctor`).
+
+## Command
+
+```bash
+npx react-doctor@latest --verbose --scope changed
+```
+
+| Flag              | Purpose                                                          |
+| ----------------- | ---------------------------------------------------------------- |
+| `.`               | Scan current directory                                           |
+| `--verbose`       | Show affected files and line numbers per rule                    |
+| `--scope changed` | Only report issues introduced vs the base branch (default: full) |
+| `--scope lines`   | Only report issues on the changed lines                          |
+| `--score`         | Output only the numeric score                                    |

--- a/.agents/skills/react-doctor/references/explain.md
+++ b/.agents/skills/react-doctor/references/explain.md
@@ -1,0 +1,72 @@
+# Explaining and configuring rules
+
+Explain React Doctor rules and edit `doctor.config.*` safely. Use this when a user
+wants to understand a rule or change which rules run — not for fixing diagnostics
+(that is the main `react-doctor` skill / `/doctor`).
+
+Triggers: "why did this rule fire", "I disagree with this rule", "turn this rule off",
+"stop flagging X", "too noisy", "disable design rules".
+
+## Workflow
+
+1. Identify the rule key from the diagnostic (e.g. `react-doctor/no-array-index-as-key`).
+2. Explain it before changing anything:
+
+```bash
+npx react-doctor@latest rules explain react-doctor/no-array-index-as-key
+```
+
+3. Pick the narrowest control that matches the user's intent (see decision guide).
+4. Apply it with a `rules` subcommand (edits your `doctor.config.*` or `package.json#reactDoctor` in place, preserving other fields and formatting).
+5. Validate the change did what they wanted:
+
+```bash
+npx react-doctor@latest --verbose --diff
+```
+
+## Commands
+
+```bash
+npx react-doctor@latest rules list                         # every rule + its effective severity
+npx react-doctor@latest rules list --configured            # only what your config changed
+npx react-doctor@latest rules list --category Performance   # filter by category
+npx react-doctor@latest rules explain <rule>               # why it matters + how to configure
+npx react-doctor@latest rules disable <rule>               # rule never runs
+npx react-doctor@latest rules enable <rule>                # turn back on at its recommended severity
+npx react-doctor@latest rules set <rule> warn              # off | warn | error
+npx react-doctor@latest rules category "React Native" off   # whole category
+npx react-doctor@latest rules ignore-tag design            # skip a rule family (design, test-noise, …)
+npx react-doctor@latest rules unignore-tag design
+```
+
+Rule references accept the full key (`react-doctor/no-danger`), the bare id (`no-danger`), or a legacy key (`react/no-danger`).
+
+## Decision guide
+
+Match the control to the intent — prefer the narrowest one:
+
+- **User disagrees with one rule / it's a false positive for them** → `rules disable <rule>` (sets `rules.<key> = "off"`; the rule stops running everywhere). This is the default for "I don't want this rule".
+- **Rule is fine but wrong severity** → `rules set <rule> warn` or `rules set <rule> error`.
+- **A disabled-by-default rule they want on** → `rules enable <rule>`.
+- **A whole area is unwanted** (e.g. all React Native rules) → `rules category "<Category>" off`.
+- **A behavioral family is noisy** (`design`, `test-noise`, `migration-hint`) → `rules ignore-tag <tag>`.
+- **Keep it locally but hide from PR comment / score / CI gate only** → do NOT disable. Edit `surfaces` in your config (`surfaces.prComment.excludeRules`, `surfaces.score.excludeTags`, `surfaces.ciFailure.excludeCategories`). The rule still shows in local `cli` output.
+
+How the layers combine: `ignore.tags` disables every rule carrying that tag **before** linting, so a tagged rule stays off even if `rules`/`categories` set it to `warn`/`error` (a rule-level override cannot re-enable a tag-ignored rule). For rules that aren't tag-disabled, `rules` overrides `categories` overrides the rule's default. `surfaces` is visibility-only and never changes whether a rule runs.
+
+## Config shape
+
+Config lives in `doctor.config.ts` (or `.js`/`.mjs`/`.cjs`/`.json`/`.jsonc`), or the `reactDoctor` key in `package.json`. The `rules` commands edit whichever exists — TS/JS edits preserve formatting (via magicast) — and create `doctor.config.json` when none does, stamping `$schema`:
+
+```ts
+// doctor.config.ts
+export default {
+  rules: { "react-doctor/no-array-index-as-key": "off" },
+  categories: { "React Native": "warn" },
+  ignore: { tags: ["design"] },
+};
+```
+
+## Educating the user
+
+When explaining a rule, lead with the "Why it matters" guidance from `rules explain` and, when they want depth, the per-rule recipe at `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md`. Only after they understand it should you offer to disable it — many "bad" rules are catching real issues.

--- a/.agents/skills/react-doctor/references/explain.md
+++ b/.agents/skills/react-doctor/references/explain.md
@@ -34,7 +34,7 @@ npx react-doctor@latest rules explain <rule>               # why it matters + ho
 npx react-doctor@latest rules disable <rule>               # rule never runs
 npx react-doctor@latest rules enable <rule>                # turn back on at its recommended severity
 npx react-doctor@latest rules set <rule> warn              # off | warn | error
-npx react-doctor@latest rules category "React Native" off   # whole category
+npx react-doctor@latest rules category Performance off      # whole category
 npx react-doctor@latest rules ignore-tag design            # skip a rule family (design, test-noise, …)
 npx react-doctor@latest rules unignore-tag design
 ```
@@ -48,8 +48,8 @@ Match the control to the intent — prefer the narrowest one:
 - **User disagrees with one rule / it's a false positive for them** → `rules disable <rule>` (sets `rules.<key> = "off"`; the rule stops running everywhere). This is the default for "I don't want this rule".
 - **Rule is fine but wrong severity** → `rules set <rule> warn` or `rules set <rule> error`.
 - **A disabled-by-default rule they want on** → `rules enable <rule>`.
-- **A whole area is unwanted** (e.g. all React Native rules) → `rules category "<Category>" off`.
-- **A behavioral family is noisy** (`design`, `test-noise`, `migration-hint`) → `rules ignore-tag <tag>`.
+- **A whole category is unwanted** (`Security`, `Bugs`, `Performance`, `Accessibility`, `Maintainability`) → `rules category "<Category>" off`.
+- **A behavioral family is noisy** (`react-native`, `design`, `test-noise`, `migration-hint`) → `rules ignore-tag <tag>`.
 - **Keep it locally but hide from PR comment / score / CI gate only** → do NOT disable. Edit `surfaces` in your config (`surfaces.prComment.excludeRules`, `surfaces.score.excludeTags`, `surfaces.ciFailure.excludeCategories`). The rule still shows in local `cli` output.
 
 How the layers combine: `ignore.tags` disables every rule carrying that tag **before** linting, so a tagged rule stays off even if `rules`/`categories` set it to `warn`/`error` (a rule-level override cannot re-enable a tag-ignored rule). For rules that aren't tag-disabled, `rules` overrides `categories` overrides the rule's default. `surfaces` is visibility-only and never changes whether a rule runs.
@@ -62,8 +62,8 @@ Config lives in `doctor.config.ts` (or `.js`/`.mjs`/`.cjs`/`.json`/`.jsonc`), or
 // doctor.config.ts
 export default {
   rules: { "react-doctor/no-array-index-as-key": "off" },
-  categories: { "React Native": "warn" },
-  ignore: { tags: ["design"] },
+  categories: { Performance: "warn" },
+  ignore: { tags: ["react-native", "design"] },
 };
 ```
 

--- a/apps/dashboard/src/app/(auth-public)/invitation/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(auth-public)/invitation/[id]/page-client.tsx
@@ -44,6 +44,9 @@ import type {
   InvitationState,
 } from "@/types/auth/invitation";
 
+type Invitation = InvitationPageClientProps["invitation"];
+type InvitationUser = NonNullable<InvitationPageClientProps["user"]>;
+
 function invitationReducer(
   state: InvitationState,
   action: InvitationAction
@@ -166,67 +169,16 @@ function PageClient({
     );
   }
 
-  // Show auth forms if user is not logged in
   if (!user) {
     return (
-      <Card className="mx-auto w-full max-w-md rounded-[24px] border bg-transparent px-5 py-7 shadow-none">
-        <CardContent>
-          <Tabs className="w-full" defaultValue="login">
-            <TabsList className="grid w-full grid-cols-2" variant="line">
-              <TabsTrigger value="login">Log in</TabsTrigger>
-              <TabsTrigger value="signup">Sign up</TabsTrigger>
-            </TabsList>
-            <TabsContent className="mt-6" value="login">
-              <div className="mb-6 text-center text-sm">
-                <strong>{invitation.inviterEmail}</strong> has invited you to
-                join their organization. Please sign in to proceed.
-              </div>
-              <LoginForm
-                description=""
-                returnTo={`/invitation/${invitationId}`}
-                showForgotPasswordLink={true}
-                showSignupLink={false}
-                title=""
-              />
-            </TabsContent>
-            <TabsContent className="mt-6" value="signup">
-              <div className="mb-6 text-center text-sm">
-                <strong>{invitation.inviterEmail}</strong> has invited you to
-                join their organization. Please sign up to proceed.
-              </div>
-              <SignupForm
-                description=""
-                returnTo={`/invitation/${invitationId}`}
-                showForgotPasswordLink={false}
-                showLoginLink={false}
-                title=""
-              />
-            </TabsContent>
-          </Tabs>
-          {error && (
-            <div className="mt-4 rounded-sm border border-destructive bg-destructive/10 p-3">
-              <p className="text-center text-destructive text-sm">
-                {error}
-                {isTeamMemberLimitError(error) && (
-                  <>
-                    {" "}
-                    <Link
-                      className="font-medium underline underline-offset-2"
-                      href={`/${invitation.organizationSlug}/settings/billing`}
-                    >
-                      View plans
-                    </Link>
-                  </>
-                )}
-              </p>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <InviteAuthCard
+        error={error}
+        invitation={invitation}
+        invitationId={invitationId}
+      />
     );
   }
 
-  // Show invitation acceptance UI if user is logged in
   return (
     <Card className="mx-auto w-full max-w-md rounded-[24px] px-5 py-7">
       <CardHeader
@@ -238,138 +190,25 @@ function PageClient({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {inviteStatus === "pending" && (
-          <div className="mt-5 flex flex-col gap-8">
-            <div className="flex items-center justify-center gap-4">
-              <Avatar className="size-14">
-                <AvatarImage src={user.image || ""} />
-                <AvatarFallback>
-                  {user.name
-                    .split(" ")
-                    .map((n) => n[0])
-                    .join("")
-                    .toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
-              <svg
-                className="size-6"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={1}
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <title>Arrow</title>
-                <path
-                  d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-              <Avatar className="size-14">
-                <AvatarImage src="" />
-                <AvatarFallback>
-                  {invitation.organizationName
-                    .split(" ")
-                    .map((n) => n[0])
-                    .join("")
-                    .toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
-            </div>
-            <p className="text-center text-sm">
-              <strong>{invitation.inviterEmail}</strong> has invited you to join{" "}
-              <strong>{invitation.organizationName}</strong>.
-            </p>
-          </div>
-        )}
-        {inviteStatus === "accepted" && (
-          <div className="space-y-4 pt-8 pb-4">
-            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
-              <HugeiconsIcon
-                className="h-8 w-8 text-green-600"
-                icon={Tick01Icon}
-              />
-            </div>
-            <h2 className="text-center font-medium text-2xl">
-              Welcome to {invitation.organizationName}!
-            </h2>
-            <p className="text-center">
-              We&apos;re excited to have you on board!
-            </p>
-          </div>
-        )}
-        {inviteStatus === "rejected" && (
-          <div className="space-y-4 pt-8 pb-4">
-            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
-              <HugeiconsIcon
-                className="h-8 w-8 text-red-600"
-                icon={Cancel01Icon}
-              />
-            </div>
-            <h2 className="text-center font-medium text-2xl">Declined</h2>
-            <p className="text-center text-muted-foreground">
-              You&apos;ve declined the invitation to join{" "}
-              {invitation.organizationName}.
-            </p>
-            <div className="flex items-center justify-center">
-              <Link
-                className={buttonVariants({
-                  variant: "outline",
-                  className: "flex items-center gap-2",
-                })}
-                href="/"
-              >
-                <HugeiconsIcon className="size-4" icon={ArrowLeft02Icon} />
-                <span>Back home</span>
-              </Link>
-            </div>
-          </div>
-        )}
+        <InviteStatusContent
+          invitation={invitation}
+          inviteStatus={inviteStatus}
+          user={user}
+        />
       </CardContent>
       {error && inviteStatus === "pending" && (
-        <div className="mt-4 rounded-sm border border-destructive bg-destructive/10 p-3">
-          <p className="text-center text-destructive text-sm">
-            {error}
-            {isTeamMemberLimitError(error) && (
-              <>
-                {" "}
-                <Link
-                  className="font-medium underline underline-offset-2"
-                  href={`/${invitation.organizationSlug}/settings/billing`}
-                >
-                  View plans
-                </Link>
-              </>
-            )}
-          </p>
-        </div>
+        <InvitationErrorMessage
+          error={error}
+          organizationSlug={invitation.organizationSlug}
+        />
       )}
       {inviteStatus === "pending" && (
-        <CardFooter className="mt-4 grid grid-cols-2 gap-6">
-          <Button
-            disabled={rejecting || accepting}
-            onClick={handleReject}
-            variant="outline"
-          >
-            {rejecting ? (
-              <Loader2Icon className="size-4 animate-spin" />
-            ) : (
-              "Reject"
-            )}
-          </Button>
-          <Button
-            disabled={accepting || rejecting}
-            onClick={handleAccept}
-            variant="default"
-          >
-            {accepting ? (
-              <Loader2Icon className="size-4 animate-spin" />
-            ) : (
-              "Accept"
-            )}
-          </Button>
-        </CardFooter>
+        <InviteActions
+          accepting={accepting}
+          onAccept={handleAccept}
+          onReject={handleReject}
+          rejecting={rejecting}
+        />
       )}
     </Card>
   );
@@ -406,4 +245,221 @@ function InviteError({ message }: { message: string }) {
       </CardContent>
     </Card>
   );
+}
+
+function InviteAuthCard({
+  error,
+  invitation,
+  invitationId,
+}: {
+  error: string | null;
+  invitation: Invitation;
+  invitationId: string;
+}) {
+  return (
+    <Card className="mx-auto w-full max-w-md rounded-[24px] border bg-transparent px-5 py-7 shadow-none">
+      <CardContent>
+        <Tabs className="w-full" defaultValue="login">
+          <TabsList className="grid w-full grid-cols-2" variant="line">
+            <TabsTrigger value="login">Log in</TabsTrigger>
+            <TabsTrigger value="signup">Sign up</TabsTrigger>
+          </TabsList>
+          <TabsContent className="mt-6" value="login">
+            <div className="mb-6 text-center text-sm">
+              <strong>{invitation.inviterEmail}</strong> has invited you to
+              join their organization. Please sign in to proceed.
+            </div>
+            <LoginForm
+              description=""
+              returnTo={`/invitation/${invitationId}`}
+              showForgotPasswordLink={true}
+              showSignupLink={false}
+              title=""
+            />
+          </TabsContent>
+          <TabsContent className="mt-6" value="signup">
+            <div className="mb-6 text-center text-sm">
+              <strong>{invitation.inviterEmail}</strong> has invited you to
+              join their organization. Please sign up to proceed.
+            </div>
+            <SignupForm
+              description=""
+              returnTo={`/invitation/${invitationId}`}
+              showForgotPasswordLink={false}
+              showLoginLink={false}
+              title=""
+            />
+          </TabsContent>
+        </Tabs>
+        {error && (
+          <InvitationErrorMessage
+            error={error}
+            organizationSlug={invitation.organizationSlug}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function InviteStatusContent({
+  invitation,
+  inviteStatus,
+  user,
+}: {
+  invitation: Invitation;
+  inviteStatus: InvitationState["inviteStatus"];
+  user: InvitationUser;
+}) {
+  if (inviteStatus === "accepted") {
+    return <InviteAccepted organizationName={invitation.organizationName} />;
+  }
+
+  if (inviteStatus === "rejected") {
+    return <InviteRejected organizationName={invitation.organizationName} />;
+  }
+
+  return <PendingInvite invitation={invitation} user={user} />;
+}
+
+function PendingInvite({
+  invitation,
+  user,
+}: {
+  invitation: Invitation;
+  user: InvitationUser;
+}) {
+  return (
+    <div className="mt-5 flex flex-col gap-8">
+      <div className="flex items-center justify-center gap-4">
+        <Avatar className="size-14">
+          <AvatarImage src={user.image || ""} />
+          <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+        </Avatar>
+        <svg
+          className="size-6"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1}
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>Arrow</title>
+          <path
+            d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        <Avatar className="size-14">
+          <AvatarImage src="" />
+          <AvatarFallback>
+            {getInitials(invitation.organizationName)}
+          </AvatarFallback>
+        </Avatar>
+      </div>
+      <p className="text-center text-sm">
+        <strong>{invitation.inviterEmail}</strong> has invited you to join{" "}
+        <strong>{invitation.organizationName}</strong>.
+      </p>
+    </div>
+  );
+}
+
+function InviteAccepted({ organizationName }: { organizationName: string }) {
+  return (
+    <div className="space-y-4 pt-8 pb-4">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+        <HugeiconsIcon className="h-8 w-8 text-green-600" icon={Tick01Icon} />
+      </div>
+      <h2 className="text-center font-medium text-2xl">
+        Welcome to {organizationName}!
+      </h2>
+      <p className="text-center">We&apos;re excited to have you on board!</p>
+    </div>
+  );
+}
+
+function InviteRejected({ organizationName }: { organizationName: string }) {
+  return (
+    <div className="space-y-4 pt-8 pb-4">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+        <HugeiconsIcon className="h-8 w-8 text-red-600" icon={Cancel01Icon} />
+      </div>
+      <h2 className="text-center font-medium text-2xl">Declined</h2>
+      <p className="text-center text-muted-foreground">
+        You&apos;ve declined the invitation to join {organizationName}.
+      </p>
+      <div className="flex items-center justify-center">
+        <Link
+          className={buttonVariants({
+            variant: "outline",
+            className: "flex items-center gap-2",
+          })}
+          href="/"
+        >
+          <HugeiconsIcon className="size-4" icon={ArrowLeft02Icon} />
+          <span>Back home</span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function InvitationErrorMessage({
+  error,
+  organizationSlug,
+}: {
+  error: string;
+  organizationSlug: string;
+}) {
+  return (
+    <div className="mt-4 rounded-sm border border-destructive bg-destructive/10 p-3">
+      <p className="text-center text-destructive text-sm">
+        {error}
+        {isTeamMemberLimitError(error) && (
+          <>
+            {" "}
+            <Link
+              className="font-medium underline underline-offset-2"
+              href={`/${organizationSlug}/settings/billing`}
+            >
+              View plans
+            </Link>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}
+
+function InviteActions({
+  accepting,
+  onAccept,
+  onReject,
+  rejecting,
+}: {
+  accepting: boolean;
+  onAccept: () => void;
+  onReject: () => void;
+  rejecting: boolean;
+}) {
+  return (
+    <CardFooter className="mt-4 grid grid-cols-2 gap-6">
+      <Button disabled={rejecting || accepting} onClick={onReject} variant="outline">
+        {rejecting ? <Loader2Icon className="size-4 animate-spin" /> : "Reject"}
+      </Button>
+      <Button disabled={accepting || rejecting} onClick={onAccept} variant="default">
+        {accepting ? <Loader2Icon className="size-4 animate-spin" /> : "Accept"}
+      </Button>
+    </CardFooter>
+  );
+}
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase();
 }

--- a/apps/dashboard/src/app/(auth-public)/invitation/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(auth-public)/invitation/[id]/page-client.tsx
@@ -266,8 +266,8 @@ function InviteAuthCard({
           </TabsList>
           <TabsContent className="mt-6" value="login">
             <div className="mb-6 text-center text-sm">
-              <strong>{invitation.inviterEmail}</strong> has invited you to
-              join their organization. Please sign in to proceed.
+              <strong>{invitation.inviterEmail}</strong> has invited you to join
+              their organization. Please sign in to proceed.
             </div>
             <LoginForm
               description=""
@@ -279,8 +279,8 @@ function InviteAuthCard({
           </TabsContent>
           <TabsContent className="mt-6" value="signup">
             <div className="mb-6 text-center text-sm">
-              <strong>{invitation.inviterEmail}</strong> has invited you to
-              join their organization. Please sign up to proceed.
+              <strong>{invitation.inviterEmail}</strong> has invited you to join
+              their organization. Please sign up to proceed.
             </div>
             <SignupForm
               description=""
@@ -446,10 +446,18 @@ function InviteActions({
 }) {
   return (
     <CardFooter className="mt-4 grid grid-cols-2 gap-6">
-      <Button disabled={rejecting || accepting} onClick={onReject} variant="outline">
+      <Button
+        disabled={rejecting || accepting}
+        onClick={onReject}
+        variant="outline"
+      >
         {rejecting ? <Loader2Icon className="size-4 animate-spin" /> : "Reject"}
       </Button>
-      <Button disabled={accepting || rejecting} onClick={onAccept} variant="default">
+      <Button
+        disabled={accepting || rejecting}
+        onClick={onAccept}
+        variant="default"
+      >
         {accepting ? <Loader2Icon className="size-4 animate-spin" /> : "Accept"}
       </Button>
     </CardFooter>

--- a/apps/dashboard/src/app/(auth-public)/invitation/[id]/page.tsx
+++ b/apps/dashboard/src/app/(auth-public)/invitation/[id]/page.tsx
@@ -26,12 +26,16 @@ export default async function InvitePage(props: {
 }
 
 async function InvitePageComponent({ invitationId }: { invitationId: string }) {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-
-  // Fetch invitation server-side to validate it exists
-  const invitationData = await getInvitationById(invitationId);
+  const sessionPromise = headers().then((requestHeaders) =>
+    auth.api.getSession({
+      headers: requestHeaders,
+    })
+  );
+  const invitationPromise = getInvitationById(invitationId);
+  const [session, invitationData] = await Promise.all([
+    sessionPromise,
+    invitationPromise,
+  ]);
 
   if (!invitationData) {
     notFound();

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -86,6 +86,7 @@ import { API_KEY_CARD_ITEMS, API_KEY_PRESETS } from "@/lib/api-keys/presets";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import { createApiKeySchema, updateApiKeySchema } from "@/schemas/api-keys";
 import type { ApiKeyExpiration, ApiKeyPermission } from "@/types/api-keys";
+import { copyToClipboard } from "@/utils/copy-to-clipboard";
 
 const NEW_KEY_CONFIG_PARSERS = {
   name: parseAsString,
@@ -586,11 +587,6 @@ export default function ApiKeysPage() {
     });
     editForm.setFieldValue("name", key.name);
     dispatchUi({ type: "editDialogChanged", open: true });
-  };
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    toast.success("Copied to clipboard");
   };
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -71,7 +71,7 @@ import type {
   V2KeysCreateKeyResponseData,
 } from "@unkey/api/models/components";
 import { parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useReducer } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
@@ -119,6 +119,64 @@ type CreateApiKeyResponse = V2KeysCreateKeyResponseData & {
 
 interface ApiKeyMutationResponse {
   success: boolean;
+}
+
+type CreatedSortOrder = false | "asc" | "desc";
+
+interface ApiKeysUiState {
+  dialogOpen: boolean;
+  createdKey: string | null;
+  createError: string | null;
+  editDialogOpen: boolean;
+  deletingKey: ApiKeyListItem | null;
+  createdSortOrder: CreatedSortOrder;
+}
+
+type ApiKeysUiAction =
+  | { type: "createDialogChanged"; open: boolean }
+  | { type: "createdKeyChanged"; createdKey: string | null }
+  | { type: "createErrorChanged"; createError: string | null }
+  | { type: "editDialogChanged"; open: boolean }
+  | { type: "deletingKeyChanged"; deletingKey: ApiKeyListItem | null }
+  | { type: "createdSortOrderChanged"; sortOrder: CreatedSortOrder }
+  | { type: "createDialogReset" };
+
+const initialApiKeysUiState: ApiKeysUiState = {
+  dialogOpen: false,
+  createdKey: null,
+  createError: null,
+  editDialogOpen: false,
+  deletingKey: null,
+  createdSortOrder: false,
+};
+
+function apiKeysUiReducer(
+  state: ApiKeysUiState,
+  action: ApiKeysUiAction
+): ApiKeysUiState {
+  switch (action.type) {
+    case "createDialogChanged":
+      return { ...state, dialogOpen: action.open };
+    case "createdKeyChanged":
+      return { ...state, createdKey: action.createdKey };
+    case "createErrorChanged":
+      return { ...state, createError: action.createError };
+    case "editDialogChanged":
+      return { ...state, editDialogOpen: action.open };
+    case "deletingKeyChanged":
+      return { ...state, deletingKey: action.deletingKey };
+    case "createdSortOrderChanged":
+      return { ...state, createdSortOrder: action.sortOrder };
+    case "createDialogReset":
+      return {
+        ...state,
+        dialogOpen: false,
+        createdKey: null,
+        createError: null,
+      };
+    default:
+      return state;
+  }
 }
 
 function formatExpiry(expires: number | null) {
@@ -271,11 +329,17 @@ export default function ApiKeysPage() {
   const { activeOrganization } = useOrganizationsContext();
   const organizationId = activeOrganization?.id;
   const queryClient = useQueryClient();
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [createdKey, setCreatedKey] = useState<string | null>(null);
-  const [createError, setCreateError] = useState<string | null>(null);
-  const [editDialogOpen, setEditDialogOpen] = useState(false);
-  const [deletingKey, setDeletingKey] = useState<ApiKeyListItem | null>(null);
+  const [
+    {
+      dialogOpen,
+      createdKey,
+      createError,
+      editDialogOpen,
+      deletingKey,
+      createdSortOrder,
+    },
+    dispatchUi,
+  ] = useReducer(apiKeysUiReducer, initialApiKeysUiState);
   const [newKeyConfig, setNewKeyConfig] = useQueryStates(
     NEW_KEY_CONFIG_PARSERS
   );
@@ -284,7 +348,7 @@ export default function ApiKeysPage() {
     newKeyConfig.permission !== null &&
     newKeyConfig.expiration !== null;
 
-  useHotkey("C", () => setDialogOpen(true), {
+  useHotkey("C", () => dispatchUi({ type: "createDialogChanged", open: true }), {
     enabled: !(
       dialogOpen ||
       editDialogOpen ||
@@ -292,10 +356,6 @@ export default function ApiKeysPage() {
       hasNewKeyConfig
     ),
   });
-
-  const [createdSortOrder, setCreatedSortOrder] = useState<
-    false | "asc" | "desc"
-  >(false);
 
   const { data: keys = [], isPending } = useQuery<ApiKeyListItem[]>({
     ...dashboardOrpc.apiKeys.list.queryOptions({
@@ -339,7 +399,7 @@ export default function ApiKeysPage() {
 
   useEffect(() => {
     if (hasNewKeyConfig) {
-      setDialogOpen(true);
+      dispatchUi({ type: "createDialogChanged", open: true });
     }
   }, [hasNewKeyConfig]);
 
@@ -353,19 +413,22 @@ export default function ApiKeysPage() {
       permission: preset.permission,
       expiration: preset.expiration,
     };
-    setCreateError(null);
-    setDialogOpen(true);
+    dispatchUi({ type: "createErrorChanged", createError: null });
+    dispatchUi({ type: "createDialogChanged", open: true });
     setNewKeyConfig(config);
   };
 
   const handleCreateSubmit = () => {
     const result = createApiKeySchema.safeParse(createInput);
     if (!result.success) {
-      setCreateError(result.error.issues[0]?.message ?? "Invalid API key");
+      dispatchUi({
+        type: "createErrorChanged",
+        createError: result.error.issues[0]?.message ?? "Invalid API key",
+      });
       return;
     }
 
-    setCreateError(null);
+    dispatchUi({ type: "createErrorChanged", createError: null });
     mutation.mutate(result.data);
   };
 
@@ -401,8 +464,8 @@ export default function ApiKeysPage() {
       }) as Promise<CreateApiKeyResponse>;
     },
     onSuccess: (data) => {
-      setCreatedKey(data.key);
-      setCreateError(null);
+      dispatchUi({ type: "createdKeyChanged", createdKey: data.key });
+      dispatchUi({ type: "createErrorChanged", createError: null });
       setNewKeyConfig(null);
       queryClient.invalidateQueries({
         queryKey: dashboardOrpc.apiKeys.list.queryKey({
@@ -434,7 +497,7 @@ export default function ApiKeysPage() {
       }) as Promise<ApiKeyMutationResponse>;
     },
     onSuccess: () => {
-      setEditDialogOpen(false);
+      dispatchUi({ type: "editDialogChanged", open: false });
       editForm.reset();
       queryClient.invalidateQueries({
         queryKey: dashboardOrpc.apiKeys.list.queryKey({
@@ -461,7 +524,7 @@ export default function ApiKeysPage() {
       }) as Promise<ApiKeyMutationResponse>;
     },
     onSuccess: () => {
-      setDeletingKey(null);
+      dispatchUi({ type: "deletingKeyChanged", deletingKey: null });
       queryClient.invalidateQueries({
         queryKey: dashboardOrpc.apiKeys.list.queryKey({
           input: { organizationId: organizationId ?? "" },
@@ -476,12 +539,12 @@ export default function ApiKeysPage() {
 
   const handleDialogClose = (open: boolean) => {
     if (!open) {
-      setCreateError(null);
+      dispatchUi({ type: "createErrorChanged", createError: null });
       mutation.reset();
-      setCreatedKey(null);
+      dispatchUi({ type: "createdKeyChanged", createdKey: null });
       setNewKeyConfig(null);
     }
-    setDialogOpen(open);
+    dispatchUi({ type: "createDialogChanged", open });
   };
 
   const handleEditDialogClose = (open: boolean) => {
@@ -491,7 +554,7 @@ export default function ApiKeysPage() {
       }
       editForm.reset();
     }
-    setEditDialogOpen(open);
+    dispatchUi({ type: "editDialogChanged", open });
   };
 
   const handleDeleteDialogClose = (open: boolean) => {
@@ -500,7 +563,7 @@ export default function ApiKeysPage() {
     }
 
     if (!open) {
-      setDeletingKey(null);
+      dispatchUi({ type: "deletingKeyChanged", deletingKey: null });
     }
   };
 
@@ -518,7 +581,7 @@ export default function ApiKeysPage() {
       expiration: getDefaultEditExpiration(key.createdAt, key.expires),
     });
     editForm.setFieldValue("name", key.name);
-    setEditDialogOpen(true);
+    dispatchUi({ type: "editDialogChanged", open: true });
   };
 
   const copyToClipboard = (text: string) => {
@@ -537,7 +600,12 @@ export default function ApiKeysPage() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <Button className="gap-1.5" onClick={() => setDialogOpen(true)}>
+            <Button
+              className="gap-1.5"
+              onClick={() =>
+                dispatchUi({ type: "createDialogChanged", open: true })
+              }
+            >
               <HugeiconsIcon className="size-4" icon={Add01Icon} />
               Create API Key
               <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
@@ -579,9 +647,11 @@ export default function ApiKeysPage() {
                   <Button
                     className="-ml-4"
                     onClick={() =>
-                      setCreatedSortOrder(
-                        createdSortOrder === "asc" ? "desc" : "asc"
-                      )
+                      dispatchUi({
+                        type: "createdSortOrderChanged",
+                        sortOrder:
+                          createdSortOrder === "asc" ? "desc" : "asc",
+                      })
                     }
                     variant="ghost"
                   >
@@ -602,7 +672,12 @@ export default function ApiKeysPage() {
                 }
                 isPending={isPending}
                 keys={sortedKeys}
-                onDelete={(key) => setDeletingKey(key)}
+                onDelete={(key) =>
+                  dispatchUi({
+                    type: "deletingKeyChanged",
+                    deletingKey: key,
+                  })
+                }
                 onEdit={openEditDialog}
               />
             </TableBody>
@@ -680,7 +755,10 @@ export default function ApiKeysPage() {
                     <Input
                       disabled={mutation.isPending}
                       onChange={(event) => {
-                        setCreateError(null);
+                        dispatchUi({
+                          type: "createErrorChanged",
+                          createError: null,
+                        });
                         setNewKeyConfig({
                           name: event.target.value || null,
                         });

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -348,14 +348,18 @@ export default function ApiKeysPage() {
     newKeyConfig.permission !== null &&
     newKeyConfig.expiration !== null;
 
-  useHotkey("C", () => dispatchUi({ type: "createDialogChanged", open: true }), {
-    enabled: !(
-      dialogOpen ||
-      editDialogOpen ||
-      !!deletingKey ||
-      hasNewKeyConfig
-    ),
-  });
+  useHotkey(
+    "C",
+    () => dispatchUi({ type: "createDialogChanged", open: true }),
+    {
+      enabled: !(
+        dialogOpen ||
+        editDialogOpen ||
+        !!deletingKey ||
+        hasNewKeyConfig
+      ),
+    }
+  );
 
   const { data: keys = [], isPending } = useQuery<ApiKeyListItem[]>({
     ...dashboardOrpc.apiKeys.list.queryOptions({
@@ -649,8 +653,7 @@ export default function ApiKeysPage() {
                     onClick={() =>
                       dispatchUi({
                         type: "createdSortOrderChanged",
-                        sortOrder:
-                          createdSortOrder === "asc" ? "desc" : "asc",
+                        sortOrder: createdSortOrder === "asc" ? "desc" : "asc",
                       })
                     }
                     variant="ghost"

--- a/apps/dashboard/src/utils/copy-to-clipboard.ts
+++ b/apps/dashboard/src/utils/copy-to-clipboard.ts
@@ -1,0 +1,6 @@
+import { toast } from "sonner";
+
+export function copyToClipboard(text: string) {
+  navigator.clipboard.writeText(text);
+  toast.success("Copied to clipboard");
+}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the dashboard invite and API keys pages to address top `react-doctor` findings, reduce re-renders, and simplify state. Also speeds up the invite page with parallel data fetching and adds a shared clipboard helper plus local `react-doctor` skill files for on-demand scans.

- **Refactors**
  - Split the invitation client page into focused components (auth card, status content, actions, error message) and small helpers; consolidated error UI.
  - Switched API Keys UI from multiple `useState` to a `useReducer` (dialogs, created key, errors, deletion target, sort order); updated hotkey and handlers to dispatch actions.
  - Hoisted copy-to-clipboard logic to `@/utils/copy-to-clipboard` and used it in API Keys (shows a success toast).
  - Fetched session and invitation together with `Promise.all` for faster render.
  - Minor typing cleanups; added `.agents/skills/react-doctor` skill and rule-explain docs (docs only).

<sup>Written for commit d5902185a03cb8b4054f51ac7b6a64b6c249b2da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

