### PR TITLE
docs(mcp): clarify oauth discovery

### DIFF
--- a/apps/docs/devtools/mcp.mdx
+++ b/apps/docs/devtools/mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MCP Server"
-description: "Connect the Notra MCP server to AI tools using bearer token authentication, with tools for posts, brand identities, integrations, and schedules."
+description: "Connect the Notra MCP server to AI tools using OAuth or API-key bearer authentication, with tools for posts, brand identities, integrations, and schedules."
 ---
 
 Notra provides a hosted MCP server at `https://mcp.usenotra.com/mcp` so AI agents can work with your Notra workspace directly.
@@ -9,7 +9,18 @@ With the MCP server connected, an AI agent can manage your brand identity, creat
 
 ## Authentication
 
-The MCP server requires a bearer API key in the `Authorization` header:
+The MCP server accepts bearer credentials in the `Authorization` header.
+OAuth clients, including ChatGPT Apps, can start with the protected resource
+metadata endpoint:
+
+```text
+https://mcp.usenotra.com/.well-known/oauth-protected-resource
+```
+
+That metadata advertises the OAuth authorization server, supported scopes, and
+supported bearer-token method.
+
+Clients that do not support OAuth discovery can use a Notra API key:
 
 ```text
 Authorization: Bearer YOUR_API_KEY
@@ -29,8 +40,9 @@ Create and manage API keys in [Authentication](/api/authentication).
 />
 
 <Tip>
-  For the best experience, use an API key with both read and write permissions so
-  the MCP server can complete the full set of actions your client requests.
+  For manual API-key connections, use an API key with both read and write
+  permissions so the MCP server can complete the full set of actions your client
+  requests.
 </Tip>
 
 ## Install

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -33,6 +33,10 @@
     {
       "source": "/sdk/getting-started",
       "destination": "/api/getting-started"
+    },
+    {
+      "source": "/integrations/mcp",
+      "destination": "/devtools/mcp"
     }
   ],
   "api": {

--- a/apps/web/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/apps/web/src/app/.well-known/mcp/server-card.json/route.ts
@@ -1,4 +1,14 @@
-import { DOCS_URL, MCP_URL } from "@/utils/urls";
+import {
+  DOCS_URL,
+  MCP_PROTECTED_RESOURCE_METADATA_URL,
+  MCP_URL,
+} from "@/utils/urls";
+
+const AUTHENTICATION_DESCRIPTION = [
+  "OAuth 2.1 bearer access token.",
+  `Discover protected resource metadata at ${MCP_PROTECTED_RESOURCE_METADATA_URL}.`,
+  "Dashboard API keys are also supported for MCP clients that use manual bearer credentials.",
+].join(" ");
 
 export function GET() {
   const body = {
@@ -13,9 +23,9 @@ export function GET() {
     capabilities: ["tools"],
     authentication: {
       type: "bearer",
-      description: "Notra API key, created at https://app.usenotra.com",
+      description: AUTHENTICATION_DESCRIPTION,
     },
-    documentation: `${DOCS_URL}/integrations/mcp`,
+    documentation: `${DOCS_URL}/devtools/mcp`,
   };
 
   return new Response(JSON.stringify(body), {

--- a/apps/web/src/app/auth.md/route.ts
+++ b/apps/web/src/app/auth.md/route.ts
@@ -6,7 +6,7 @@ Notra exposes an authenticated API and MCP server for agents that generate, read
 
 ## Discover
 
-Start at \`/.well-known/agent.json\`, \`/.well-known/agent-card.json\`, and \`/.well-known/api-catalog\`. The API resource server is \`https://api.usenotra.com\`, and its protected resource metadata is published at \`https://api.usenotra.com/.well-known/oauth-protected-resource\`. Unauthenticated API requests return a \`WWW-Authenticate\` header with a \`resource_metadata\` URL.
+Start at \`/.well-known/agent.json\`, \`/.well-known/agent-card.json\`, and \`/.well-known/api-catalog\`. The API resource server is \`https://api.usenotra.com\`, and its protected resource metadata is published at \`https://api.usenotra.com/.well-known/oauth-protected-resource\`. The MCP resource server is \`https://mcp.usenotra.com\`, and its protected resource metadata is published at \`https://mcp.usenotra.com/.well-known/oauth-protected-resource\`. Unauthenticated API and MCP requests return a \`WWW-Authenticate\` header with a \`resource_metadata\` URL.
 
 ## Pick a method
 
@@ -22,7 +22,7 @@ Call \`POST /agent/auth/claim\` to check the claim endpoint shape. It returns ma
 
 ## Use the credential
 
-Send the credential as \`Authorization: Bearer <NOTRA_API_KEY>\`. For MCP, use the same bearer credential when connecting to \`https://mcp.usenotra.com/mcp\`.
+Send the credential as \`Authorization: Bearer <NOTRA_API_KEY>\`. For MCP clients that support OAuth discovery, start at \`https://mcp.usenotra.com/.well-known/oauth-protected-resource\`; for manual clients, use the same bearer credential when connecting to \`https://mcp.usenotra.com/mcp\`.
 
 ## Errors
 

--- a/apps/web/src/utils/urls.ts
+++ b/apps/web/src/utils/urls.ts
@@ -6,6 +6,9 @@ export const DOCS_URL = "https://docs.usenotra.com";
 
 export const MCP_URL = "https://mcp.usenotra.com/mcp";
 
+export const MCP_PROTECTED_RESOURCE_METADATA_URL =
+  "https://mcp.usenotra.com/.well-known/oauth-protected-resource";
+
 export const HOMEPAGE_LINK_HEADER = [
   '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
   `<${DOCS_URL}>; rel="service-doc"; type="text/html"`,


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies OAuth discovery for the Notra MCP server so OAuth-capable clients can auto-discover the authorization server, while still supporting API-key bearer tokens. Also updates the server card and docs links to point to the right endpoints.

- **Docs + Discovery**
  - Updated `devtools/mcp.mdx` to document `/.well-known/oauth-protected-resource` and clarify manual API-key usage.
  - Expanded `/auth.md` with MCP resource metadata and guidance for OAuth vs manual clients.

- **Refactors**
  - `server-card.json` now advertises OAuth 2.1 bearer tokens and links to discovery; docs link points to `/devtools/mcp`.
  - Added redirect from `/integrations/mcp` to `/devtools/mcp`.
  - Introduced `MCP_PROTECTED_RESOURCE_METADATA_URL` in `utils/urls`.

<sup>Written for commit d757930287b37aab9bac78568580c31521eac9b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

