### PR TITLE
fix(auth): allow mcp endpoint resource

### DIFF
--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -21,6 +21,7 @@ export const OAUTH_DEFAULT_SCOPES = ["api.read"] as const;
 export const OAUTH_SUPPORTED_RESOURCES = [
   "https://api.usenotra.com",
   "https://mcp.usenotra.com",
+  "https://mcp.usenotra.com/mcp",
 ] as const;
 
 export const OAUTH_SUPPORTED_RESOURCE_SET: ReadonlySet<string> = new Set(

--- a/apps/dashboard/src/schemas/oauth.ts
+++ b/apps/dashboard/src/schemas/oauth.ts
@@ -52,6 +52,16 @@ export const oauthConsentFormSchema = z.object({
   decision: z.enum(["approve", "deny"]),
 });
 
-export const oauthConsentResponseSchema = z.object({
-  redirect_uri: z.string().url(),
-});
+export const oauthConsentResponseSchema = z
+  .union([
+    z.object({
+      redirect_uri: z.string().url(),
+    }),
+    z.object({
+      redirect: z.literal(true),
+      url: z.string().url(),
+    }),
+  ])
+  .transform((value) => ({
+    redirect_uri: "redirect_uri" in value ? value.redirect_uri : value.url,
+  }));


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth consent redirect handling and allow the MCP endpoint resource. This prevents failed redirects and invalid resource errors during login.

- **Bug Fixes**
  - Accept `{ redirect: true, url }` in `oauthConsentResponseSchema` and normalize to `redirect_uri`.
  - Add `https://mcp.usenotra.com/mcp` to `OAUTH_SUPPORTED_RESOURCES`.

<sup>Written for commit d01ec464eb75733ea831bf7c2f1c94763c1ab8dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

