### PR TITLE
fix: back button in settings routing you wrong

### DIFF
--- a/apps/dashboard/src/components/dashboard/nav-settings.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-settings.tsx
@@ -87,7 +87,7 @@ export function NavSettings({ slug }: NavSettingsProps) {
               isActive={isActive(item.url)}
               key={item.label}
               render={
-                <Link href={`/${slug}/${item.url}`}>
+                <Link href={`/${slug}/${item.url}`} replace>
                   <HugeiconsIcon icon={item.icon} />
                   <span>{item.label}</span>
                 </Link>
@@ -106,7 +106,7 @@ export function NavSettings({ slug }: NavSettingsProps) {
               isActive={isActive(item.url)}
               key={item.label}
               render={
-                <Link href={`/${slug}/${item.url}`}>
+                <Link href={`/${slug}/${item.url}`} replace>
                   <HugeiconsIcon icon={item.icon} />
                   <span>{item.label}</span>
                 </Link>


### PR DESCRIPTION
### Description
- fixes settings navigation not sending you back to the main page but instead sending you down the stack you went through tabs 
- matches functionality to how the back button in the ai chat works 

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the back button in Settings so it returns to the previous page instead of stepping through visited tabs. Uses `replace` on `next/link` for settings tab links to avoid stacking history entries, matching the AI chat behavior.

<sup>Written for commit 62ae1d8483010d6fc865fabfca2cc0c1ecfa5f4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

