### PR TITLE
fix(ai): use axiom token config

### DIFF
--- a/packages/ai/src/evlog.ts
+++ b/packages/ai/src/evlog.ts
@@ -7,7 +7,7 @@ const service = process.env.NODE_ENV === "development" ? "notra-dev" : "notra";
 const drain =
   process.env.AXIOM_TOKEN && process.env.AXIOM_AI_DATASET
     ? createAxiomDrain({
-        apiKey: process.env.AXIOM_TOKEN,
+        token: process.env.AXIOM_TOKEN,
         dataset: process.env.AXIOM_AI_DATASET,
         orgId: process.env.AXIOM_ORG_ID,
       })


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Axiom drain `token` config instead of `apiKey` in `packages/ai/src/evlog.ts`. Fixes authentication so events are sent to `AXIOM_AI_DATASET` when `AXIOM_TOKEN` and `AXIOM_ORG_ID` are set.

<sup>Written for commit 2af83b75e16d3ac39db21a36a835444cba4b4f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

