### PR TITLE
fix(ai): escape markdown alt backslashes

### DIFF
--- a/packages/ai/src/utils/html.ts
+++ b/packages/ai/src/utils/html.ts
@@ -10,7 +10,7 @@ export function escapeHtml(value: string) {
 }
 
 export function escapeMarkdownAlt(value: string) {
-  return value.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+  return value.replace(/[\\[\]]/g, "\\$&");
 }
 
 export function buildGeneratedImageMarkdown(params: {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes markdown alt text escaping in `packages/ai` by also escaping backslashes. Updates escapeMarkdownAlt to escape `\`, `[` and `]` to prevent malformed Markdown in generated image links and labels.

<sup>Written for commit bb4d72725f99ed71e55bc13274f6993401f2b36a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

