### PR TITLE
fix(auth): preserve signed oauth authorize query

### DIFF
--- a/apps/dashboard/src/app/agent/auth/authorize/oauth-query-input.tsx
+++ b/apps/dashboard/src/app/agent/auth/authorize/oauth-query-input.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const noop = () => undefined;
+
+function subscribeToLocationChanges() {
+  return noop;
+}
+
+function getOAuthQuerySnapshot() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  return window.location.search.startsWith("?")
+    ? window.location.search.slice(1)
+    : window.location.search;
+}
+
+function getServerOAuthQuerySnapshot() {
+  return "";
+}
+
+export function OAuthQueryInput() {
+  const oauthQuery = useSyncExternalStore(
+    subscribeToLocationChanges,
+    getOAuthQuerySnapshot,
+    getServerOAuthQuerySnapshot
+  );
+
+  return <input name="oauth_query" readOnly type="hidden" value={oauthQuery} />;
+}

--- a/apps/dashboard/src/app/agent/auth/authorize/page.tsx
+++ b/apps/dashboard/src/app/agent/auth/authorize/page.tsx
@@ -12,6 +12,7 @@ import {
   buildOAuthQueryString,
   hasSignedOAuthQuery,
 } from "@/utils/oauth";
+import { OAuthQueryInput } from "./oauth-query-input";
 
 export const metadata: Metadata = {
   title: "Authorize OAuth Client",
@@ -23,6 +24,10 @@ function getDisplayValue(value: string | string[] | undefined) {
   }
 
   return value.length > 80 ? `${value.slice(0, 77)}...` : value;
+}
+
+function isExpiredOAuthQuery(exp: number) {
+  return exp * 1000 < Date.now();
 }
 
 function OAuthAuthorizeError({
@@ -95,25 +100,24 @@ export default async function OAuthAuthorizePage({
     );
   }
 
-  const client = await auth.api
-    .getOAuthClientPublicPrelogin({
-      body: {
-        client_id: parsedQuery.data.client_id,
-        oauth_query: oauthQuery,
-      },
-      headers: await headers(),
-    })
-    .catch(() => undefined);
-
-  if (typeof client === "undefined") {
+  if (isExpiredOAuthQuery(parsedQuery.data.exp)) {
     return (
       <OAuthAuthorizeError
         clientId={getDisplayValue(parsedQuery.data.client_id)}
-        description="Notra could not verify this authorization request. The link may be expired or the signed OAuth request may be invalid."
+        description="This authorization link has expired. Restart the OAuth flow from the client to generate a fresh authorization request."
         title="Authorization request expired"
       />
     );
   }
+
+  const client = await auth.api
+    .getOAuthClientPublicPrelogin({
+      body: {
+        client_id: parsedQuery.data.client_id,
+      },
+      headers: await headers(),
+    })
+    .catch(() => null);
 
   if (!client) {
     return (
@@ -158,7 +162,7 @@ export default async function OAuthAuthorizePage({
           </p>
         </div>
 
-        <input name="oauth_query" type="hidden" value={oauthQuery} />
+        <OAuthQueryInput />
 
         {scope ? (
           <p className="text-muted-foreground text-xs">Scopes: {scope}</p>


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth authorize flow by preserving the signed query string and adding a clear expired-link error. This prevents verification failures from query reformatting and improves the error UX.

- **Bug Fixes**
  - Preserve the exact signed `oauth_query` via a client component (`OAuthQueryInput`) that reads `window.location.search`.
  - Validate expiration locally and show “Authorization request expired” with guidance to restart the flow.
  - Stop sending `oauth_query` to the prelogin API; only `client_id` is used for client lookup.

<sup>Written for commit 0550ea4796f899ebb801acb257bee2278f49daba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

