### PR TITLE
fix: organize route

### DIFF
--- a/apps/dashboard/src/app/agent/auth/authorize/consent/route.ts
+++ b/apps/dashboard/src/app/agent/auth/authorize/consent/route.ts
@@ -1,10 +1,13 @@
-import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth/server";
 import {
   oauthConsentFormSchema,
   oauthConsentResponseSchema,
 } from "@/schemas/oauth";
+import { buildOAuthForwardedHeaders } from "@/utils/oauth-proxy";
+
+const INTERNAL_AUTH_ORIGIN = "http://notra.internal";
+const OAUTH_CONSENT_PATH = "/api/auth/oauth2/consent";
 
 async function parseConsentForm(request: Request) {
   return request
@@ -25,17 +28,30 @@ export async function POST(request: Request) {
     );
   }
 
-  const result = await auth.api
-    .oauth2Consent({
-      body: {
+  const response = await auth.handler(
+    new Request(new URL(OAUTH_CONSENT_PATH, INTERNAL_AUTH_ORIGIN), {
+      body: JSON.stringify({
         accept: parsed.data.decision === "approve",
         oauth_query: parsed.data.oauth_query,
-      },
-      headers: await headers(),
+      }),
+      headers: buildOAuthForwardedHeaders(request.headers, {
+        accept: "application/json",
+        "content-type": "application/json",
+      }),
+      method: "POST",
     })
-    .catch(() => {
-      return null;
-    });
+  );
+  const result = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    return NextResponse.json(
+      result ?? {
+        error: "server_error",
+        error_description: "OAuth consent failed",
+      },
+      { status: response.status }
+    );
+  }
 
   const body = oauthConsentResponseSchema.safeParse(result);
   if (!body.success) {

--- a/apps/dashboard/src/lib/orpc/routers/api-keys.ts
+++ b/apps/dashboard/src/lib/orpc/routers/api-keys.ts
@@ -1,5 +1,8 @@
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
+import type {
+  KeyResponseData,
+  V2ApisListKeysResponseBody,
+} from "@unkey/api/models/components";
+import { z } from "zod";
 import { API_KEY_EXPIRATION_MS } from "@/constants/api-keys";
 import {
   getPermissionLevel,
@@ -77,18 +80,45 @@ function requireUnkeyConfig() {
   };
 }
 
+type ListKeysResult =
+  | V2ApisListKeysResponseBody
+  | AsyncIterable<{ result: V2ApisListKeysResponseBody }>;
+
+function isListKeysResponseBody(
+  result: ListKeysResult
+): result is V2ApisListKeysResponseBody {
+  return "data" in result && Array.isArray(result.data);
+}
+
+async function listOrganizationKeys(
+  client: NonNullable<typeof unkey>,
+  apiId: string,
+  organizationId: string
+) {
+  const result = (await client.apis.listKeys({
+    apiId,
+    externalId: organizationId,
+  })) as ListKeysResult;
+
+  if (isListKeysResponseBody(result)) {
+    return result.data;
+  }
+
+  const keys: KeyResponseData[] = [];
+  for await (const page of result) {
+    keys.push(...page.result.data);
+  }
+
+  return keys;
+}
+
 async function findOrganizationKey(
   client: NonNullable<typeof unkey>,
   apiId: string,
   organizationId: string,
   keyId: string
 ) {
-  const keysResult = await client.apis.listKeys({
-    apiId,
-    externalId: organizationId,
-  });
-
-  const keys = keysResult?.data ?? [];
+  const keys = await listOrganizationKeys(client, apiId, organizationId);
   return keys.find((key) => key.keyId === keyId) ?? null;
 }
 
@@ -103,12 +133,11 @@ export const apiKeysRouter = {
       });
 
       const { apiId, client } = requireUnkeyConfig();
-      const result = await client.apis.listKeys({
+      const keysData = await listOrganizationKeys(
+        client,
         apiId,
-        externalId: input.organizationId,
-      });
-
-      const keysData = result.data ?? [];
+        input.organizationId
+      );
 
       return keysData.map((key) => {
         const meta = key.meta ?? {};

--- a/apps/dashboard/src/utils/oauth-proxy.ts
+++ b/apps/dashboard/src/utils/oauth-proxy.ts
@@ -13,15 +13,26 @@ const FORWARDED_HEADER_NAMES = [
   "authorization",
   "content-type",
   "cookie",
+  "origin",
+  "referer",
   "user-agent",
 ] as const;
 
-function buildForwardedHeaders(request: Request) {
+export function buildOAuthForwardedHeaders(
+  source: Headers,
+  overrides?: HeadersInit
+) {
   const headers = new Headers();
 
   for (const name of FORWARDED_HEADER_NAMES) {
-    const value = request.headers.get(name);
+    const value = source.get(name);
     if (value) {
+      headers.set(name, value);
+    }
+  }
+
+  if (overrides) {
+    for (const [name, value] of new Headers(overrides)) {
       headers.set(name, value);
     }
   }
@@ -48,7 +59,7 @@ export async function proxyOAuthRequest(request: Request, pathname: string) {
   const response = await auth.handler(
     new Request(targetUrl, {
       body,
-      headers: buildForwardedHeaders(request),
+      headers: buildOAuthForwardedHeaders(request.headers),
       method: request.method,
       redirect: "manual",
     })

--- a/packages/ai/src/evlog.ts
+++ b/packages/ai/src/evlog.ts
@@ -1,6 +1,6 @@
 import { createAxiomDrain } from "evlog/axiom";
 import { createEvlog } from "evlog/next";
-import { createInstrumentation } from "evlog/next/instrumentation";
+import { createInstrumentation } from "evlog/next/instrumentation/create";
 
 const service = process.env.NODE_ENV === "development" ? "notra-dev" : "notra";
 


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route OAuth consent through the internal auth handler with stable header forwarding, and align API key listing with the latest Unkey SDK to prevent failures. Improves reliability of the consent flow and API key queries.

- **Bug Fixes**
  - Proxy POST to `/api/auth/oauth2/consent` via `auth.handler` using internal origin/path; forward `cookie`, `origin`, `referer`; send decision and `oauth_query` as JSON; return consistent JSON errors with proper status.
  - Update API key listing to handle `client.apis.listKeys` returning either a body or an async iterable; add a shared `listOrganizationKeys` helper and use it in `list` and `findOrganizationKey` for correct pagination compatibility with `@unkey/api` types (`KeyResponseData`, `V2ApisListKeysResponseBody`).

- **Refactors**
  - Extract `buildOAuthForwardedHeaders` with optional overrides and use it across the OAuth proxy.
  - Adjust `evlog` import to `evlog/next/instrumentation/create`.

<sup>Written for commit 34f622286f1b65910a31b859f00714f99bb8ef64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

