### PR TITLE
fix(chat): stabilize model selector popover

### DIFF
--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -1804,6 +1804,7 @@ export function ChatInputAdvanced({
                 </DropdownMenu>
 
                 <Popover
+                  modal
                   onOpenChange={setIsModelPickerOpen}
                   open={isModelPickerOpen}
                 >
@@ -1828,6 +1829,7 @@ export function ChatInputAdvanced({
                   <PopoverContent
                     align="start"
                     className="w-72 p-0"
+                    showBackdrop
                     sideOffset={6}
                   >
                     <Command>

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -17,6 +17,7 @@ function PopoverContent({
   className,
   align = "center",
   alignOffset = 0,
+  showBackdrop = false,
   side = "bottom",
   sideOffset = 4,
   ...props
@@ -24,9 +25,17 @@ function PopoverContent({
   Pick<
     PopoverPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & {
+    showBackdrop?: boolean
+  }) {
   return (
     <PopoverPrimitive.Portal>
+      {showBackdrop ? (
+        <PopoverPrimitive.Backdrop
+          className="data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-40 bg-black/8 duration-100 data-closed:animate-out data-open:animate-in dark:bg-black/30"
+          data-slot="popover-backdrop"
+        />
+      ) : null}
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}


### PR DESCRIPTION
### Description
- fixes model selector toggle behavior
- adds backdrop (consistent with context & reasoning)
- style is the same :D 

### Screenshot/Recording (if applicable)
https://cap.link/22t3g694r2afhab

<details>
<summary>Checklist</summary>

- [X] I ran a self-review before opening this PR
- [X] I ran formatting/linting/type checks locally
- [X] I updated docs when behavior or setup changed
- [X] I only added comments where the logic is not obvious
- [X] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [X] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the chat model selector by making the popover modal and adding a backdrop to block background clicks. Prevents accidental closes and matches the behavior of context/reasoning pickers.

- **Bug Fixes**
  - Chat: set `modal` on the model selector `Popover`.
  - UI: add `showBackdrop` to `PopoverContent` and render a backdrop when enabled; enabled for the model selector.

<sup>Written for commit fd2d3b4fa1041b38b1dfc99437051ee4402073f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

