### PR TITLE
feat: add brand sitemap identity view

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-sitemap-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/add-sitemap-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { GlobalIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { Input } from "@notra/ui/components/ui/input";
+import { Label } from "@notra/ui/components/ui/label";
+import { Loader2Icon } from "lucide-react";
+import { type KeyboardEvent, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/button";
+import { useCreateSitemap } from "@/lib/hooks/use-brand-sitemaps";
+import {
+  getRegistrableHost,
+  isUrlWithinBrandHost,
+  normalizeSitemapUrl,
+} from "@/lib/sitemap/sitemap-url";
+import type { AddSitemapDialogProps } from "@/types/hooks/brand-sitemaps";
+
+export function AddSitemapDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  voiceId,
+  voiceWebsiteUrl,
+}: AddSitemapDialogProps) {
+  const [url, setUrl] = useState("");
+  const [label, setLabel] = useState("");
+  const createSitemap = useCreateSitemap(organizationId, voiceId);
+
+  const brandHost = getRegistrableHost(voiceWebsiteUrl ?? "");
+
+  const trimmedUrl = url.trim();
+  const isOffHost =
+    trimmedUrl.length > 0 && !isUrlWithinBrandHost(trimmedUrl, voiceWebsiteUrl);
+
+  const handleClose = () => {
+    setUrl("");
+    setLabel("");
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!trimmedUrl) {
+      toast.error("Please enter a sitemap URL");
+      return;
+    }
+
+    if (!isUrlWithinBrandHost(trimmedUrl, voiceWebsiteUrl)) {
+      toast.error(
+        brandHost
+          ? `Sitemaps must stay on ${brandHost} or its subdomains`
+          : "Set a website on this brand identity first"
+      );
+      return;
+    }
+
+    const normalizedUrl = normalizeSitemapUrl(trimmedUrl);
+
+    try {
+      await createSitemap.mutateAsync({
+        url: normalizedUrl,
+        label: label.trim() || undefined,
+      });
+      toast.success("Sitemap added");
+      handleClose();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to add sitemap"
+      );
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter" && !createSitemap.isPending) {
+      event.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <ResponsiveDialog onOpenChange={handleClose} open={open}>
+      <ResponsiveDialogContent className="[&>*]:min-w-0">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Add Sitemap</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Track indexed pages and monitor site health for AI discovery.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="sitemap-url">Sitemap or site URL</Label>
+            <Input
+              aria-invalid={isOffHost}
+              id="sitemap-url"
+              onChange={(event) => setUrl(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={
+                brandHost
+                  ? `https://${brandHost}/sitemap.xml`
+                  : "https://example.com/sitemap.xml"
+              }
+              value={url}
+            />
+            {isOffHost ? (
+              <p className="text-destructive text-xs">
+                {brandHost
+                  ? `URLs must stay on ${brandHost} or its subdomains.`
+                  : "Set a website on this brand identity first."}
+              </p>
+            ) : (
+              <p className="flex items-center gap-1.5 text-muted-foreground text-xs">
+                <HugeiconsIcon className="size-3.5" icon={GlobalIcon} />
+                {brandHost
+                  ? `Scoped to ${brandHost} and its subdomains`
+                  : "Scoped to this brand identity's website"}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="sitemap-label">Label (optional)</Label>
+            <Input
+              id="sitemap-label"
+              onChange={(event) => setLabel(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Marketing site"
+              value={label}
+            />
+          </div>
+        </div>
+
+        <ResponsiveDialogFooter>
+          <Button onClick={handleClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            disabled={createSitemap.isPending || !trimmedUrl || isOffHost}
+            onClick={handleSubmit}
+          >
+            {createSitemap.isPending ? (
+              <>
+                <Loader2Icon className="size-4 animate-spin" />
+                Adding...
+              </>
+            ) : (
+              "Add Sitemap"
+            )}
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-header.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-header.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Kbd } from "@notra/ui/components/ui/kbd";
+import { Button } from "@/components/button";
+import { BRAND_TAB_HEADERS } from "../constants/brand-identity";
+
+type BrandTab = "identity" | "references" | "sitemap";
+
+interface BrandIdentityHeaderProps {
+  activeTab: BrandTab;
+  onAddIdentity: () => void;
+  onAddReference: () => void;
+  onAddSitemap: () => void;
+}
+
+export function BrandIdentityHeader({
+  activeTab,
+  onAddIdentity,
+  onAddReference,
+  onAddSitemap,
+}: BrandIdentityHeaderProps) {
+  const actionByTab = {
+    identity: {
+      label: "Create Identity",
+      onClick: onAddIdentity,
+    },
+    references: {
+      label: "Create Reference",
+      onClick: onAddReference,
+    },
+    sitemap: {
+      label: "Add Sitemap",
+      onClick: onAddSitemap,
+    },
+  } satisfies Record<BrandTab, { label: string; onClick: () => void }>;
+  const action = actionByTab[activeTab];
+
+  return (
+    <div className="flex items-start justify-between">
+      <div className="space-y-1">
+        <h1 className="font-bold text-3xl tracking-tight">
+          {BRAND_TAB_HEADERS[activeTab].title}
+        </h1>
+        <p className="text-muted-foreground">
+          {BRAND_TAB_HEADERS[activeTab].description}
+        </p>
+      </div>
+      <Button className="gap-1.5" onClick={action.onClick}>
+        <HugeiconsIcon className="size-4" icon={Add01Icon} />
+        {action.label}
+        <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+      </Button>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-tabs.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-tabs.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@notra/ui/components/ui/tabs";
+import type { BrandFormInitialData } from "../types/brand-identity";
+import { BrandForm } from "./brand-form";
+import { ReferencesList } from "./references-list";
+import { SitemapList } from "./sitemap-list";
+
+type BrandTab = "identity" | "references" | "sitemap";
+
+interface BrandIdentityTabsProps {
+  activeTab: BrandTab;
+  addReferenceOpen: boolean;
+  addSitemapOpen: boolean;
+  initialData: BrandFormInitialData;
+  onActiveTabChange: (tab: BrandTab) => void;
+  onAddReferenceOpenChange: (open: boolean) => void;
+  onAddSitemapOpenChange: (open: boolean) => void;
+  onSavedAtChange: (savedAt: Date) => void;
+  onSavingChange: (isSaving: boolean) => void;
+  organizationId: string;
+  referenceCount: number;
+  saveStatusText: string;
+  sitemapCount: number;
+  voiceId: string;
+  voiceWebsiteUrl: string | null;
+}
+
+export function BrandIdentityTabs({
+  activeTab,
+  addReferenceOpen,
+  addSitemapOpen,
+  initialData,
+  onActiveTabChange,
+  onAddReferenceOpenChange,
+  onAddSitemapOpenChange,
+  onSavedAtChange,
+  onSavingChange,
+  organizationId,
+  referenceCount,
+  saveStatusText,
+  sitemapCount,
+  voiceId,
+  voiceWebsiteUrl,
+}: BrandIdentityTabsProps) {
+  return (
+    <Tabs
+      onValueChange={(value) => onActiveTabChange(value as BrandTab)}
+      value={activeTab}
+    >
+      <div className="flex items-center justify-between">
+        <TabsList variant="line">
+          <TabsTrigger value="identity">Company Info</TabsTrigger>
+          <TabsTrigger value="references">
+            References
+            {referenceCount > 0 && (
+              <span className="text-muted-foreground">({referenceCount})</span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="sitemap">
+            Sitemap
+            {sitemapCount > 0 && (
+              <span className="text-muted-foreground">({sitemapCount})</span>
+            )}
+          </TabsTrigger>
+        </TabsList>
+        {activeTab === "identity" && (
+          <span className="text-muted-foreground text-xs">
+            {saveStatusText}
+          </span>
+        )}
+      </div>
+
+      <TabsContent className="mt-6" value="identity">
+        <BrandForm
+          initialData={initialData}
+          key={voiceId}
+          onSavedAtChange={onSavedAtChange}
+          onSavingChange={onSavingChange}
+          organizationId={organizationId}
+          voiceId={voiceId}
+        />
+      </TabsContent>
+
+      <TabsContent className="mt-6" value="references">
+        <ReferencesList
+          dialogOpen={addReferenceOpen}
+          key={`refs-${voiceId}`}
+          onDialogOpenChange={onAddReferenceOpenChange}
+          organizationId={organizationId}
+          voiceId={voiceId}
+        />
+      </TabsContent>
+
+      <TabsContent className="mt-6" value="sitemap">
+        <SitemapList
+          dialogOpen={addSitemapOpen}
+          key={`sitemap-${voiceId}`}
+          onDialogOpenChange={onAddSitemapOpenChange}
+          organizationId={organizationId}
+          voiceId={voiceId}
+          voiceWebsiteUrl={voiceWebsiteUrl}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/empty-brand-identity-state.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/empty-brand-identity-state.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@notra/ui/components/ui/card";
+import { PageContainer } from "@/components/layout/container";
+import { getModalDescription, getModalTitle } from "../utils/brand-identity";
+import { ModalContent } from "./modal-content";
+
+interface EmptyBrandIdentityStateProps {
+  effectiveProgress: {
+    status: string;
+    currentStep: number;
+  };
+  handleInitialAnalyze: () => void;
+  isAnalyzing: boolean;
+  isPending: boolean;
+  progressError?: string;
+  setUrl: (url: string) => void;
+  url: string;
+}
+
+export function EmptyBrandIdentityState({
+  effectiveProgress,
+  handleInitialAnalyze,
+  isAnalyzing,
+  isPending,
+  progressError,
+  setUrl,
+  url,
+}: EmptyBrandIdentityStateProps) {
+  return (
+    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+      <div className="w-full px-4 lg:px-6">
+        <div className="relative min-h-125">
+          <div className="pointer-events-none blur-sm">
+            <div className="mb-6 space-y-1">
+              <h1 className="font-bold text-3xl tracking-tight">
+                Brand Identity
+              </h1>
+              <p className="text-muted-foreground">
+                Configure your brand identity and tone
+              </p>
+            </div>
+            <div className="space-y-8">
+              <div className="h-16 w-80 rounded-lg border bg-muted/20" />
+              <div className="h-16 w-80 rounded-lg border bg-muted/20" />
+              <div className="h-32 w-full max-w-xl rounded-lg border bg-muted/20" />
+              <div className="h-24 w-80 rounded-lg border bg-muted/20" />
+            </div>
+          </div>
+
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Card className="w-full max-w-md border-border/50 shadow-xs">
+              <CardHeader className="text-center">
+                <CardTitle>
+                  {getModalTitle(false, isAnalyzing, effectiveProgress.status)}
+                </CardTitle>
+                <CardDescription>
+                  {getModalDescription(
+                    false,
+                    isAnalyzing,
+                    effectiveProgress.status,
+                    progressError
+                  )}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <ModalContent
+                  handleAnalyze={handleInitialAnalyze}
+                  inlineError={progressError}
+                  isAnalyzing={isAnalyzing}
+                  isPending={isPending}
+                  isPendingSettings={false}
+                  progress={effectiveProgress}
+                  setUrl={setUrl}
+                  url={url}
+                />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-list.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-list.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import {
+  Delete02Icon,
+  GlobalIcon,
+  LinkSquare02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogAction,
+  ResponsiveAlertDialogCancel,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogDescription,
+  ResponsiveAlertDialogFooter,
+  ResponsiveAlertDialogHeader,
+  ResponsiveAlertDialogTitle,
+} from "@notra/ui/components/shared/responsive-alert-dialog";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/button";
+import { EmptyState } from "@/components/empty-state";
+import { useDeleteSitemap, useSitemaps } from "@/lib/hooks/use-brand-sitemaps";
+import { getSafeHttpUrl } from "@/lib/sitemap/sitemap-url";
+import type { SitemapListProps } from "@/types/hooks/brand-sitemaps";
+import { SITEMAP_STAT_SKELETON_KEYS } from "../constants/sitemap-ui";
+import { AddSitemapDialog } from "./add-sitemap-dialog";
+import { SitemapPagesTable } from "./sitemap-pages-table";
+import { SitemapSelector } from "./sitemap-selector";
+import { SitemapStats } from "./sitemap-stats";
+
+export function SitemapList({
+  organizationId,
+  voiceId,
+  voiceWebsiteUrl,
+  dialogOpen,
+  onDialogOpenChange,
+}: SitemapListProps) {
+  const { data, isError, isPending, refetch } = useSitemaps(
+    organizationId,
+    voiceId
+  );
+  const deleteSitemap = useDeleteSitemap(organizationId, voiceId);
+  const sitemaps = data?.sitemaps ?? [];
+
+  const [selectedSitemapId, setSelectedSitemapId] = useState<string | null>(
+    null
+  );
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+
+  const selectedSitemap =
+    sitemaps.find((sitemap) => sitemap.id === selectedSitemapId) ??
+    sitemaps.at(0) ??
+    null;
+  const deleteTarget =
+    sitemaps.find((sitemap) => sitemap.id === deleteTargetId) ?? null;
+
+  const handleDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    try {
+      await deleteSitemap.mutateAsync(deleteTarget.id);
+      toast.success("Sitemap removed");
+      setDeleteTargetId(null);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove sitemap"
+      );
+    }
+  };
+
+  if (isPending) {
+    return (
+      <div className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {SITEMAP_STAT_SKELETON_KEYS.map((key) => (
+            <Skeleton className="h-28 w-full" key={key} />
+          ))}
+        </div>
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <EmptyState
+        actionIcon={<HugeiconsIcon className="size-4" icon={GlobalIcon} />}
+        actionLabel="Retry"
+        description="We couldn't load this brand identity's sitemaps."
+        onActionClick={() => refetch()}
+        title="Sitemaps unavailable"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {sitemaps.length === 0 ? (
+        <EmptyState
+          actionIcon={<HugeiconsIcon className="size-4" icon={GlobalIcon} />}
+          actionLabel="Add Sitemap"
+          description="Add a sitemap to track indexed pages and monitor site health for AI discovery."
+          onActionClick={() => onDialogOpenChange(true)}
+          title="No sitemaps yet"
+        />
+      ) : (
+        <>
+          <SitemapSelector
+            onSelect={setSelectedSitemapId}
+            selectedSitemapId={selectedSitemapId}
+            sitemaps={sitemaps}
+          />
+
+          {selectedSitemap ? (
+            <div className="space-y-6">
+              <div className="flex items-center justify-between gap-3">
+                {(() => {
+                  const safeUrl = getSafeHttpUrl(selectedSitemap.url);
+                  return safeUrl ? (
+                    <a
+                      className="group flex min-w-0 items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground"
+                      href={safeUrl}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <HugeiconsIcon
+                        className="size-4 shrink-0"
+                        icon={GlobalIcon}
+                      />
+                      <span className="truncate group-hover:underline">
+                        {selectedSitemap.url}
+                      </span>
+                      <HugeiconsIcon
+                        className="size-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                        icon={LinkSquare02Icon}
+                      />
+                    </a>
+                  ) : (
+                    <div className="flex min-w-0 items-center gap-2 text-muted-foreground text-sm">
+                      <HugeiconsIcon
+                        className="size-4 shrink-0"
+                        icon={GlobalIcon}
+                      />
+                      <span className="truncate">{selectedSitemap.url}</span>
+                    </div>
+                  );
+                })()}
+                <Button
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => setDeleteTargetId(selectedSitemap.id)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  <HugeiconsIcon className="size-4" icon={Delete02Icon} />
+                  Remove
+                </Button>
+              </div>
+
+              <SitemapStats sitemap={selectedSitemap} />
+
+              <SitemapPagesTable
+                organizationId={organizationId}
+                sitemapId={selectedSitemap.id}
+                voiceId={voiceId}
+              />
+            </div>
+          ) : null}
+        </>
+      )}
+
+      <AddSitemapDialog
+        onOpenChange={onDialogOpenChange}
+        open={dialogOpen}
+        organizationId={organizationId}
+        voiceId={voiceId}
+        voiceWebsiteUrl={voiceWebsiteUrl}
+      />
+
+      <ResponsiveAlertDialog
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTargetId(null);
+          }
+        }}
+        open={!!deleteTargetId}
+      >
+        <ResponsiveAlertDialogContent>
+          <ResponsiveAlertDialogHeader>
+            <ResponsiveAlertDialogTitle>
+              Remove sitemap?
+            </ResponsiveAlertDialogTitle>
+            <ResponsiveAlertDialogDescription>
+              This removes
+              {deleteTarget ? ` ${deleteTarget.label}` : " this sitemap"} and
+              its crawled pages from this brand identity.
+            </ResponsiveAlertDialogDescription>
+          </ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogFooter>
+            <ResponsiveAlertDialogCancel disabled={deleteSitemap.isPending}>
+              Cancel
+            </ResponsiveAlertDialogCancel>
+            <ResponsiveAlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteSitemap.isPending}
+              onClick={handleDelete}
+            >
+              {deleteSitemap.isPending ? "Removing…" : "Remove Sitemap"}
+            </ResponsiveAlertDialogAction>
+          </ResponsiveAlertDialogFooter>
+        </ResponsiveAlertDialogContent>
+      </ResponsiveAlertDialog>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-pages-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-pages-table.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { LinkSquare02Icon, Search01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Badge } from "@notra/ui/components/ui/badge";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@notra/ui/components/ui/input-group";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@notra/ui/components/ui/table";
+import { useState } from "react";
+import { useSitemapPages } from "@/lib/hooks/use-brand-sitemaps";
+import {
+  formatTextRatio,
+  formatWordCount,
+  getStatusCodeClassName,
+} from "@/lib/sitemap/display";
+import {
+  formatRelativeCrawlTime,
+  getSafeHttpUrl,
+} from "@/lib/sitemap/sitemap-url";
+import { cn } from "@/lib/utils";
+import type {
+  SitemapPage,
+  SitemapPageCategory,
+  SitemapPagesTableProps,
+} from "@/types/hooks/brand-sitemaps";
+import {
+  PAGE_FILTER_TABS,
+  SITEMAP_PAGE_SKELETON_KEYS,
+} from "../constants/sitemap-ui";
+
+export function SitemapPagesTable({
+  sitemapId,
+  organizationId,
+  voiceId,
+}: SitemapPagesTableProps) {
+  const { data, isPending } = useSitemapPages(
+    organizationId,
+    voiceId,
+    sitemapId
+  );
+  const [activeFilter, setActiveFilter] =
+    useState<SitemapPageCategory>("crawled");
+  const [search, setSearch] = useState("");
+
+  const pages = data?.pages ?? [];
+
+  const countsByCategory = (() => {
+    const counts: Record<SitemapPageCategory, number> = {
+      crawled: 0,
+      redirect: 0,
+      queued: 0,
+      failed: 0,
+    };
+    for (const page of pages) {
+      counts[page.category] += 1;
+    }
+    return counts;
+  })();
+
+  const visiblePages = (() => {
+    const query = search.trim().toLowerCase();
+    return pages.filter((page) => {
+      if (page.category !== activeFilter) {
+        return false;
+      }
+      if (!query) {
+        return true;
+      }
+      return (
+        page.url.toLowerCase().includes(query) ||
+        (page.title?.toLowerCase().includes(query) ?? false)
+      );
+    });
+  })();
+
+  if (isPending) {
+    return (
+      <div className="space-y-3">
+        {SITEMAP_PAGE_SKELETON_KEYS.map((key) => (
+          <Skeleton className="h-12 w-full" key={key} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <InputGroup className="h-9 sm:max-w-80">
+          <InputGroupAddon>
+            <HugeiconsIcon
+              className="size-4 text-muted-foreground"
+              icon={Search01Icon}
+            />
+          </InputGroupAddon>
+          <InputGroupInput
+            aria-label="Search sitemap URLs"
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search URLs..."
+            value={search}
+          />
+        </InputGroup>
+
+        <div className="flex flex-wrap gap-1.5">
+          {PAGE_FILTER_TABS.map((tab) => {
+            const isActive = tab.value === activeFilter;
+            return (
+              <button
+                className={cn(
+                  "rounded-lg border px-3 py-1.5 font-medium text-xs transition-colors",
+                  isActive
+                    ? "border-primary bg-muted/60 text-foreground"
+                    : "border-transparent text-muted-foreground hover:bg-muted/40"
+                )}
+                key={tab.value}
+                onClick={() => setActiveFilter(tab.value)}
+                type="button"
+              >
+                {tab.label} ({countsByCategory[tab.value]})
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {visiblePages.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-muted-foreground text-sm">
+            {search.trim()
+              ? "No URLs match your search."
+              : "No URLs in this view yet."}
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>URL</TableHead>
+                <TableHead className="w-24">Status</TableHead>
+                <TableHead className="w-40">Content</TableHead>
+                <TableHead className="w-28">Links</TableHead>
+                <TableHead className="w-28">Crawled</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {visiblePages.map((page) => (
+                <PageRow key={page.id} page={page} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PageRow({ page }: { page: SitemapPage }) {
+  const textRatio = formatTextRatio(page.textRatio);
+  const safeUrl = getSafeHttpUrl(page.url);
+
+  return (
+    <TableRow>
+      <TableCell className="max-w-0">
+        <div className="flex items-start gap-2">
+          <HugeiconsIcon
+            className="mt-0.5 size-3.5 shrink-0 text-muted-foreground"
+            icon={LinkSquare02Icon}
+          />
+          <div className="min-w-0">
+            {safeUrl ? (
+              <a
+                className="block truncate font-medium text-primary text-sm hover:underline"
+                href={safeUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {page.path}
+              </a>
+            ) : (
+              <span className="block truncate font-medium text-sm">
+                {page.path}
+              </span>
+            )}
+            <p className="truncate text-muted-foreground text-xs">
+              {page.category === "redirect" && page.redirectTarget
+                ? `→ ${page.redirectTarget}`
+                : (page.title ?? page.url)}
+            </p>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        {page.statusCode === null ? (
+          <Badge variant="secondary">Queued</Badge>
+        ) : (
+          <span
+            className={cn(
+              "font-medium text-sm tabular-nums",
+              getStatusCodeClassName(page.statusCode)
+            )}
+          >
+            {page.statusCode}
+          </span>
+        )}
+      </TableCell>
+      <TableCell>
+        <div className="text-sm">{formatWordCount(page.wordCount)}</div>
+        {textRatio ? (
+          <div className="text-muted-foreground text-xs">{textRatio}</div>
+        ) : null}
+      </TableCell>
+      <TableCell className="text-muted-foreground text-sm tabular-nums">
+        {page.internalLinks === null && page.externalLinks === null
+          ? "—"
+          : `${page.internalLinks ?? 0} int / ${page.externalLinks ?? 0} ext`}
+      </TableCell>
+      <TableCell className="text-muted-foreground text-sm">
+        {formatRelativeCrawlTime(page.crawledAt)}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-selector.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-selector.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { GlobalIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { cn } from "@/lib/utils";
+import type { SitemapSelectorProps } from "@/types/hooks/brand-sitemaps";
+import { SITEMAP_STATUS_META } from "../constants/sitemap-ui";
+
+export function SitemapSelector({
+  sitemaps,
+  selectedSitemapId,
+  onSelect,
+}: SitemapSelectorProps) {
+  if (sitemaps.length <= 1) {
+    return null;
+  }
+
+  return (
+    <fieldset className="flex flex-wrap gap-2">
+      <legend className="sr-only">Sitemap</legend>
+      {sitemaps.map((sitemap) => {
+        const isSelected = sitemap.id === selectedSitemapId;
+        const statusMeta = SITEMAP_STATUS_META[sitemap.status];
+
+        return (
+          <label
+            className={cn(
+              "flex min-w-[12rem] items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
+              isSelected
+                ? "border-primary bg-muted/40"
+                : "border-border hover:bg-muted/40"
+            )}
+            key={sitemap.id}
+          >
+            <input
+              checked={isSelected}
+              className="sr-only"
+              name="brand-sitemap"
+              onChange={() => onSelect(sitemap.id)}
+              type="radio"
+            />
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
+              <HugeiconsIcon className="size-4" icon={GlobalIcon} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-medium text-sm">{sitemap.label}</p>
+              <p className="flex items-center gap-1.5 text-muted-foreground text-xs">
+                <span
+                  className={cn(
+                    "size-1.5 shrink-0 rounded-full",
+                    statusMeta.dotClassName
+                  )}
+                />
+                {sitemap.indexedPages} indexed
+              </p>
+            </div>
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-stats.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-stats.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import {
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+  GlobalIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Card, CardContent } from "@notra/ui/components/ui/card";
+import { formatRelativeCrawlTime } from "@/lib/sitemap/sitemap-url";
+import type { SitemapStatsProps } from "@/types/hooks/brand-sitemaps";
+import { SITEMAP_STATUS_META } from "../constants/sitemap-ui";
+
+export function SitemapStats({ sitemap }: SitemapStatsProps) {
+  const { indexedPages, failedPages, totalPages } = sitemap;
+  const accountedPages = indexedPages + failedPages;
+  const successPercent = totalPages > 0 ? (indexedPages / totalPages) * 100 : 0;
+  const failedPercent = totalPages > 0 ? (failedPages / totalPages) * 100 : 0;
+  const statusMeta = SITEMAP_STATUS_META[sitemap.status];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <Card>
+        <CardContent className="space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="font-medium text-muted-foreground text-sm">
+              Indexed Pages
+            </p>
+            <HugeiconsIcon
+              className="size-4 text-muted-foreground"
+              icon={CheckmarkCircle02Icon}
+            />
+          </div>
+          <p className="font-bold text-3xl tabular-nums">
+            {indexedPages}
+            <span className="ml-1 font-normal text-base text-muted-foreground">
+              / {totalPages}
+            </span>
+          </p>
+          <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full bg-emerald-500"
+              style={{ width: `${successPercent}%` }}
+            />
+            <div
+              className="h-full bg-red-500"
+              style={{ width: `${failedPercent}%` }}
+            />
+          </div>
+          <div className="flex items-center gap-4 text-xs">
+            <span className="text-emerald-600 dark:text-emerald-400">
+              Successful: {indexedPages}
+            </span>
+            <span className="text-red-600 dark:text-red-400">
+              Failed: {failedPages}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="font-medium text-muted-foreground text-sm">
+              Crawl Status
+            </p>
+            <HugeiconsIcon
+              className="size-4 text-muted-foreground"
+              icon={Clock01Icon}
+            />
+          </div>
+          <p className="flex items-center gap-2 font-semibold text-2xl">
+            <span
+              className={`size-2.5 rounded-full ${statusMeta.dotClassName}`}
+            />
+            {statusMeta.label}
+          </p>
+          <p className="text-muted-foreground text-sm">
+            {sitemap.lastCrawledAt
+              ? `Last crawled ${formatRelativeCrawlTime(sitemap.lastCrawledAt)}`
+              : "Not crawled yet"}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="font-medium text-muted-foreground text-sm">
+              Coverage
+            </p>
+            <HugeiconsIcon
+              className="size-4 text-muted-foreground"
+              icon={GlobalIcon}
+            />
+          </div>
+          <p className="font-bold text-3xl tabular-nums">{totalPages}</p>
+          <p className="text-muted-foreground text-sm">
+            {accountedPages} of {totalPages} URLs processed
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/constants/brand-identity.ts
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/constants/brand-identity.ts
@@ -55,3 +55,21 @@ export const LANGUAGE_FLAGS: Record<
 export const FULL_URL_REGEX = /^https?:\/\//i;
 
 export const IDENTITY_NAME_MAX_LENGTH = 13;
+
+export const BRAND_TAB_HEADERS: Record<
+  "identity" | "references" | "sitemap",
+  { title: string; description: string }
+> = {
+  identity: {
+    title: "Company Info",
+    description: "Configure your brand identity and tone",
+  },
+  references: {
+    title: "References",
+    description: "Real posts that help the AI learn your writing style",
+  },
+  sitemap: {
+    title: "Sitemap",
+    description: "Track indexed pages and monitor site health for AI discovery",
+  },
+};

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/constants/sitemap-ui.ts
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/constants/sitemap-ui.ts
@@ -1,0 +1,37 @@
+import type {
+  SitemapPageCategory,
+  SitemapStatus,
+} from "@/types/hooks/brand-sitemaps";
+
+export const SITEMAP_STATUS_META: Record<
+  SitemapStatus,
+  { label: string; dotClassName: string }
+> = {
+  queued: { label: "Queued", dotClassName: "bg-muted-foreground" },
+  crawling: { label: "Crawling", dotClassName: "bg-blue-500" },
+  ready: { label: "Ready", dotClassName: "bg-emerald-500" },
+  failed: { label: "Failed", dotClassName: "bg-red-500" },
+};
+
+export const PAGE_FILTER_TABS: {
+  value: SitemapPageCategory;
+  label: string;
+}[] = [
+  { value: "crawled", label: "Crawled Pages" },
+  { value: "redirect", label: "Redirects" },
+  { value: "queued", label: "Queued" },
+  { value: "failed", label: "Failed" },
+];
+
+export const SITEMAP_STAT_SKELETON_KEYS = [
+  "total-pages",
+  "indexed-pages",
+  "failed-pages",
+];
+
+export const SITEMAP_PAGE_SKELETON_KEYS = [
+  "page-row-1",
+  "page-row-2",
+  "page-row-3",
+  "page-row-4",
+];

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -1,34 +1,17 @@
 "use client";
 
-import { Add01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { ToneProfile } from "@notra/ai/schemas/tone";
 import {
   Alert,
   AlertDescription,
   AlertTitle,
 } from "@notra/ui/components/ui/alert";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@notra/ui/components/ui/card";
-import { Kbd } from "@notra/ui/components/ui/kbd";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@notra/ui/components/ui/tabs";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import { toast } from "sonner";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
-import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { getValidLanguage } from "@/schemas/brand";
@@ -47,24 +30,84 @@ import {
   useSetDefaultBrandVoice,
 } from "../../../../../lib/hooks/use-brand-analysis";
 import { useReferences } from "../../../../../lib/hooks/use-brand-references";
+import { useSitemaps } from "../../../../../lib/hooks/use-brand-sitemaps";
 import { AddIdentityDialog } from "./components/add-identity-dialog";
 import { AnalysisStepper } from "./components/analysis-stepper";
-import { BrandForm } from "./components/brand-form";
-import { ModalContent } from "./components/modal-content";
-import { ReferencesList } from "./components/references-list";
+import { BrandIdentityHeader } from "./components/brand-identity-header";
+import { BrandIdentityTabs } from "./components/brand-identity-tabs";
+import { EmptyBrandIdentityState } from "./components/empty-brand-identity-state";
 import { VoiceSelector } from "./components/voice-selector";
 import { BrandIdentityPageSkeleton } from "./skeleton";
 import type {
   BrandFormInitialData,
   PageClientProps,
 } from "./types/brand-identity";
-import {
-  getModalDescription,
-  getModalTitle,
-  sanitizeBrandUrlInput,
-} from "./utils/brand-identity";
+import { sanitizeBrandUrlInput } from "./utils/brand-identity";
 
-const TAB_VALUES = ["identity", "references"] as const;
+const TAB_VALUES = ["identity", "references", "sitemap"] as const;
+
+interface BrandIdentityUiState {
+  addIdentityOpen: boolean;
+  addReferenceOpen: boolean;
+  addSitemapOpen: boolean;
+  deleteTargetVoiceId: string | null;
+  isSaving: boolean;
+  lastSavedAtMs: number | null;
+  relativeTimeNow: number;
+  storedVoiceId: string | null;
+  url: string;
+}
+
+type BrandIdentityUiAction =
+  | { type: "set-add-identity-open"; open: boolean }
+  | { type: "set-add-reference-open"; open: boolean }
+  | { type: "set-add-sitemap-open"; open: boolean }
+  | { type: "set-delete-target-voice-id"; voiceId: string | null }
+  | { type: "set-is-saving"; isSaving: boolean }
+  | { type: "set-last-saved-at-ms"; savedAtMs: number | null }
+  | { type: "set-relative-time-now"; now: number }
+  | { type: "set-stored-voice-id"; voiceId: string | null }
+  | { type: "set-url"; url: string };
+
+const initialUiState: BrandIdentityUiState = {
+  addIdentityOpen: false,
+  addReferenceOpen: false,
+  addSitemapOpen: false,
+  deleteTargetVoiceId: null,
+  isSaving: false,
+  lastSavedAtMs: null,
+  relativeTimeNow: Date.now(),
+  storedVoiceId: null,
+  url: "",
+};
+
+function brandIdentityUiReducer(
+  state: BrandIdentityUiState,
+  action: BrandIdentityUiAction
+): BrandIdentityUiState {
+  switch (action.type) {
+    case "set-add-identity-open":
+      return { ...state, addIdentityOpen: action.open };
+    case "set-add-reference-open":
+      return { ...state, addReferenceOpen: action.open };
+    case "set-add-sitemap-open":
+      return { ...state, addSitemapOpen: action.open };
+    case "set-delete-target-voice-id":
+      return { ...state, deleteTargetVoiceId: action.voiceId };
+    case "set-is-saving":
+      return { ...state, isSaving: action.isSaving };
+    case "set-last-saved-at-ms":
+      return { ...state, lastSavedAtMs: action.savedAtMs };
+    case "set-relative-time-now":
+      return { ...state, relativeTimeNow: action.now };
+    case "set-stored-voice-id":
+      return { ...state, storedVoiceId: action.voiceId };
+    case "set-url":
+      return { ...state, url: action.url };
+    default:
+      return state;
+  }
+}
 
 export default function PageClient({ organizationSlug }: PageClientProps) {
   const { getOrganization, activeOrganization } = useOrganizationsContext();
@@ -98,25 +141,24 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     progress.status === "failed" ? progress.error : undefined;
 
   const voices = data?.voices ?? [];
+  const [uiState, dispatchUi] = useReducer(
+    brandIdentityUiReducer,
+    initialUiState
+  );
   const [activeVoiceId, setActiveVoiceId] = useQueryState(
     "voice",
     parseAsString
-  );
-  const [addIdentityOpen, setAddIdentityOpen] = useState(false);
-  const [addReferenceOpen, setAddReferenceOpen] = useState(false);
-  const [deleteTargetVoiceId, setDeleteTargetVoiceId] = useState<string | null>(
-    null
   );
   const [activeTab, setActiveTab] = useQueryState(
     "view",
     parseAsStringLiteral(TAB_VALUES).withDefault("identity")
   );
   const [newIdentityParam, setNewIdentityParam] = useQueryState("new");
-  const isAddIdentityOpen = addIdentityOpen || Boolean(newIdentityParam);
-  const [storedVoiceId, setStoredVoiceId] = useState<string | null>(null);
+  const isAddIdentityOpen =
+    uiState.addIdentityOpen || Boolean(newIdentityParam);
 
   const handleAddIdentityOpenChange = (open: boolean) => {
-    setAddIdentityOpen(open);
+    dispatchUi({ type: "set-add-identity-open", open });
     if (!open && newIdentityParam) {
       setNewIdentityParam(null);
     }
@@ -124,7 +166,10 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
   useEffect(() => {
     if (organizationId) {
-      setStoredVoiceId(readStoredBrandIdentityId(organizationId));
+      dispatchUi({
+        type: "set-stored-voice-id",
+        voiceId: readStoredBrandIdentityId(organizationId),
+      });
     }
   }, [organizationId]);
 
@@ -132,35 +177,43 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     "C",
     () => {
       if (activeTab === "identity") {
-        setAddIdentityOpen(true);
+        dispatchUi({ type: "set-add-identity-open", open: true });
+      } else if (activeTab === "references") {
+        dispatchUi({ type: "set-add-reference-open", open: true });
       } else {
-        setAddReferenceOpen(true);
+        dispatchUi({ type: "set-add-sitemap-open", open: true });
       }
     },
-    { enabled: !(isAddIdentityOpen || addReferenceOpen) }
+    {
+      enabled: !(
+        isAddIdentityOpen ||
+        uiState.addReferenceOpen ||
+        uiState.addSitemapOpen
+      ),
+    }
   );
 
   const selectedVoice = findSelectedBrandIdentity(
     voices,
     activeVoiceId,
-    storedVoiceId
+    uiState.storedVoiceId
   );
 
   const handleSelectVoice = (voiceId: string) => {
     writeStoredBrandIdentityId(organizationId, voiceId);
-    setStoredVoiceId(voiceId);
+    dispatchUi({ type: "set-stored-voice-id", voiceId });
     setActiveVoiceId(voiceId);
   };
 
-  const deleteTargetVoice = deleteTargetVoiceId
-    ? voices.find((v) => v.id === deleteTargetVoiceId)
+  const deleteTargetVoice = uiState.deleteTargetVoiceId
+    ? voices.find((v) => v.id === uiState.deleteTargetVoiceId)
     : null;
 
   const { data: affectedData, isLoading: isLoadingAffected } =
     useBrandVoiceAffectedTriggers(
       organizationId,
-      deleteTargetVoiceId ?? "",
-      !!deleteTargetVoiceId &&
+      uiState.deleteTargetVoiceId ?? "",
+      !!uiState.deleteTargetVoiceId &&
         !!deleteTargetVoice &&
         !deleteTargetVoice.isDefault
     );
@@ -170,38 +223,46 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     selectedVoice?.id ?? ""
   );
   const referenceCount = referencesData?.references.length ?? 0;
+
+  const { data: sitemapsData } = useSitemaps(
+    organizationId,
+    selectedVoice?.id ?? ""
+  );
+  const sitemapCount = sitemapsData?.sitemaps.length ?? 0;
   const selectedVoiceId = selectedVoice?.id;
   const selectedVoiceUpdatedAt = selectedVoice?.updatedAt;
-
-  const [isSaving, setIsSaving] = useState(false);
-  const [lastSavedAtMs, setLastSavedAtMs] = useState<number | null>(null);
-  const [relativeTimeNow, setRelativeTimeNow] = useState(() => Date.now());
-  const [url, setUrl] = useState("");
-  const effectiveUrl = url.trim();
+  const effectiveUrl = uiState.url.trim();
 
   useEffect(() => {
     if (!selectedVoiceId || !selectedVoiceUpdatedAt) {
-      setLastSavedAtMs(null);
+      dispatchUi({ type: "set-last-saved-at-ms", savedAtMs: null });
       return;
     }
 
-    setLastSavedAtMs(new Date(selectedVoiceUpdatedAt).getTime());
+    dispatchUi({
+      type: "set-last-saved-at-ms",
+      savedAtMs: new Date(selectedVoiceUpdatedAt).getTime(),
+    });
   }, [selectedVoiceId, selectedVoiceUpdatedAt]);
 
   useEffect(() => {
-    if (activeTab !== "identity" || isSaving || !lastSavedAtMs) {
+    if (
+      activeTab !== "identity" ||
+      uiState.isSaving ||
+      !uiState.lastSavedAtMs
+    ) {
       return;
     }
 
-    setRelativeTimeNow(Date.now());
+    dispatchUi({ type: "set-relative-time-now", now: Date.now() });
     const interval = window.setInterval(() => {
-      setRelativeTimeNow(Date.now());
+      dispatchUi({ type: "set-relative-time-now", now: Date.now() });
     }, 10_000);
 
     return () => {
       window.clearInterval(interval);
     };
-  }, [activeTab, isSaving, lastSavedAtMs]);
+  }, [activeTab, uiState.isSaving, uiState.lastSavedAtMs]);
 
   const triggerAnalysis = async (rawUrl: string, voiceId?: string) => {
     let urlToAnalyze = rawUrl.trim();
@@ -251,7 +312,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
       if (activeVoiceId === deleteTargetVoice.id) {
         setActiveVoiceId(null);
       }
-      setDeleteTargetVoiceId(null);
+      dispatchUi({ type: "set-delete-target-voice-id", voiceId: null });
 
       const disabledCount =
         (result.disabledSchedules?.length ?? 0) +
@@ -311,62 +372,15 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
   if (!hasVoices) {
     return (
-      <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-        <div className="w-full px-4 lg:px-6">
-          <div className="relative min-h-125">
-            <div className="pointer-events-none blur-sm">
-              <div className="mb-6 space-y-1">
-                <h1 className="font-bold text-3xl tracking-tight">
-                  Brand Identity
-                </h1>
-                <p className="text-muted-foreground">
-                  Configure your brand identity and tone
-                </p>
-              </div>
-              <div className="space-y-8">
-                <div className="h-16 w-80 rounded-lg border bg-muted/20" />
-                <div className="h-16 w-80 rounded-lg border bg-muted/20" />
-                <div className="h-32 w-full max-w-xl rounded-lg border bg-muted/20" />
-                <div className="h-24 w-80 rounded-lg border bg-muted/20" />
-              </div>
-            </div>
-
-            <div className="absolute inset-0 flex items-center justify-center">
-              <Card className="w-full max-w-md border-border/50 shadow-xs">
-                <CardHeader className="text-center">
-                  <CardTitle>
-                    {getModalTitle(
-                      false,
-                      isAnalyzing,
-                      effectiveProgress.status
-                    )}
-                  </CardTitle>
-                  <CardDescription>
-                    {getModalDescription(
-                      false,
-                      isAnalyzing,
-                      effectiveProgress.status,
-                      progress.error
-                    )}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <ModalContent
-                    handleAnalyze={handleInitialAnalyze}
-                    inlineError={progressError}
-                    isAnalyzing={isAnalyzing}
-                    isPending={analyzeMutation.isPending}
-                    isPendingSettings={false}
-                    progress={effectiveProgress}
-                    setUrl={setUrl}
-                    url={url}
-                  />
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </div>
-      </PageContainer>
+      <EmptyBrandIdentityState
+        effectiveProgress={effectiveProgress}
+        handleInitialAnalyze={handleInitialAnalyze}
+        isAnalyzing={isAnalyzing}
+        isPending={analyzeMutation.isPending}
+        progressError={progressError}
+        setUrl={(url) => dispatchUi({ type: "set-url", url })}
+        url={uiState.url}
+      />
     );
   }
 
@@ -390,55 +404,36 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   };
   let saveStatusText = "Saved just now";
 
-  if (isSaving) {
+  if (uiState.isSaving) {
     saveStatusText = "Saving...";
-  } else if (lastSavedAtMs) {
+  } else if (uiState.lastSavedAtMs) {
     saveStatusText = formatRelativeTime(
-      new Date(lastSavedAtMs),
-      relativeTimeNow
+      new Date(uiState.lastSavedAtMs),
+      uiState.relativeTimeNow
     );
   }
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
-        <div className="flex items-start justify-between">
-          <div className="space-y-1">
-            <h1 className="font-bold text-3xl tracking-tight">
-              {activeTab === "identity" ? "Company Info" : "References"}
-            </h1>
-            <p className="text-muted-foreground">
-              {activeTab === "identity"
-                ? "Configure your brand identity and tone"
-                : "Real posts the AI can learn your writing style from"}
-            </p>
-          </div>
-          {activeTab === "identity" ? (
-            <Button
-              className="gap-1.5"
-              onClick={() => setAddIdentityOpen(true)}
-            >
-              <HugeiconsIcon className="size-4" icon={Add01Icon} />
-              Create Identity
-              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
-            </Button>
-          ) : (
-            <Button
-              className="gap-1.5"
-              onClick={() => setAddReferenceOpen(true)}
-            >
-              <HugeiconsIcon className="size-4" icon={Add01Icon} />
-              Create Reference
-              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
-            </Button>
-          )}
-        </div>
+        <BrandIdentityHeader
+          activeTab={activeTab}
+          onAddIdentity={() =>
+            dispatchUi({ type: "set-add-identity-open", open: true })
+          }
+          onAddReference={() =>
+            dispatchUi({ type: "set-add-reference-open", open: true })
+          }
+          onAddSitemap={() =>
+            dispatchUi({ type: "set-add-sitemap-open", open: true })
+          }
+        />
 
         <VoiceSelector
           activeVoiceId={selectedVoice.id}
           affectedEvents={affectedData?.affectedEvents ?? []}
           affectedSchedules={affectedData?.affectedSchedules ?? []}
-          isDeleteDialogOpen={!!deleteTargetVoiceId}
+          isDeleteDialogOpen={!!uiState.deleteTargetVoiceId}
           isDeleting={deleteVoiceMutation.isPending}
           isLoadingAffected={isLoadingAffected}
           isReanalyzing={analyzeMutation.isPending}
@@ -446,11 +441,16 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           onDelete={handleDeleteVoice}
           onDeleteDialogChange={(open) => {
             if (!open) {
-              setDeleteTargetVoiceId(null);
+              dispatchUi({
+                type: "set-delete-target-voice-id",
+                voiceId: null,
+              });
             }
           }}
           onReanalyze={handleReanalyze}
-          onRequestDelete={setDeleteTargetVoiceId}
+          onRequestDelete={(voiceId) =>
+            dispatchUi({ type: "set-delete-target-voice-id", voiceId })
+          }
           onSelect={handleSelectVoice}
           onSetDefault={handleSetDefault}
           organizationId={organizationId}
@@ -483,52 +483,34 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           </Alert>
         )}
 
-        <Tabs
-          onValueChange={(v) => {
-            setActiveTab(v as "identity" | "references");
-          }}
-          value={activeTab}
-        >
-          <div className="flex items-center justify-between">
-            <TabsList variant="line">
-              <TabsTrigger value="identity">Company Info</TabsTrigger>
-              <TabsTrigger value="references">
-                References
-                {referenceCount > 0 && (
-                  <span className="text-muted-foreground">
-                    ({referenceCount})
-                  </span>
-                )}
-              </TabsTrigger>
-            </TabsList>
-            {activeTab === "identity" && (
-              <span className="text-muted-foreground text-xs">
-                {saveStatusText}
-              </span>
-            )}
-          </div>
-
-          <TabsContent className="mt-6" value="identity">
-            <BrandForm
-              initialData={initialData}
-              key={selectedVoice.id}
-              onSavedAtChange={(savedAt) => setLastSavedAtMs(savedAt.getTime())}
-              onSavingChange={setIsSaving}
-              organizationId={organizationId}
-              voiceId={selectedVoice.id}
-            />
-          </TabsContent>
-
-          <TabsContent className="mt-6" value="references">
-            <ReferencesList
-              dialogOpen={addReferenceOpen}
-              key={`refs-${selectedVoice.id}`}
-              onDialogOpenChange={setAddReferenceOpen}
-              organizationId={organizationId}
-              voiceId={selectedVoice.id}
-            />
-          </TabsContent>
-        </Tabs>
+        <BrandIdentityTabs
+          activeTab={activeTab}
+          addReferenceOpen={uiState.addReferenceOpen}
+          addSitemapOpen={uiState.addSitemapOpen}
+          initialData={initialData}
+          onActiveTabChange={setActiveTab}
+          onAddReferenceOpenChange={(open) =>
+            dispatchUi({ type: "set-add-reference-open", open })
+          }
+          onAddSitemapOpenChange={(open) =>
+            dispatchUi({ type: "set-add-sitemap-open", open })
+          }
+          onSavedAtChange={(savedAt) =>
+            dispatchUi({
+              type: "set-last-saved-at-ms",
+              savedAtMs: savedAt.getTime(),
+            })
+          }
+          onSavingChange={(isSaving) =>
+            dispatchUi({ type: "set-is-saving", isSaving })
+          }
+          organizationId={organizationId}
+          referenceCount={referenceCount}
+          saveStatusText={saveStatusText}
+          sitemapCount={sitemapCount}
+          voiceId={selectedVoice.id}
+          voiceWebsiteUrl={selectedVoice.websiteUrl}
+        />
       </div>
     </PageContainer>
   );

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/brand-identities/[voiceId]/sitemaps/[sitemapId]/pages/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/brand-identities/[voiceId]/sitemaps/[sitemapId]/pages/route.ts
@@ -1,0 +1,78 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { withOrganizationAuth } from "@/lib/auth/organization";
+import { getSitemapBrandIdentity } from "@/lib/sitemap/brand-identity";
+import { getStoredSitemapPages } from "@/lib/sitemap/storage";
+import type { SitemapPageCategory } from "@/types/hooks/brand-sitemaps";
+
+interface RouteContext {
+  params: Promise<{
+    organizationId: string;
+    voiceId: string;
+    sitemapId: string;
+  }>;
+}
+
+const SITEMAP_PAGE_CATEGORIES = new Set<SitemapPageCategory>([
+  "crawled",
+  "failed",
+  "queued",
+  "redirect",
+]);
+
+function parseLimit(value: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const limit = Number.parseInt(value, 10);
+  return Number.isFinite(limit) ? limit : undefined;
+}
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const { organizationId, voiceId, sitemapId } = await params;
+  const auth = await withOrganizationAuth(request, organizationId);
+
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const brandIdentity = await getSitemapBrandIdentity(organizationId, voiceId);
+  if (!brandIdentity) {
+    return NextResponse.json(
+      { error: "Brand identity not found" },
+      { status: 404 }
+    );
+  }
+
+  try {
+    const { searchParams } = request.nextUrl;
+    const category = searchParams.get("category");
+    const result = await getStoredSitemapPages(
+      organizationId,
+      voiceId,
+      sitemapId,
+      {
+        category:
+          category &&
+          SITEMAP_PAGE_CATEGORIES.has(category as SitemapPageCategory)
+            ? (category as SitemapPageCategory)
+            : undefined,
+        cursor: searchParams.get("cursor") ?? undefined,
+        limit: parseLimit(searchParams.get("limit")),
+        query: searchParams.get("q")?.trim() || undefined,
+      }
+    );
+
+    if (!result) {
+      return NextResponse.json({ error: "Sitemap not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json(
+      { error: "Sitemap storage is unavailable" },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/brand-identities/[voiceId]/sitemaps/[sitemapId]/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/brand-identities/[voiceId]/sitemaps/[sitemapId]/route.ts
@@ -1,0 +1,54 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { withOrganizationAuth } from "@/lib/auth/organization";
+import { deleteStoredSitemap } from "@/lib/sitemap/storage";
+import { deleteSitemapSchema } from "@/schemas/sitemap";
+
+interface RouteContext {
+  params: Promise<{
+    organizationId: string;
+    voiceId: string;
+    sitemapId: string;
+  }>;
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const { organizationId, voiceId, sitemapId } = await params;
+  const auth = await withOrganizationAuth(request, organizationId);
+
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const parseResult = deleteSitemapSchema.safeParse({
+    organizationId,
+    voiceId,
+    sitemapId,
+  });
+
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { error: "Invalid sitemap", details: parseResult.error.issues },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const deleted = await deleteStoredSitemap({
+      organizationId,
+      sitemapId,
+      voiceId,
+    });
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Sitemap not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json(
+      { error: "Sitemap storage is unavailable" },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/brand-identities/[voiceId]/sitemaps/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/brand-identities/[voiceId]/sitemaps/route.ts
@@ -1,0 +1,99 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { withOrganizationAuth } from "@/lib/auth/organization";
+import { getSitemapBrandIdentity } from "@/lib/sitemap/brand-identity";
+import { getContextDevSitemap } from "@/lib/sitemap/context-dev";
+import { readJsonRequest } from "@/lib/sitemap/request";
+import { listStoredSitemaps, saveStoredSitemap } from "@/lib/sitemap/storage";
+import { createSitemapSchema } from "@/schemas/sitemap";
+
+interface RouteContext {
+  params: Promise<{ organizationId: string; voiceId: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const { organizationId, voiceId } = await params;
+  const auth = await withOrganizationAuth(request, organizationId);
+
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const brandIdentity = await getSitemapBrandIdentity(organizationId, voiceId);
+  if (!brandIdentity) {
+    return NextResponse.json(
+      { error: "Brand identity not found" },
+      { status: 404 }
+    );
+  }
+
+  try {
+    const sitemaps = await listStoredSitemaps(organizationId, voiceId);
+    return NextResponse.json({ sitemaps });
+  } catch {
+    return NextResponse.json(
+      { error: "Sitemap storage is unavailable" },
+      { status: 503 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const { organizationId, voiceId } = await params;
+  const auth = await withOrganizationAuth(request, organizationId);
+
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const json = await readJsonRequest(request);
+  if (!json.ok) {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  const parseResult = createSitemapSchema.safeParse({
+    ...json.body,
+    organizationId,
+    voiceId,
+  });
+
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", details: parseResult.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const brandIdentity = await getSitemapBrandIdentity(organizationId, voiceId);
+  if (!brandIdentity) {
+    return NextResponse.json(
+      { error: "Brand identity not found" },
+      { status: 404 }
+    );
+  }
+
+  try {
+    const result = await getContextDevSitemap({
+      brandSettingsId: brandIdentity.id,
+      label: parseResult.data.label,
+      url: parseResult.data.url,
+    });
+
+    await saveStoredSitemap({
+      organizationId,
+      pages: result.pages,
+      sitemap: result.sitemap,
+      voiceId,
+    });
+
+    return NextResponse.json(result, { status: 201 });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to crawl sitemap" },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { Comment01Icon, CorporateIcon } from "@hugeicons/core-free-icons";
+import {
+  Comment01Icon,
+  CorporateIcon,
+  GlobalIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   SidebarMenu,
@@ -13,6 +17,7 @@ import { useEffect, useState } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import { useReferences } from "@/lib/hooks/use-brand-references";
+import { useSitemaps } from "@/lib/hooks/use-brand-sitemaps";
 import {
   findSelectedBrandIdentity,
   readStoredBrandIdentityId,
@@ -31,8 +36,9 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
   const brandBasePath = `/${slug}/brand/identity`;
   const isOnBrandPage = pathname === brandBasePath;
   const voiceParam = searchParams.get("voice");
-  const isReferencesView =
-    isOnBrandPage && searchParams.get("view") === "references";
+  const currentView = searchParams.get("view");
+  const isReferencesView = isOnBrandPage && currentView === "references";
+  const isSitemapView = isOnBrandPage && currentView === "sitemap";
 
   const [storedVoiceId, setStoredVoiceId] = useState<string | null>(null);
   useEffect(() => {
@@ -54,6 +60,12 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
   );
   const referenceCount = referencesData?.references.length ?? 0;
 
+  const { data: sitemapsData } = useSitemaps(
+    organizationId,
+    activeVoiceId ?? ""
+  );
+  const sitemapCount = sitemapsData?.sitemaps.length ?? 0;
+
   if (!organizationId) {
     return null;
   }
@@ -64,13 +76,16 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
   const referencesHref = activeVoiceId
     ? `${brandBasePath}?voice=${activeVoiceId}&view=references`
     : `${brandBasePath}?view=references`;
+  const sitemapHref = activeVoiceId
+    ? `${brandBasePath}?voice=${activeVoiceId}&view=sitemap`
+    : `${brandBasePath}?view=sitemap`;
 
   return (
     <CollapsibleSidebarGroup label="Brand Identity">
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton
-            isActive={isOnBrandPage && !isReferencesView}
+            isActive={isOnBrandPage && !isReferencesView && !isSitemapView}
             render={
               <Link href={companyInfoHref}>
                 <HugeiconsIcon icon={CorporateIcon} />
@@ -95,6 +110,23 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
               </Link>
             }
             tooltip="References"
+          />
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={isSitemapView}
+            render={
+              <Link href={sitemapHref}>
+                <HugeiconsIcon icon={GlobalIcon} />
+                <span>Sitemap</span>
+                {sitemapCount > 0 ? (
+                  <span className="ml-auto text-muted-foreground text-xs tabular-nums group-data-[collapsible=icon]:hidden">
+                    {sitemapCount}
+                  </span>
+                ) : null}
+              </Link>
+            }
+            tooltip="Sitemap"
           />
         </SidebarMenuItem>
       </SidebarMenu>

--- a/apps/dashboard/src/constants/sitemap.ts
+++ b/apps/dashboard/src/constants/sitemap.ts
@@ -1,0 +1,3 @@
+export const CONTEXT_DEV_SITEMAP_ID_PREFIX = "context-dev";
+export const CONTEXT_DEV_SITEMAP_MAX_LINKS = 250;
+export const CONTEXT_DEV_SITEMAP_TIMEOUT_MS = 30_000;

--- a/apps/dashboard/src/lib/hooks/use-brand-sitemaps.ts
+++ b/apps/dashboard/src/lib/hooks/use-brand-sitemaps.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  Sitemap,
+  SitemapListResponse,
+  SitemapPagesResponse,
+} from "@/types/hooks/brand-sitemaps";
+import { fetchSitemapJson } from "../sitemap/api-client";
+import { sitemapPagesKey, sitemapsKey } from "../sitemap/query-keys";
+
+export function useSitemaps(organizationId: string, voiceId: string) {
+  return useQuery<SitemapListResponse>({
+    queryKey: sitemapsKey(organizationId, voiceId),
+    queryFn: () =>
+      fetchSitemapJson<SitemapListResponse>(
+        `/api/organizations/${organizationId}/brand-identities/${voiceId}/sitemaps`
+      ),
+    enabled: !!organizationId && !!voiceId,
+  });
+}
+
+export function useSitemapPages(
+  organizationId: string,
+  voiceId: string,
+  sitemapId: string
+) {
+  return useQuery<SitemapPagesResponse>({
+    queryKey: sitemapPagesKey(organizationId, voiceId, sitemapId),
+    queryFn: () =>
+      fetchSitemapJson<SitemapPagesResponse>(
+        `/api/organizations/${organizationId}/brand-identities/${voiceId}/sitemaps/${sitemapId}/pages`
+      ),
+    enabled: !!organizationId && !!voiceId && !!sitemapId,
+  });
+}
+
+export function useCreateSitemap(organizationId: string, voiceId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Sitemap, Error, { url: string; label?: string }>({
+    mutationFn: async (input) => {
+      const result = await fetchSitemapJson<{
+        sitemap: Sitemap;
+        pages: SitemapPagesResponse["pages"];
+      }>(
+        `/api/organizations/${organizationId}/brand-identities/${voiceId}/sitemaps`,
+        {
+          body: JSON.stringify(input),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        }
+      );
+
+      queryClient.setQueryData<SitemapPagesResponse>(
+        sitemapPagesKey(organizationId, voiceId, result.sitemap.id),
+        { pages: result.pages }
+      );
+
+      return result.sitemap;
+    },
+    onSuccess: (sitemap) => {
+      queryClient.setQueryData<SitemapListResponse>(
+        sitemapsKey(organizationId, voiceId),
+        (current) => ({
+          sitemaps: [
+            ...(current?.sitemaps.filter((item) => item.id !== sitemap.id) ??
+              []),
+            sitemap,
+          ],
+        })
+      );
+    },
+  });
+}
+
+export function useDeleteSitemap(organizationId: string, voiceId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (sitemapId) => {
+      await fetchSitemapJson(
+        `/api/organizations/${organizationId}/brand-identities/${voiceId}/sitemaps/${sitemapId}`,
+        { method: "DELETE" }
+      );
+    },
+    onSuccess: (_data, sitemapId) => {
+      queryClient.setQueryData<SitemapListResponse>(
+        sitemapsKey(organizationId, voiceId),
+        (current) => ({
+          sitemaps:
+            current?.sitemaps.filter((sitemap) => sitemap.id !== sitemapId) ??
+            [],
+        })
+      );
+      queryClient.removeQueries({
+        queryKey: sitemapPagesKey(organizationId, voiceId, sitemapId),
+      });
+    },
+  });
+}

--- a/apps/dashboard/src/lib/sitemap/api-client.ts
+++ b/apps/dashboard/src/lib/sitemap/api-client.ts
@@ -1,0 +1,15 @@
+export async function fetchSitemapJson<T>(
+  url: string,
+  init?: RequestInit
+): Promise<T> {
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(payload?.error ?? "Request failed");
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/apps/dashboard/src/lib/sitemap/brand-identity.ts
+++ b/apps/dashboard/src/lib/sitemap/brand-identity.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import { db } from "@notra/db/drizzle";
+import { brandSettings } from "@notra/db/schema";
+import { and, eq } from "drizzle-orm";
+
+export function getSitemapBrandIdentity(
+  organizationId: string,
+  voiceId: string
+) {
+  return db.query.brandSettings.findFirst({
+    where: and(
+      eq(brandSettings.id, voiceId),
+      eq(brandSettings.organizationId, organizationId)
+    ),
+    columns: {
+      id: true,
+      websiteUrl: true,
+    },
+  });
+}

--- a/apps/dashboard/src/lib/sitemap/context-dev.ts
+++ b/apps/dashboard/src/lib/sitemap/context-dev.ts
@@ -1,0 +1,115 @@
+import "server-only";
+
+import { crawlSitemap } from "@notra/ai/utils/context-dev";
+import {
+  CONTEXT_DEV_SITEMAP_ID_PREFIX,
+  CONTEXT_DEV_SITEMAP_MAX_LINKS,
+  CONTEXT_DEV_SITEMAP_TIMEOUT_MS,
+} from "@/constants/sitemap";
+import type { Sitemap, SitemapPage } from "@/types/hooks/brand-sitemaps";
+import {
+  getHostname,
+  getRegistrableHost,
+  normalizeSitemapUrl,
+} from "./sitemap-url";
+
+function encodeSitemapId(url: string) {
+  const encodedUrl = Buffer.from(url, "utf8").toString("base64url");
+  return `${CONTEXT_DEV_SITEMAP_ID_PREFIX}:${encodedUrl}`;
+}
+
+function getPathFromUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
+function toSitemapPage(sitemapId: string, url: string): SitemapPage {
+  return {
+    id: `${sitemapId}:${Buffer.from(url, "utf8").toString("base64url")}`,
+    sitemapId,
+    url,
+    path: getPathFromUrl(url),
+    title: null,
+    category: "crawled",
+    statusCode: null,
+    redirectTarget: null,
+    wordCount: null,
+    textRatio: null,
+    internalLinks: null,
+    externalLinks: null,
+    crawledAt: new Date().toISOString(),
+  };
+}
+
+function getUniqueUrls(urls: string[]) {
+  return Array.from(new Set(urls));
+}
+
+function getFailedPageCount(input: {
+  errors: number;
+  sitemapsSkipped: number;
+  urlCount: number;
+}) {
+  if (input.urlCount > 0) {
+    return input.errors;
+  }
+
+  return Math.max(input.errors + input.sitemapsSkipped, 1);
+}
+
+export async function getContextDevSitemap(input: {
+  brandSettingsId: string;
+  url: string;
+  label?: string;
+}): Promise<{ sitemap: Sitemap; pages: SitemapPage[] }> {
+  const normalizedUrl = normalizeSitemapUrl(input.url);
+  const hostname = getHostname(normalizedUrl);
+
+  if (!hostname) {
+    throw new Error("Invalid sitemap URL");
+  }
+
+  const response = await crawlSitemap({
+    domain: hostname,
+    maxLinks: CONTEXT_DEV_SITEMAP_MAX_LINKS,
+    timeoutMS: CONTEXT_DEV_SITEMAP_TIMEOUT_MS,
+  });
+
+  const now = new Date().toISOString();
+  const sitemapId = encodeSitemapId(normalizedUrl);
+  const urls = getUniqueUrls(response.urls);
+  const pages = urls.map((url) => toSitemapPage(sitemapId, url));
+  const failedPages = getFailedPageCount({
+    errors: response.meta.errors,
+    sitemapsSkipped: response.meta.sitemapsSkipped,
+    urlCount: urls.length,
+  });
+  const totalPages = urls.length + failedPages;
+  const isReady = urls.length > 0;
+
+  return {
+    sitemap: {
+      id: sitemapId,
+      brandSettingsId: input.brandSettingsId,
+      label:
+        input.label?.trim() || getRegistrableHost(normalizedUrl) || hostname,
+      url: normalizedUrl,
+      hostname,
+      status: isReady ? "ready" : "failed",
+      totalPages,
+      indexedPages: urls.length,
+      failedPages,
+      contextDevMeta: response.meta,
+      lastCrawlError: isReady ? null : "No crawlable sitemap URLs found",
+      lastCrawlStartedAt: now,
+      lastCrawledAt: now,
+      createdAt: now,
+      updatedAt: now,
+    },
+    pages,
+  };
+}

--- a/apps/dashboard/src/lib/sitemap/display.ts
+++ b/apps/dashboard/src/lib/sitemap/display.ts
@@ -1,0 +1,26 @@
+export function getStatusCodeClassName(statusCode: number | null): string {
+  if (statusCode === null) {
+    return "text-muted-foreground";
+  }
+  if (statusCode >= 200 && statusCode < 300) {
+    return "text-emerald-600 dark:text-emerald-400";
+  }
+  if (statusCode >= 300 && statusCode < 400) {
+    return "text-amber-600 dark:text-amber-400";
+  }
+  return "text-red-600 dark:text-red-400";
+}
+
+export function formatWordCount(wordCount: number | null): string {
+  if (wordCount === null) {
+    return "—";
+  }
+  return `${wordCount.toLocaleString()} words`;
+}
+
+export function formatTextRatio(textRatio: number | null): string | null {
+  if (textRatio === null) {
+    return null;
+  }
+  return `${Math.round(textRatio * 100)}% text ratio`;
+}

--- a/apps/dashboard/src/lib/sitemap/query-keys.ts
+++ b/apps/dashboard/src/lib/sitemap/query-keys.ts
@@ -1,0 +1,11 @@
+export function sitemapsKey(organizationId: string, voiceId: string) {
+  return ["brand-sitemaps", organizationId, voiceId] as const;
+}
+
+export function sitemapPagesKey(
+  organizationId: string,
+  voiceId: string,
+  sitemapId: string
+) {
+  return ["brand-sitemap-pages", organizationId, voiceId, sitemapId] as const;
+}

--- a/apps/dashboard/src/lib/sitemap/request.ts
+++ b/apps/dashboard/src/lib/sitemap/request.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from "next/server";
+
+export async function readJsonRequest(request: NextRequest) {
+  try {
+    return { ok: true as const, body: await request.json() };
+  } catch {
+    return { ok: false as const };
+  }
+}

--- a/apps/dashboard/src/lib/sitemap/sitemap-url.ts
+++ b/apps/dashboard/src/lib/sitemap/sitemap-url.ts
@@ -1,0 +1,91 @@
+const PROTOCOL_PREFIX_REGEX = /^https?:\/\//i;
+const LEADING_WWW_REGEX = /^www\./;
+
+export function normalizeSitemapUrl(value: string): string {
+  const trimmed = value.trim();
+  return PROTOCOL_PREFIX_REGEX.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+export function getHostname(value: string): string | null {
+  try {
+    const parsed = new URL(normalizeSitemapUrl(value));
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function getRegistrableHost(value: string): string | null {
+  const hostname = getHostname(value);
+  return hostname ? hostname.replace(LEADING_WWW_REGEX, "") : null;
+}
+
+export function isUrlWithinBrandHost(
+  inputUrl: string,
+  brandWebsiteUrl: string | null
+): boolean {
+  if (!brandWebsiteUrl) {
+    return false;
+  }
+
+  const brandHost = getRegistrableHost(brandWebsiteUrl);
+  const inputHost = getRegistrableHost(inputUrl);
+
+  if (!(brandHost && inputHost)) {
+    return false;
+  }
+
+  return inputHost === brandHost || inputHost.endsWith(`.${brandHost}`);
+}
+
+export function getSafeHttpUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function formatRelativeCrawlTime(value: string | null): string {
+  if (!value) {
+    return "Never crawled";
+  }
+
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) {
+    return "Never crawled";
+  }
+
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+
+  if (seconds < 60) {
+    return "Just now";
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} min ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `${days}d ago`;
+  }
+
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/dashboard/src/lib/sitemap/storage.ts
+++ b/apps/dashboard/src/lib/sitemap/storage.ts
@@ -1,0 +1,243 @@
+import "server-only";
+
+import { db } from "@notra/db/drizzle";
+import { brandSitemapPages, brandSitemaps } from "@notra/db/schema";
+import { and, count, desc, eq, ilike, sql } from "drizzle-orm";
+import type {
+  Sitemap,
+  SitemapPage,
+  SitemapPageCategory,
+} from "@/types/hooks/brand-sitemaps";
+
+const DEFAULT_PAGE_LIMIT = 50;
+const MAX_PAGE_LIMIT = 100;
+
+function toIsoString(value: Date | null) {
+  return value ? value.toISOString() : null;
+}
+
+function toDate(value: string | null) {
+  return value ? new Date(value) : null;
+}
+
+function toSitemap(row: typeof brandSitemaps.$inferSelect): Sitemap {
+  return {
+    brandSettingsId: row.brandSettingsId,
+    contextDevMeta: row.contextDevMeta,
+    createdAt: row.createdAt.toISOString(),
+    failedPages: row.failedPages,
+    hostname: row.hostname,
+    id: row.id,
+    indexedPages: row.indexedPages,
+    label: row.label,
+    lastCrawlError: row.lastCrawlError,
+    lastCrawlStartedAt: toIsoString(row.lastCrawlStartedAt),
+    lastCrawledAt: toIsoString(row.lastCrawledAt),
+    status: row.status,
+    totalPages: row.totalPages,
+    updatedAt: row.updatedAt.toISOString(),
+    url: row.url,
+  };
+}
+
+function toSitemapPage(
+  row: typeof brandSitemapPages.$inferSelect
+): SitemapPage {
+  return {
+    category: row.category,
+    crawledAt: toIsoString(row.crawledAt),
+    externalLinks: row.externalLinks,
+    id: row.id,
+    internalLinks: row.internalLinks,
+    path: row.path,
+    redirectTarget: row.redirectTarget,
+    sitemapId: row.sitemapId,
+    statusCode: row.statusCode,
+    textRatio: row.textRatio,
+    title: row.title,
+    url: row.url,
+    wordCount: row.wordCount,
+  };
+}
+
+function toPageInsert(page: SitemapPage) {
+  return {
+    category: page.category,
+    crawledAt: toDate(page.crawledAt),
+    externalLinks: page.externalLinks,
+    id: page.id,
+    internalLinks: page.internalLinks,
+    path: page.path,
+    redirectTarget: page.redirectTarget,
+    sitemapId: page.sitemapId,
+    statusCode: page.statusCode,
+    textRatio: page.textRatio,
+    title: page.title,
+    url: page.url,
+    wordCount: page.wordCount,
+  };
+}
+
+function getSitemapCountsFromSnapshot(sitemap: Sitemap) {
+  return {
+    crawled: sitemap.indexedPages,
+    failed: sitemap.failedPages,
+    queued: 0,
+    redirect: 0,
+  } satisfies Record<SitemapPageCategory, number>;
+}
+
+export async function listStoredSitemaps(
+  _organizationId: string,
+  voiceId: string
+) {
+  const rows = await db.query.brandSitemaps.findMany({
+    orderBy: [desc(brandSitemaps.updatedAt)],
+    where: eq(brandSitemaps.brandSettingsId, voiceId),
+  });
+
+  return rows.map(toSitemap);
+}
+
+export async function getStoredSitemapPages(
+  _organizationId: string,
+  voiceId: string,
+  sitemapId: string,
+  options: {
+    category?: SitemapPageCategory;
+    cursor?: string;
+    limit?: number;
+    query?: string;
+  } = {}
+) {
+  const sitemapRow = await db.query.brandSitemaps.findFirst({
+    where: and(
+      eq(brandSitemaps.id, sitemapId),
+      eq(brandSitemaps.brandSettingsId, voiceId)
+    ),
+  });
+
+  if (!sitemapRow) {
+    return null;
+  }
+
+  const limit = Math.min(
+    Math.max(options.limit ?? DEFAULT_PAGE_LIMIT, 1),
+    MAX_PAGE_LIMIT
+  );
+  const filters = [
+    eq(brandSitemapPages.sitemapId, sitemapId),
+    options.category
+      ? eq(brandSitemapPages.category, options.category)
+      : undefined,
+    options.query
+      ? sql`(${brandSitemapPages.url} ilike ${`%${options.query}%`} or ${brandSitemapPages.title} ilike ${`%${options.query}%`})`
+      : undefined,
+    options.cursor
+      ? sql`${brandSitemapPages.id} > ${options.cursor}`
+      : undefined,
+  ].filter(Boolean);
+  const where = and(...filters);
+
+  const [rows, countRows] = await Promise.all([
+    db
+      .select()
+      .from(brandSitemapPages)
+      .where(where)
+      .orderBy(brandSitemapPages.id)
+      .limit(limit + 1),
+    db
+      .select({
+        category: brandSitemapPages.category,
+        total: count(),
+      })
+      .from(brandSitemapPages)
+      .where(eq(brandSitemapPages.sitemapId, sitemapId))
+      .groupBy(brandSitemapPages.category),
+  ]);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const categoryCounts = getSitemapCountsFromSnapshot(toSitemap(sitemapRow));
+
+  for (const row of countRows) {
+    categoryCounts[row.category] = row.total;
+  }
+
+  return {
+    counts: categoryCounts,
+    hasMore,
+    nextCursor: hasMore ? (pageRows.at(-1)?.id ?? null) : null,
+    pages: pageRows.map(toSitemapPage),
+  };
+}
+
+export async function saveStoredSitemap(input: {
+  organizationId: string;
+  voiceId: string;
+  sitemap: Sitemap;
+  pages: SitemapPage[];
+}) {
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(brandSitemaps)
+      .values({
+        brandSettingsId: input.voiceId,
+        contextDevMeta: input.sitemap.contextDevMeta,
+        failedPages: input.sitemap.failedPages,
+        hostname: input.sitemap.hostname,
+        id: input.sitemap.id,
+        indexedPages: input.sitemap.indexedPages,
+        label: input.sitemap.label,
+        lastCrawlError: input.sitemap.lastCrawlError ?? null,
+        lastCrawlStartedAt: toDate(input.sitemap.lastCrawlStartedAt ?? null),
+        lastCrawledAt: toDate(input.sitemap.lastCrawledAt),
+        status: input.sitemap.status,
+        totalPages: input.sitemap.totalPages,
+        url: input.sitemap.url,
+      })
+      .onConflictDoUpdate({
+        set: {
+          contextDevMeta: input.sitemap.contextDevMeta,
+          failedPages: input.sitemap.failedPages,
+          hostname: input.sitemap.hostname,
+          indexedPages: input.sitemap.indexedPages,
+          label: input.sitemap.label,
+          lastCrawlError: input.sitemap.lastCrawlError ?? null,
+          lastCrawlStartedAt: toDate(input.sitemap.lastCrawlStartedAt ?? null),
+          lastCrawledAt: toDate(input.sitemap.lastCrawledAt),
+          status: input.sitemap.status,
+          totalPages: input.sitemap.totalPages,
+          updatedAt: new Date(),
+          url: input.sitemap.url,
+        },
+        target: brandSitemaps.id,
+      });
+
+    await tx
+      .delete(brandSitemapPages)
+      .where(eq(brandSitemapPages.sitemapId, input.sitemap.id));
+
+    if (input.pages.length > 0) {
+      await tx.insert(brandSitemapPages).values(input.pages.map(toPageInsert));
+    }
+  });
+}
+
+export async function deleteStoredSitemap(input: {
+  organizationId: string;
+  voiceId: string;
+  sitemapId: string;
+}) {
+  const deleted = await db
+    .delete(brandSitemaps)
+    .where(
+      and(
+        eq(brandSitemaps.id, input.sitemapId),
+        eq(brandSitemaps.brandSettingsId, input.voiceId)
+      )
+    )
+    .returning({ id: brandSitemaps.id });
+
+  return deleted.length > 0;
+}

--- a/apps/dashboard/src/schemas/sitemap.ts
+++ b/apps/dashboard/src/schemas/sitemap.ts
@@ -1,0 +1,19 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+export const createSitemapSchema = z.object({
+  organizationId: z.string().min(1),
+  voiceId: z.string().min(1),
+  url: z.url("Please enter a valid URL"),
+  label: z.string().trim().min(1).max(60).optional(),
+});
+
+export type CreateSitemapInput = z.infer<typeof createSitemapSchema>;
+
+export const deleteSitemapSchema = z.object({
+  organizationId: z.string().min(1),
+  voiceId: z.string().min(1),
+  sitemapId: z.string().min(1),
+});
+
+export type DeleteSitemapInput = z.infer<typeof deleteSitemapSchema>;

--- a/apps/dashboard/src/types/hooks/brand-sitemaps.ts
+++ b/apps/dashboard/src/types/hooks/brand-sitemaps.ts
@@ -1,0 +1,80 @@
+export type SitemapStatus = "queued" | "crawling" | "ready" | "failed";
+
+export type SitemapPageCategory = "crawled" | "redirect" | "queued" | "failed";
+
+export interface Sitemap {
+  id: string;
+  brandSettingsId: string;
+  label: string;
+  url: string;
+  hostname: string;
+  status: SitemapStatus;
+  totalPages: number;
+  indexedPages: number;
+  failedPages: number;
+  contextDevMeta?: unknown;
+  lastCrawlStartedAt?: string | null;
+  lastCrawlError?: string | null;
+  lastCrawledAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SitemapPage {
+  id: string;
+  sitemapId: string;
+  url: string;
+  path: string;
+  title: string | null;
+  category: SitemapPageCategory;
+  statusCode: number | null;
+  redirectTarget: string | null;
+  wordCount: number | null;
+  textRatio: number | null;
+  internalLinks: number | null;
+  externalLinks: number | null;
+  crawledAt: string | null;
+}
+
+export interface SitemapListResponse {
+  sitemaps: Sitemap[];
+}
+
+export interface SitemapPagesResponse {
+  pages: SitemapPage[];
+  counts?: Record<SitemapPageCategory, number>;
+  hasMore?: boolean;
+  nextCursor?: string | null;
+}
+
+export interface SitemapListProps {
+  organizationId: string;
+  voiceId: string;
+  voiceWebsiteUrl: string | null;
+  dialogOpen: boolean;
+  onDialogOpenChange: (open: boolean) => void;
+}
+
+export interface AddSitemapDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  voiceId: string;
+  voiceWebsiteUrl: string | null;
+}
+
+export interface SitemapSelectorProps {
+  sitemaps: Sitemap[];
+  selectedSitemapId: string | null;
+  onSelect: (sitemapId: string) => void;
+}
+
+export interface SitemapStatsProps {
+  sitemap: Sitemap;
+}
+
+export interface SitemapPagesTableProps {
+  sitemapId: string;
+  organizationId: string;
+  voiceId: string;
+}

--- a/apps/web/src/app/api/v1/route.ts
+++ b/apps/web/src/app/api/v1/route.ts
@@ -1,1 +1,15 @@
-export { GET } from "../route";
+import { apiUrl, siteUrl } from "@/utils/agent-metadata";
+import { jsonResponse } from "@/utils/http";
+
+export function GET() {
+  return jsonResponse({
+    name: "Notra API",
+    description:
+      "Public API discovery endpoint. Use the production API host for versioned operations.",
+    status: siteUrl("/api/status"),
+    production: apiUrl(),
+    openapi: apiUrl("/openapi.json"),
+    catalog: siteUrl("/.well-known/api-catalog"),
+    auth: siteUrl("/auth.md"),
+  });
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -138,99 +138,120 @@ const speakableJsonLd = {
   },
 };
 
-export default function LandingPage() {
+function LandingPageJsonLd() {
   return (
-    <div className="flex w-full flex-col items-center justify-start overflow-hidden border-border/70 border-b">
+    <>
       <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: SSR'd JSON-LD payload, escaped via serializeJsonLd
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(softwareJsonLd) }}
         type="application/ld+json"
       />
       <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: SSR'd JSON-LD payload, escaped via serializeJsonLd
         dangerouslySetInnerHTML={{
           __html: serializeJsonLd(organizationJsonLd),
         }}
         type="application/ld+json"
       />
       <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: SSR'd JSON-LD payload, escaped via serializeJsonLd
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(serviceJsonLd) }}
         type="application/ld+json"
       />
       <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: SSR'd JSON-LD payload, escaped via serializeJsonLd
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqJsonLd) }}
         type="application/ld+json"
       />
       <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: SSR'd JSON-LD payload, escaped via serializeJsonLd
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(speakableJsonLd) }}
         type="application/ld+json"
       />
-      <main className="flex w-full flex-col items-center justify-start pt-28 sm:pt-20 md:pt-24 lg:pt-36">
-        <div className="flex w-full max-w-234.25 flex-col items-center justify-center gap-3 sm:gap-4 md:gap-5 lg:gap-6">
-          <div className="flex flex-col items-center justify-center gap-4 self-stretch rounded-[3px] sm:gap-5 md:gap-6 lg:gap-8">
-            <h1 className="flex w-full max-w-[46.8rem] flex-col justify-center text-pretty px-2 text-center font-normal font-serif text-[2rem] text-foreground leading-[1.1] sm:px-4 sm:text-[2.625rem] sm:leading-[1.15] md:px-0 md:text-[3.25rem] md:leading-[1.2] lg:text-[5rem] lg:leading-24">
-              {SITE_TAGLINE}
-            </h1>
-            <div className="flex w-full max-w-[31.63rem] flex-col justify-center text-pretty px-2 text-center font-medium font-sans text-foreground/80 text-sm leading-[1.4] sm:px-4 sm:text-lg sm:leading-[1.45] md:px-0 md:text-xl md:leading-normal lg:text-lg lg:leading-7">
-              {SITE_DESCRIPTION}
-            </div>
-            <p className="sr-only" id="agent-readable-summary">
-              Notra is an AI content-generation platform for product and
-              engineering teams. It turns shipped work from tools like GitHub
-              into changelogs, launch posts, blog drafts, marketing assets, and
-              social updates in the team's saved brand voice.
-            </p>
-          </div>
-        </div>
+    </>
+  );
+}
 
-        <div className="relative z-10 mt-6 mb-16 flex w-full max-w-124.25 flex-col items-center justify-center gap-6 sm:mt-8 sm:mb-0 sm:gap-8 md:mt-10 md:gap-10 lg:mt-12 lg:gap-12">
-          <div className="flex items-center justify-start gap-3 backdrop-blur-[0.515625rem] sm:gap-4">
-            <TrackedSignupLink source="landing_page_hero_cta">
-              <Button className="corner-squircle h-10 overflow-hidden rounded-[1rem] border-transparent bg-primary px-6 py-2 shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.08)_inset] hover:bg-primary-hover supports-[corner-shape:round]:rounded-[1.25rem] sm:h-11 sm:px-8 sm:py-1.5 md:h-12 md:px-10 lg:px-12">
-                <span className="flex flex-col justify-center font-medium font-sans text-primary-foreground text-sm leading-5 sm:text-base md:text-[0.9375rem]">
-                  Start for free
-                </span>
-              </Button>
-            </TrackedSignupLink>
-            <Button
-              className="corner-squircle h-10 overflow-hidden rounded-[1rem] px-6 py-2 supports-[corner-shape:round]:rounded-[1.25rem] sm:h-11 sm:px-8 sm:py-1.5 md:h-12 md:px-10 lg:px-12"
-              nativeButton={false}
-              render={<Link href="#how-it-works" />}
-              variant="outline"
-            >
-              <span className="flex flex-col justify-center font-medium font-sans text-foreground text-sm leading-5 sm:text-base md:text-[0.9375rem]">
-                How it works
+function LandingHero() {
+  return (
+    <>
+      <div className="flex w-full max-w-234.25 flex-col items-center justify-center gap-3 sm:gap-4 md:gap-5 lg:gap-6">
+        <div className="flex flex-col items-center justify-center gap-4 self-stretch rounded-[3px] sm:gap-5 md:gap-6 lg:gap-8">
+          <h1 className="flex w-full max-w-[46.8rem] flex-col justify-center text-pretty px-2 text-center font-normal font-serif text-[2rem] text-foreground leading-[1.1] sm:px-4 sm:text-[2.625rem] sm:leading-[1.15] md:px-0 md:text-[3.25rem] md:leading-[1.2] lg:text-[5rem] lg:leading-24">
+            {SITE_TAGLINE}
+          </h1>
+          <div className="flex w-full max-w-[31.63rem] flex-col justify-center text-pretty px-2 text-center font-medium font-sans text-foreground/80 text-sm leading-[1.4] sm:px-4 sm:text-lg sm:leading-[1.45] md:px-0 md:text-xl md:leading-normal lg:text-lg lg:leading-7">
+            {SITE_DESCRIPTION}
+          </div>
+          <p className="sr-only" id="agent-readable-summary">
+            Notra is an AI content-generation platform for product and
+            engineering teams. It turns shipped work from tools like GitHub into
+            changelogs, launch posts, blog drafts, marketing assets, and social
+            updates in the team's saved brand voice.
+          </p>
+        </div>
+      </div>
+
+      <div className="relative z-10 mt-6 mb-16 flex w-full max-w-124.25 flex-col items-center justify-center gap-6 sm:mt-8 sm:mb-0 sm:gap-8 md:mt-10 md:gap-10 lg:mt-12 lg:gap-12">
+        <div className="flex items-center justify-start gap-3 backdrop-blur-[0.515625rem] sm:gap-4">
+          <TrackedSignupLink source="landing_page_hero_cta">
+            <Button className="corner-squircle h-10 overflow-hidden rounded-[1rem] border-transparent bg-primary px-6 py-2 shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.08)_inset] hover:bg-primary-hover supports-[corner-shape:round]:rounded-[1.25rem] sm:h-11 sm:px-8 sm:py-1.5 md:h-12 md:px-10 lg:px-12">
+              <span className="flex flex-col justify-center font-medium font-sans text-primary-foreground text-sm leading-5 sm:text-base md:text-[0.9375rem]">
+                Start for free
               </span>
             </Button>
+          </TrackedSignupLink>
+          <Button
+            className="corner-squircle h-10 overflow-hidden rounded-[1rem] px-6 py-2 supports-[corner-shape:round]:rounded-[1.25rem] sm:h-11 sm:px-8 sm:py-1.5 md:h-12 md:px-10 lg:px-12"
+            nativeButton={false}
+            render={<Link href="#how-it-works" />}
+            variant="outline"
+          >
+            <span className="flex flex-col justify-center font-medium font-sans text-foreground text-sm leading-5 sm:text-base md:text-[0.9375rem]">
+              How it works
+            </span>
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-8 hidden items-stretch justify-center self-stretch border-border border-y sm:mt-10 md:mt-12 md:flex lg:mt-14">
+        <HatchPattern className="w-4 sm:w-6 md:w-8 lg:w-12" />
+
+        <div className="relative z-5 flex flex-1 flex-col">
+          <div className="flex aspect-video w-full flex-col items-start justify-start overflow-hidden rounded-md bg-card shadow-[0px_0px_0px_1px_rgba(0,0,0,0.08)] sm:rounded-lg lg:rounded-[0.566rem]">
+            <Image
+              alt="Notra product demo"
+              className="h-full w-full object-cover dark:hidden"
+              height={1080}
+              priority
+              sizes="(max-width: 640px) calc(100vw - 2rem), (max-width: 768px) calc(100vw - 3rem), (max-width: 1024px) calc(100vw - 4rem), calc(100vw - 6rem)"
+              src="/demo.webp"
+              width={1920}
+            />
+            <Image
+              alt="Notra product demo"
+              className="hidden h-full w-full object-cover dark:block"
+              height={1080}
+              priority
+              sizes="(max-width: 640px) calc(100vw - 2rem), (max-width: 768px) calc(100vw - 3rem), (max-width: 1024px) calc(100vw - 4rem), calc(100vw - 6rem)"
+              src="/demo-dark.webp"
+              width={1920}
+            />
           </div>
         </div>
 
-        <div className="mt-8 hidden items-stretch justify-center self-stretch border-border border-y sm:mt-10 md:mt-12 md:flex lg:mt-14">
-          <HatchPattern className="w-4 sm:w-6 md:w-8 lg:w-12" />
+        <HatchPattern className="w-4 sm:w-6 md:w-8 lg:w-12" />
+      </div>
+    </>
+  );
+}
 
-          <div className="relative z-5 flex flex-1 flex-col">
-            <div className="flex aspect-video w-full flex-col items-start justify-start overflow-hidden rounded-md bg-card shadow-[0px_0px_0px_1px_rgba(0,0,0,0.08)] sm:rounded-lg lg:rounded-[0.566rem]">
-              <Image
-                alt="Notra product demo"
-                className="h-full w-full object-cover dark:hidden"
-                height={1080}
-                priority
-                sizes="(max-width: 640px) calc(100vw - 2rem), (max-width: 768px) calc(100vw - 3rem), (max-width: 1024px) calc(100vw - 4rem), calc(100vw - 6rem)"
-                src="/demo.webp"
-                width={1920}
-              />
-              <Image
-                alt="Notra product demo"
-                className="hidden h-full w-full object-cover dark:block"
-                height={1080}
-                priority
-                sizes="(max-width: 640px) calc(100vw - 2rem), (max-width: 768px) calc(100vw - 3rem), (max-width: 1024px) calc(100vw - 4rem), calc(100vw - 6rem)"
-                src="/demo-dark.webp"
-                width={1920}
-              />
-            </div>
-          </div>
-
-          <HatchPattern className="w-4 sm:w-6 md:w-8 lg:w-12" />
-        </div>
+export default function LandingPage() {
+  return (
+    <div className="flex w-full flex-col items-center justify-start overflow-hidden border-border/70 border-b">
+      <LandingPageJsonLd />
+      <main className="flex w-full flex-col items-center justify-start pt-28 sm:pt-20 md:pt-24 lg:pt-36">
+        <LandingHero />
 
         <section
           className="flex w-full flex-col items-center justify-center border-border border-b content-defer"

--- a/apps/web/src/app/v1/route.ts
+++ b/apps/web/src/app/v1/route.ts
@@ -1,1 +1,15 @@
-export { GET } from "../api/route";
+import { apiUrl, siteUrl } from "@/utils/agent-metadata";
+import { jsonResponse } from "@/utils/http";
+
+export function GET() {
+  return jsonResponse({
+    name: "Notra API",
+    description:
+      "Public API discovery endpoint. Use the production API host for versioned operations.",
+    status: siteUrl("/api/status"),
+    production: apiUrl(),
+    openapi: apiUrl("/openapi.json"),
+    catalog: siteUrl("/.well-known/api-catalog"),
+    auth: siteUrl("/auth.md"),
+  });
+}

--- a/apps/web/src/app/v1/status/route.ts
+++ b/apps/web/src/app/v1/status/route.ts
@@ -1,1 +1,17 @@
-export { GET } from "../../api/status/route";
+import { apiUrl, siteUrl } from "@/utils/agent-metadata";
+import { jsonResponse } from "@/utils/http";
+
+export function GET() {
+  return jsonResponse({
+    status: "ok",
+    service: "Notra API discovery",
+    public: true,
+    production_status: apiUrl("/v1/status"),
+    openapi: apiUrl("/openapi.json"),
+    authentication: {
+      type: "bearer",
+      resource_metadata: apiUrl("/.well-known/oauth-protected-resource"),
+      guide: siteUrl("/auth.md"),
+    },
+  });
+}

--- a/packages/ai/src/constants/context-dev.ts
+++ b/packages/ai/src/constants/context-dev.ts
@@ -1,0 +1,35 @@
+export const BRAND_ANALYSIS_MAX_CONTENT_LENGTH = 80_000;
+export const BRAND_ANALYSIS_SITEMAP_MAX_LINKS = 250;
+export const BRAND_ANALYSIS_SITEMAP_TIMEOUT_MS = 30_000;
+export const BRAND_ANALYSIS_MAX_PAGES = 6;
+export const BRAND_ANALYSIS_PAGE_SEPARATOR = "\n\n---\n\n";
+export const BRAND_ANALYSIS_WWW_PREFIX = "www.";
+export const BRAND_ANALYSIS_EXCLUDED_PATH_PARTS = [
+  "/api/",
+  "/auth",
+  "/blog/",
+  "/careers",
+  "/changelog",
+  "/docs/",
+  "/legal",
+  "/login",
+  "/privacy",
+  "/rss",
+  "/signin",
+  "/signup",
+  "/support",
+  "/terms",
+];
+export const BRAND_ANALYSIS_PAGE_WEIGHTS = [
+  { pattern: /^\/$/, weight: 100 },
+  { pattern: /\/about\/?$/i, weight: 95 },
+  { pattern: /\/company\/?$/i, weight: 90 },
+  { pattern: /\/brand\/?$/i, weight: 85 },
+  { pattern: /\/product\/?$/i, weight: 80 },
+  { pattern: /\/platform\/?$/i, weight: 78 },
+  { pattern: /\/features?\/?$/i, weight: 75 },
+  { pattern: /\/solutions?\/?$/i, weight: 70 },
+  { pattern: /\/customers?\/?$/i, weight: 60 },
+  { pattern: /\/case-stud(y|ies)\/?$/i, weight: 55 },
+  { pattern: /\/pricing\/?$/i, weight: 35 },
+];

--- a/packages/ai/src/types/context-dev.ts
+++ b/packages/ai/src/types/context-dev.ts
@@ -59,6 +59,25 @@ export interface ContextDevFetchWebpageResponse {
   };
 }
 
+export interface ContextDevCrawlSitemapInput {
+  domain: string;
+  maxLinks?: number;
+  timeoutMS?: number;
+  urlRegex?: string;
+}
+
+export interface ContextDevCrawlSitemapResponse {
+  success: true;
+  domain: string;
+  urls: string[];
+  meta: {
+    sitemapsDiscovered: number;
+    sitemapsFetched: number;
+    sitemapsSkipped: number;
+    errors: number;
+  };
+}
+
 export interface ContextDevSearchResult {
   url: string;
   title: string;

--- a/packages/ai/src/utils/context-dev.ts
+++ b/packages/ai/src/utils/context-dev.ts
@@ -1,4 +1,6 @@
 import type {
+  ContextDevCrawlSitemapInput,
+  ContextDevCrawlSitemapResponse,
   ContextDevErrorResponse,
   ContextDevFetchWebpageInput,
   ContextDevFetchWebpageResponse,
@@ -8,9 +10,18 @@ import type {
   ContextDevWebSearchInput,
   ContextDevWebSearchResponse,
 } from "@notra/ai/types/context-dev";
+import {
+  BRAND_ANALYSIS_EXCLUDED_PATH_PARTS,
+  BRAND_ANALYSIS_MAX_CONTENT_LENGTH,
+  BRAND_ANALYSIS_MAX_PAGES,
+  BRAND_ANALYSIS_PAGE_SEPARATOR,
+  BRAND_ANALYSIS_PAGE_WEIGHTS,
+  BRAND_ANALYSIS_SITEMAP_MAX_LINKS,
+  BRAND_ANALYSIS_SITEMAP_TIMEOUT_MS,
+  BRAND_ANALYSIS_WWW_PREFIX,
+} from "../constants/context-dev";
 
 const CONTEXT_DEV_API_BASE_URL = "https://api.context.dev/v1";
-const BRAND_ANALYSIS_MAX_CONTENT_LENGTH = 80_000;
 
 class ContextDevApiError extends Error {
   readonly code?: string;
@@ -120,22 +131,196 @@ function mapContextDevError(error: unknown): ContextDevScrapingResult {
   };
 }
 
+function getDomainFromUrl(url: string): string {
+  return new URL(url).hostname;
+}
+
+function normalizeBrandHostname(hostname: string): string {
+  return hostname.startsWith(BRAND_ANALYSIS_WWW_PREFIX)
+    ? hostname.slice(BRAND_ANALYSIS_WWW_PREFIX.length)
+    : hostname;
+}
+
+function normalizeUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.hash = "";
+  return parsed.toString();
+}
+
+function getCanonicalUrlKey(url: string): string {
+  const parsed = new URL(url);
+  parsed.hash = "";
+  parsed.hostname = normalizeBrandHostname(parsed.hostname);
+  return parsed.toString();
+}
+
+function dedupeUrls(urls: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const url of urls) {
+    try {
+      const normalized = normalizeUrl(url);
+      const key = getCanonicalUrlKey(normalized);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      result.push(normalized);
+    } catch {
+      // Ignore malformed sitemap entries returned by external crawlers.
+    }
+  }
+
+  return result;
+}
+
+function shouldSkipBrandAnalysisUrl(url: string): boolean {
+  try {
+    const { pathname } = new URL(url);
+    const lowerPath = pathname.toLowerCase();
+    const segments = lowerPath.split("/").filter(Boolean);
+    return BRAND_ANALYSIS_EXCLUDED_PATH_PARTS.some((part) => {
+      const blockedSegment = part.replace(/^\/|\/$/g, "");
+      return segments.includes(blockedSegment);
+    });
+  } catch {
+    return true;
+  }
+}
+
+function scoreBrandAnalysisUrl(url: string, sourceUrl: string): number {
+  try {
+    const parsed = new URL(url);
+    const source = new URL(sourceUrl);
+
+    if (
+      normalizeBrandHostname(parsed.hostname) !==
+      normalizeBrandHostname(source.hostname)
+    ) {
+      return -1;
+    }
+
+    if (shouldSkipBrandAnalysisUrl(url)) {
+      return -1;
+    }
+
+    const path = parsed.pathname.endsWith("/")
+      ? parsed.pathname
+      : `${parsed.pathname}/`;
+    const pathDepth = path.split("/").filter(Boolean).length;
+    const weightedScore =
+      BRAND_ANALYSIS_PAGE_WEIGHTS.find(({ pattern }) => pattern.test(path))
+        ?.weight ?? Math.max(10, 45 - pathDepth * 10);
+
+    return weightedScore - parsed.search.length * 0.1;
+  } catch {
+    return -1;
+  }
+}
+
+function pickBrandAnalysisUrls(sourceUrl: string, sitemapUrls: string[]) {
+  const [source, ...candidates] = dedupeUrls([sourceUrl, ...sitemapUrls]);
+  if (!source) {
+    return [];
+  }
+
+  const rankedCandidates = candidates
+    .map((url) => ({ score: scoreBrandAnalysisUrl(url, source), url }))
+    .filter(({ score }) => score >= 0)
+    .sort((a, b) => b.score - a.score)
+    .map(({ url }) => url);
+
+  return dedupeUrls([source, ...rankedCandidates]).slice(
+    0,
+    BRAND_ANALYSIS_MAX_PAGES
+  );
+}
+
+function formatScrapedPagesForBrandAnalysis(
+  pages: ContextDevFetchWebpageResponse[]
+) {
+  return pages
+    .map((page) => {
+      const title = page.metadata?.title
+        ? `\nTitle: ${page.metadata.title}`
+        : "";
+      return `Source URL: ${page.url}${title}\n\n${page.markdown}`;
+    })
+    .join(BRAND_ANALYSIS_PAGE_SEPARATOR);
+}
+
 export async function scrapeWebsiteForBrandAnalysis(
   url: string
 ): Promise<ContextDevScrapingResult> {
   try {
-    const response = await fetchWebpage({
-      includeImages: false,
-      includeLinks: true,
-      onlyMainContent: true,
-      url,
-    });
+    const sitemapResult = await crawlSitemapForBrandAnalysis(url).catch(
+      (error) => {
+        console.warn("[Context.dev] Sitemap crawl failed for brand analysis", {
+          error: error instanceof Error ? error.message : "Unknown error",
+          url,
+        });
+        return null;
+      }
+    );
 
-    return { success: true, content: truncateContent(response.markdown) };
+    const urls = pickBrandAnalysisUrls(url, sitemapResult?.urls ?? []);
+    const scrapeResult = await scrapeBrandAnalysisPages(
+      urls.length > 0 ? urls : [url]
+    );
+    const { pages } = scrapeResult;
+
+    if (pages.length === 0) {
+      return scrapeResult.firstError
+        ? mapContextDevError(scrapeResult.firstError)
+        : {
+            success: false,
+            error: "Failed to scrape website",
+            fatal: false,
+          };
+    }
+
+    return {
+      success: true,
+      content: truncateContent(formatScrapedPagesForBrandAnalysis(pages)),
+    };
   } catch (error) {
     console.error("Error scraping website:", error);
     return mapContextDevError(error);
   }
+}
+
+async function scrapeBrandAnalysisPages(urls: string[]) {
+  const settledPages = await Promise.allSettled(
+    urls.map((pageUrl) =>
+      fetchWebpage({
+        includeImages: false,
+        includeLinks: true,
+        onlyMainContent: true,
+        timeoutMS: 20_000,
+        url: pageUrl,
+      })
+    )
+  );
+
+  const firstError = settledPages.find(
+    (result) => result.status === "rejected"
+  )?.reason;
+
+  return {
+    firstError,
+    pages: settledPages.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value] : []
+    ),
+  };
+}
+
+async function crawlSitemapForBrandAnalysis(url: string) {
+  return crawlSitemap({
+    domain: getDomainFromUrl(url),
+    maxLinks: BRAND_ANALYSIS_SITEMAP_MAX_LINKS,
+    timeoutMS: BRAND_ANALYSIS_SITEMAP_TIMEOUT_MS,
+  });
 }
 
 export async function fetchWebpage(
@@ -171,6 +356,29 @@ export async function fetchWebpage(
     metadata: response.metadata,
     url: response.url,
   };
+}
+
+export async function crawlSitemap(
+  input: ContextDevCrawlSitemapInput
+): Promise<ContextDevCrawlSitemapResponse> {
+  const params = new URLSearchParams({
+    domain: input.domain,
+  });
+
+  if (input.maxLinks !== undefined) {
+    params.set("maxLinks", String(input.maxLinks));
+  }
+  if (input.timeoutMS !== undefined) {
+    params.set("timeoutMS", String(input.timeoutMS));
+  }
+  if (input.urlRegex !== undefined) {
+    params.set("urlRegex", input.urlRegex);
+  }
+
+  return requestContextDev<ContextDevCrawlSitemapResponse>(
+    `/web/scrape/sitemap?${params.toString()}`,
+    { method: "GET" }
+  );
 }
 
 function shouldScrapeMarkdown(input: ContextDevWebSearchInput): boolean {

--- a/packages/db/migrations/0043_chunky_mordo.sql
+++ b/packages/db/migrations/0043_chunky_mordo.sql
@@ -1,0 +1,45 @@
+CREATE TYPE "public"."brand_sitemap_page_category" AS ENUM('crawled', 'redirect', 'queued', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."brand_sitemap_status" AS ENUM('queued', 'crawling', 'ready', 'failed');--> statement-breakpoint
+CREATE TABLE "brand_sitemap_pages" (
+	"id" text PRIMARY KEY NOT NULL,
+	"sitemap_id" text NOT NULL,
+	"url" text NOT NULL,
+	"path" text NOT NULL,
+	"title" text,
+	"category" "brand_sitemap_page_category" NOT NULL,
+	"status_code" integer,
+	"redirect_target" text,
+	"word_count" integer,
+	"text_ratio" real,
+	"internal_links" integer,
+	"external_links" integer,
+	"crawled_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "brand_sitemaps" (
+	"id" text PRIMARY KEY NOT NULL,
+	"brand_settings_id" text NOT NULL,
+	"label" text NOT NULL,
+	"url" text NOT NULL,
+	"hostname" text NOT NULL,
+	"status" "brand_sitemap_status" DEFAULT 'queued' NOT NULL,
+	"total_pages" integer DEFAULT 0 NOT NULL,
+	"indexed_pages" integer DEFAULT 0 NOT NULL,
+	"failed_pages" integer DEFAULT 0 NOT NULL,
+	"context_dev_meta" jsonb,
+	"last_crawl_started_at" timestamp,
+	"last_crawled_at" timestamp,
+	"last_crawl_error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "brand_sitemap_pages" ADD CONSTRAINT "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk" FOREIGN KEY ("sitemap_id") REFERENCES "public"."brand_sitemaps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "brand_sitemaps" ADD CONSTRAINT "brand_sitemaps_brand_settings_id_brand_settings_id_fk" FOREIGN KEY ("brand_settings_id") REFERENCES "public"."brand_settings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "brandSitemapPages_sitemapId_idx" ON "brand_sitemap_pages" USING btree ("sitemap_id");--> statement-breakpoint
+CREATE INDEX "brandSitemapPages_sitemap_category_idx" ON "brand_sitemap_pages" USING btree ("sitemap_id","category");--> statement-breakpoint
+CREATE UNIQUE INDEX "brandSitemapPages_sitemap_url_uidx" ON "brand_sitemap_pages" USING btree ("sitemap_id","url");--> statement-breakpoint
+CREATE INDEX "brandSitemaps_brandSettingsId_idx" ON "brand_sitemaps" USING btree ("brand_settings_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "brandSitemaps_brandSettings_url_uidx" ON "brand_sitemaps" USING btree ("brand_settings_id","url");

--- a/packages/db/migrations/meta/0043_snapshot.json
+++ b/packages/db/migrations/meta/0043_snapshot.json
@@ -1,0 +1,4066 @@
+{
+  "id": "113694ce-5812-4ca7-9e22-d609e84789ab",
+  "prevId": "c87a25f9-c57c-4cc8-a14f-5f1f230f8f7c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_references": {
+      "name": "brand_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_document_id": {
+          "name": "supermemory_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_memory_id": {
+          "name": "supermemory_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_synced_at": {
+          "name": "supermemory_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_last_sync_error": {
+          "name": "supermemory_last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to": {
+          "name": "applicable_to",
+          "type": "applicable_platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['all']::applicable_platform[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandReferences_brandSettingsId_idx": {
+          "name": "brandReferences_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_references_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_references_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_references",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_settings": {
+      "name": "brand_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_description": {
+          "name": "company_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone_profile": {
+          "name": "tone_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_tone": {
+          "name": "custom_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'English'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSettings_org_name_uidx": {
+          "name": "brandSettings_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_org_default_uidx": {
+          "name": "brandSettings_org_default_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brand_settings\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_organizationId_idx": {
+          "name": "brandSettings_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_settings_organization_id_organizations_id_fk": {
+          "name": "brand_settings_organization_id_organizations_id_fk",
+          "tableFrom": "brand_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemap_pages": {
+      "name": "brand_sitemap_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sitemap_id": {
+          "name": "sitemap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "brand_sitemap_page_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_ratio": {
+          "name": "text_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_links": {
+          "name": "internal_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_links": {
+          "name": "external_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawled_at": {
+          "name": "crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemapPages_sitemapId_idx": {
+          "name": "brandSitemapPages_sitemapId_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemapPages_sitemap_category_idx": {
+          "name": "brandSitemapPages_sitemap_category_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemapPages_sitemap_url_uidx": {
+          "name": "brandSitemapPages_sitemap_url_uidx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk": {
+          "name": "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk",
+          "tableFrom": "brand_sitemap_pages",
+          "tableTo": "brand_sitemaps",
+          "columnsFrom": [
+            "sitemap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemaps": {
+      "name": "brand_sitemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "brand_sitemap_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indexed_pages": {
+          "name": "indexed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_pages": {
+          "name": "failed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context_dev_meta": {
+          "name": "context_dev_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_started_at": {
+          "name": "last_crawl_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawled_at": {
+          "name": "last_crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_error": {
+          "name": "last_crawl_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemaps_brandSettingsId_idx": {
+          "name": "brandSitemaps_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemaps_brandSettings_url_uidx": {
+          "name": "brandSitemaps_brandSettings_url_uidx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemaps_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_sitemaps_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_sitemaps",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_attachments": {
+      "name": "chat_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatAttachments_organizationId_createdAt_idx": {
+          "name": "chatAttachments_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatAttachments_userId_idx": {
+          "name": "chatAttachments_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_attachments_organization_id_organizations_id_fk": {
+          "name": "chat_attachments_organization_id_organizations_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_attachments_user_id_users_id_fk": {
+          "name": "chat_attachments_user_id_users_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_attachments_key_unique": {
+          "name": "chat_attachments_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_source": {
+          "name": "external_channel_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_id": {
+          "name": "external_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatSessions_organizationId_idx": {
+          "name": "chatSessions_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_organizationId_deletedAt_idx": {
+          "name": "chatSessions_organizationId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_org_externalChannel_uidx": {
+          "name": "chatSessions_org_externalChannel_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_sessions\".\"external_channel_source\" IN ('discord', 'slack') AND \"chat_sessions\".\"external_channel_id\" IS NOT NULL AND \"chat_sessions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_sessions_organization_id_organizations_id_fk": {
+          "name": "chat_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_social_accounts": {
+      "name": "connected_social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectedSocialAccounts_organizationId_idx": {
+          "name": "connectedSocialAccounts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connectedSocialAccounts_org_provider_account_uidx": {
+          "name": "connectedSocialAccounts_org_provider_account_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connected_social_accounts_organization_id_organizations_id_fk": {
+          "name": "connected_social_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "connected_social_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_trigger_lookback_windows": {
+      "name": "content_trigger_lookback_windows",
+      "schema": "",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "lookback_window",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk": {
+          "name": "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk",
+          "tableFrom": "content_trigger_lookback_windows",
+          "tableTo": "content_triggers",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_triggers": {
+      "name": "content_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Schedule'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_config": {
+          "name": "output_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_hash": {
+          "name": "dedupe_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_publish": {
+          "name": "auto_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentTriggers_organizationId_idx": {
+          "name": "contentTriggers_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contentTriggers_organization_dedupe_uidx": {
+          "name": "contentTriggers_organization_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_triggers_organization_id_organizations_id_fk": {
+          "name": "content_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "content_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_avatar_url": {
+          "name": "account_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubAppInstallations_organizationId_idx": {
+          "name": "githubAppInstallations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubAppInstallations_createdByUserId_idx": {
+          "name": "githubAppInstallations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubAppInstallations_organization_installation_uidx": {
+          "name": "githubAppInstallations_organization_installation_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_users_id_fk": {
+          "name": "github_app_installations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_app_installation_id": {
+          "name": "github_app_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_private": {
+          "name": "github_repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_enabled": {
+          "name": "repository_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubIntegrations_organizationId_idx": {
+          "name": "githubIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_createdByUserId_idx": {
+          "name": "githubIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_organization_owner_repo_uidx": {
+          "name": "githubIntegrations_organization_owner_repo_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_organization_id_organizations_id_fk": {
+          "name": "github_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_created_by_user_id_users_id_fk": {
+          "name": "github_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_github_app_installation_id_github_app_installations_id_fk": {
+          "name": "github_integrations_github_app_installation_id_github_app_installations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "github_app_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitations_organizationId_idx": {
+          "name": "invitations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_integrations": {
+      "name": "linear_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_id": {
+          "name": "linear_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_name": {
+          "name": "linear_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linearIntegrations_organizationId_idx": {
+          "name": "linearIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_createdByUserId_idx": {
+          "name": "linearIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_no_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_no_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"linear_integrations\".\"linear_team_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_integrations_organization_id_organizations_id_fk": {
+          "name": "linear_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_integrations_created_by_user_id_users_id_fk": {
+          "name": "linear_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_integrations": {
+      "name": "mcp_server_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_tool_sync_at": {
+          "name": "last_tool_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_sync_status": {
+          "name": "tool_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "tool_sync_error": {
+          "name": "tool_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_tool_count": {
+          "name": "indexed_tool_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpServerIntegrations_organizationId_idx": {
+          "name": "mcpServerIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_createdByUserId_idx": {
+          "name": "mcpServerIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_id_uidx": {
+          "name": "mcpServerIntegrations_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_name_uidx": {
+          "name": "mcpServerIntegrations_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_integrations_organization_id_organizations_id_fk": {
+          "name": "mcp_server_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_integrations_created_by_user_id_users_id_fk": {
+          "name": "mcp_server_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_session_tool_activations": {
+      "name": "mcp_session_tool_activations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_tool_index_id": {
+          "name": "mcp_tool_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_query": {
+          "name": "source_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcpSessionToolActivations_session_tool_uidx": {
+          "name": "mcpSessionToolActivations_session_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mcp_tool_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpSessionToolActivations_session_idx": {
+          "name": "mcpSessionToolActivations_session_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpSessionToolActivations_expiresAt_idx": {
+          "name": "mcpSessionToolActivations_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_session_tool_activations_organization_id_organizations_id_fk": {
+          "name": "mcp_session_tool_activations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk": {
+          "name": "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "mcp_tool_index",
+          "columnsFrom": [
+            "mcp_tool_index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpSessionToolActivations_org_tool_fk": {
+          "name": "mcpSessionToolActivations_org_tool_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "mcp_tool_index",
+          "columnsFrom": [
+            "organization_id",
+            "mcp_tool_index_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tool_index": {
+      "name": "mcp_tool_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_tool_name": {
+          "name": "server_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_indexed_at": {
+          "name": "last_indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpToolIndex_server_tool_uidx": {
+          "name": "mcpToolIndex_server_tool_uidx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_org_id_uidx": {
+          "name": "mcpToolIndex_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_org_runtime_tool_uidx": {
+          "name": "mcpToolIndex_org_runtime_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_organizationId_status_idx": {
+          "name": "mcpToolIndex_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_serverIntegrationId_status_idx": {
+          "name": "mcpToolIndex_serverIntegrationId_status_idx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_searchText_gin_idx": {
+          "name": "mcpToolIndex_searchText_gin_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"search_text\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_index_organization_id_organizations_id_fk": {
+          "name": "mcp_tool_index_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpToolIndex_org_server_fk": {
+          "name": "mcpToolIndex_org_server_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_organizationId_idx": {
+          "name": "members_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_userId_idx": {
+          "name": "members_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_notification_settings": {
+      "name": "organization_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_content_creation": {
+          "name": "scheduled_content_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_content_failed": {
+          "name": "scheduled_content_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scheduled_content_skipped": {
+          "name": "scheduled_content_skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orgNotificationSettings_organizationId_uidx": {
+          "name": "orgNotificationSettings_organizationId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_settings_organization_id_organizations_id_fk": {
+          "name": "organization_notification_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_dismissed": {
+          "name": "onboarding_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "organizations_slug_uidx": {
+          "name": "organizations_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_collections": {
+      "name": "post_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "post_collection_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_source": {
+          "name": "name_source",
+          "type": "post_collection_name_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generated'"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_post_count": {
+          "name": "expected_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_post_count": {
+          "name": "completed_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_collections_org_created_at_idx": {
+          "name": "post_collections_org_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_collections_source_idx": {
+          "name": "post_collections_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_collections_chat_source_uidx": {
+          "name": "post_collections_chat_source_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"post_collections\".\"source\" = 'chat' AND \"post_collections\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_collections_organization_id_organizations_id_fk": {
+          "name": "post_collections_organization_id_organizations_id_fk",
+          "tableFrom": "post_collections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_org_slug_uidx": {
+          "name": "posts_org_slug_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_org_createdAt_id_idx": {
+          "name": "posts_org_createdAt_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_collection_id_idx": {
+          "name": "posts_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_organization_id_organizations_id_fk": {
+          "name": "posts_organization_id_organizations_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_collection_id_post_collections_id_fk": {
+          "name": "posts_collection_id_post_collections_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "post_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_outputs": {
+      "name": "repository_outputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositoryOutputs_repositoryId_idx": {
+          "name": "repositoryOutputs_repositoryId_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositoryOutputs_repository_outputType_uidx": {
+          "name": "repositoryOutputs_repository_outputType_uidx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "output_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_outputs_repository_id_github_integrations_id_fk": {
+          "name": "repository_outputs_repository_id_github_integrations_id_fk",
+          "tableFrom": "repository_outputs",
+          "tableTo": "github_integrations",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skills_organizationId_idx": {
+          "name": "skills_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skills_org_name_uidx": {
+          "name": "skills_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_organization_id_organizations_id_fk": {
+          "name": "skills_organization_id_organizations_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_personal_data": {
+          "name": "hide_personal_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_agent_stats": {
+          "name": "show_agent_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.applicable_platform": {
+      "name": "applicable_platform",
+      "schema": "public",
+      "values": [
+        "all",
+        "twitter",
+        "linkedin",
+        "blog"
+      ]
+    },
+    "public.brand_sitemap_page_category": {
+      "name": "brand_sitemap_page_category",
+      "schema": "public",
+      "values": [
+        "crawled",
+        "redirect",
+        "queued",
+        "failed"
+      ]
+    },
+    "public.brand_sitemap_status": {
+      "name": "brand_sitemap_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "crawling",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.lookback_window": {
+      "name": "lookback_window",
+      "schema": "public",
+      "values": [
+        "current_day",
+        "yesterday",
+        "last_7_days",
+        "last_14_days",
+        "last_30_days"
+      ]
+    },
+    "public.post_collection_name_source": {
+      "name": "post_collection_name_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user",
+        "backfill"
+      ]
+    },
+    "public.post_collection_source": {
+      "name": "post_collection_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "chat",
+        "schedule",
+        "automation",
+        "api",
+        "backfill"
+      ]
+    },
+    "public.post_status": {
+      "name": "post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.reference_type": {
+      "name": "reference_type",
+      "schema": "public",
+      "values": [
+        "twitter_post",
+        "linkedin_post",
+        "blog_post",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1781904369212,
       "tag": "0042_silky_darkhawk",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1782236353008,
+      "tag": "0043_chunky_mordo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,7 @@ import {
   jsonb,
   pgEnum,
   pgTable,
+  real,
   text,
   timestamp,
   uniqueIndex,
@@ -612,6 +613,18 @@ export const applicablePlatformEnum = pgEnum("applicable_platform", [
   "blog",
 ]);
 
+export const brandSitemapStatusEnum = pgEnum("brand_sitemap_status", [
+  "queued",
+  "crawling",
+  "ready",
+  "failed",
+]);
+
+export const brandSitemapPageCategoryEnum = pgEnum(
+  "brand_sitemap_page_category",
+  ["crawled", "redirect", "queued", "failed"]
+);
+
 export const brandReferences = pgTable(
   "brand_references",
   {
@@ -639,6 +652,76 @@ export const brandReferences = pgTable(
   },
   (table) => [
     index("brandReferences_brandSettingsId_idx").on(table.brandSettingsId),
+  ]
+);
+
+export const brandSitemaps = pgTable(
+  "brand_sitemaps",
+  {
+    id: text("id").primaryKey(),
+    brandSettingsId: text("brand_settings_id")
+      .notNull()
+      .references(() => brandSettings.id, { onDelete: "cascade" }),
+    label: text("label").notNull(),
+    url: text("url").notNull(),
+    hostname: text("hostname").notNull(),
+    status: brandSitemapStatusEnum("status").default("queued").notNull(),
+    totalPages: integer("total_pages").default(0).notNull(),
+    indexedPages: integer("indexed_pages").default(0).notNull(),
+    failedPages: integer("failed_pages").default(0).notNull(),
+    contextDevMeta: jsonb("context_dev_meta"),
+    lastCrawlStartedAt: timestamp("last_crawl_started_at"),
+    lastCrawledAt: timestamp("last_crawled_at"),
+    lastCrawlError: text("last_crawl_error"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("brandSitemaps_brandSettingsId_idx").on(table.brandSettingsId),
+    uniqueIndex("brandSitemaps_brandSettings_url_uidx").on(
+      table.brandSettingsId,
+      table.url
+    ),
+  ]
+);
+
+export const brandSitemapPages = pgTable(
+  "brand_sitemap_pages",
+  {
+    id: text("id").primaryKey(),
+    sitemapId: text("sitemap_id")
+      .notNull()
+      .references(() => brandSitemaps.id, { onDelete: "cascade" }),
+    url: text("url").notNull(),
+    path: text("path").notNull(),
+    title: text("title"),
+    category: brandSitemapPageCategoryEnum("category").notNull(),
+    statusCode: integer("status_code"),
+    redirectTarget: text("redirect_target"),
+    wordCount: integer("word_count"),
+    textRatio: real("text_ratio"),
+    internalLinks: integer("internal_links"),
+    externalLinks: integer("external_links"),
+    crawledAt: timestamp("crawled_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("brandSitemapPages_sitemapId_idx").on(table.sitemapId),
+    index("brandSitemapPages_sitemap_category_idx").on(
+      table.sitemapId,
+      table.category
+    ),
+    uniqueIndex("brandSitemapPages_sitemap_url_uidx").on(
+      table.sitemapId,
+      table.url
+    ),
   ]
 );
 
@@ -1062,6 +1145,7 @@ export const brandSettingsRelations = relations(
       references: [organizations.id],
     }),
     references: many(brandReferences),
+    sitemaps: many(brandSitemaps),
   })
 );
 
@@ -1071,6 +1155,27 @@ export const brandReferencesRelations = relations(
     brandSettings: one(brandSettings, {
       fields: [brandReferences.brandSettingsId],
       references: [brandSettings.id],
+    }),
+  })
+);
+
+export const brandSitemapsRelations = relations(
+  brandSitemaps,
+  ({ one, many }) => ({
+    brandSettings: one(brandSettings, {
+      fields: [brandSitemaps.brandSettingsId],
+      references: [brandSettings.id],
+    }),
+    pages: many(brandSitemapPages),
+  })
+);
+
+export const brandSitemapPagesRelations = relations(
+  brandSitemapPages,
+  ({ one }) => ({
+    sitemap: one(brandSitemaps, {
+      fields: [brandSitemapPages.sitemapId],
+      references: [brandSitemaps.id],
     }),
   })
 );


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Sitemap tab under Brand Identity to add, crawl, and manage sitemaps with stats and a searchable pages table. Data is persisted in Postgres and powered by Context.dev crawling.

- **New Features**
  - New “Sitemap” tab and sidebar item with counts; selector for multiple sitemaps; add dialog with same‑host validation and tips; delete with confirm.
  - Stats cards for indexed/failed/total, crawl status, last crawled, and coverage; pages table with search and filters (crawled, redirects, queued, failed) plus status code, words, links, and relative crawl time.
  - API routes: GET/POST `/sitemaps`, GET `/sitemaps/:id/pages`, DELETE `/sitemaps/:id`; org‑auth and brand identity checks; Zod request validation; uses Context.dev via `@notra/ai` `crawlSitemap` with link/time limits. Sitemaps and pages are stored in Postgres (`brand_sitemaps`, `brand_sitemap_pages`) via Drizzle migrations.
  - Client hooks using `@tanstack/react-query` for list/pages and create/delete with cache keys; URL utilities (normalization, host scoping, safe links) and display formatters.
  - Public API discovery endpoints on the web app: `/v1`, `/v1/status`, and `/api/v1` return service status and links to production and OpenAPI.

- **Refactors**
  - Extracted Brand Identity header and tabs with tab‑specific primary action and “C” hotkey; nav updated to include Sitemap with count.
  - Landing page JSON‑LD and hero split into components (no behavior change).

<sup>Written for commit b5cffc1ccdb2a10d40aebb86bb538e72327f8a09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

