### PR TITLE
fix(web): make bydefault token optional

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -3,10 +3,13 @@ import { createDualmarkMiddleware } from "@dualmark/nextjs";
 import { after, type NextRequest, NextResponse } from "next/server";
 import { HOMEPAGE_LINK_HEADER, SITE_URL } from "@/utils/urls";
 
-const tracker = new Tracker({
-  token: process.env.BYDEFAULT_TOKEN as string,
-  exclude: ["/api"],
-});
+const bydefaultToken = process.env.BYDEFAULT_TOKEN;
+const tracker = bydefaultToken
+  ? new Tracker({
+      token: bydefaultToken,
+      exclude: ["/api"],
+    })
+  : null;
 
 const dualmarkProxy = createDualmarkMiddleware({
   siteUrl: SITE_URL,
@@ -50,18 +53,22 @@ export async function proxy(request: NextRequest) {
   ) {
     const response = NextResponse.rewrite(new URL("/agent", request.url));
 
-    after(async () => {
-      await tracker.track(request);
-    });
+    if (tracker) {
+      after(async () => {
+        await tracker.track(request);
+      });
+    }
 
     return response;
   }
 
   const response = await dualmarkProxy(request);
 
-  after(async () => {
-    await tracker.track(request);
-  });
+  if (tracker) {
+    after(async () => {
+      await tracker.track(request);
+    });
+  }
 
   if (
     request.nextUrl.pathname === "/" &&


### PR DESCRIPTION
### Description
- make bydefault optional (only use when env checked)

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `BYDEFAULT_TOKEN` optional in the web proxy. Tracking only runs when the env var is set, preventing errors in dev and preview.

- **Bug Fixes**
  - Create the tracker only when `process.env.BYDEFAULT_TOKEN` exists; otherwise skip.
  - Guard `after(() => tracker.track(request))` calls so they run only if a tracker is available.

<sup>Written for commit c8b14beb9d11370f48e847c6b644938f748e3e98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

