### PR TITLE
fix(auth): preserve oauth consent redirect after login

### DIFF
--- a/apps/dashboard/src/app/(auth)/login/page.tsx
+++ b/apps/dashboard/src/app/(auth)/login/page.tsx
@@ -1,5 +1,5 @@
 import { LoginForm } from "@/components/auth/login-form";
-import { buildOAuthAuthorizePath, hasSignedOAuthQuery } from "@/utils/oauth";
+import { buildOAuthConsentPath, hasSignedOAuthQuery } from "@/utils/oauth";
 
 export default async function Login({
   searchParams,
@@ -10,7 +10,7 @@ export default async function Login({
   let returnTo: string | undefined;
 
   if (hasSignedOAuthQuery(resolvedSearchParams)) {
-    returnTo = buildOAuthAuthorizePath(resolvedSearchParams);
+    returnTo = buildOAuthConsentPath(resolvedSearchParams);
   } else if (typeof resolvedSearchParams.returnTo === "string") {
     returnTo = resolvedSearchParams.returnTo;
   }

--- a/apps/dashboard/src/app/agent/auth/authorize/page.tsx
+++ b/apps/dashboard/src/app/agent/auth/authorize/page.tsx
@@ -6,7 +6,8 @@ import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
 import { auth } from "@/lib/auth/server";
 import { oauthSignedAuthorizeQuerySchema } from "@/schemas/oauth";
 import {
-  buildOAuthAuthorizePath,
+  buildOAuthConsentPath,
+  buildOAuthInternalAuthorizePath,
   buildOAuthQueryString,
   hasSignedOAuthQuery,
 } from "@/utils/oauth";
@@ -31,13 +32,13 @@ export default async function OAuthAuthorizePage({
   const resolvedSearchParams = await searchParams;
 
   if (!hasSignedOAuthQuery(resolvedSearchParams)) {
-    redirect(buildOAuthAuthorizePath(resolvedSearchParams));
+    redirect(buildOAuthInternalAuthorizePath(resolvedSearchParams));
   }
 
   const session = await getSession();
   if (!session?.user) {
     redirect(
-      `/login?returnTo=${encodeURIComponent(buildOAuthAuthorizePath(resolvedSearchParams))}`
+      `/login?returnTo=${encodeURIComponent(buildOAuthConsentPath(resolvedSearchParams))}`
     );
   }
 
@@ -48,7 +49,7 @@ export default async function OAuthAuthorizePage({
   );
 
   if (!parsedQuery.success) {
-    redirect(buildOAuthAuthorizePath(resolvedSearchParams));
+    redirect(buildOAuthInternalAuthorizePath(resolvedSearchParams));
   }
 
   const client = await auth.api

--- a/apps/dashboard/src/utils/oauth.ts
+++ b/apps/dashboard/src/utils/oauth.ts
@@ -29,9 +29,17 @@ export function hasSignedOAuthQuery(searchParams: OAuthSearchParams) {
   );
 }
 
-export function buildOAuthAuthorizePath(searchParams: OAuthSearchParams) {
+function buildOAuthPath(pathname: string, searchParams: OAuthSearchParams) {
   const query = buildOAuthQueryString(searchParams);
-  return query
-    ? `/api/auth/oauth2/authorize?${query}`
-    : "/api/auth/oauth2/authorize";
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+export function buildOAuthConsentPath(searchParams: OAuthSearchParams) {
+  return buildOAuthPath("/agent/auth/authorize", searchParams);
+}
+
+export function buildOAuthInternalAuthorizePath(
+  searchParams: OAuthSearchParams
+) {
+  return buildOAuthPath("/api/auth/oauth2/authorize", searchParams);
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the OAuth consent redirect after login so users return to the consent screen with their original signed params. Splits the user-facing consent route from the internal authorize endpoint to avoid losing state.

- **Bug Fixes**
  - Added `buildOAuthConsentPath` and `buildOAuthInternalAuthorizePath` via a shared `buildOAuthPath`.
  - Login now sets `returnTo` to the consent route when `hasSignedOAuthQuery` is present.
  - Authorize page redirects unsigned/invalid queries to the internal authorize route, and unauthenticated users to login with `returnTo` set to the consent route.

<sup>Written for commit 80de258d13e338bd2e521f6a66fb555e8cc24300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

