### PR TITLE
feat(web): add contact page with email delivery and rate limiting

### DIFF
--- a/apps/web/src/app/api/contact/route.ts
+++ b/apps/web/src/app/api/contact/route.ts
@@ -1,0 +1,55 @@
+import { Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  enforceContactMessageRateLimit,
+  getContactRateLimitHeaders,
+} from "@/lib/contact/ratelimit";
+import { sendContactMessageEmail } from "@/lib/contact/send-message-email";
+import { contactMessageSchema } from "@/schemas/contact";
+import { jsonError } from "@/utils/revalidate-route";
+
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError("Invalid JSON payload", 400);
+  }
+
+  const parsed = contactMessageSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return jsonError("Invalid contact message", 400);
+  }
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const rateLimit = yield* enforceContactMessageRateLimit(request);
+      yield* sendContactMessageEmail(parsed.data);
+
+      return NextResponse.json(
+        { success: true },
+        { headers: getContactRateLimitHeaders(rateLimit) }
+      );
+    }).pipe(
+      Effect.match({
+        onFailure: (error) => {
+          if (error._tag === "ContactMessageRateLimitExceeded") {
+            return NextResponse.json(
+              { error: "Rate limit exceeded" },
+              { headers: getContactRateLimitHeaders(error, true), status: 429 }
+            );
+          }
+
+          console.error("Failed to send contact message email", error);
+          return jsonError("Failed to send message", 500);
+        },
+        onSuccess: (response) => response,
+      })
+    )
+  );
+}

