### PR TITLE
fix(api): validate oauth issuer with auth base path

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -27,8 +27,10 @@ interface AuthOptions {
 }
 
 const BEARER_HEADER_REGEX = /^Bearer\s+(.+)$/i;
-const DEFAULT_OAUTH_ISSUER = "https://app.usenotra.com";
-const OAUTH_JWKS_PATH = "/api/auth/jwks";
+const DEFAULT_OAUTH_BASE_URL = "https://app.usenotra.com";
+const OAUTH_BASE_PATH = "/api/auth";
+const OAUTH_JWKS_PATH = `${OAUTH_BASE_PATH}/jwks`;
+const TRAILING_SLASH_REGEX = /\/$/;
 const OAUTH_AUDIENCES = [
   API_URL,
   "https://mcp.usenotra.com",
@@ -55,7 +57,13 @@ type AuthResult =
   | { success: false; error: string; status: 401 | 403 | 503 };
 
 function getOAuthIssuer(c: Context) {
-  return c.env.BETTER_AUTH_URL ?? DEFAULT_OAUTH_ISSUER;
+  const baseUrl = (c.env.BETTER_AUTH_URL ?? DEFAULT_OAUTH_BASE_URL).replace(
+    TRAILING_SLASH_REGEX,
+    ""
+  );
+  return baseUrl.endsWith(OAUTH_BASE_PATH)
+    ? baseUrl
+    : `${baseUrl}${OAUTH_BASE_PATH}`;
 }
 
 function getOAuthJwksUrl(c: Context) {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -30,7 +30,7 @@ const BEARER_HEADER_REGEX = /^Bearer\s+(.+)$/i;
 const DEFAULT_OAUTH_BASE_URL = "https://app.usenotra.com";
 const OAUTH_BASE_PATH = "/api/auth";
 const OAUTH_JWKS_PATH = `${OAUTH_BASE_PATH}/jwks`;
-const TRAILING_SLASH_REGEX = /\/$/;
+const TRAILING_SLASH_REGEX = /\/+$/;
 const OAUTH_AUDIENCES = [
   API_URL,
   "https://mcp.usenotra.com",


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the OAuth issuer by trimming trailing slashes and ensuring the `/api/auth` base path is appended to `BETTER_AUTH_URL` (or the default). Build the JWKS URL from this issuer to prevent 401s caused by missing auth path or trailing slashes.

<sup>Written for commit ab3610b10bbcb09d2c190b8825096a69d85fc0de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

