### PR TITLE
fix(web): avoid regex tag stripping in blog toc

### DIFF
--- a/apps/web/src/utils/blog-toc.ts
+++ b/apps/web/src/utils/blog-toc.ts
@@ -2,13 +2,14 @@ import type { TOCItemType } from "fumadocs-core/toc";
 import { HTML_ENTITY_MAP, HTML_ENTITY_REGEX } from "@/utils/constants";
 
 const HEADING_WITH_TAG_REGEX = /<h([2-4])([^>]*)>([\s\S]*?)<\/h\1>/gi;
-const HTML_TAG_REGEX = /<[^>]+>/g;
 const WHITESPACE_REGEX = /\s+/g;
 const ID_ATTRIBUTE_REGEX = /\sid\s*=\s*["']([^"']+)["']/i;
 const DIACRITICS_REGEX = /[̀-ͯ]/g;
 const NON_ALPHANUM_REGEX = /[^a-z0-9]+/g;
 const TRIM_DASHES_REGEX = /^-+|-+$/g;
 const SLUG_FALLBACK = "section";
+const LESS_THAN = "<";
+const GREATER_THAN = ">";
 
 function decodeHtmlEntities(value: string) {
   return value.replace(
@@ -17,8 +18,31 @@ function decodeHtmlEntities(value: string) {
   );
 }
 
+function htmlTextContent(value: string) {
+  let text = "";
+  let insideTag = false;
+
+  for (const character of value) {
+    if (character === LESS_THAN) {
+      insideTag = true;
+      continue;
+    }
+
+    if (character === GREATER_THAN && insideTag) {
+      insideTag = false;
+      continue;
+    }
+
+    if (!insideTag) {
+      text += character;
+    }
+  }
+
+  return text;
+}
+
 function stripHtml(value: string) {
-  return decodeHtmlEntities(value.replace(HTML_TAG_REGEX, ""))
+  return decodeHtmlEntities(htmlTextContent(value))
     .replace(WHITESPACE_REGEX, " ")
     .trim();
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blog TOC text extraction by using a simple tag-aware parser instead of regex. Prevents broken TOC titles and slugs when headings include nested tags or angle brackets.

- **Bug Fixes**
  - Added a lightweight `htmlTextContent` parser to read text outside HTML tags.
  - Kept entity decoding and whitespace normalization in `stripHtml` for clean titles.

<sup>Written for commit 7d93b05290d4df8d082382e6a31d1b440dea5177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

