### PR TITLE
feat(dashboard): paginate sitemap pages table

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-pages-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-pages-table.tsx
@@ -213,24 +213,25 @@ export function SitemapPagesTable({
                 }}
               />
             </PaginationItem>
-            {getPageNumbers(currentPage, totalPages).map((pageNumber, index) =>
-              pageNumber === "ellipsis" ? (
-                <PaginationItem key={`ellipsis-${index}`}>
-                  <PaginationEllipsis />
-                </PaginationItem>
-              ) : (
-                <PaginationItem key={pageNumber}>
-                  <PaginationLink
-                    isActive={pageNumber === currentPage}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      setPage(pageNumber);
-                    }}
-                  >
-                    {pageNumber}
-                  </PaginationLink>
-                </PaginationItem>
-              )
+            {getPageNumbers(currentPage, totalPages).map(
+              (pageNumber, index, pages) =>
+                pageNumber === "ellipsis" ? (
+                  <PaginationItem key={`ellipsis-${pages[index - 1]}`}>
+                    <PaginationEllipsis />
+                  </PaginationItem>
+                ) : (
+                  <PaginationItem key={pageNumber}>
+                    <PaginationLink
+                      isActive={pageNumber === currentPage}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        setPage(pageNumber);
+                      }}
+                    >
+                      {pageNumber}
+                    </PaginationLink>
+                  </PaginationItem>
+                )
             )}
             <PaginationItem>
               <PaginationNext

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-pages-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-pages-table.tsx
@@ -8,6 +8,15 @@ import {
   InputGroupAddon,
   InputGroupInput,
 } from "@notra/ui/components/ui/input-group";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@notra/ui/components/ui/pagination";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import {
   Table,
