### PR TITLE
fix(auth): render oauth authorize errors

### DIFF
--- a/apps/dashboard/src/app/agent/auth/authorize/page.tsx
+++ b/apps/dashboard/src/app/agent/auth/authorize/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { notFound, redirect } from "next/navigation";
-import { Button } from "@/components/button";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Button, buttonVariants } from "@/components/button";
 import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
 import { auth } from "@/lib/auth/server";
 import { oauthSignedAuthorizeQuerySchema } from "@/schemas/oauth";
@@ -22,6 +23,43 @@ function getDisplayValue(value: string | string[] | undefined) {
   }
 
   return value.length > 80 ? `${value.slice(0, 77)}...` : value;
+}
+
+function OAuthAuthorizeError({
+  clientId,
+  description,
+  title,
+}: {
+  clientId?: string;
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-4 py-12">
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <h1 className="font-semibold text-2xl tracking-tight">{title}</h1>
+          <p className="text-muted-foreground text-sm">{description}</p>
+        </div>
+
+        {clientId ? (
+          <p className="rounded-md border border-border bg-muted/40 px-3 py-2 font-mono text-muted-foreground text-xs">
+            client_id: {clientId}
+          </p>
+        ) : null}
+
+        <Link
+          className={buttonVariants({
+            className: "w-full",
+            variant: "outline",
+          })}
+          href="/dashboard"
+        >
+          Back to Notra
+        </Link>
+      </div>
+    </div>
+  );
 }
 
 export default async function OAuthAuthorizePage({
@@ -49,7 +87,12 @@ export default async function OAuthAuthorizePage({
   );
 
   if (!parsedQuery.success) {
-    redirect(buildOAuthInternalAuthorizePath(resolvedSearchParams));
+    return (
+      <OAuthAuthorizeError
+        description="The authorization request is missing required OAuth parameters or includes unsupported scopes."
+        title="Invalid authorization request"
+      />
+    );
   }
 
   const client = await auth.api
@@ -60,10 +103,36 @@ export default async function OAuthAuthorizePage({
       },
       headers: await headers(),
     })
-    .catch(() => null);
+    .catch(() => undefined);
 
-  if (!client || client.disabled) {
-    notFound();
+  if (typeof client === "undefined") {
+    return (
+      <OAuthAuthorizeError
+        clientId={getDisplayValue(parsedQuery.data.client_id)}
+        description="Notra could not verify this authorization request. The link may be expired or the signed OAuth request may be invalid."
+        title="Authorization request expired"
+      />
+    );
+  }
+
+  if (!client) {
+    return (
+      <OAuthAuthorizeError
+        clientId={getDisplayValue(parsedQuery.data.client_id)}
+        description="Notra could not find an OAuth client for this request. Register the client again, then restart the authorization flow."
+        title="OAuth client not found"
+      />
+    );
+  }
+
+  if (client.disabled) {
+    return (
+      <OAuthAuthorizeError
+        clientId={getDisplayValue(client.client_id)}
+        description="This OAuth client is disabled and cannot request access to your Notra account."
+        title="OAuth client disabled"
+      />
+    );
   }
 
   const clientName =


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show user-friendly error pages on the OAuth authorize route so users know why authorization failed and what to do next. Replaces silent redirects and 404s with clear messages and a “Back to Notra” button.

- **Bug Fixes**
  - Render errors for: invalid/missing OAuth params, expired/invalid signed request, client not found, and client disabled.
  - Added `OAuthAuthorizeError` component to display titles, descriptions, and optional `client_id`.
  - Replaced `redirect()`/`notFound()` with inline error UI and a `Link` using `buttonVariants` to `/dashboard`.

<sup>Written for commit ba9d45d53638f73a6e1d4ae44295f3f8d72b385d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

