### PR TITLE
fix(api): accept oauth bearer tokens

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
     "autumn-js": "^1.2.5",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.0",
+    "jose": "^6.2.3",
     "marked": "^16.3.0",
     "nanoid": "^5.1.11",
     "sanitize-html": "^2.17.0",

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,15 +1,22 @@
 import type { createDb } from "@notra/db/drizzle-http";
 import { Unkey } from "@unkey/api";
-import type { V2KeysVerifyKeyResponseData } from "@unkey/api/models/components";
 import type { Context, Next } from "hono";
 import {
+  createRemoteJWKSet,
+  type JWTPayload,
+  errors as joseErrors,
+  jwtVerify,
+} from "jose";
+import type { AuthData } from "../types/auth";
+import {
+  API_URL,
   AUTH_GUIDE_URL,
   RESOURCE_METADATA_URL,
 } from "../utils/agent-discovery";
 
 declare module "hono" {
   interface ContextVariableMap {
-    auth: V2KeysVerifyKeyResponseData;
+    auth: AuthData;
     db: ReturnType<typeof createDb>;
   }
 }
@@ -20,6 +27,18 @@ interface AuthOptions {
 }
 
 const BEARER_HEADER_REGEX = /^Bearer\s+(.+)$/i;
+const DEFAULT_OAUTH_ISSUER = "https://app.usenotra.com";
+const OAUTH_JWKS_PATH = "/api/auth/jwks";
+const OAUTH_AUDIENCES = [
+  API_URL,
+  "https://mcp.usenotra.com",
+  "https://mcp.usenotra.com/mcp",
+] as const;
+const SCOPE_SEPARATOR_REGEX = /\s+/;
+const remoteJwksByUrl = new Map<
+  string,
+  ReturnType<typeof createRemoteJWKSet>
+>();
 
 function extractBearerToken(c: Context): string | null {
   const header = c.req.header("Authorization");
@@ -32,8 +51,132 @@ function extractBearerToken(c: Context): string | null {
 }
 
 type AuthResult =
-  | { success: true; auth: V2KeysVerifyKeyResponseData }
+  | { success: true; auth: AuthData }
   | { success: false; error: string; status: 401 | 403 | 503 };
+
+function getOAuthIssuer(c: Context) {
+  return c.env.BETTER_AUTH_URL ?? DEFAULT_OAUTH_ISSUER;
+}
+
+function getOAuthJwksUrl(c: Context) {
+  return new URL(OAUTH_JWKS_PATH, getOAuthIssuer(c)).toString();
+}
+
+function getRemoteJwks(jwksUrl: string): ReturnType<typeof createRemoteJWKSet> {
+  const cached = remoteJwksByUrl.get(jwksUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const jwks = createRemoteJWKSet(new URL(jwksUrl), {
+    cacheMaxAge: 10 * 60 * 1000,
+    cooldownDuration: 30_000,
+  });
+  remoteJwksByUrl.set(jwksUrl, jwks);
+  return jwks;
+}
+
+function decodeJsonSegment(segment: string): unknown {
+  try {
+    const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "="
+    );
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function looksLikeJwt(token: string) {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  const [headerSegment, payloadSegment] = parts as [string, string, string];
+  const header = decodeJsonSegment(headerSegment);
+  const payload = decodeJsonSegment(payloadSegment);
+  return (
+    typeof header === "object" &&
+    header !== null &&
+    typeof payload === "object" &&
+    payload !== null
+  );
+}
+
+function extractScopes(payload: JWTPayload): string[] {
+  const rawScopes = payload.scope ?? payload.scp ?? payload.scopes;
+  if (typeof rawScopes === "string") {
+    return rawScopes.split(SCOPE_SEPARATOR_REGEX).filter(Boolean);
+  }
+  if (Array.isArray(rawScopes)) {
+    return rawScopes.filter(
+      (scope): scope is string => typeof scope === "string" && scope.length > 0
+    );
+  }
+  return [];
+}
+
+function hasRequiredScope(scopes: string[], requiredScope?: string) {
+  if (!requiredScope) {
+    return true;
+  }
+
+  return scopes.includes(requiredScope) || scopes.includes("*");
+}
+
+async function verifyOAuthToken(
+  c: Context,
+  token: string,
+  requiredScope?: string
+): Promise<AuthResult> {
+  try {
+    const { payload } = await jwtVerify(
+      token,
+      getRemoteJwks(getOAuthJwksUrl(c)),
+      {
+        audience: [...OAUTH_AUDIENCES],
+        issuer: getOAuthIssuer(c),
+      }
+    );
+    const scopes = extractScopes(payload);
+    const organizationId = payload.organizationId;
+
+    if (!payload.sub) {
+      return { success: false, error: "Missing OAuth subject", status: 401 };
+    }
+
+    if (!(typeof organizationId === "string" && organizationId.length > 0)) {
+      return {
+        success: false,
+        error: "Missing OAuth organization",
+        status: 401,
+      };
+    }
+
+    if (!hasRequiredScope(scopes, requiredScope)) {
+      return { success: false, error: "Forbidden", status: 403 };
+    }
+
+    return {
+      success: true,
+      auth: {
+        type: "oauth",
+        userId: payload.sub,
+        scopes,
+        identity: { externalId: organizationId },
+      },
+    };
+  } catch (error) {
+    if (error instanceof joseErrors.JOSEError) {
+      return { success: false, error: error.code, status: 401 };
+    }
+
+    return { success: false, error: "Invalid OAuth token", status: 401 };
+  }
+}
 
 function getRecovery(status: 401 | 403 | 503) {
   if (status === 401) {
@@ -56,6 +199,14 @@ async function verifyRequestAuth(
 
   if (!apiKey) {
     return { success: false, error: "Missing API key", status: 401 };
+  }
+
+  if (looksLikeJwt(apiKey)) {
+    const oauthResult = await verifyOAuthToken(c, apiKey, options.permissions);
+    if (oauthResult.success) {
+      c.set("auth", oauthResult.auth);
+    }
+    return oauthResult;
   }
 
   try {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -164,6 +164,7 @@ async function verifyOAuthToken(
       success: true,
       auth: {
         type: "oauth",
+        keyId: `oauth:${payload.sub}:${organizationId}`,
         userId: payload.sub,
         scopes,
         identity: { externalId: organizationId },
@@ -174,7 +175,11 @@ async function verifyOAuthToken(
       return { success: false, error: error.code, status: 401 };
     }
 
-    return { success: false, error: "Invalid OAuth token", status: 401 };
+    return {
+      success: false,
+      error: "OAuth verification unavailable",
+      status: 503,
+    };
   }
 }
 

--- a/apps/api/src/types/auth.ts
+++ b/apps/api/src/types/auth.ts
@@ -1,6 +1,17 @@
 import type { V2KeysVerifyKeyResponseData } from "@unkey/api/models/components";
 
-type AuthData = V2KeysVerifyKeyResponseData;
+type ApiKeyAuthData = V2KeysVerifyKeyResponseData;
+
+interface OAuthAuthData {
+  type: "oauth";
+  userId: string;
+  scopes: string[];
+  identity: {
+    externalId: string;
+  };
+}
+
+export type AuthData = ApiKeyAuthData | OAuthAuthData;
 
 export function getOrganizationIdFromAuth(auth: AuthData): string | null {
   return auth.identity?.externalId ?? null;

--- a/apps/api/src/types/auth.ts
+++ b/apps/api/src/types/auth.ts
@@ -4,6 +4,7 @@ type ApiKeyAuthData = V2KeysVerifyKeyResponseData;
 
 interface OAuthAuthData {
   type: "oauth";
+  keyId: string;
   userId: string;
   scopes: string[];
   identity: {

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -21,6 +21,7 @@ export const OAUTH_DEFAULT_SCOPES = ["api.read"] as const;
 export const OAUTH_SUPPORTED_RESOURCES = [
   "https://api.usenotra.com",
   "https://mcp.usenotra.com",
+  "https://mcp.usenotra.com/mcp",
 ] as const;
 
 export const OAUTH_SUPPORTED_RESOURCE_SET: ReadonlySet<string> = new Set(

--- a/apps/dashboard/src/schemas/oauth.ts
+++ b/apps/dashboard/src/schemas/oauth.ts
@@ -52,6 +52,16 @@ export const oauthConsentFormSchema = z.object({
   decision: z.enum(["approve", "deny"]),
 });
 
-export const oauthConsentResponseSchema = z.object({
-  redirect_uri: z.string().url(),
-});
+export const oauthConsentResponseSchema = z
+  .union([
+    z.object({
+      redirect_uri: z.string().url(),
+    }),
+    z.object({
+      redirect: z.literal(true),
+      url: z.string().url(),
+    }),
+  ])
+  .transform((value) => ({
+    redirect_uri: "redirect_uri" in value ? value.redirect_uri : value.url,
+  }));

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "autumn-js": "^1.2.5",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.0",
+        "jose": "^6.2.3",
         "marked": "^16.3.0",
         "nanoid": "^5.1.11",
         "sanitize-html": "^2.17.0",


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept OAuth Bearer tokens (JWT) in the API Authorization header alongside API keys. Also fix OAuth consent redirect handling and add the MCP endpoint as a supported OAuth resource.

- **New Features**
  - Accept OAuth Bearer JWTs and verify with `jose` via remote JWKS from `BETTER_AUTH_URL` (default https://app.usenotra.com); validate issuer and audiences (`API_URL` + MCP) with JWKS caching.
  - Enforce scopes and require `sub` and `organizationId`; set `auth` to `{ type: "oauth", keyId, userId, scopes, identity.externalId }`.

- **Bug Fixes**
  - Support both consent response shapes and normalize to `redirect_uri` (accept `{ redirect: true, url }`).
  - Add `https://mcp.usenotra.com/mcp` to supported OAuth resources; improve errors (401 for JOSE verification failures, 503 when JWKS is unavailable).

<sup>Written for commit a519b33128c61fc1aaa66cb6e8c3fb6231de8beb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

