### PR TITLE
fix(security): validate urls before dom sinks

### DIFF
--- a/apps/dashboard/src/lib/utils/github.ts
+++ b/apps/dashboard/src/lib/utils/github.ts
@@ -1,6 +1,13 @@
 import { GITHUB_URL_PATTERNS } from "@/constants/github";
 import type { GitHubRepoInfo } from "@/types/integrations";
 
+const GITHUB_OWNER_REGEX = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
+const GITHUB_REPO_REGEX = /^[a-z\d._-]{1,100}$/i;
+
+function isValidGitHubPath(owner: string, repo: string) {
+  return GITHUB_OWNER_REGEX.test(owner) && GITHUB_REPO_REGEX.test(repo);
+}
+
 export function parseGitHubUrl(url: string): GitHubRepoInfo | null {
   const trimmed = url.trim();
 
@@ -12,10 +19,15 @@ export function parseGitHubUrl(url: string): GitHubRepoInfo | null {
       if (!(owner && repo)) {
         continue;
       }
+      if (!isValidGitHubPath(owner, repo)) {
+        continue;
+      }
       return {
         owner,
         repo,
-        fullUrl: `https://github.com/${owner}/${repo}`,
+        fullUrl: `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(
+          repo
+        )}`,
       };
     }
   }

--- a/packages/ui/src/components/ai-elements/web-preview.tsx
+++ b/packages/ui/src/components/ai-elements/web-preview.tsx
@@ -16,8 +16,12 @@ import {
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
 import type { ComponentProps, ReactNode } from "react";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, use, useState } from "react";
 import { cn } from "@notra/ui/lib/utils";
+
+const HTTP_PROTOCOLS = new Set(["http:", "https:"]);
+const URL_SCHEME_REGEX = /^[a-z][a-z\d+.-]*:/i;
+const EMPTY_LOGS: WebPreviewConsoleProps["logs"] = [];
 
 export interface WebPreviewContextValue {
   url: string;
@@ -29,12 +33,31 @@ export interface WebPreviewContextValue {
 const WebPreviewContext = createContext<WebPreviewContextValue | null>(null);
 
 const useWebPreview = () => {
-  const context = useContext(WebPreviewContext);
+  const context = use(WebPreviewContext);
   if (!context) {
     throw new Error("WebPreview components must be used within a WebPreview");
   }
   return context;
 };
+
+function toWebPreviewUrl(value: string) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  const candidate = URL_SCHEME_REGEX.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(candidate);
+    return HTTP_PROTOCOLS.has(parsed.protocol) ? parsed.toString() : "";
+  } catch {
+    return "";
+  }
+}
 
 export type WebPreviewProps = ComponentProps<"div"> & {
   defaultUrl?: string;
@@ -48,12 +71,13 @@ export const WebPreview = ({
   onUrlChange,
   ...props
 }: WebPreviewProps) => {
-  const [url, setUrl] = useState(defaultUrl);
+  const [url, setUrl] = useState(() => toWebPreviewUrl(defaultUrl));
   const [consoleOpen, setConsoleOpen] = useState(false);
 
   const handleUrlChange = (newUrl: string) => {
-    setUrl(newUrl);
-    onUrlChange?.(newUrl);
+    const safeUrl = toWebPreviewUrl(newUrl);
+    setUrl(safeUrl);
+    onUrlChange?.(safeUrl);
   };
 
   const contextValue: WebPreviewContextValue = {
@@ -129,19 +153,19 @@ export const WebPreviewNavigationButton = ({
 
 export type WebPreviewUrlProps = ComponentProps<typeof Input>;
 
-export const WebPreviewUrl = ({
+type WebPreviewUrlInputProps = WebPreviewUrlProps & {
+  initialValue: string;
+};
+
+const WebPreviewUrlInput = ({
+  initialValue,
   value,
   onChange,
   onKeyDown,
   ...props
-}: WebPreviewUrlProps) => {
-  const { url, setUrl } = useWebPreview();
-  const [inputValue, setInputValue] = useState(url);
-
-  // Sync input value with context URL when it changes externally
-  useEffect(() => {
-    setInputValue(url);
-  }, [url]);
+}: WebPreviewUrlInputProps) => {
+  const { setUrl } = useWebPreview();
+  const [inputValue, setInputValue] = useState(initialValue);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
@@ -168,6 +192,26 @@ export const WebPreviewUrl = ({
   );
 };
 
+export const WebPreviewUrl = ({
+  value,
+  onChange,
+  onKeyDown,
+  ...props
+}: WebPreviewUrlProps) => {
+  const { url } = useWebPreview();
+
+  return (
+    <WebPreviewUrlInput
+      initialValue={url}
+      key={url}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+      value={value}
+      {...props}
+    />
+  );
+};
+
 export type WebPreviewBodyProps = ComponentProps<"iframe"> & {
   loading?: ReactNode;
 };
@@ -175,17 +219,19 @@ export type WebPreviewBodyProps = ComponentProps<"iframe"> & {
 export const WebPreviewBody = ({
   className,
   loading,
+  sandbox: _sandbox,
   src,
   ...props
 }: WebPreviewBodyProps) => {
   const { url } = useWebPreview();
+  const previewSrc = typeof src === "string" ? toWebPreviewUrl(src) : url;
 
   return (
     <div className="flex-1">
       <iframe
         className={cn("size-full", className)}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
-        src={(src ?? url) || undefined}
+        sandbox="allow-scripts allow-forms allow-popups allow-presentation"
+        src={previewSrc || undefined}
         title="Preview"
         {...props}
       />
@@ -204,7 +250,7 @@ export type WebPreviewConsoleProps = ComponentProps<"div"> & {
 
 export const WebPreviewConsole = ({
   className,
-  logs = [],
+  logs = EMPTY_LOGS,
   children,
   ...props
 }: WebPreviewConsoleProps) => {
@@ -244,7 +290,7 @@ export const WebPreviewConsole = ({
           {logs.length === 0 ? (
             <p className="text-muted-foreground">No console output</p>
           ) : (
-            logs.map((log, index) => (
+            logs.map((log) => (
               <div
                 className={cn(
                   "text-xs",
@@ -252,7 +298,7 @@ export const WebPreviewConsole = ({
                   log.level === "warn" && "text-yellow-600",
                   log.level === "log" && "text-foreground"
                 )}
-                key={`${log.timestamp.getTime()}-${index}`}
+                key={`${log.timestamp.getTime()}-${log.level}-${log.message}`}
               >
                 <span className="text-muted-foreground">
                   {log.timestamp.toLocaleTimeString()}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate and sanitize URLs before they reach iframes and GitHub link builders to prevent unsafe inputs from hitting DOM sinks. This hardens the web preview and GitHub URL parsing against malformed paths, non-http(s) protocols, and over-privileged iframe sandboxes.

- **Bug Fixes**
  - Web preview: added `toWebPreviewUrl` to normalize/validate URLs (http/https only, auto-add https); applied to `defaultUrl`, `onUrlChange`, `<iframe src>`, and the `src` prop.
  - Iframe security: removed `allow-same-origin` from the sandbox to reduce data access in previews.
  - GitHub parsing: enforced owner/repo regex validation and used `encodeURIComponent` when building `fullUrl`.

<sup>Written for commit 67bc53416442eca94f6344bb01e4c56994fac0d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

