### PR TITLE
fix(auth): enable oauth prelogin metadata

### DIFF
--- a/apps/dashboard/src/app/.well-known/oauth-authorization-server/api/auth/route.ts
+++ b/apps/dashboard/src/app/.well-known/oauth-authorization-server/api/auth/route.ts
@@ -1,8 +1,4 @@
-import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
 import { auth } from "@/lib/auth/server";
+import { publicOAuthAuthorizationServerMetadata } from "@/utils/oauth-metadata";
 
-export const GET = oauthProviderAuthServerMetadata(auth, {
-  headers: {
-    "Cache-Control": "public, max-age=3600",
-  },
-});
+export const GET = publicOAuthAuthorizationServerMetadata(auth);

--- a/apps/dashboard/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/dashboard/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,8 +1,4 @@
-import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
 import { auth } from "@/lib/auth/server";
+import { publicOAuthAuthorizationServerMetadata } from "@/utils/oauth-metadata";
 
-export const GET = oauthProviderAuthServerMetadata(auth, {
-  headers: {
-    "Cache-Control": "public, max-age=3600",
-  },
-});
+export const GET = publicOAuthAuthorizationServerMetadata(auth);

--- a/apps/dashboard/src/app/agent/auth/authorize/page.tsx
+++ b/apps/dashboard/src/app/agent/auth/authorize/page.tsx
@@ -30,6 +30,35 @@ function isExpiredOAuthQuery(exp: number) {
   return exp * 1000 < Date.now();
 }
 