@@ -17,6 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from "@notra/ui/components/ui/table";
+import { parseAsInteger, useQueryState } from "nuqs";
 import { useState } from "react";
 import { useSitemapPages } from "@/lib/hooks/use-brand-sitemaps";
 import {
@@ -34,9 +44,11 @@ import type {
   SitemapPageCategory,
   SitemapPagesTableProps,
 } from "@/types/hooks/brand-sitemaps";
+import { getPageNumbers } from "@/utils/content-preview";
 import {
   PAGE_FILTER_TABS,
   SITEMAP_PAGE_SKELETON_KEYS,
+  SITEMAP_PAGES_PER_PAGE,
 } from "../constants/sitemap-ui";
 
 export function SitemapPagesTable({
@@ -52,6 +64,20 @@ export function SitemapPagesTable({
   const [activeFilter, setActiveFilter] =
     useState<SitemapPageCategory>("crawled");
   const [search, setSearch] = useState("");
+  const [rawPage, setPage] = useQueryState(
+    "page",
+    parseAsInteger.withDefault(1).withOptions({ clearOnDefault: true })
+  );
+
+  const handleFilterChange = (filter: SitemapPageCategory) => {
+    setActiveFilter(filter);
+    setPage(1);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setPage(1);
+  };
 
   const pages = data?.pages ?? [];
 
@@ -84,6 +110,16 @@ export function SitemapPagesTable({
     });
   })();
 
+  const totalPages = Math.max(
+    1,
+    Math.ceil(visiblePages.length / SITEMAP_PAGES_PER_PAGE)
+  );
+  const currentPage = Math.min(Math.max(1, rawPage), totalPages);
+  const paginatedPages = visiblePages.slice(
+    (currentPage - 1) * SITEMAP_PAGES_PER_PAGE,
+    currentPage * SITEMAP_PAGES_PER_PAGE
+  );
+
   if (isPending) {
     return (
       <div className="space-y-3">
@@ -106,7 +142,7 @@ export function SitemapPagesTable({
           </InputGroupAddon>
           <InputGroupInput
             aria-label="Search sitemap URLs"
-            onChange={(event) => setSearch(event.target.value)}
+            onChange={(event) => handleSearchChange(event.target.value)}
             placeholder="Search URLs..."
             value={search}
           />
@@ -124,7 +160,7 @@ export function SitemapPagesTable({
                     : "border-transparent text-muted-foreground hover:bg-muted/40"
                 )}
                 key={tab.value}
-                onClick={() => setActiveFilter(tab.value)}
+                onClick={() => handleFilterChange(tab.value)}
                 type="button"
               >
                 {tab.label} ({countsByCategory[tab.value]})
@@ -155,12 +191,60 @@ export function SitemapPagesTable({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {visiblePages.map((page) => (
+              {paginatedPages.map((page) => (
                 <PageRow key={page.id} page={page} />
               ))}
             </TableBody>
           </Table>
         </div>
+      )}
+
+      {totalPages > 1 && (
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                className={cn(
+                  currentPage === 1 && "pointer-events-none opacity-50"
+                )}
+                onClick={(event) => {
+                  event.preventDefault();
+                  setPage(Math.max(1, currentPage - 1));
+                }}
+              />
+            </PaginationItem>
+            {getPageNumbers(currentPage, totalPages).map((pageNumber, index) =>
+              pageNumber === "ellipsis" ? (
+                <PaginationItem key={`ellipsis-${index}`}>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              ) : (
+                <PaginationItem key={pageNumber}>
+                  <PaginationLink
+                    isActive={pageNumber === currentPage}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      setPage(pageNumber);
+                    }}
+                  >
+                    {pageNumber}
+                  </PaginationLink>
+                </PaginationItem>
+              )
+            )}
+            <PaginationItem>
+              <PaginationNext
+                className={cn(
+                  currentPage === totalPages && "pointer-events-none opacity-50"
+                )}
+                onClick={(event) => {
+                  event.preventDefault();
+                  setPage(Math.min(totalPages, currentPage + 1));
+                }}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       )}
     </div>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/constants/sitemap-ui.ts
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/constants/sitemap-ui.ts
@@ -35,3 +35,5 @@ export const SITEMAP_PAGE_SKELETON_KEYS = [
   "page-row-3",
   "page-row-4",
 ];
+
+export const SITEMAP_PAGES_PER_PAGE = 25;

--- a/apps/dashboard/src/constants/sitemap.ts
+++ b/apps/dashboard/src/constants/sitemap.ts
@@ -1,3 +1,4 @@
 export const CONTEXT_DEV_SITEMAP_ID_PREFIX = "context-dev";
 export const CONTEXT_DEV_SITEMAP_MAX_LINKS = 250;
 export const CONTEXT_DEV_SITEMAP_TIMEOUT_MS = 30_000;
+export const SITEMAP_PAGES_FETCH_LIMIT = 100;

--- a/apps/dashboard/src/lib/hooks/use-brand-sitemaps.ts
+++ b/apps/dashboard/src/lib/hooks/use-brand-sitemaps.ts
@@ -6,7 +6,7 @@ import type {
   SitemapListResponse,
   SitemapPagesResponse,
 } from "@/types/hooks/brand-sitemaps";
-import { fetchSitemapJson } from "../sitemap/api-client";
+import { fetchAllSitemapPages, fetchSitemapJson } from "../sitemap/api-client";
 import { sitemapPagesKey, sitemapsKey } from "../sitemap/query-keys";
 
 export function useSitemaps(organizationId: string, voiceId: string) {
@@ -27,10 +27,7 @@ export function useSitemapPages(
 ) {
   return useQuery<SitemapPagesResponse>({
     queryKey: sitemapPagesKey(organizationId, voiceId, sitemapId),
-    queryFn: () =>
-      fetchSitemapJson<SitemapPagesResponse>(
-        `/api/organizations/${organizationId}/brand-identities/${voiceId}/sitemaps/${sitemapId}/pages`
-      ),
+    queryFn: () => fetchAllSitemapPages(organizationId, voiceId, sitemapId),
     enabled: !!organizationId && !!voiceId && !!sitemapId,
   });
 }

--- a/apps/dashboard/src/lib/sitemap/api-client.ts
+++ b/apps/dashboard/src/lib/sitemap/api-client.ts
@@ -1,3 +1,9 @@
+import { SITEMAP_PAGES_FETCH_LIMIT } from "@/constants/sitemap";
+import type {
+  SitemapPage,
+  SitemapPagesResponse,
+} from "@/types/hooks/brand-sitemaps";
+
 export async function fetchSitemapJson<T>(
   url: string,
   init?: RequestInit
@@ -12,4 +18,36 @@ export async function fetchSitemapJson<T>(
   }
 
   return response.json() as Promise<T>;
+}
+
+export async function fetchAllSitemapPages(
+  organizationId: string,
+  voiceId: string,
+  sitemapId: string
+): Promise<SitemapPagesResponse> {
+  const basePath = `/api/organizations/${organizationId}/brand-identities/${voiceId}/sitemaps/${sitemapId}/pages`;
+  const pages: SitemapPage[] = [];
+  let counts: SitemapPagesResponse["counts"];
+  let cursor: string | undefined;
+
+  do {
+    const params = new URLSearchParams({
+      limit: String(SITEMAP_PAGES_FETCH_LIMIT),
+    });
+    if (cursor) {
+      params.set("cursor", cursor);
+    }
+
+    const result = await fetchSitemapJson<SitemapPagesResponse>(
+      `${basePath}?${params.toString()}`
+    );
+
+    for (const page of result.pages) {
+      pages.push(page);
+    }
+    counts = result.counts;
+    cursor = result.hasMore ? (result.nextCursor ?? undefined) : undefined;
+  } while (cursor);
+
+  return { counts, pages };
 }


### PR DESCRIPTION
### Description
The sitemap pages table fetched only the first 50 rows while the tab counts/stats reflected the full crawl, so it silently showed 50 of N pages. This loads all pages via the existing cursor pagination and adds nuqs-driven pagination using the shared `Pagination` component (page size 25, `?page=` URL state). This also fixes client-side search/category filtering, which previously only filtered within the first 50.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated the sitemap pages table so it shows all crawled pages, not just the first 50, and made search/filter work across the full dataset.

- **New Features**
  - Fetch all pages via cursor pagination in the API client (`SITEMAP_PAGES_FETCH_LIMIT=100`) and paginate the UI with `@notra/ui` `Pagination` and `nuqs` `?page=` state (25 per page).
  - Reset to page 1 on search or filter changes; compact page number display with ellipses.

- **Bug Fixes**
  - Fixed search and category filters only affecting the first 50 rows; they now cover all pages. Used stable keys for pagination ellipses to avoid key warnings.

<sup>Written for commit 1fefc8c90baebabca8958d06fc9b5dc817b6b18e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

