### PR TITLE
fix(auth): accept oauth consent redirect response

### DIFF
--- a/apps/dashboard/src/schemas/oauth.ts
+++ b/apps/dashboard/src/schemas/oauth.ts
@@ -52,6 +52,16 @@ export const oauthConsentFormSchema = z.object({
   decision: z.enum(["approve", "deny"]),
 });
 
-export const oauthConsentResponseSchema = z.object({
-  redirect_uri: z.string().url(),
-});
+export const oauthConsentResponseSchema = z
+  .union([
+    z.object({
+      redirect_uri: z.string().url(),
+    }),
+    z.object({
+      redirect: z.literal(true),
+      url: z.string().url(),
+    }),
+  ])
+  .transform((value) => ({
+    redirect_uri: "redirect_uri" in value ? value.redirect_uri : value.url,
+  }));


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth consent redirect handling by updating `oauthConsentResponseSchema` to accept both `{ redirect_uri }` and `{ redirect: true, url }` responses, normalizing to `redirect_uri`. Prevents broken redirects after consent across providers.

- **Bug Fixes**
  - Updated `oauthConsentResponseSchema` to a union with a transform, so both shapes are accepted and consumers always receive `redirect_uri`.

<sup>Written for commit 6622fe4c03e455e8e395447afa9d65c05802120b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