--- a/apps/web/src/app/contact/page.tsx
+++ b/apps/web/src/app/contact/page.tsx
@@ -1,48 +1,143 @@
+import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ContactEmail } from "@/components/contact/contact-email";
+import { ContactForm } from "@/components/contact/contact-form";
+import {
+  CONTACT_RESOURCE_LINKS,
+  CONTACT_RESPONSE_TIME,
+} from "@/constants/contact";
+import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
+import { SITE_URL } from "@/utils/urls";
+
+const title = "Contact Notra";
+const description =
+  "Talk to the Notra team about sales, support, security disclosures, partnerships, and developer integration help. A real human writes back.";
+const url = `${SITE_URL}/contact`;
 
 export const metadata: Metadata = {
-  title: "Contact Notra",
-  description:
-    "Contact Notra for support, sales, security questions, and agent integration help.",
+  title,
+  description,
+  alternates: { canonical: url },
+  openGraph: {
+    title,
+    description,
+    url,
+    type: "website",
+    siteName: "Notra",
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE.url],
+    site: TWITTER_HANDLE,
+    creator: TWITTER_HANDLE,
+  },
 };
 
 export default function ContactPage() {
   return (
-    <main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-28">
-      <div className="flex flex-col gap-4">
-        <h1 className="font-semibold text-4xl tracking-tight">Contact Notra</h1>
-        <p className="text-muted-foreground leading-7">
-          Contact Notra for product questions, support, security reports,
-          partnership requests, and developer integration help. The best general
-          contact address is{" "}
-          <a className="underline" href="mailto:hello@usenotra.com">
-            hello@usenotra.com
-          </a>
-          . For product support, write to{" "}
-          <a className="underline" href="mailto:support@usenotra.com">
-            support@usenotra.com
-          </a>
-          . Include your workspace name, the API endpoint or MCP client you are
-          using, relevant request IDs, and a short description of the issue.
-        </p>
-        <p className="text-muted-foreground leading-7">
-          Developers and AI agents should start with the{" "}
-          <Link className="underline" href="/auth.md">
-            agent authentication guide
-          </Link>
-          , the{" "}
-          <Link className="underline" href="/.well-known/api-catalog">
-            API catalog
-          </Link>
-          , and the scoped{" "}
-          <Link className="underline" href="/developers/llms.txt">
-            developer llms.txt
-          </Link>
-          . These resources describe API authentication, OpenAPI discovery, MCP
-          usage, sandbox reachability, and retry guidance.
-        </p>
-      </div>
-    </main>
+    <div className="flex w-full flex-col items-center justify-start overflow-hidden border-border/70 border-b pt-20 sm:pt-24 md:pt-28 lg:pt-32">
+      <section className="flex w-full items-center justify-center px-6 py-12 md:px-24 md:py-16">
+        <div className="flex w-full max-w-[640px] flex-col items-center gap-4">
+          <h1 className="text-balance text-center font-sans font-semibold text-4xl text-foreground leading-tight tracking-tight md:text-6xl">
+            We read every message.{" "}
+            <span className="text-primary">Let's talk.</span>
+          </h1>
+          <p className="text-pretty text-center font-normal font-sans text-base text-muted-foreground leading-7">
+            Tell us what you're working on and a real human will write back.
+            Typical response time: {CONTACT_RESPONSE_TIME}
+          </p>
+        </div>
+      </section>
+
+      <section className="w-full border-border/70 border-t px-6 py-12 md:px-24 md:py-16">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-8">
+          <ContactEmail />
+          <ContactForm />
+        </div>
+      </section>
+
+      <section className="w-full border-border/70 border-t px-6 py-12 md:px-24 md:py-16">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+          <div className="flex flex-col gap-2">
+            <h2 className="font-sans font-semibold text-2xl text-foreground tracking-tight md:text-3xl">
+              Looking for something specific?
+            </h2>
+            <p className="max-w-2xl font-normal font-sans text-muted-foreground text-sm leading-6">
+              You might find a faster answer in one of these.
+            </p>
+          </div>
+          <div className="grid gap-px overflow-hidden rounded-2xl border border-border bg-border sm:grid-cols-2">
+            {CONTACT_RESOURCE_LINKS.map((resource) => (
+              <Link
+                className="group flex flex-col gap-1.5 bg-card p-6 transition-colors hover:bg-muted/40"
+                href={resource.href}
+                key={resource.href}
+                rel={resource.external ? "noopener noreferrer" : undefined}
+                target={resource.external ? "_blank" : undefined}
+              >
+                <div className="flex items-center gap-2.5">
+                  <HugeiconsIcon
+                    className="size-4 text-primary"
+                    icon={resource.icon}
+                    strokeWidth={2}
+                  />
+                  <h3 className="flex items-center gap-1 font-medium font-sans text-base text-foreground">
+                    {resource.label}
+                    {resource.external ? (
+                      <HugeiconsIcon
+                        className="group-hover:-translate-y-0.5 size-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                        icon={ArrowUpRight01Icon}
+                        strokeWidth={2}
+                      />
+                    ) : null}
+                  </h3>
+                </div>
+                <p className="font-normal font-sans text-muted-foreground text-sm leading-6">
+                  {resource.description}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="w-full border-border/70 border-t px-6 py-12 md:px-24 md:py-16">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+          <h2 className="font-sans font-semibold text-2xl text-foreground tracking-tight md:text-3xl">
+            For developers and AI agents
+          </h2>
+          <p className="font-normal font-sans text-muted-foreground text-sm leading-7">
+            Start with the{" "}
+            <Link
+              className="font-medium text-primary underline underline-offset-2 hover:text-primary-hover"
+              href="/auth.md"
+            >
+              agent authentication guide
+            </Link>
+            , the{" "}
+            <Link
+              className="font-medium text-primary underline underline-offset-2 hover:text-primary-hover"
+              href="/.well-known/api-catalog"
+            >
+              API catalog
+            </Link>
+            , and the scoped{" "}
+            <Link
+              className="font-medium text-primary underline underline-offset-2 hover:text-primary-hover"
+              href="/developers/llms.txt"
+            >
+              developer llms.txt
+            </Link>
+            . These describe API authentication, OpenAPI discovery, MCP usage,
+            sandbox reachability, and retry guidance.
+          </p>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/src/components/contact/contact-email.tsx
+++ b/apps/web/src/components/contact/contact-email.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@notra/ui/components/ui/button";
+import { useState } from "react";
+import { CONTACT_PURPOSE, CONTACT_RECIPIENT } from "@/constants/contact";
+import { copyToClipboard } from "@/utils/copy-to-clipboard";
+
+const COPIED_RESET_MS = 2000;
+
+export function ContactEmail() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const didCopy = await copyToClipboard(
+      CONTACT_RECIPIENT,
+      "Email address copied"
+    );
+
+    if (didCopy) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-3 rounded-2xl border border-border bg-card p-5 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-1">
+        <a
+          className="font-medium font-sans text-foreground text-lg transition-colors hover:text-primary"
+          href={`mailto:${CONTACT_RECIPIENT}`}
+        >
+          {CONTACT_RECIPIENT}
+        </a>
+        <p className="font-normal font-sans text-muted-foreground text-sm leading-6">
+          {CONTACT_PURPOSE}
+        </p>
+      </div>
+      <Button
+        aria-label="Copy email address"
+        className="shrink-0 gap-2 sm:self-start"
+        onClick={handleCopy}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <HugeiconsIcon
+          className="size-4"
+          icon={copied ? Tick02Icon : Copy01Icon}
+          strokeWidth={2}
+        />
+        <span className="font-medium font-sans text-sm">
+          {copied ? "Copied" : "Copy"}
+        </span>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/contact/contact-form.tsx
+++ b/apps/web/src/components/contact/contact-form.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { Confetti } from "@neoconfetti/react";
+import { Button } from "@notra/ui/components/ui/button";
+import { Input } from "@notra/ui/components/ui/input";
+import { Label } from "@notra/ui/components/ui/label";
+import { Textarea } from "@notra/ui/components/ui/textarea";
+import { useForm } from "@tanstack/react-form";
+import Link from "next/link";
+import { useState } from "react";
+import { CONTACT_MESSAGE_MIN_LENGTH } from "@/constants/contact";
+import { contactMessageSchema } from "@/schemas/contact";
+
+type SubmitStatus =
+  | "idle"
+  | "submitting"
+  | "success"
+  | "error"
+  | "validation-error"
+  | "rate-limited";
+
+const fieldErrorClass = "text-destructive text-sm";
+const labelClass = "font-medium font-sans text-foreground text-sm";
+
+export function ContactForm() {
+  const [status, setStatus] = useState<SubmitStatus>("idle");
+
+  const form = useForm({
+    defaultValues: {
+      name: "",
+      email: "",
+      company: "",
+      message: "",
+    },
+    onSubmit: async ({ value }) => {
+      const parsed = contactMessageSchema.safeParse(value);
+
+      if (!parsed.success) {
+        setStatus("validation-error");
+        return;
+      }
+
+      setStatus("submitting");
+
+      try {
+        const response = await fetch("/api/contact", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(parsed.data),
+        });
+
+        if (response.status === 429) {
+          setStatus("rate-limited");
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error("Request failed");
+        }
+
+        setStatus("success");
+      } catch {
+        setStatus("error");
+      }
+    },
+  });
+
+  if (status === "success") {
+    return (
+      <div
+        aria-live="polite"
+        className="relative flex w-full flex-col items-center gap-3 rounded-2xl border border-border bg-card px-6 py-10 text-center"
+      >
+        <div className="-translate-x-1/2 pointer-events-none absolute top-0 left-1/2">
+          <Confetti
+            colors={[
+              "var(--primary)",
+              "#FFC700",
+              "#FF6B6B",
+              "#41BBC7",
+              "#A78BFA",
+              "#34D399",
+            ]}
+            duration={3000}
+            force={0.5}
+            particleCount={120}
+            particleShape="mix"
+            particleSize={8}
+            stageHeight={500}
+            stageWidth={800}
+          />
+        </div>
+        <h3 className="relative font-sans font-semibold text-foreground text-xl">
+          Message sent
+        </h3>
+        <p className="relative max-w-md text-pretty font-sans text-muted-foreground text-sm leading-6">
+          Thanks for reaching out. A real human will write back, usually within
+          one business day.
+        </p>
+      </div>
+    );
+  }
+
+  const isSubmitting = status === "submitting";
+
+  return (
+    <form
+      className="flex w-full flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        form.handleSubmit();
+      }}
+    >
+      <div className="grid gap-5 sm:grid-cols-2">
+        <form.Field
+          name="name"
+          validators={{
+            onBlur: ({ value }) =>
+              contactMessageSchema.shape.name.safeParse(value).error?.issues[0]
+                ?.message,
+          }}
+        >
+          {(field) => (
+            <div className="flex flex-col gap-2">
+              <Label className={labelClass} htmlFor={field.name}>
+                Your name
+              </Label>
+              <Input
+                aria-invalid={field.state.meta.errors.length > 0}
+                id={field.name}
+                name={field.name}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+                placeholder="Jane Doe"
+                required
+                value={field.state.value}
+              />
+              {field.state.meta.errors.length > 0 ? (
+                <p className={fieldErrorClass}>{field.state.meta.errors[0]}</p>
+              ) : null}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field
+          name="email"
+          validators={{
+            onBlur: ({ value }) =>
+              contactMessageSchema.shape.email.safeParse(value).error?.issues[0]
+                ?.message,
+          }}
+        >
+          {(field) => (
+            <div className="flex flex-col gap-2">
+              <Label className={labelClass} htmlFor={field.name}>
+                Email
+              </Label>
+              <Input
+                aria-invalid={field.state.meta.errors.length > 0}
+                id={field.name}
+                inputMode="email"
+                name={field.name}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+                placeholder="jane@example.com"
+                required
+                type="email"
+                value={field.state.value}
+              />
+              {field.state.meta.errors.length > 0 ? (
+                <p className={fieldErrorClass}>{field.state.meta.errors[0]}</p>
+              ) : null}
+            </div>
+          )}
+        </form.Field>
+      </div>
+
+      <form.Field
+        name="company"
+        validators={{
+          onBlur: ({ value }) =>
+            contactMessageSchema.shape.company.safeParse(value).error?.issues[0]
+              ?.message,
+        }}
+      >
+        {(field) => (
+          <div className="flex flex-col gap-2">
+            <Label className={labelClass} htmlFor={field.name}>
+              Company{" "}
+              <span className="font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              aria-invalid={field.state.meta.errors.length > 0}
+              id={field.name}
+              name={field.name}
+              onBlur={field.handleBlur}
+              onChange={(event) => field.handleChange(event.target.value)}
+              placeholder="Acme Inc."
+              value={field.state.value}
+            />
+            {field.state.meta.errors.length > 0 ? (
+              <p className={fieldErrorClass}>{field.state.meta.errors[0]}</p>
+            ) : null}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field
+        name="message"
+        validators={{
+          onBlur: ({ value }) =>
+            contactMessageSchema.shape.message.safeParse(value).error?.issues[0]
+              ?.message,
+        }}
+      >
+        {(field) => {
+          const trimmedLength = field.state.value.trim().length;
+          const charsRemaining = CONTACT_MESSAGE_MIN_LENGTH - trimmedLength;
+
+          return (
+            <div className="flex flex-col gap-2">
+              <Label className={labelClass} htmlFor={field.name}>
+                Message
+              </Label>
+              <Textarea
+                aria-invalid={field.state.meta.errors.length > 0}
+                className="min-h-32"
+                id={field.name}
+                name={field.name}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+                placeholder="Tell us what you're working on and how we can help."
+                required
+                value={field.state.value}
+              />
+              <div className="flex items-center justify-between gap-3">
+                {field.state.meta.errors.length > 0 ? (
+                  <p className={fieldErrorClass}>
+                    {field.state.meta.errors[0]}
+                  </p>
+                ) : null}
+                <span className="ml-auto shrink-0 font-sans text-muted-foreground text-xs">
+                  {charsRemaining > 0
+                    ? `${charsRemaining} more character${charsRemaining === 1 ? "" : "s"} needed`
+                    : `${trimmedLength} characters`}
+                </span>
+              </div>
+            </div>
+          );
+        }}
+      </form.Field>
+
+      <div aria-live="assertive" role="alert">
+        {status === "validation-error" ? (
+          <p className={fieldErrorClass}>
+            Please complete the required fields before sending your message.
+          </p>
+        ) : null}
+
+        {status === "error" ? (
+          <p className={fieldErrorClass}>
+            Something went wrong sending your message. Please try again, or
+            email us at hello@usenotra.com.
+          </p>
+        ) : null}
+
+        {status === "rate-limited" ? (
+          <p className={fieldErrorClass}>
+            You've sent too many messages recently. Please try again in about an
+            hour, or email us at hello@usenotra.com.
+          </p>
+        ) : null}
+      </div>
+
+      <p className="text-pretty font-sans text-muted-foreground text-xs leading-5">
+        By submitting this form you agree to our{" "}
+        <Link
+          className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+          href="/privacy"
+        >
+          Privacy Policy
+        </Link>
+        . We'll only use your details to respond to your message.
+      </p>
+
+      <form.Subscribe selector={(state) => state.canSubmit}>
+        {(canSubmit) => (
+          <Button
+            className="h-11 w-full overflow-hidden rounded-lg border-transparent bg-primary px-6 hover:bg-primary-hover sm:w-auto sm:self-start"
+            disabled={!canSubmit || isSubmitting}
+            type="submit"
+          >
+            <span className="font-medium font-sans text-primary-foreground text-sm">
+              {isSubmitting ? "Sending..." : "Send message"}
+            </span>
+          </Button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}

--- a/apps/web/src/components/contact/contact-form.tsx
+++ b/apps/web/src/components/contact/contact-form.tsx
@@ -42,26 +42,23 @@ export function ContactForm() {
 
       setStatus("submitting");
 
-      try {
-        const response = await fetch("/api/contact", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(parsed.data),
-        });
+      const response = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      }).catch(() => null);
 
-        if (response.status === 429) {
-          setStatus("rate-limited");
-          return;
-        }
-
-        if (!response.ok) {
-          throw new Error("Request failed");
-        }
-
-        setStatus("success");
-      } catch {
+      if (!response) {
         setStatus("error");
+        return;
       }
+
+      if (response.status === 429) {
+        setStatus("rate-limited");
+        return;
+      }
+
+      setStatus(response.ok ? "success" : "error");
     },
   });
 

--- a/apps/web/src/constants/contact.ts
+++ b/apps/web/src/constants/contact.ts
@@ -1,0 +1,53 @@
+import {
+  AiBrain01Icon,
+  BookOpen01Icon,
+  SparklesIcon,
+  UserGroupIcon,
+} from "@hugeicons/core-free-icons";
+
+export const CONTACT_RECIPIENT = "hello@usenotra.com";
+
+export const CONTACT_RATE_LIMIT = {
+  requests: 3,
+  window: "1h",
+} as const;
+
+export const CONTACT_MESSAGE_MIN_LENGTH = 10;
+export const CONTACT_MESSAGE_MAX_LENGTH = 2000;
+
+export const CONTACT_RESPONSE_TIME =
+  "Within one business day, often the same hour.";
+
+export const CONTACT_PURPOSE =
+  "For sales, support, security disclosures, and general questions.";
+
+export const CONTACT_RESOURCE_LINKS = [
+  {
+    href: "https://docs.usenotra.com",
+    label: "Documentation",
+    description: "Guides, API reference, and setup walkthroughs.",
+    icon: BookOpen01Icon,
+    external: true,
+  },
+  {
+    href: "https://docs.usenotra.com/devtools/mcp",
+    label: "MCP server",
+    description: "Connect Notra to your agents and editors.",
+    icon: AiBrain01Icon,
+    external: true,
+  },
+  {
+    href: "/oss-program",
+    label: "OSS program",
+    description: "Free Notra Pro for open source maintainers.",
+    icon: UserGroupIcon,
+    external: false,
+  },
+  {
+    href: "/pricing",
+    label: "Pricing",
+    description: "Plans and limits for every team size.",
+    icon: SparklesIcon,
+    external: false,
+  },
+] as const;

--- a/apps/web/src/lib/contact/ratelimit.ts
+++ b/apps/web/src/lib/contact/ratelimit.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { Data, Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { CONTACT_RATE_LIMIT } from "@/constants/contact";
+
+class ContactMessageRateLimitExceeded extends Data.TaggedError(
+  "ContactMessageRateLimitExceeded"
+)<{
+  readonly limit: number;
+  readonly remaining: number;
+  readonly reset: number;
+}> {}
+
+class ContactMessageRateLimitError extends Data.TaggedError(
+  "ContactMessageRateLimitError"
+)<{
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+let limiter: Ratelimit | null = null;
+
+function getLimiter(): Ratelimit | null {
+  if (limiter) {
+    return limiter;
+  }
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!(url && token)) {
+    return null;
+  }
+
+  limiter = new Ratelimit({
+    redis: new Redis({ url, token }),
+    analytics: true,
+    prefix: "ratelimit:web:contact-message",
+    limiter: Ratelimit.slidingWindow(
+      CONTACT_RATE_LIMIT.requests,
+      CONTACT_RATE_LIMIT.window
+    ),
+  });
+
+  return limiter;
+}
+
+function getClientIp(request: NextRequest): string {
+  const vercelForwardedFor = request.headers
+    .get("x-vercel-forwarded-for")
+    ?.split(",")[0]
+    ?.trim();
+
+  if (vercelForwardedFor) {
+    return vercelForwardedFor;
+  }
+
+  if (process.env.VERCEL) {
+    return "unknown";
+  }
+
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip")?.trim() ||
+    "unknown"
+  );
+}
+
+function getRateLimitKey(request: NextRequest): string {
+  return createHash("sha256").update(getClientIp(request)).digest("hex");
+}
+
+export function getContactRateLimitHeaders(
+  result: {
+    limit: number;
+    remaining: number;
+    reset: number;
+  },
+  includeRetryAfter = false
+): Headers {
+  const resetSeconds = Math.max(
+    0,
+    Math.ceil((result.reset - Date.now()) / 1000)
+  );
+
+  const headers = new Headers({
+    "RateLimit-Limit": String(result.limit),
+    "RateLimit-Remaining": String(Math.max(0, result.remaining)),
+    "RateLimit-Reset": String(resetSeconds),
+    "X-RateLimit-Limit": String(result.limit),
+    "X-RateLimit-Remaining": String(Math.max(0, result.remaining)),
+    "X-RateLimit-Reset": String(Math.ceil(result.reset / 1000)),
+  });
+
+  if (includeRetryAfter) {
+    headers.set("Retry-After", String(resetSeconds));
+  }
+
+  return headers;
+}
+
+export const enforceContactMessageRateLimit = Effect.fn(
+  "enforceContactMessageRateLimit"
+)(function* (request: NextRequest) {
+  const ratelimit = getLimiter();
+
+  if (!ratelimit) {
+    if (process.env.NODE_ENV === "production") {
+      return yield* Effect.fail(
+        new ContactMessageRateLimitError({
+          message: "Rate limit service is not configured",
+          cause: new Error(
+            "UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN is not set"
+          ),
+        })
+      );
+    }
+
+    return {
+      limit: CONTACT_RATE_LIMIT.requests,
+      remaining: CONTACT_RATE_LIMIT.requests,
+      reset: Date.now() + 60 * 60 * 1000,
+    };
+  }
+
+  const result = yield* Effect.tryPromise({
+    try: () => ratelimit.limit(getRateLimitKey(request)),
+    catch: (cause) =>
+      new ContactMessageRateLimitError({
+        message: "Failed to enforce contact message rate limit",
+        cause,
+      }),
+  });
+
+  if (!result.success) {
+    return yield* Effect.fail(
+      new ContactMessageRateLimitExceeded({
+        limit: result.limit,
+        remaining: Math.max(0, result.remaining),
+        reset: result.reset,
+      })
+    );
+  }
+
+  return {
+    limit: result.limit,
+    remaining: result.remaining,
+    reset: result.reset,
+  };
+});

--- a/apps/web/src/lib/contact/send-message-email.ts
+++ b/apps/web/src/lib/contact/send-message-email.ts
@@ -8,6 +8,8 @@ import { Data, Effect } from "effect";
 import { CONTACT_RECIPIENT } from "@/constants/contact";
 import type { ContactMessageInput } from "@/types/contact";
 
+const HEADER_NEWLINE_REGEX = /[\r\n]+/g;
+
 class ContactMessageEmailError extends Data.TaggedError(
   "ContactMessageEmailError"
 )<{
@@ -17,6 +19,10 @@ class ContactMessageEmailError extends Data.TaggedError(
 
 function getRecipient(): string {
   return process.env.CONTACT_EMAIL_TO || CONTACT_RECIPIENT;
+}
+
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(HEADER_NEWLINE_REGEX, " ").trim();
 }
 
 function buildPlainText(message: ContactMessageEmailProps): string {
@@ -59,7 +65,7 @@ export const sendContactMessageEmail = Effect.fn("sendContactMessageEmail")(
       company: input.company,
       message: input.message,
     };
-    const subject = `New contact message from ${message.name}`;
+    const subject = `New contact message from ${sanitizeHeaderValue(message.name)}`;
     const idempotencyKey = buildIdempotencyKey(message, to);
     const text = buildPlainText(message);
 

--- a/apps/web/src/lib/contact/send-message-email.ts
+++ b/apps/web/src/lib/contact/send-message-email.ts
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto";
+import { ContactMessageEmail } from "@notra/email/emails/contact";
+import type { ContactMessageEmailProps } from "@notra/email/types/contact";
+import { EMAIL_CONFIG } from "@notra/email/utils/config";
+import { sendDevEmail } from "@notra/email/utils/dev";
+import { getResend } from "@notra/email/utils/resend";
+import { Data, Effect } from "effect";
+import { CONTACT_RECIPIENT } from "@/constants/contact";
+import type { ContactMessageInput } from "@/types/contact";
+
+class ContactMessageEmailError extends Data.TaggedError(
+  "ContactMessageEmailError"
+)<{
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+function getRecipient(): string {
+  return process.env.CONTACT_EMAIL_TO || CONTACT_RECIPIENT;
+}
+
+function buildPlainText(message: ContactMessageEmailProps): string {
+  return [
+    `From: ${message.name} <${message.email}>`,
+    message.company ? `Company: ${message.company}` : null,
+    "",
+    message.message,
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+}
+
+function buildIdempotencyKey(
+  message: ContactMessageEmailProps,
+  recipient: string
+): string {
+  const hash = createHash("sha256");
+
+  for (const value of [
+    recipient,
+    message.name,
+    message.email,
+    message.company ?? "",
+    message.message,
+  ]) {
+    hash.update(value);
+    hash.update("\0");
+  }
+
+  return `notra:contact:${hash.digest("hex")}`;
+}
+
+export const sendContactMessageEmail = Effect.fn("sendContactMessageEmail")(
+  function* (input: ContactMessageInput) {
+    const to = getRecipient();
+    const message: ContactMessageEmailProps = {
+      name: input.name,
+      email: input.email,
+      company: input.company,
+      message: input.message,
+    };
+    const subject = `New contact message from ${message.name}`;
+    const idempotencyKey = buildIdempotencyKey(message, to);
+    const text = buildPlainText(message);
+
+    const resend = getResend();
+
+    if (!resend) {
+      if (process.env.NODE_ENV === "production") {
+        return yield* Effect.fail(
+          new ContactMessageEmailError({
+            message: "Email service is not configured",
+            cause: new Error("RESEND_API_KEY is not set"),
+          })
+        );
+      }
+
+      yield* Effect.tryPromise({
+        try: () =>
+          sendDevEmail({
+            from: EMAIL_CONFIG.from,
+            replyTo: message.email,
+            to,
+            subject,
+            text,
+          }),
+        catch: (cause) =>
+          new ContactMessageEmailError({
+            message: "Failed to log development contact email",
+            cause,
+          }),
+      });
+
+      return { success: true } as const;
+    }
+
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        resend.emails.send(
+          {
+            from: EMAIL_CONFIG.from,
+            replyTo: message.email,
+            to,
+            subject,
+            react: ContactMessageEmail(message),
+            text,
+            tags: [{ name: "category", value: "contact" }],
+          },
+          { idempotencyKey }
+        ),
+      catch: (cause) =>
+        new ContactMessageEmailError({
+          message: "Failed to send contact message email",
+          cause,
+        }),
+    });
+
+    if (result.error) {
+      return yield* Effect.fail(
+        new ContactMessageEmailError({
+          message: result.error.message,
+          cause: result.error,
+        })
+      );
+    }
+
+    return { success: true } as const;
+  }
+);

--- a/apps/web/src/schemas/contact.ts
+++ b/apps/web/src/schemas/contact.ts
@@ -1,0 +1,34 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+import {
+  CONTACT_MESSAGE_MAX_LENGTH,
+  CONTACT_MESSAGE_MIN_LENGTH,
+} from "@/constants/contact";
+
+const COMPANY_MAX_LENGTH = 120;
+
+export const contactMessageSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(2, "Please enter your name.")
+    .max(80, "That name is a little too long."),
+  email: z.email("Enter a valid email address."),
+  company: z
+    .string()
+    .trim()
+    .max(COMPANY_MAX_LENGTH, "That company name is a little too long.")
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  message: z
+    .string()
+    .trim()
+    .min(
+      CONTACT_MESSAGE_MIN_LENGTH,
+      `Please include at least ${CONTACT_MESSAGE_MIN_LENGTH} characters.`
+    )
+    .max(
+      CONTACT_MESSAGE_MAX_LENGTH,
+      `Please keep this under ${CONTACT_MESSAGE_MAX_LENGTH} characters.`
+    ),
+});

--- a/apps/web/src/types/contact.ts
+++ b/apps/web/src/types/contact.ts
@@ -1,0 +1,4 @@
+import type { z } from "zod";
+import type { contactMessageSchema } from "@/schemas/contact";
+
+export type ContactMessageInput = z.infer<typeof contactMessageSchema>;

--- a/apps/web/src/utils/navigation.ts
+++ b/apps/web/src/utils/navigation.ts
@@ -233,6 +233,10 @@ export const FOOTER_PRODUCT_LINKS = [
     label: "OSS Program",
   },
   {
+    href: "/contact",
+    label: "Contact",
+  },
+  {
     href: "https://www.notrareviews.com/",
     label: "Reviews",
     target: "_blank",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -4,6 +4,7 @@
   "exports": {
     "./emails/feedback": "./src/emails/feedback.tsx",
     "./emails/ai-credits-depleted": "./src/emails/ai-credits-depleted.tsx",
+    "./emails/contact": "./src/emails/contact.tsx",
     "./emails/invite": "./src/emails/invite.tsx",
     "./emails/oss-application": "./src/emails/oss-application.tsx",
     "./emails/reset": "./src/emails/reset.tsx",
@@ -13,6 +14,7 @@
     "./emails/verify": "./src/emails/verify.tsx",
     "./emails/welcome": "./src/emails/welcome.tsx",
     "./types/ai-credits-depleted": "./src/types/ai-credits-depleted.ts",
+    "./types/contact": "./src/types/contact.ts",
     "./types/feedback": "./src/types/feedback.ts",
     "./types/oss-application": "./src/types/oss-application.ts",
     "./utils/config": "./src/utils/config.ts",

--- a/packages/email/src/emails/contact.tsx
+++ b/packages/email/src/emails/contact.tsx
@@ -18,7 +18,7 @@ import { EMAIL_CONFIG } from "../utils/config";
 export const ContactMessageEmail = ({
   name = "Jane Doe",
   email = "jane@example.com",
-  company = "Acme Inc.",
+  company,
   message = "We're evaluating Notra for our team and would love to chat about volume pricing.",
 }: ContactMessageEmailProps) => {
   const logoUrl = EMAIL_CONFIG.getLogoUrl();

--- a/packages/email/src/emails/contact.tsx
+++ b/packages/email/src/emails/contact.tsx
@@ -1,0 +1,84 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+import { EmailFooter } from "../components/footer";
+import type { ContactMessageEmailProps } from "../types/contact";
+import { EMAIL_CONFIG } from "../utils/config";
+
+export const ContactMessageEmail = ({
+  name = "Jane Doe",
+  email = "jane@example.com",
+  company = "Acme Inc.",
+  message = "We're evaluating Notra for our team and would love to chat about volume pricing.",
+}: ContactMessageEmailProps) => {
+  const logoUrl = EMAIL_CONFIG.getLogoUrl();
+
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        New contact message from {name}
+        {company ? ` (${company})` : ""}
+      </Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white px-2 font-sans">
+          <Container className="mx-auto my-[40px] max-w-[520px] rounded p-[20px]">
+            <Section className="mt-[32px]">
+              <Img
+                alt="Notra Logo"
+                className="mx-auto"
+                height="40"
+                src={logoUrl}
+                width="40"
+              />
+            </Section>
+
+            <Heading className="my-6 text-center font-medium text-2xl text-black">
+              New contact message
+            </Heading>
+
+            <Section className="mt-6 rounded-md border border-[#eaeaea] border-solid bg-[#fafafa] p-5">
+              <Text className="m-0 whitespace-pre-wrap text-[15px] text-black leading-[22px]">
+                {message}
+              </Text>
+            </Section>
+
+            <Section className="mt-8">
+              <Text className="m-0 text-[#666666] text-[12px] uppercase tracking-wide">
+                From
+              </Text>
+              <Text className="mt-1 mb-0 text-[14px] text-black leading-[22px]">
+                {name} &lt;{email}&gt;
+              </Text>
+            </Section>
+
+            {company ? (
+              <Section className="mt-4">
+                <Text className="m-0 text-[#666666] text-[12px] uppercase tracking-wide">
+                  Company
+                </Text>
+                <Text className="mt-1 mb-0 text-[14px] text-black leading-[22px]">
+                  {company}
+                </Text>
+              </Section>
+            ) : null}
+
+            <EmailFooter />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default ContactMessageEmail;

--- a/packages/email/src/types/contact.ts
+++ b/packages/email/src/types/contact.ts
@@ -1,0 +1,6 @@
+export interface ContactMessageEmailProps {
+  name: string;
+  email: string;
+  company?: string;
+  message: string;
+}


### PR DESCRIPTION
### Description
Adds a `/contact` page inspired by context.dev/contact. The static page is replaced with a hero ("We read every message. Let's talk."), a copy-to-clipboard contact email, a contact form (name, email, optional company, message), a "Looking for something specific?" resources grid, and the existing developer/agent links.

Form submissions POST to a new `/api/contact` route that validates the body with Zod, enforces an Upstash sliding-window rate limit, and delivers the message through Resend. Rate limiting and email sending are composed with Effect, mirroring the OSS program and data-deletion-request handlers from the last commit. Also adds a `ContactMessageEmail` react-email template and a Contact link in the footer.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a new /contact page with a user-friendly form and copy-to-email, plus a backend route that validates, rate-limits, and emails messages. Also hardens email delivery by stripping CR/LF from the subject to prevent header injection and removes the sample company default so real emails never include placeholder company data.

- **New Features**
  - New `/contact` page with hero, copy-to-clipboard email, form (name, email, optional company, message), resources grid, and developer links.
  - API: `POST /api/contact` validates with Zod, enforces `@upstash/ratelimit` sliding window (3/hr), and returns standard rate limit + `Retry-After` headers with 429 on overflow.
  - Email delivery via Resend using `@notra/email` `ContactMessageEmail`; idempotency key to prevent duplicates; dev fallback logs messages.
  - New `ContactEmail` and `ContactForm` components with inline validation, min-length counter, success state; added footer link and SEO/OpenGraph metadata; submit handler optimized for React Compiler memoization.

- **Migration**
  - Set `RESEND_API_KEY` in production; optional `CONTACT_EMAIL_TO` to override recipient.
  - Configure Upstash rate limiting: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` (required in prod).
  - No data migrations.

<sup>Written for commit c4e60056f479a5598479745e1ec997708721985a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