+function getOAuthClientLookupError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return "unknown";
+  }
+
+  const status =
+    "status" in error && typeof error.status === "number"
+      ? error.status
+      : undefined;
+  const body =
+    "body" in error && error.body && typeof error.body === "object"
+      ? error.body
+      : undefined;
+  const errorCode =
+    body && "error" in body && typeof body.error === "string"
+      ? body.error
+      : undefined;
+
+  if (status === 404 || error.message === "client not found") {
+    return "not-found";
+  }
+
+  if (status === 400 || status === 401 || errorCode === "invalid_signature") {
+    return "invalid-request";
+  }
+
+  return "unknown";
+}
+
 function OAuthAuthorizeError({
   clientId,
   description,
@@ -110,16 +139,31 @@ export default async function OAuthAuthorizePage({
     );
   }
 
-  const client = await auth.api
+  const clientResult = await auth.api
     .getOAuthClientPublicPrelogin({
       body: {
         client_id: parsedQuery.data.client_id,
+        oauth_query: oauthQuery,
       },
       headers: await headers(),
     })
-    .catch(() => null);
+    .then((client) => ({ client, error: null }))
+    .catch((error) => ({
+      client: null,
+      error: getOAuthClientLookupError(error),
+    }));
 
-  if (!client) {
+  if (!clientResult.client) {
+    if (clientResult.error === "invalid-request") {
+      return (
+        <OAuthAuthorizeError
+          clientId={getDisplayValue(parsedQuery.data.client_id)}
+          description="Notra could not verify this authorization request. Restart the OAuth flow from the client to generate a fresh signed request."
+          title="Invalid authorization request"
+        />
+      );
+    }
+
     return (
       <OAuthAuthorizeError
         clientId={getDisplayValue(parsedQuery.data.client_id)}
@@ -128,6 +172,8 @@ export default async function OAuthAuthorizePage({
       />
     );
   }
+
+  const client = clientResult.client;
 
   if (client.disabled) {
     return (

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -29,3 +29,11 @@ export const OAUTH_SUPPORTED_RESOURCE_SET: ReadonlySet<string> = new Set(
 
 export const OAUTH_AUTHORIZATION_CODE_GRANT = "authorization_code";
 export const OAUTH_REFRESH_TOKEN_GRANT = "refresh_token";
+
+export const OAUTH_METADATA_CACHE_CONTROL = "public, max-age=3600";
+export const OAUTH_METADATA_ERROR_CACHE_CONTROL = "no-store";
+
+export const OAUTH_PUBLIC_AUTHORIZATION_ENDPOINT = "/agent/auth/authorize";
+export const OAUTH_PUBLIC_TOKEN_ENDPOINT = "/agent/auth/token";
+export const OAUTH_PUBLIC_REGISTRATION_ENDPOINT = "/agent/auth/register";
+export const OAUTH_PUBLIC_REVOCATION_ENDPOINT = "/agent/auth/revoke";

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -305,6 +305,7 @@ export const auth = betterAuth({
       accessTokenExpiresIn: OAUTH_ACCESS_TOKEN_TTL_SECONDS,
       codeExpiresIn: OAUTH_AUTH_CODE_TTL_MS / 1000,
       refreshTokenExpiresIn: OAUTH_REFRESH_TOKEN_TTL_MS / 1000,
+      allowPublicClientPrelogin: true,
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
       clientRegistrationDefaultScopes: [...OAUTH_DEFAULT_SCOPES],

--- a/apps/dashboard/src/utils/oauth-metadata.ts
+++ b/apps/dashboard/src/utils/oauth-metadata.ts
@@ -1,0 +1,47 @@
+import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
+import type { auth } from "@/lib/auth/server";
+
+const METADATA_CACHE_CONTROL = "public, max-age=3600";
+
+function buildPublicOAuthEndpoint(request: Request, pathname: string) {
+  return new URL(pathname, request.url).toString();
+}
+
+export function publicOAuthAuthorizationServerMetadata(
+  authInstance: typeof auth
+) {
+  const getMetadata = oauthProviderAuthServerMetadata(authInstance, {
+    headers: {
+      "Cache-Control": METADATA_CACHE_CONTROL,
+    },
+  });
+
+  return async (request: Request) => {
+    const response = await getMetadata(request);
+    const metadata = await response.json();
+
+    return Response.json(
+      {
+        ...metadata,
+        authorization_endpoint: buildPublicOAuthEndpoint(
+          request,
+          "/agent/auth/authorize"
+        ),
+        token_endpoint: buildPublicOAuthEndpoint(request, "/agent/auth/token"),
+        registration_endpoint: buildPublicOAuthEndpoint(
+          request,
+          "/agent/auth/register"
+        ),
+        revocation_endpoint: buildPublicOAuthEndpoint(
+          request,
+          "/agent/auth/revoke"
+        ),
+      },
+      {
+        headers: {
+          "Cache-Control": METADATA_CACHE_CONTROL,
+        },
+      }
+    );
+  };
+}

--- a/apps/dashboard/src/utils/oauth-metadata.ts
+++ b/apps/dashboard/src/utils/oauth-metadata.ts
@@ -1,7 +1,13 @@
 import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
+import {
+  OAUTH_METADATA_CACHE_CONTROL,
+  OAUTH_METADATA_ERROR_CACHE_CONTROL,
+  OAUTH_PUBLIC_AUTHORIZATION_ENDPOINT,
+  OAUTH_PUBLIC_REGISTRATION_ENDPOINT,
+  OAUTH_PUBLIC_REVOCATION_ENDPOINT,
+  OAUTH_PUBLIC_TOKEN_ENDPOINT,
+} from "@/constants/oauth";
 import type { auth } from "@/lib/auth/server";
-
-const METADATA_CACHE_CONTROL = "public, max-age=3600";
 
 function buildPublicOAuthEndpoint(request: Request, pathname: string) {
   return new URL(pathname, request.url).toString();
@@ -12,7 +18,7 @@ export function publicOAuthAuthorizationServerMetadata(
 ) {
   const getMetadata = oauthProviderAuthServerMetadata(authInstance, {
     headers: {
-      "Cache-Control": METADATA_CACHE_CONTROL,
+      "Cache-Control": OAUTH_METADATA_CACHE_CONTROL,
     },
   });
 
@@ -20,27 +26,40 @@ export function publicOAuthAuthorizationServerMetadata(
     const response = await getMetadata(request);
     const metadata = await response.json();
 
+    if (!response.ok) {
+      return Response.json(metadata, {
+        headers: {
+          "Cache-Control": OAUTH_METADATA_ERROR_CACHE_CONTROL,
+        },
+        status: response.status,
+      });
+    }
+
     return Response.json(
       {
         ...metadata,
         authorization_endpoint: buildPublicOAuthEndpoint(
           request,
-          "/agent/auth/authorize"
+          OAUTH_PUBLIC_AUTHORIZATION_ENDPOINT
         ),
-        token_endpoint: buildPublicOAuthEndpoint(request, "/agent/auth/token"),
+        token_endpoint: buildPublicOAuthEndpoint(
+          request,
+          OAUTH_PUBLIC_TOKEN_ENDPOINT
+        ),
         registration_endpoint: buildPublicOAuthEndpoint(
           request,
-          "/agent/auth/register"
+          OAUTH_PUBLIC_REGISTRATION_ENDPOINT
         ),
         revocation_endpoint: buildPublicOAuthEndpoint(
           request,
-          "/agent/auth/revoke"
+          OAUTH_PUBLIC_REVOCATION_ENDPOINT
         ),
       },
       {
         headers: {
-          "Cache-Control": METADATA_CACHE_CONTROL,
+          "Cache-Control": OAUTH_METADATA_CACHE_CONTROL,
         },
+        status: response.status,
       }
     );
   };


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable OAuth prelogin and publish discovery metadata that points to public agent endpoints with correct status and caching. Improve the authorize flow with signed-request validation and clearer errors.

- **Bug Fixes**
  - Turned on `allowPublicClientPrelogin: true` in `auth` config.
  - Serve `.well-known` metadata via `publicOAuthAuthorizationServerMetadata` with `/agent/auth/*` endpoints, preserve upstream status, and set `Cache-Control` (cache on success, `no-store` on errors).
  - Authorize page sends `oauth_query` to `getOAuthClientPublicPrelogin` and shows friendly messages for invalid requests and not-found clients.

<sup>Written for commit 4e6762ddd0046c2d273cda15bd66d446ed2b0261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

