### PR TITLE
feat(auth): add granular API scopes

### DIFF
--- a/apps/api/src/constants/oauth-scopes.ts
+++ b/apps/api/src/constants/oauth-scopes.ts
@@ -1,17 +1,45 @@
-export const PUBLIC_API_SCOPES = [
-  "posts.read",
-  "posts.write",
-  "brand-identities.read",
-  "brand-identities.write",
-  "integrations.read",
-  "integrations.write",
-  "schedules.read",
-  "schedules.write",
-  "chats.read",
-  "chats.write",
-  "skills.read",
-  "skills.write",
+export const PUBLIC_API_SCOPE_RESOURCES = [
+  {
+    id: "posts",
+    paths: ["/posts"],
+    readScope: "posts.read",
+    writeScope: "posts.write",
+  },
+  {
+    id: "brand-identities",
+    paths: ["/brand-identities"],
+    readScope: "brand-identities.read",
+    writeScope: "brand-identities.write",
+  },
+  {
+    id: "integrations",
+    paths: ["/integrations"],
+    readScope: "integrations.read",
+    writeScope: "integrations.write",
+  },
+  {
+    id: "schedules",
+    paths: ["/schedules"],
+    readScope: "schedules.read",
+    writeScope: "schedules.write",
+  },
+  {
+    id: "chats",
+    paths: ["/chats"],
+    readScope: "chats.read",
+    writeScope: "chats.write",
+  },
+  {
+    id: "skills",
+    paths: ["/skills"],
+    readScope: "skills.read",
+    writeScope: "skills.write",
+  },
 ] as const;
+
+export const PUBLIC_API_SCOPES = PUBLIC_API_SCOPE_RESOURCES.flatMap(
+  (resource) => [resource.readScope, resource.writeScope]
+);
 
 export const LEGACY_API_READ_SCOPE = "api.read";
 export const LEGACY_API_WRITE_SCOPE = "api.write";

--- a/apps/api/src/constants/oauth-scopes.ts
+++ b/apps/api/src/constants/oauth-scopes.ts
@@ -1,0 +1,17 @@
+export const PUBLIC_API_SCOPES = [
+  "posts.read",
+  "posts.write",
+  "brand-identities.read",
+  "brand-identities.write",
+  "integrations.read",
+  "integrations.write",
+  "schedules.read",
+  "schedules.write",
+  "chats.read",
+  "chats.write",
+  "skills.read",
+  "skills.write",
+] as const;
+
+export const LEGACY_API_READ_SCOPE = "api.read";
+export const LEGACY_API_WRITE_SCOPE = "api.write";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,10 @@ import "./tcc";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { createDb } from "@notra/db/drizzle-http";
 import { trimTrailingSlash } from "hono/trailing-slash";
+import {
+  LEGACY_API_READ_SCOPE,
+  LEGACY_API_WRITE_SCOPE,
+} from "./constants/oauth-scopes";
 import { authMiddleware } from "./middleware/auth";
 import { subscriptionMiddleware } from "./middleware/subscription";
 import { brandIdentitiesRoutes } from "./routes/brand-identities";
@@ -21,6 +25,7 @@ import {
   SITE_URL,
 } from "./utils/agent-discovery";
 import { assertRequiredEnv } from "./utils/env";
+import { getRequiredOAuthScope } from "./utils/oauth-scopes";
 
 const FRAMER_PLUGIN_ID = "8d4wmwtko6960jsu3ojmalvqm";
 
@@ -156,10 +161,20 @@ app.openapi(publicStatusRoute, (c) => {
 });
 
 app.use("/v1/*", (c, next) => {
-  const permissions = ["POST", "PUT", "PATCH", "DELETE"].includes(c.req.method)
-    ? "api.write"
-    : "api.read";
-  return authMiddleware({ permissions })(c, next);
+  const requiredScope = getRequiredOAuthScope(
+    new URL(c.req.url).pathname,
+    c.req.method
+  );
+  const legacyPermission = ["POST", "PUT", "PATCH", "DELETE"].includes(
+    c.req.method
+  )
+    ? LEGACY_API_WRITE_SCOPE
+    : LEGACY_API_READ_SCOPE;
+
+  return authMiddleware({
+    legacyPermissions: [legacyPermission],
+    permissions: requiredScope,
+  })(c, next);
 });
 
 app.use("/v1/*", subscriptionMiddleware());

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -7,6 +7,10 @@ import {
   errors as joseErrors,
   jwtVerify,
 } from "jose";
+import {
+  LEGACY_API_READ_SCOPE,
+  LEGACY_API_WRITE_SCOPE,
+} from "../constants/oauth-scopes";
 import type { AuthData } from "../types/auth";
 import {
   API_URL,
@@ -133,7 +137,17 @@ function hasRequiredScope(scopes: string[], requiredScope?: string) {
     return true;
   }
 
-  return scopes.includes(requiredScope) || scopes.includes("*");
+  if (scopes.includes(requiredScope) || scopes.includes("*")) {
+    return true;
+  }
+
+  if (scopes.includes(LEGACY_API_WRITE_SCOPE)) {
+    return true;
+  }
+
+  return (
+    requiredScope.endsWith(".read") && scopes.includes(LEGACY_API_READ_SCOPE)
+  );
 }
 
 async function verifyOAuthToken(

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -23,6 +23,7 @@ declare module "hono" {
 
 interface AuthOptions {
   getKey?: (c: Context) => string | null;
+  legacyPermissions?: string[];
   permissions?: string;
 }
 
@@ -224,10 +225,33 @@ async function verifyRequestAuth(
 
   try {
     const unkey = new Unkey({ rootKey: c.env.UNKEY_ROOT_KEY });
-    const result = await unkey.keys.verifyKey({
+    const permissionsToTry = [
+      options.permissions,
+      ...(options.legacyPermissions ?? []),
+    ].filter(
+      (permission, index, permissions): permission is string =>
+        typeof permission === "string" &&
+        permission.length > 0 &&
+        permissions.indexOf(permission) === index
+    );
+    let result = await unkey.keys.verifyKey({
       key: apiKey,
-      permissions: options.permissions,
+      ...(permissionsToTry[0] ? { permissions: permissionsToTry[0] } : {}),
     });
+
+    for (const permission of permissionsToTry.slice(1)) {
+      if (
+        result.data.valid ||
+        result.data.code !== "INSUFFICIENT_PERMISSIONS"
+      ) {
+        break;
+      }
+
+      result = await unkey.keys.verifyKey({
+        key: apiKey,
+        permissions: permission,
+      });
+    }
 
     if (!result.data.valid) {
       if (result.data.code === "INSUFFICIENT_PERMISSIONS") {

--- a/apps/api/src/utils/agent-discovery.ts
+++ b/apps/api/src/utils/agent-discovery.ts
@@ -1,17 +1,10 @@
+import { PUBLIC_API_SCOPES } from "../constants/oauth-scopes";
+
 export const API_URL = "https://api.usenotra.com";
 export const SITE_URL = "https://www.usenotra.com";
 
 export const RESOURCE_METADATA_URL = `${API_URL}/.well-known/oauth-protected-resource`;
 export const AUTH_GUIDE_URL = `${SITE_URL}/auth.md`;
-
-const PUBLIC_API_SCOPES = [
-  "api.read",
-  "api.write",
-  "posts.read",
-  "posts.write",
-  "skills.read",
-  "skills.write",
-] as const;
 
 const AGENT_AUTH_METADATA = {
   register_uri: `${SITE_URL}/agent/auth/register`,

--- a/apps/api/src/utils/oauth-scopes.ts
+++ b/apps/api/src/utils/oauth-scopes.ts
@@ -1,0 +1,50 @@
+const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const VERSION_PREFIX_REGEX = /^\/v1(?=\/|$)/;
+const LEGACY_ORGANIZATION_POSTS_REGEX = /^\/[^/]+\/posts(?:\/|$)/;
+const LEGACY_ORGANIZATION_SCHEDULES_REGEX = /^\/[^/]+\/schedules(?:\/|$)/;
+
+function scopeForResource(resource: string, method: string) {
+  return `${resource}.${MUTATION_METHODS.has(method) ? "write" : "read"}`;
+}
+
+export function getRequiredOAuthScope(pathname: string, method: string) {
+  const path = pathname.replace(VERSION_PREFIX_REGEX, "") || "/";
+
+  if (path === "/status") {
+    return undefined;
+  }
+
+  if (path.startsWith("/posts/") || path === "/posts") {
+    return scopeForResource("posts", method);
+  }
+
+  if (LEGACY_ORGANIZATION_POSTS_REGEX.test(path)) {
+    return scopeForResource("posts", method);
+  }
+
+  if (path.startsWith("/brand-identities/") || path === "/brand-identities") {
+    return scopeForResource("brand-identities", method);
+  }
+
+  if (path.startsWith("/integrations/") || path === "/integrations") {
+    return scopeForResource("integrations", method);
+  }
+
+  if (path.startsWith("/schedules/") || path === "/schedules") {
+    return scopeForResource("schedules", method);
+  }
+
+  if (LEGACY_ORGANIZATION_SCHEDULES_REGEX.test(path)) {
+    return scopeForResource("schedules", method);
+  }
+
+  if (path.startsWith("/chats/") || path === "/chats") {
+    return scopeForResource("chats", method);
+  }
+
+  if (path.startsWith("/skills/") || path === "/skills") {
+    return scopeForResource("skills", method);
+  }
+
+  return scopeForResource("posts", method);
+}

--- a/apps/api/src/utils/oauth-scopes.ts
+++ b/apps/api/src/utils/oauth-scopes.ts
@@ -1,3 +1,5 @@
+import { PUBLIC_API_SCOPE_RESOURCES } from "../constants/oauth-scopes";
+
 const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const VERSION_PREFIX_REGEX = /^\/v1(?=\/|$)/;
 const LEGACY_ORGANIZATION_POSTS_REGEX = /^\/[^/]+\/posts(?:\/|$)/;
@@ -14,36 +16,24 @@ export function getRequiredOAuthScope(pathname: string, method: string) {
     return undefined;
   }
 
-  if (path.startsWith("/posts/") || path === "/posts") {
-    return scopeForResource("posts", method);
-  }
-
   if (LEGACY_ORGANIZATION_POSTS_REGEX.test(path)) {
     return scopeForResource("posts", method);
-  }
-
-  if (path.startsWith("/brand-identities/") || path === "/brand-identities") {
-    return scopeForResource("brand-identities", method);
-  }
-
-  if (path.startsWith("/integrations/") || path === "/integrations") {
-    return scopeForResource("integrations", method);
-  }
-
-  if (path.startsWith("/schedules/") || path === "/schedules") {
-    return scopeForResource("schedules", method);
   }
 
   if (LEGACY_ORGANIZATION_SCHEDULES_REGEX.test(path)) {
     return scopeForResource("schedules", method);
   }
 
-  if (path.startsWith("/chats/") || path === "/chats") {
-    return scopeForResource("chats", method);
-  }
-
-  if (path.startsWith("/skills/") || path === "/skills") {
-    return scopeForResource("skills", method);
+  const resource = PUBLIC_API_SCOPE_RESOURCES.find((item) =>
+    item.paths.some(
+      (resourcePath) =>
+        path === resourcePath || path.startsWith(`${resourcePath}/`)
+    )
+  );
+  if (resource) {
+    return MUTATION_METHODS.has(method)
+      ? resource.writeScope
+      : resource.readScope;
   }
 
   return undefined;

--- a/apps/api/src/utils/oauth-scopes.ts
+++ b/apps/api/src/utils/oauth-scopes.ts
@@ -46,5 +46,5 @@ export function getRequiredOAuthScope(pathname: string, method: string) {
     return scopeForResource("skills", method);
   }
 
-  return scopeForResource("posts", method);
+  return undefined;
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -78,7 +78,12 @@ import {
   parseAsStringLiteral,
   useQueryStates,
 } from "nuqs";
-import { useEffect, useMemo, useReducer } from "react";
+import {
+  type ComponentType,
+  type ReactNode,
+  useEffect,
+  useReducer,
+} from "react";
 import { toast } from "sonner";
 import { ApiKeyRevealField } from "@/components/api-keys/api-key-reveal-field";
 import { ApiKeyPermissionSelector } from "@/components/api-keys/permission-selector";
@@ -120,6 +125,26 @@ const EDIT_FORM_DEFAULTS: ApiKeyFormValues = {
   scopes: [...API_KEY_DEFAULT_SCOPES],
   expiration: "never",
 };
+
+interface ApiKeyEditForm {
+  // TanStack Form's Field component carries deep generics that are local to the
+  // useForm call site. The dialog only renders fields from that instance.
+  Field: ComponentType<{
+    name: string;
+    validators?: unknown;
+    children: (field: {
+      handleBlur: () => void;
+      handleChange: (value: string | string[]) => void;
+      state: {
+        value: unknown;
+        meta: {
+          isTouched: boolean;
+          errors: unknown[];
+        };
+      };
+    }) => ReactNode;
+  }>;
+}
 
 type ApiKeyListItem = Omit<
   Pick<
@@ -242,6 +267,33 @@ function getDefaultEditExpiration(
   return "90d";
 }
 
+function getSortIcon(isSorted: false | "asc" | "desc") {
+  if (isSorted === "asc") {
+    return ArrowUp01Icon;
+  }
+  if (isSorted === "desc") {
+    return ArrowDown01Icon;
+  }
+  return ArrowUpDownIcon;
+}
+
+function sortApiKeys(
+  keys: ApiKeyListItem[],
+  createdSortOrder: false | "asc" | "desc"
+) {
+  if (createdSortOrder === false) {
+    return keys;
+  }
+
+  return keys
+    .slice()
+    .sort((a, b) =>
+      createdSortOrder === "desc"
+        ? b.createdAt - a.createdAt
+        : a.createdAt - b.createdAt
+    );
+}
+
 function ApiKeysTableContent({
   isPending,
   keys,
@@ -329,6 +381,403 @@ function ApiKeysTableContent({
   ));
 }
 
+function ApiKeysHeader({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="space-y-1">
+        <h1 className="font-bold text-3xl tracking-tight">API Keys</h1>
+        <p className="text-muted-foreground">
+          Manage API keys for programmatic access to your organization
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button className="gap-1.5" onClick={onCreate}>
+          <HugeiconsIcon className="size-4" icon={Add01Icon} />
+          Create API Key
+          <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+        </Button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  onClick={() =>
+                    window.open(
+                      "https://docs.usenotra.com/api/getting-started",
+                      "_blank",
+                      "noopener,noreferrer"
+                    )
+                  }
+                  size="icon"
+                  variant="outline"
+                />
+              }
+            >
+              <HugeiconsIcon className="size-4" icon={Book01Icon} />
+            </TooltipTrigger>
+            <TooltipContent>View API documentation</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
+  );
+}
+
+function ApiKeysTable({
+  actionsDisabled,
+  createdSortOrder,
+  isPending,
+  keys,
+  onDelete,
+  onEdit,
+  onSort,
+}: {
+  actionsDisabled: boolean;
+  createdSortOrder: false | "asc" | "desc";
+  isPending: boolean;
+  keys: ApiKeyListItem[];
+  onDelete: (key: ApiKeyListItem) => void;
+  onEdit: (key: ApiKeyListItem) => void;
+  onSort: () => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/80 border-b-border/40 bg-muted/80 shadow-2xs">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Key</TableHead>
+            <TableHead>Permission</TableHead>
+            <TableHead className="w-35">Expires</TableHead>
+            <TableHead className="w-35">
+              <Button className="-ml-4" onClick={onSort} variant="ghost">
+                Created At
+                <HugeiconsIcon
+                  className="ml-2 size-4"
+                  icon={getSortIcon(createdSortOrder)}
+                />
+              </Button>
+            </TableHead>
+            <TableHead className="w-12" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <ApiKeysTableContent
+            actionsDisabled={actionsDisabled}
+            isPending={isPending}
+            keys={keys}
+            onDelete={onDelete}
+            onEdit={onEdit}
+          />
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function ApiKeyQuickStart({ onSelect }: { onSelect: (id: string) => void }) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="font-semibold text-lg tracking-tight">Quick start</h2>
+        <p className="text-muted-foreground text-sm">
+          Spin up a key preconfigured for how you plan to use the API.
+        </p>
+      </div>
+      <ConnectedCards items={API_KEY_CARD_ITEMS} onSelect={onSelect} />
+    </div>
+  );
+}
+
+function CreateApiKeyDialog({
+  createError,
+  createdKey,
+  input,
+  isPending,
+  onExpirationChange,
+  onNameChange,
+  onOpenChange,
+  onScopesChange,
+  onSubmit,
+  open,
+}: {
+  createError: string | null;
+  createdKey: string | null;
+  input: ApiKeyCreateConfig;
+  isPending: boolean;
+  onExpirationChange: (expiration: ApiKeyExpiration) => void;
+  onNameChange: (name: string | null) => void;
+  onOpenChange: (open: boolean) => void;
+  onScopesChange: (scopes: string[]) => void;
+  onSubmit: () => void;
+  open: boolean;
+}) {
+  return (
+    <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
+      <ResponsiveDialogContent
+        className={createdKey ? "sm:max-w-md" : "sm:max-w-2xl"}
+      >
+        {createdKey ? (
+          <>
+            <ResponsiveDialogHeader>
+              <ResponsiveDialogTitle>View API Key</ResponsiveDialogTitle>
+            </ResponsiveDialogHeader>
+            <div className="space-y-4">
+              <Alert className="border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300">
+                <HugeiconsIcon icon={InformationCircleIcon} />
+                <AlertDescription className="text-blue-700 dark:text-blue-300">
+                  You can only see this key once.{" "}
+                  <span className="font-medium text-foreground">
+                    Store it safely.
+                  </span>
+                </AlertDescription>
+              </Alert>
+              <Field>
+                <FieldLabel>API Key</FieldLabel>
+                <ApiKeyRevealField value={createdKey} />
+              </Field>
+            </div>
+            <ResponsiveDialogFooter>
+              <ResponsiveDialogClose render={<Button>Done</Button>} />
+            </ResponsiveDialogFooter>
+          </>
+        ) : (
+          <>
+            <ResponsiveDialogHeader>
+              <ResponsiveDialogTitle className="text-2xl">
+                Create API Key
+              </ResponsiveDialogTitle>
+              <ResponsiveDialogDescription>
+                Create a new API key for your organization.
+              </ResponsiveDialogDescription>
+            </ResponsiveDialogHeader>
+            <form action={onSubmit}>
+              <div className="space-y-4 py-4">
+                <Field>
+                  <FieldLabel>
+                    Name<span className="-ml-1 text-destructive">*</span>
+                  </FieldLabel>
+                  <Input
+                    disabled={isPending}
+                    onChange={(event) =>
+                      onNameChange(event.target.value || null)
+                    }
+                    placeholder="e.g. CI/CD Pipeline"
+                    value={input.name}
+                  />
+                  {createError ? (
+                    <p className="text-destructive text-sm">{createError}</p>
+                  ) : null}
+                </Field>
+
+                <Field>
+                  <FieldLabel>
+                    Permission
+                    <span className="-ml-1 text-destructive">*</span>
+                  </FieldLabel>
+                  <ApiKeyPermissionSelector
+                    disabled={isPending}
+                    onValueChange={onScopesChange}
+                    value={input.scopes}
+                  />
+                </Field>
+
+                <Field>
+                  <FieldLabel>
+                    Expiration
+                    <span className="-ml-1 text-muted-foreground text-xs">
+                      (Optional)
+                    </span>
+                  </FieldLabel>
+                  <Select
+                    disabled={isPending}
+                    onValueChange={(value) =>
+                      onExpirationChange(value as ApiKeyExpiration)
+                    }
+                    value={input.expiration}
+                  >
+                    <SelectTrigger>
+                      <SelectValue className="capitalize" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {API_KEY_EXPIRATION_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              </div>
+              <ResponsiveDialogFooter>
+                <ResponsiveDialogClose
+                  disabled={isPending}
+                  render={<Button variant="outline">Cancel</Button>}
+                />
+                <Button disabled={isPending} type="submit">
+                  {isPending ? "Creating…" : "Create Key"}
+                </Button>
+              </ResponsiveDialogFooter>
+            </form>
+          </>
+        )}
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}
+
+function EditApiKeyDialog({
+  editForm,
+  isPending,
+  onOpenChange,
+  onSubmit,
+  open,
+}: {
+  editForm: ApiKeyEditForm;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: () => void;
+  open: boolean;
+}) {
+  return (
+    <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
+      <ResponsiveDialogContent className="sm:max-w-2xl">
+        <form action={onSubmit}>
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle className="text-2xl">
+              Edit API Key
+            </ResponsiveDialogTitle>
+          </ResponsiveDialogHeader>
+          <div className="space-y-4 py-4">
+            <editForm.Field
+              name="name"
+              validators={{ onChange: updateApiKeySchema.shape.name }}
+            >
+              {(field) => (
+                <Field>
+                  <FieldLabel>
+                    Name<span className="-ml-1 text-destructive">*</span>
+                  </FieldLabel>
+                  <Input
+                    autoFocus
+                    disabled={isPending}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    placeholder="e.g. CI/CD Pipeline"
+                    value={field.state.value as string}
+                  />
+                  {field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0 ? (
+                    <p className="text-destructive text-sm">
+                      {typeof field.state.meta.errors[0] === "string"
+                        ? field.state.meta.errors[0]
+                        : ((field.state.meta.errors[0] as { message?: string })
+                            ?.message ?? "Invalid value")}
+                    </p>
+                  ) : null}
+                </Field>
+              )}
+            </editForm.Field>
+
+            <editForm.Field name="scopes">
+              {(field) => (
+                <Field>
+                  <FieldLabel>
+                    Permission
+                    <span className="-ml-1 text-destructive">*</span>
+                  </FieldLabel>
+                  <ApiKeyPermissionSelector
+                    disabled={isPending}
+                    onValueChange={(scopes) => field.handleChange(scopes)}
+                    value={field.state.value as string[]}
+                  />
+                </Field>
+              )}
+            </editForm.Field>
+
+            <editForm.Field name="expiration">
+              {(field) => (
+                <Field>
+                  <FieldLabel>Expiration</FieldLabel>
+                  <Select
+                    disabled={isPending}
+                    onValueChange={(value) =>
+                      field.handleChange(value as ApiKeyExpiration)
+                    }
+                    value={field.state.value as ApiKeyExpiration}
+                  >
+                    <SelectTrigger>
+                      <SelectValue className="capitalize" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {API_KEY_EXPIRATION_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              )}
+            </editForm.Field>
+          </div>
+          <ResponsiveDialogFooter>
+            <ResponsiveDialogClose
+              disabled={isPending}
+              render={<Button variant="outline">Cancel</Button>}
+            />
+            <Button disabled={isPending} type="submit">
+              {isPending ? "Saving…" : "Save Changes"}
+            </Button>
+          </ResponsiveDialogFooter>
+        </form>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}
+
+function DeleteApiKeyDialog({
+  apiKey,
+  isPending,
+  onConfirm,
+  onOpenChange,
+}: {
+  apiKey: ApiKeyListItem | null;
+  isPending: boolean;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <ResponsiveAlertDialog onOpenChange={onOpenChange} open={!!apiKey}>
+      <ResponsiveAlertDialogContent>
+        <ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogTitle>
+            Delete API Key?
+          </ResponsiveAlertDialogTitle>
+          <ResponsiveAlertDialogDescription>
+            This will permanently delete
+            {apiKey ? ` ${apiKey.name}` : " this API key"}. This action cannot
+            be undone.
+          </ResponsiveAlertDialogDescription>
+        </ResponsiveAlertDialogHeader>
+        <ResponsiveAlertDialogFooter>
+          <ResponsiveAlertDialogCancel disabled={isPending}>
+            Cancel
+          </ResponsiveAlertDialogCancel>
+          <ResponsiveAlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={!apiKey || isPending}
+            onClick={onConfirm}
+          >
+            {isPending ? "Deleting…" : "Delete API Key"}
+          </ResponsiveAlertDialogAction>
+        </ResponsiveAlertDialogFooter>
+      </ResponsiveAlertDialogContent>
+    </ResponsiveAlertDialog>
+  );
+}
+
 export default function ApiKeysPage() {
   const { activeOrganization } = useOrganizationsContext();
   const organizationId = activeOrganization?.id;
@@ -372,27 +821,7 @@ export default function ApiKeysPage() {
     enabled: !!organizationId,
   });
 
-  const sortedKeys = useMemo(() => {
-    if (createdSortOrder === false) {
-      return keys;
-    }
-    return [...keys].sort((a, b) => {
-      return createdSortOrder === "desc"
-        ? b.createdAt - a.createdAt
-        : a.createdAt - b.createdAt;
-    });
-  }, [keys, createdSortOrder]);
-
-  function getSortIcon(isSorted: false | "asc" | "desc") {
-    if (isSorted === "asc") {
-      return ArrowUp01Icon;
-    }
-    if (isSorted === "desc") {
-      return ArrowDown01Icon;
-    }
-    return ArrowUpDownIcon;
-  }
-  const createdSortIcon = getSortIcon(createdSortOrder);
+  const sortedKeys = sortApiKeys(keys, createdSortOrder);
 
   const newKeyName = newKeyConfig.name;
   const newKeyScopes = newKeyConfig.scopes ?? DEFAULT_NEW_KEY_CONFIG.scopes;
@@ -576,379 +1005,70 @@ export default function ApiKeysPage() {
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <h1 className="font-bold text-3xl tracking-tight">API Keys</h1>
-            <p className="text-muted-foreground">
-              Manage API keys for programmatic access to your organization
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              className="gap-1.5"
-              onClick={() =>
-                dispatchUi({ type: "createDialogChanged", open: true })
-              }
-            >
-              <HugeiconsIcon className="size-4" icon={Add01Icon} />
-              Create API Key
-              <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
-            </Button>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      onClick={() =>
-                        window.open(
-                          "https://docs.usenotra.com/api/getting-started",
-                          "_blank",
-                          "noopener,noreferrer"
-                        )
-                      }
-                      size="icon"
-                      variant="outline"
-                    />
-                  }
-                >
-                  <HugeiconsIcon className="size-4" icon={Book01Icon} />
-                </TooltipTrigger>
-                <TooltipContent>View API documentation</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-        </div>
+        <ApiKeysHeader
+          onCreate={() =>
+            dispatchUi({ type: "createDialogChanged", open: true })
+          }
+        />
 
-        <div className="overflow-hidden rounded-lg border border-border/80 border-b-border/40 bg-muted/80 shadow-2xs">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Key</TableHead>
-                <TableHead>Permission</TableHead>
-                <TableHead className="w-35">Expires</TableHead>
-                <TableHead className="w-35">
-                  <Button
-                    className="-ml-4"
-                    onClick={() =>
-                      dispatchUi({
-                        type: "createdSortOrderChanged",
-                        sortOrder: createdSortOrder === "asc" ? "desc" : "asc",
-                      })
-                    }
-                    variant="ghost"
-                  >
-                    Created At
-                    <HugeiconsIcon
-                      className="ml-2 size-4"
-                      icon={createdSortIcon}
-                    />
-                  </Button>
-                </TableHead>
-                <TableHead className="w-12" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              <ApiKeysTableContent
-                actionsDisabled={
-                  editMutation.isPending || deleteMutation.isPending
-                }
-                isPending={isPending}
-                keys={sortedKeys}
-                onDelete={(key) =>
-                  dispatchUi({
-                    type: "deletingKeyChanged",
-                    deletingKey: key,
-                  })
-                }
-                onEdit={openEditDialog}
-              />
-            </TableBody>
-          </Table>
-        </div>
+        <ApiKeysTable
+          actionsDisabled={editMutation.isPending || deleteMutation.isPending}
+          createdSortOrder={createdSortOrder}
+          isPending={isPending}
+          keys={sortedKeys}
+          onDelete={(key) =>
+            dispatchUi({
+              type: "deletingKeyChanged",
+              deletingKey: key,
+            })
+          }
+          onEdit={openEditDialog}
+          onSort={() =>
+            dispatchUi({
+              type: "createdSortOrderChanged",
+              sortOrder: createdSortOrder === "asc" ? "desc" : "asc",
+            })
+          }
+        />
 
-        <div className="space-y-3">
-          <div className="space-y-1">
-            <h2 className="font-semibold text-lg tracking-tight">
-              Quick start
-            </h2>
-            <p className="text-muted-foreground text-sm">
-              Spin up a key preconfigured for how you plan to use the API.
-            </p>
-          </div>
-          <ConnectedCards
-            items={API_KEY_CARD_ITEMS}
-            onSelect={handlePresetSelect}
-          />
-        </div>
+        <ApiKeyQuickStart onSelect={handlePresetSelect} />
       </div>
 
-      <ResponsiveDialog onOpenChange={handleDialogClose} open={dialogOpen}>
-        <ResponsiveDialogContent
-          className={createdKey ? "sm:max-w-md" : "sm:max-w-2xl"}
-        >
-          {createdKey ? (
-            <>
-              <ResponsiveDialogHeader>
-                <ResponsiveDialogTitle>View API Key</ResponsiveDialogTitle>
-              </ResponsiveDialogHeader>
-              <div className="space-y-4">
-                <Alert className="border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300">
-                  <HugeiconsIcon icon={InformationCircleIcon} />
-                  <AlertDescription className="text-blue-700 dark:text-blue-300">
-                    You can only see this key once.{" "}
-                    <span className="font-medium text-foreground">
-                      Store it safely.
-                    </span>
-                  </AlertDescription>
-                </Alert>
-                <Field>
-                  <FieldLabel>API Key</FieldLabel>
-                  <ApiKeyRevealField value={createdKey} />
-                </Field>
-              </div>
-              <ResponsiveDialogFooter>
-                <ResponsiveDialogClose render={<Button>Done</Button>} />
-              </ResponsiveDialogFooter>
-            </>
-          ) : (
-            <>
-              <ResponsiveDialogHeader>
-                <ResponsiveDialogTitle className="text-2xl">
-                  Create API Key
-                </ResponsiveDialogTitle>
-                <ResponsiveDialogDescription>
-                  Create a new API key for your organization.
-                </ResponsiveDialogDescription>
-              </ResponsiveDialogHeader>
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleCreateSubmit();
-                }}
-              >
-                <div className="space-y-4 py-4">
-                  <Field>
-                    <FieldLabel>
-                      Name<span className="-ml-1 text-destructive">*</span>
-                    </FieldLabel>
-                    <Input
-                      disabled={mutation.isPending}
-                      onChange={(event) => {
-                        dispatchUi({
-                          type: "createErrorChanged",
-                          createError: null,
-                        });
-                        setNewKeyConfig({
-                          name: event.target.value || null,
-                        });
-                      }}
-                      placeholder="e.g. CI/CD Pipeline"
-                      value={createInput.name}
-                    />
-                    {createError ? (
-                      <p className="text-destructive text-sm">{createError}</p>
-                    ) : null}
-                  </Field>
+      <CreateApiKeyDialog
+        createdKey={createdKey}
+        createError={createError}
+        input={createInput}
+        isPending={mutation.isPending}
+        onExpirationChange={(expiration) => setNewKeyConfig({ expiration })}
+        onNameChange={(name) => {
+          dispatchUi({ type: "createErrorChanged", createError: null });
+          setNewKeyConfig({ name });
+        }}
+        onOpenChange={handleDialogClose}
+        onScopesChange={(scopes) => setNewKeyConfig({ scopes })}
+        onSubmit={handleCreateSubmit}
+        open={dialogOpen}
+      />
 
-                  <Field>
-                    <FieldLabel>
-                      Permission
-                      <span className="-ml-1 text-destructive">*</span>
-                    </FieldLabel>
-                    <ApiKeyPermissionSelector
-                      disabled={mutation.isPending}
-                      onValueChange={(scopes) => setNewKeyConfig({ scopes })}
-                      value={createInput.scopes}
-                    />
-                  </Field>
-
-                  <Field>
-                    <FieldLabel>
-                      Expiration
-                      <span className="-ml-1 text-muted-foreground text-xs">
-                        (Optional)
-                      </span>
-                    </FieldLabel>
-                    <Select
-                      disabled={mutation.isPending}
-                      onValueChange={(value) =>
-                        setNewKeyConfig({
-                          expiration: value as ApiKeyExpiration,
-                        })
-                      }
-                      value={createInput.expiration}
-                    >
-                      <SelectTrigger>
-                        <SelectValue className="capitalize" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {API_KEY_EXPIRATION_OPTIONS.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                </div>
-                <ResponsiveDialogFooter>
-                  <ResponsiveDialogClose
-                    disabled={mutation.isPending}
-                    render={<Button variant="outline">Cancel</Button>}
-                  />
-                  <Button disabled={mutation.isPending} type="submit">
-                    {mutation.isPending ? "Creating…" : "Create Key"}
-                  </Button>
-                </ResponsiveDialogFooter>
-              </form>
-            </>
-          )}
-        </ResponsiveDialogContent>
-      </ResponsiveDialog>
-
-      <ResponsiveDialog
+      <EditApiKeyDialog
+        editForm={editForm as unknown as ApiKeyEditForm}
+        isPending={editMutation.isPending}
         onOpenChange={handleEditDialogClose}
+        onSubmit={editForm.handleSubmit}
         open={editDialogOpen}
-      >
-        <ResponsiveDialogContent className="sm:max-w-2xl">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              editForm.handleSubmit();
-            }}
-          >
-            <ResponsiveDialogHeader>
-              <ResponsiveDialogTitle className="text-2xl">
-                Edit API Key
-              </ResponsiveDialogTitle>
-            </ResponsiveDialogHeader>
-            <div className="space-y-4 py-4">
-              <editForm.Field
-                name="name"
-                validators={{
-                  onChange: updateApiKeySchema.shape.name,
-                }}
-              >
-                {(field) => (
-                  <Field>
-                    <FieldLabel>
-                      Name<span className="-ml-1 text-destructive">*</span>
-                    </FieldLabel>
-                    <Input
-                      autoFocus
-                      disabled={editMutation.isPending}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      onFocus={(e) => e.currentTarget.select()}
-                      placeholder="e.g. CI/CD Pipeline"
-                      value={field.state.value}
-                    />
-                    {field.state.meta.isTouched &&
-                    field.state.meta.errors.length > 0 ? (
-                      <p className="text-destructive text-sm">
-                        {typeof field.state.meta.errors[0] === "string"
-                          ? field.state.meta.errors[0]
-                          : ((
-                              field.state.meta.errors[0] as { message?: string }
-                            )?.message ?? "Invalid value")}
-                      </p>
-                    ) : null}
-                  </Field>
-                )}
-              </editForm.Field>
+      />
 
-              <editForm.Field name="scopes">
-                {(field) => (
-                  <Field>
-                    <FieldLabel>
-                      Permission
-                      <span className="-ml-1 text-destructive">*</span>
-                    </FieldLabel>
-                    <ApiKeyPermissionSelector
-                      disabled={editMutation.isPending}
-                      onValueChange={(scopes) => field.handleChange(scopes)}
-                      value={field.state.value}
-                    />
-                  </Field>
-                )}
-              </editForm.Field>
-
-              <editForm.Field name="expiration">
-                {(field) => (
-                  <Field>
-                    <FieldLabel>Expiration</FieldLabel>
-                    <Select
-                      disabled={editMutation.isPending}
-                      onValueChange={(value) =>
-                        field.handleChange(value as ApiKeyExpiration)
-                      }
-                      value={field.state.value}
-                    >
-                      <SelectTrigger>
-                        <SelectValue className="capitalize" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {API_KEY_EXPIRATION_OPTIONS.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                )}
-              </editForm.Field>
-            </div>
-            <ResponsiveDialogFooter>
-              <ResponsiveDialogClose
-                disabled={editMutation.isPending}
-                render={<Button variant="outline">Cancel</Button>}
-              />
-              <Button disabled={editMutation.isPending} type="submit">
-                {editMutation.isPending ? "Saving…" : "Save Changes"}
-              </Button>
-            </ResponsiveDialogFooter>
-          </form>
-        </ResponsiveDialogContent>
-      </ResponsiveDialog>
-
-      <ResponsiveAlertDialog
+      <DeleteApiKeyDialog
+        apiKey={deletingKey}
+        isPending={deleteMutation.isPending}
+        onConfirm={() => {
+          if (!deletingKey) {
+            return;
+          }
+          deleteMutation.mutate(deletingKey.keyId);
+        }}
         onOpenChange={handleDeleteDialogClose}
-        open={!!deletingKey}
-      >
-        <ResponsiveAlertDialogContent>
-          <ResponsiveAlertDialogHeader>
-            <ResponsiveAlertDialogTitle>
-              Delete API Key?
-            </ResponsiveAlertDialogTitle>
-            <ResponsiveAlertDialogDescription>
-              This will permanently delete
-              {deletingKey ? ` ${deletingKey.name}` : " this API key"}. This
-              action cannot be undone.
-            </ResponsiveAlertDialogDescription>
-          </ResponsiveAlertDialogHeader>
-          <ResponsiveAlertDialogFooter>
-            <ResponsiveAlertDialogCancel disabled={deleteMutation.isPending}>
-              Cancel
-            </ResponsiveAlertDialogCancel>
-            <ResponsiveAlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              disabled={!deletingKey || deleteMutation.isPending}
-              onClick={() => {
-                if (!deletingKey) {
-                  return;
-                }
-                deleteMutation.mutate(deletingKey.keyId);
-              }}
-            >
-              {deleteMutation.isPending ? "Deleting…" : "Delete API Key"}
-            </ResponsiveAlertDialogAction>
-          </ResponsiveAlertDialogFooter>
-        </ResponsiveAlertDialogContent>
-      </ResponsiveAlertDialog>
+      />
     </PageContainer>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -960,6 +960,10 @@ export default function ApiKeysPage() {
   });
 
   const handleDialogClose = (open: boolean) => {
+    if (!open && mutation.isPending) {
+      return;
+    }
+
     if (!open) {
       dispatchUi({ type: "createErrorChanged", createError: null });
       mutation.reset();
@@ -995,7 +999,7 @@ export default function ApiKeysPage() {
     editForm.reset({
       keyId: key.keyId,
       name: key.name,
-      scopes: scopes.length > 0 ? scopes : [...API_KEY_DEFAULT_SCOPES],
+      scopes,
       expiration: getDefaultEditExpiration(key.createdAt, key.expires),
     });
     editForm.setFieldValue("name", key.name);

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -6,10 +6,10 @@ import {
   ArrowUp01Icon,
   ArrowUpDownIcon,
   Book01Icon,
-  Copy01Icon,
   Delete02Icon,
   Dots,
   Edit02Icon,
+  InformationCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ConnectedCards } from "@notra/ui/components/shared/connected-cards";
@@ -27,10 +27,12 @@ import {
   ResponsiveDialog,
   ResponsiveDialogClose,
   ResponsiveDialogContent,
+  ResponsiveDialogDescription,
   ResponsiveDialogFooter,
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@notra/ui/components/shared/responsive-dialog";
+import { Alert, AlertDescription } from "@notra/ui/components/ui/alert";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -70,34 +72,53 @@ import type {
   KeyResponseData,
   V2KeysCreateKeyResponseData,
 } from "@unkey/api/models/components";
-import { parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
+import {
+  parseAsArrayOf,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from "nuqs";
 import { useEffect, useMemo, useReducer } from "react";
 import { toast } from "sonner";
+import { ApiKeyRevealField } from "@/components/api-keys/api-key-reveal-field";
+import { ApiKeyPermissionSelector } from "@/components/api-keys/permission-selector";
 import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
+  API_KEY_DEFAULT_SCOPES,
   API_KEY_EXPIRATION_OPTIONS,
   API_KEY_EXPIRATION_VALUES,
-  API_KEY_PERMISSION_LABELS,
-  API_KEY_PERMISSIONS,
+  API_KEY_PERMISSION_SUMMARY,
 } from "@/constants/api-keys";
 import { API_KEY_CARD_ITEMS, API_KEY_PRESETS } from "@/lib/api-keys/presets";
+import { expandLegacyApiKeyScopes } from "@/lib/api-keys/scopes";
 import { dashboardOrpc } from "@/lib/orpc/query";
+import type { CreateApiKeyInput, UpdateApiKeyInput } from "@/schemas/api-keys";
 import { createApiKeySchema, updateApiKeySchema } from "@/schemas/api-keys";
-import type { ApiKeyExpiration, ApiKeyPermission } from "@/types/api-keys";
-import { copyToClipboard } from "@/utils/copy-to-clipboard";
+import type {
+  ApiKeyCreateConfig,
+  ApiKeyExpiration,
+  ApiKeyFormValues,
+} from "@/types/api-keys";
 
 const NEW_KEY_CONFIG_PARSERS = {
   name: parseAsString,
-  permission: parseAsStringLiteral(API_KEY_PERMISSIONS),
+  scopes: parseAsArrayOf(parseAsString),
   expiration: parseAsStringLiteral(API_KEY_EXPIRATION_VALUES),
 };
 
-const DEFAULT_NEW_KEY_CONFIG = {
+const DEFAULT_NEW_KEY_CONFIG: ApiKeyCreateConfig = {
   name: "",
-  permission: "api.read" as ApiKeyPermission,
-  expiration: "never" as ApiKeyExpiration,
+  scopes: [...API_KEY_DEFAULT_SCOPES],
+  expiration: "never",
+};
+
+const EDIT_FORM_DEFAULTS: ApiKeyFormValues = {
+  keyId: "",
+  name: "",
+  scopes: [...API_KEY_DEFAULT_SCOPES],
+  expiration: "never",
 };
 
 type ApiKeyListItem = Omit<
@@ -109,7 +130,7 @@ type ApiKeyListItem = Omit<
 > & {
   name: string;
   expires: number | null;
-  permission: string;
+  permission: keyof typeof API_KEY_PERMISSION_SUMMARY;
   permissions: string[];
   createdBy: string | null;
 };
@@ -192,25 +213,7 @@ function formatExpiry(expires: number | null) {
 }
 
 function formatPermissionLabel(apiKey: ApiKeyListItem) {
-  const hasRead = apiKey.permissions.includes("api.read");
-  const hasWrite = apiKey.permissions.includes("api.write");
-
-  if (hasRead && hasWrite) {
-    return "Read & write";
-  }
-
-  if (hasWrite) {
-    return "Read & write";
-  }
-
-  if (hasRead) {
-    return "Read only";
-  }
-
-  return (
-    API_KEY_PERMISSION_LABELS[apiKey.permission as ApiKeyPermission] ??
-    apiKey.permission
-  );
+  return API_KEY_PERMISSION_SUMMARY[apiKey.permission];
 }
 
 function getDefaultEditExpiration(
@@ -346,7 +349,7 @@ export default function ApiKeysPage() {
   );
   const hasNewKeyConfig =
     newKeyConfig.name !== null &&
-    newKeyConfig.permission !== null &&
+    newKeyConfig.scopes !== null &&
     newKeyConfig.expiration !== null;
 
   useHotkey(
@@ -392,13 +395,12 @@ export default function ApiKeysPage() {
   const createdSortIcon = getSortIcon(createdSortOrder);
 
   const newKeyName = newKeyConfig.name;
-  const newKeyPermission =
-    newKeyConfig.permission ?? DEFAULT_NEW_KEY_CONFIG.permission;
+  const newKeyScopes = newKeyConfig.scopes ?? DEFAULT_NEW_KEY_CONFIG.scopes;
   const newKeyExpiration =
     newKeyConfig.expiration ?? DEFAULT_NEW_KEY_CONFIG.expiration;
   const createInput = {
     name: newKeyName ?? DEFAULT_NEW_KEY_CONFIG.name,
-    permission: newKeyPermission,
+    scopes: newKeyScopes,
     expiration: newKeyExpiration,
   };
 
@@ -415,7 +417,7 @@ export default function ApiKeysPage() {
     }
     const config = {
       name: preset.defaultName,
-      permission: preset.permission,
+      scopes: preset.scopes,
       expiration: preset.expiration,
     };
     dispatchUi({ type: "createErrorChanged", createError: null });
@@ -438,12 +440,7 @@ export default function ApiKeysPage() {
   };
 
   const editForm = useForm({
-    defaultValues: {
-      keyId: "",
-      name: "",
-      permission: "api.read" as ApiKeyPermission,
-      expiration: "never" as ApiKeyExpiration,
-    },
+    defaultValues: EDIT_FORM_DEFAULTS,
     onSubmit: ({ value }) => {
       const result = updateApiKeySchema.safeParse(value);
       if (!result.success) {
@@ -454,11 +451,7 @@ export default function ApiKeysPage() {
   });
 
   const mutation = useMutation({
-    mutationFn: async (values: {
-      name: string;
-      permission: ApiKeyPermission;
-      expiration: ApiKeyExpiration;
-    }) => {
+    mutationFn: async (values: CreateApiKeyInput) => {
       if (!organizationId) {
         throw new Error("Organization ID is required");
       }
@@ -485,12 +478,7 @@ export default function ApiKeysPage() {
   });
 
   const editMutation = useMutation({
-    mutationFn: async (values: {
-      keyId: string;
-      name: string;
-      permission: ApiKeyPermission;
-      expiration: ApiKeyExpiration;
-    }) => {
+    mutationFn: async (values: UpdateApiKeyInput) => {
       if (!organizationId) {
         throw new Error("Organization ID is required");
       }
@@ -573,16 +561,12 @@ export default function ApiKeysPage() {
   };
 
   const openEditDialog = (key: ApiKeyListItem) => {
-    const permission = API_KEY_PERMISSIONS.includes(
-      key.permission as ApiKeyPermission
-    )
-      ? (key.permission as ApiKeyPermission)
-      : "api.read";
+    const scopes = expandLegacyApiKeyScopes(key.permissions);
 
     editForm.reset({
       keyId: key.keyId,
       name: key.name,
-      permission,
+      scopes: scopes.length > 0 ? scopes : [...API_KEY_DEFAULT_SCOPES],
       expiration: getDefaultEditExpiration(key.createdAt, key.expires),
     });
     editForm.setFieldValue("name", key.name);
@@ -699,46 +683,44 @@ export default function ApiKeysPage() {
         </div>
       </div>
 
-      <ResponsiveAlertDialog onOpenChange={handleDialogClose} open={dialogOpen}>
-        <ResponsiveAlertDialogContent className="sm:max-w-120">
+      <ResponsiveDialog onOpenChange={handleDialogClose} open={dialogOpen}>
+        <ResponsiveDialogContent
+          className={createdKey ? "sm:max-w-md" : "sm:max-w-2xl"}
+        >
           {createdKey ? (
             <>
-              <ResponsiveAlertDialogHeader>
-                <ResponsiveAlertDialogTitle>
-                  API Key Created
-                </ResponsiveAlertDialogTitle>
-                <ResponsiveAlertDialogDescription>
-                  Copy this key now. You won't be able to see it again.
-                </ResponsiveAlertDialogDescription>
-              </ResponsiveAlertDialogHeader>
-              <div className="flex items-center gap-2">
-                <Input readOnly value={createdKey} />
-                <Button
-                  onClick={() => copyToClipboard(createdKey)}
-                  size="icon"
-                  variant="outline"
-                >
-                  <HugeiconsIcon className="size-4" icon={Copy01Icon} />
-                </Button>
+              <ResponsiveDialogHeader>
+                <ResponsiveDialogTitle>View API Key</ResponsiveDialogTitle>
+              </ResponsiveDialogHeader>
+              <div className="space-y-4">
+                <Alert className="border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300">
+                  <HugeiconsIcon icon={InformationCircleIcon} />
+                  <AlertDescription className="text-blue-700 dark:text-blue-300">
+                    You can only see this key once.{" "}
+                    <span className="font-medium text-foreground">
+                      Store it safely.
+                    </span>
+                  </AlertDescription>
+                </Alert>
+                <Field>
+                  <FieldLabel>API Key</FieldLabel>
+                  <ApiKeyRevealField value={createdKey} />
+                </Field>
               </div>
-              <ResponsiveAlertDialogFooter>
-                <ResponsiveAlertDialogAction
-                  onClick={() => handleDialogClose(false)}
-                >
-                  Done
-                </ResponsiveAlertDialogAction>
-              </ResponsiveAlertDialogFooter>
+              <ResponsiveDialogFooter>
+                <ResponsiveDialogClose render={<Button>Done</Button>} />
+              </ResponsiveDialogFooter>
             </>
           ) : (
             <>
-              <ResponsiveAlertDialogHeader>
-                <ResponsiveAlertDialogTitle className="text-2xl">
+              <ResponsiveDialogHeader>
+                <ResponsiveDialogTitle className="text-2xl">
                   Create API Key
-                </ResponsiveAlertDialogTitle>
-                <ResponsiveAlertDialogDescription>
+                </ResponsiveDialogTitle>
+                <ResponsiveDialogDescription>
                   Create a new API key for your organization.
-                </ResponsiveAlertDialogDescription>
-              </ResponsiveAlertDialogHeader>
+                </ResponsiveDialogDescription>
+              </ResponsiveDialogHeader>
               <form
                 onSubmit={(e) => {
                   e.preventDefault();
@@ -775,25 +757,11 @@ export default function ApiKeysPage() {
                       Permission
                       <span className="-ml-1 text-destructive">*</span>
                     </FieldLabel>
-                    <Select
+                    <ApiKeyPermissionSelector
                       disabled={mutation.isPending}
-                      onValueChange={(value) =>
-                        setNewKeyConfig({
-                          permission: value as ApiKeyPermission,
-                        })
-                      }
-                      value={createInput.permission}
-                    >
-                      <SelectTrigger>
-                        <SelectValue>
-                          {API_KEY_PERMISSION_LABELS[createInput.permission]}
-                        </SelectValue>
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="api.read">Read only</SelectItem>
-                        <SelectItem value="api.write">Read & write</SelectItem>
-                      </SelectContent>
-                    </Select>
+                      onValueChange={(scopes) => setNewKeyConfig({ scopes })}
+                      value={createInput.scopes}
+                    />
                   </Field>
 
                   <Field>
@@ -825,25 +793,26 @@ export default function ApiKeysPage() {
                     </Select>
                   </Field>
                 </div>
-                <ResponsiveAlertDialogFooter>
-                  <ResponsiveAlertDialogCancel disabled={mutation.isPending}>
-                    Cancel
-                  </ResponsiveAlertDialogCancel>
+                <ResponsiveDialogFooter>
+                  <ResponsiveDialogClose
+                    disabled={mutation.isPending}
+                    render={<Button variant="outline">Cancel</Button>}
+                  />
                   <Button disabled={mutation.isPending} type="submit">
                     {mutation.isPending ? "Creating…" : "Create Key"}
                   </Button>
-                </ResponsiveAlertDialogFooter>
+                </ResponsiveDialogFooter>
               </form>
             </>
           )}
-        </ResponsiveAlertDialogContent>
-      </ResponsiveAlertDialog>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
 
       <ResponsiveDialog
         onOpenChange={handleEditDialogClose}
         open={editDialogOpen}
       >
-        <ResponsiveDialogContent className="sm:max-w-120">
+        <ResponsiveDialogContent className="sm:max-w-2xl">
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -891,30 +860,18 @@ export default function ApiKeysPage() {
                 )}
               </editForm.Field>
 
-              <editForm.Field name="permission">
+              <editForm.Field name="scopes">
                 {(field) => (
                   <Field>
                     <FieldLabel>
                       Permission
                       <span className="-ml-1 text-destructive">*</span>
                     </FieldLabel>
-                    <Select
+                    <ApiKeyPermissionSelector
                       disabled={editMutation.isPending}
-                      onValueChange={(value) =>
-                        field.handleChange(value as ApiKeyPermission)
-                      }
+                      onValueChange={(scopes) => field.handleChange(scopes)}
                       value={field.state.value}
-                    >
-                      <SelectTrigger>
-                        <SelectValue>
-                          {API_KEY_PERMISSION_LABELS[field.state.value]}
-                        </SelectValue>
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="api.read">Read only</SelectItem>
-                        <SelectItem value="api.write">Read & write</SelectItem>
-                      </SelectContent>
-                    </Select>
+                    />
                   </Field>
                 )}
               </editForm.Field>

--- a/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
+++ b/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
@@ -32,8 +32,8 @@ export function ApiKeyRevealField({
     []
   );
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(value);
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(value);
     setCopied(true);
     if (copyTimer.current) {
       clearTimeout(copyTimer.current);

--- a/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
+++ b/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
@@ -33,7 +33,13 @@ export function ApiKeyRevealField({
   );
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(value);
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      setCopied(false);
+      return;
+    }
+
     setCopied(true);
     if (copyTimer.current) {
       clearTimeout(copyTimer.current);

--- a/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
+++ b/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  Copy01Icon,
+  Tick02Icon,
+  ViewIcon,
+  ViewOffSlashIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Input } from "@notra/ui/components/ui/input";
+import { cn } from "@notra/ui/lib/utils";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/button";
+import type { ApiKeyRevealFieldProps } from "@/types/api-keys";
+
+const COPIED_RESET_MS = 2000;
+
+export function ApiKeyRevealField({
+  value,
+  className,
+}: ApiKeyRevealFieldProps) {
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimer.current) {
+        clearTimeout(copyTimer.current);
+      }
+    },
+    []
+  );
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    if (copyTimer.current) {
+      clearTimeout(copyTimer.current);
+    }
+    copyTimer.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
+  };
+
+  return (
+    <div className={cn("relative", className)}>
+      <Input
+        className="h-10 pr-16 font-mono text-sm"
+        readOnly
+        type={revealed ? "text" : "password"}
+        value={value}
+      />
+      <div className="absolute inset-y-0 right-1.5 flex items-center gap-0.5">
+        <Button
+          aria-label={revealed ? "Hide API key" : "Show API key"}
+          className="size-7 text-muted-foreground"
+          onClick={() => setRevealed((current) => !current)}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <HugeiconsIcon
+            className="size-4"
+            icon={revealed ? ViewOffSlashIcon : ViewIcon}
+          />
+        </Button>
+        <Button
+          aria-label="Copy API key"
+          className={cn(
+            "size-7 text-muted-foreground",
+            copied && "text-emerald-600 dark:text-emerald-400"
+          )}
+          onClick={handleCopy}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <HugeiconsIcon
+            className="size-4"
+            icon={copied ? Tick02Icon : Copy01Icon}
+          />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
+++ b/apps/dashboard/src/components/api-keys/api-key-reveal-field.tsx
@@ -10,6 +10,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Input } from "@notra/ui/components/ui/input";
 import { cn } from "@notra/ui/lib/utils";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/button";
 import type { ApiKeyRevealFieldProps } from "@/types/api-keys";
 
@@ -33,10 +34,16 @@ export function ApiKeyRevealField({
   );
 
   const handleCopy = async () => {
+    if (!navigator.clipboard) {
+      toast.error("Clipboard not supported");
+      return;
+    }
+
     try {
       await navigator.clipboard.writeText(value);
     } catch {
       setCopied(false);
+      toast.error("Failed to copy to clipboard");
       return;
     }
 

--- a/apps/dashboard/src/components/api-keys/permission-selector.tsx
+++ b/apps/dashboard/src/components/api-keys/permission-selector.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+  PermissionOption,
+  PermissionRow,
+  PermissionSelector,
+} from "@notra/ui/components/ui/permission-selector";
+import {
+  API_KEY_SCOPE_GROUPS,
+  applyScopeLevel,
+  deriveScopeLevel,
+  sortApiKeyScopes,
+} from "@/lib/api-keys/scopes";
+import type {
+  ApiKeyPermissionSelectorProps,
+  ApiKeyScopeGroup,
+} from "@/types/api-keys";
+
+export function ApiKeyPermissionSelector({
+  value,
+  onValueChange,
+  disabled,
+  className,
+}: ApiKeyPermissionSelectorProps) {
+  const selected = new Set(value);
+
+  const handleLevelChange = (group: ApiKeyScopeGroup, levelValue: string) => {
+    onValueChange(
+      sortApiKeyScopes([...applyScopeLevel(selected, group, levelValue)])
+    );
+  };
+
+  return (
+    <PermissionSelector className={className} label="API key permissions">
+      {API_KEY_SCOPE_GROUPS.map((group) => (
+        <PermissionRow
+          description={group.description}
+          disabled={disabled}
+          key={group.id}
+          label={group.label}
+          onValueChange={(levelValue) => handleLevelChange(group, levelValue)}
+          value={deriveScopeLevel(selected, group)}
+        >
+          {group.levels.map((level) => (
+            <PermissionOption
+              key={level.value}
+              tone={level.tone}
+              value={level.value}
+            >
+              {level.label}
+            </PermissionOption>
+          ))}
+        </PermissionRow>
+      ))}
+    </PermissionSelector>
+  );
+}

--- a/apps/dashboard/src/constants/api-keys.ts
+++ b/apps/dashboard/src/constants/api-keys.ts
@@ -1,5 +1,90 @@
 export const API_KEY_PERMISSIONS = ["api.read", "api.write"] as const;
 
+export const API_KEY_GRANULAR_READ_PERMISSIONS = [
+  "posts.read",
+  "brand-identities.read",
+  "integrations.read",
+  "schedules.read",
+  "chats.read",
+  "skills.read",
+] as const;
+
+export const API_KEY_GRANULAR_WRITE_PERMISSIONS = [
+  "posts.write",
+  "brand-identities.write",
+  "integrations.write",
+  "schedules.write",
+  "chats.write",
+  "skills.write",
+] as const;
+
+export const API_KEY_GRANULAR_PERMISSIONS = [
+  ...API_KEY_GRANULAR_READ_PERMISSIONS,
+  ...API_KEY_GRANULAR_WRITE_PERMISSIONS,
+] as const;
+
+export const API_KEY_LEGACY_PERMISSIONS = ["api.read", "api.write"] as const;
+
+export const API_KEY_ACCEPTED_PERMISSIONS = [
+  ...API_KEY_GRANULAR_PERMISSIONS,
+  ...API_KEY_LEGACY_PERMISSIONS,
+] as const;
+
+export const API_KEY_DEFAULT_SCOPES = [
+  ...API_KEY_GRANULAR_READ_PERMISSIONS,
+] as const;
+
+export const API_KEY_SCOPE_LEVEL = {
+  none: "none",
+  read: "read",
+  write: "write",
+} as const;
+
+export const API_KEY_SCOPE_RESOURCES = [
+  {
+    id: "posts",
+    label: "Posts",
+    description: "Read and manage your posts and drafts",
+    readScope: "posts.read",
+    writeScope: "posts.write",
+  },
+  {
+    id: "brand-identities",
+    label: "Brand identities",
+    description: "Read and manage saved brand voices",
+    readScope: "brand-identities.read",
+    writeScope: "brand-identities.write",
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    description: "Read and manage connected content sources",
+    readScope: "integrations.read",
+    writeScope: "integrations.write",
+  },
+  {
+    id: "schedules",
+    label: "Schedules",
+    description: "Read and manage scheduled content generation",
+    readScope: "schedules.read",
+    writeScope: "schedules.write",
+  },
+  {
+    id: "chats",
+    label: "Chats",
+    description: "Read and manage chat sessions",
+    readScope: "chats.read",
+    writeScope: "chats.write",
+  },
+  {
+    id: "skills",
+    label: "Skills",
+    description: "Read and manage your skills",
+    readScope: "skills.read",
+    writeScope: "skills.write",
+  },
+] as const;
+
 export const API_KEY_PRESET_IDS = ["mcp", "sdk", "cli"] as const;
 
 export const API_KEY_EXPIRATION_VALUES = [
@@ -21,6 +106,19 @@ export const API_KEY_EXPIRATION_OPTIONS = [
 export const API_KEY_PERMISSION_LABELS = {
   "api.read": "Read only",
   "api.write": "Read & write",
+} as const;
+
+export const API_KEY_PERMISSION_SUMMARY = {
+  none: "No access",
+  read: "Read only",
+  write: "Read & write",
+  custom: "Custom",
+} as const;
+
+export const API_KEY_SCOPE_LEVEL_LABELS = {
+  none: "None",
+  read: "Read",
+  write: "Write",
 } as const;
 
 export const API_KEY_EXPIRATION_MS = {

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -3,20 +3,46 @@ export const OAUTH_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 export const OAUTH_REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
 export const OAUTH_SUPPORTED_SCOPES = [
-  "api.read",
-  "api.write",
   "offline_access",
   "posts.read",
   "posts.write",
+  "brand-identities.read",
+  "brand-identities.write",
+  "integrations.read",
+  "integrations.write",
+  "schedules.read",
+  "schedules.write",
+  "chats.read",
+  "chats.write",
   "skills.read",
   "skills.write",
+] as const;
+
+export const OAUTH_LEGACY_SCOPES = ["api.read", "api.write"] as const;
+
+export const OAUTH_ACCEPTED_SCOPES = [
+  ...OAUTH_SUPPORTED_SCOPES,
+  ...OAUTH_LEGACY_SCOPES,
 ] as const;
 
 export const OAUTH_SUPPORTED_SCOPE_SET: ReadonlySet<string> = new Set(
   OAUTH_SUPPORTED_SCOPES
 );
 
-export const OAUTH_DEFAULT_SCOPES = ["api.read"] as const;
+export const OAUTH_DEFAULT_SCOPES = [
+  "posts.read",
+  "posts.write",
+  "brand-identities.read",
+  "brand-identities.write",
+  "integrations.read",
+  "integrations.write",
+  "schedules.read",
+  "schedules.write",
+  "chats.read",
+  "chats.write",
+  "skills.read",
+  "skills.write",
+] as const;
 
 export const OAUTH_GRANT_QUERY_PARAM = "grant";
 
@@ -35,18 +61,39 @@ export const OAUTH_SCOPE_RESOURCES = [
     writeScope: "posts.write",
   },
   {
+    id: "brand-identities",
+    label: "Brand identities",
+    description: "Read and manage saved brand voices",
+    readScope: "brand-identities.read",
+    writeScope: "brand-identities.write",
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    description: "Read and manage connected content sources",
+    readScope: "integrations.read",
+    writeScope: "integrations.write",
+  },
+  {
+    id: "schedules",
+    label: "Schedules",
+    description: "Read and manage scheduled content generation",
+    readScope: "schedules.read",
+    writeScope: "schedules.write",
+  },
+  {
+    id: "chats",
+    label: "Chats",
+    description: "Read and manage chat sessions",
+    readScope: "chats.read",
+    writeScope: "chats.write",
+  },
+  {
     id: "skills",
     label: "Skills",
     description: "Read and manage your skills",
     readScope: "skills.read",
     writeScope: "skills.write",
-  },
-  {
-    id: "api",
-    label: "API",
-    description: "Programmatic access to the Notra API",
-    readScope: "api.read",
-    writeScope: "api.write",
   },
 ] as const;
 

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -31,17 +31,11 @@ export const OAUTH_SUPPORTED_SCOPE_SET: ReadonlySet<string> = new Set(
 
 export const OAUTH_DEFAULT_SCOPES = [
   "posts.read",
-  "posts.write",
   "brand-identities.read",
-  "brand-identities.write",
   "integrations.read",
-  "integrations.write",
   "schedules.read",
-  "schedules.write",
   "chats.read",
-  "chats.write",
   "skills.read",
-  "skills.write",
 ] as const;
 
 export const OAUTH_GRANT_QUERY_PARAM = "grant";

--- a/apps/dashboard/src/lib/api-keys/permissions.ts
+++ b/apps/dashboard/src/lib/api-keys/permissions.ts
@@ -1,20 +1,11 @@
+import {
+  API_KEY_GRANULAR_PERMISSIONS,
+  API_KEY_GRANULAR_READ_PERMISSIONS,
+} from "@/constants/api-keys";
 import type { ApiKeyPermission } from "@/types/api-keys";
 
 export function getPermissionsForLevel(permission: ApiKeyPermission) {
-  return permission === "api.write" ? ["api.read", "api.write"] : ["api.read"];
-}
-
-export function getPermissionLevel(
-  permissions: string[],
-  fallbackPermission: unknown = "api.read"
-): ApiKeyPermission {
-  if (permissions.includes("api.write")) {
-    return "api.write";
-  }
-
-  if (permissions.includes("api.read")) {
-    return "api.read";
-  }
-
-  return fallbackPermission === "api.write" ? "api.write" : "api.read";
+  return permission === "api.write"
+    ? [...API_KEY_GRANULAR_PERMISSIONS]
+    : [...API_KEY_GRANULAR_READ_PERMISSIONS];
 }

--- a/apps/dashboard/src/lib/api-keys/presets.ts
+++ b/apps/dashboard/src/lib/api-keys/presets.ts
@@ -4,6 +4,10 @@ import {
   SourceCodeIcon,
 } from "@hugeicons/core-free-icons";
 import type { ConnectedCardItem } from "@notra/ui/components/shared/connected-cards";
+import {
+  API_KEY_GRANULAR_PERMISSIONS,
+  API_KEY_GRANULAR_READ_PERMISSIONS,
+} from "@/constants/api-keys";
 import type { ApiKeyPreset } from "@/types/api-keys";
 
 const DOCS_BASE_URL = "https://docs.usenotra.com";
@@ -17,7 +21,7 @@ export const API_KEY_PRESETS: ApiKeyPreset[] = [
       "Connect Claude, Cursor, and other MCP clients to read and write your content.",
     docsHref: `${DOCS_BASE_URL}/devtools/mcp`,
     defaultName: "MCP Server",
-    permission: "api.write",
+    scopes: [...API_KEY_GRANULAR_PERMISSIONS],
     expiration: "never",
   },
   {
@@ -28,7 +32,7 @@ export const API_KEY_PRESETS: ApiKeyPreset[] = [
       "Pull your data programmatically with the TypeScript and Python SDKs.",
     docsHref: `${DOCS_BASE_URL}/api/getting-started`,
     defaultName: "SDK",
-    permission: "api.read",
+    scopes: [...API_KEY_GRANULAR_READ_PERMISSIONS],
     expiration: "never",
   },
   {
@@ -39,7 +43,7 @@ export const API_KEY_PRESETS: ApiKeyPreset[] = [
       "Script and automate your workflow from the terminal with full access.",
     docsHref: `${DOCS_BASE_URL}/devtools/cli`,
     defaultName: "CLI",
-    permission: "api.write",
+    scopes: [...API_KEY_GRANULAR_PERMISSIONS],
     expiration: "never",
   },
 ];

--- a/apps/dashboard/src/lib/api-keys/scopes.ts
+++ b/apps/dashboard/src/lib/api-keys/scopes.ts
@@ -1,0 +1,134 @@
+import {
+  API_KEY_GRANULAR_PERMISSIONS,
+  API_KEY_GRANULAR_READ_PERMISSIONS,
+  API_KEY_SCOPE_LEVEL,
+  API_KEY_SCOPE_LEVEL_LABELS,
+  API_KEY_SCOPE_RESOURCES,
+} from "@/constants/api-keys";
+import type { ApiKeyGranularScope, ApiKeyScopeGroup } from "@/types/api-keys";
+
+const GRANULAR_SCOPE_SET: ReadonlySet<string> = new Set(
+  API_KEY_GRANULAR_PERMISSIONS
+);
+
+const SCOPE_ORDER = new Map(
+  API_KEY_GRANULAR_PERMISSIONS.map((scope, index) => [scope as string, index])
+);
+
+export const API_KEY_SCOPE_GROUPS: ApiKeyScopeGroup[] =
+  API_KEY_SCOPE_RESOURCES.map((resource) => ({
+    id: resource.id,
+    label: resource.label,
+    description: resource.description,
+    readScope: resource.readScope,
+    writeScope: resource.writeScope,
+    levels: [
+      {
+        value: API_KEY_SCOPE_LEVEL.none,
+        label: API_KEY_SCOPE_LEVEL_LABELS.none,
+        tone: "neutral",
+        scopes: [],
+      },
+      {
+        value: API_KEY_SCOPE_LEVEL.read,
+        label: API_KEY_SCOPE_LEVEL_LABELS.read,
+        tone: "success",
+        scopes: [resource.readScope],
+      },
+      {
+        value: API_KEY_SCOPE_LEVEL.write,
+        label: API_KEY_SCOPE_LEVEL_LABELS.write,
+        tone: "warning",
+        scopes: [resource.readScope, resource.writeScope],
+      },
+    ],
+  }));
+
+export function deriveScopeLevel(
+  selected: Set<string>,
+  group: ApiKeyScopeGroup
+): string {
+  if (selected.has(group.writeScope)) {
+    return API_KEY_SCOPE_LEVEL.write;
+  }
+  if (selected.has(group.readScope)) {
+    return API_KEY_SCOPE_LEVEL.read;
+  }
+  return API_KEY_SCOPE_LEVEL.none;
+}
+
+export function applyScopeLevel(
+  selected: Set<string>,
+  group: ApiKeyScopeGroup,
+  levelValue: string
+): Set<string> {
+  const next = new Set(selected);
+  next.delete(group.readScope);
+  next.delete(group.writeScope);
+
+  const level = group.levels.find((item) => item.value === levelValue);
+  if (level) {
+    for (const scope of level.scopes) {
+      next.add(scope);
+    }
+  }
+
+  return next;
+}
+
+export function expandLegacyApiKeyScopes(
+  scopes: readonly string[]
+): ApiKeyGranularScope[] {
+  const next = new Set<string>();
+
+  for (const scope of scopes) {
+    if (GRANULAR_SCOPE_SET.has(scope)) {
+      next.add(scope);
+      continue;
+    }
+    if (scope === "api.write" || scope.endsWith(".write")) {
+      for (const granular of API_KEY_GRANULAR_PERMISSIONS) {
+        next.add(granular);
+      }
+      continue;
+    }
+    if (scope === "api.read" || scope.endsWith(".read")) {
+      for (const granular of API_KEY_GRANULAR_READ_PERMISSIONS) {
+        next.add(granular);
+      }
+    }
+  }
+
+  return sortApiKeyScopes([...next]);
+}
+
+export function sortApiKeyScopes(scopes: string[]): ApiKeyGranularScope[] {
+  return scopes
+    .filter((scope): scope is ApiKeyGranularScope =>
+      GRANULAR_SCOPE_SET.has(scope)
+    )
+    .sort((a, b) => (SCOPE_ORDER.get(a) ?? 0) - (SCOPE_ORDER.get(b) ?? 0));
+}
+
+export function summarizeApiKeyScopes(scopes: readonly string[]) {
+  const selected = new Set(scopes);
+  if (selected.size === 0) {
+    return "none" as const;
+  }
+
+  const everyWrite = API_KEY_SCOPE_GROUPS.every((group) =>
+    selected.has(group.writeScope)
+  );
+  if (everyWrite) {
+    return "write" as const;
+  }
+
+  const everyReadOnly = API_KEY_SCOPE_GROUPS.every(
+    (group) => selected.has(group.readScope) && !selected.has(group.writeScope)
+  );
+  if (everyReadOnly) {
+    return "read" as const;
+  }
+
+  return "custom" as const;
+}

--- a/apps/dashboard/src/lib/api-keys/scopes.ts
+++ b/apps/dashboard/src/lib/api-keys/scopes.ts
@@ -1,6 +1,7 @@
 import {
   API_KEY_GRANULAR_PERMISSIONS,
   API_KEY_GRANULAR_READ_PERMISSIONS,
+  API_KEY_LEGACY_PERMISSIONS,
   API_KEY_SCOPE_LEVEL,
   API_KEY_SCOPE_LEVEL_LABELS,
   API_KEY_SCOPE_RESOURCES,
@@ -9,6 +10,9 @@ import type { ApiKeyGranularScope, ApiKeyScopeGroup } from "@/types/api-keys";
 
 const GRANULAR_SCOPE_SET: ReadonlySet<string> = new Set(
   API_KEY_GRANULAR_PERMISSIONS
+);
+const LEGACY_SCOPE_SET: ReadonlySet<string> = new Set(
+  API_KEY_LEGACY_PERMISSIONS
 );
 
 const SCOPE_ORDER = new Map(
@@ -86,13 +90,13 @@ export function expandLegacyApiKeyScopes(
       next.add(scope);
       continue;
     }
-    if (scope === "api.write" || scope.endsWith(".write")) {
+    if (scope === "api.write") {
       for (const granular of API_KEY_GRANULAR_PERMISSIONS) {
         next.add(granular);
       }
       continue;
     }
-    if (scope === "api.read" || scope.endsWith(".read")) {
+    if (scope === "api.read") {
       for (const granular of API_KEY_GRANULAR_READ_PERMISSIONS) {
         next.add(granular);
       }
@@ -108,6 +112,12 @@ export function sortApiKeyScopes(scopes: string[]): ApiKeyGranularScope[] {
       GRANULAR_SCOPE_SET.has(scope)
     )
     .sort((a, b) => (SCOPE_ORDER.get(a) ?? 0) - (SCOPE_ORDER.get(b) ?? 0));
+}
+
+export function getUnknownApiKeyPermissions(scopes: readonly string[]) {
+  return scopes.filter(
+    (scope) => !(GRANULAR_SCOPE_SET.has(scope) || LEGACY_SCOPE_SET.has(scope))
+  );
 }
 
 export function summarizeApiKeyScopes(scopes: readonly string[]) {

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -22,6 +22,7 @@ import { isValid as isNotDisposableEmail } from "mailchecker";
 import { cookies } from "next/headers";
 import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
 import {
+  OAUTH_ACCEPTED_SCOPES,
   OAUTH_ACCESS_TOKEN_TTL_SECONDS,
   OAUTH_AUTH_CODE_TTL_MS,
   OAUTH_DEFAULT_SCOPES,
@@ -299,7 +300,7 @@ export const auth = betterAuth({
     oauthProvider({
       loginPage: "/login",
       consentPage: "/agent/auth/authorize",
-      scopes: [...OAUTH_SUPPORTED_SCOPES],
+      scopes: [...OAUTH_ACCEPTED_SCOPES],
       validAudiences: [...OAUTH_SUPPORTED_RESOURCES],
       grantTypes: ["authorization_code", "refresh_token"],
       accessTokenExpiresIn: OAUTH_ACCESS_TOKEN_TTL_SECONDS,

--- a/apps/dashboard/src/lib/orpc/routers/api-keys.ts
+++ b/apps/dashboard/src/lib/orpc/routers/api-keys.ts
@@ -5,9 +5,9 @@ import type {
 import { z } from "zod";
 import { API_KEY_EXPIRATION_MS } from "@/constants/api-keys";
 import {
-  getPermissionLevel,
-  getPermissionsForLevel,
-} from "@/lib/api-keys/permissions";
+  expandLegacyApiKeyScopes,
+  summarizeApiKeyScopes,
+} from "@/lib/api-keys/scopes";
 import { unkey } from "@/lib/api-keys/unkey";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { assertActiveSubscription } from "@/lib/billing/subscription";
@@ -148,10 +148,7 @@ export const apiKeysRouter = {
             )
           : [];
 
-        const normalizedPermission = getPermissionLevel(
-          permissions,
-          meta.permission
-        );
+        const scopes = expandLegacyApiKeyScopes(permissions);
 
         return {
           createdAt: key.createdAt,
@@ -160,8 +157,8 @@ export const apiKeysRouter = {
           expires: key.expires ?? null,
           keyId: key.keyId,
           name: key.name ?? "Unnamed",
-          permission: normalizedPermission,
-          permissions,
+          permission: summarizeApiKeyScopes(scopes),
+          permissions: scopes,
           start: key.start,
         };
       });
@@ -186,10 +183,9 @@ export const apiKeysRouter = {
         externalId: input.organizationId,
         meta: {
           createdBy: context.user.name,
-          permission: input.permission,
         },
         name: input.name,
-        permissions: getPermissionsForLevel(input.permission),
+        permissions: input.scopes,
         prefix: "ntra",
       });
 
@@ -256,12 +252,9 @@ export const apiKeysRouter = {
       await client.keys.updateKey({
         expires,
         keyId: input.payload.keyId,
-        meta: {
-          ...meta,
-          permission: input.payload.permission,
-        },
+        meta,
         name: input.payload.name,
-        permissions: getPermissionsForLevel(input.payload.permission),
+        permissions: input.payload.scopes,
       });
 
       return { success: true };

--- a/apps/dashboard/src/lib/orpc/routers/api-keys.ts
+++ b/apps/dashboard/src/lib/orpc/routers/api-keys.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { API_KEY_EXPIRATION_MS } from "@/constants/api-keys";
 import {
   expandLegacyApiKeyScopes,
+  getUnknownApiKeyPermissions,
   summarizeApiKeyScopes,
 } from "@/lib/api-keys/scopes";
 import { unkey } from "@/lib/api-keys/unkey";
@@ -158,7 +159,7 @@ export const apiKeysRouter = {
           keyId: key.keyId,
           name: key.name ?? "Unnamed",
           permission: summarizeApiKeyScopes(scopes),
-          permissions: scopes,
+          permissions,
           start: key.start,
         };
       });
@@ -249,12 +250,20 @@ export const apiKeysRouter = {
           Date.now() + (API_KEY_EXPIRATION_MS[input.payload.expiration] ?? 0);
       }
 
+      const currentPermissions = Array.isArray(key.permissions)
+        ? key.permissions.filter(
+            (permission): permission is string => typeof permission === "string"
+          )
+        : [];
+      const unknownPermissions =
+        getUnknownApiKeyPermissions(currentPermissions);
+
       await client.keys.updateKey({
         expires,
         keyId: input.payload.keyId,
         meta,
         name: input.payload.name,
-        permissions: input.payload.scopes,
+        permissions: [...input.payload.scopes, ...unknownPermissions],
       });
 
       return { success: true };

--- a/apps/dashboard/src/schemas/api-keys.ts
+++ b/apps/dashboard/src/schemas/api-keys.ts
@@ -2,19 +2,23 @@
 import * as z from "zod";
 import {
   API_KEY_EXPIRATION_VALUES,
-  API_KEY_PERMISSIONS,
+  API_KEY_GRANULAR_PERMISSIONS,
 } from "@/constants/api-keys";
+
+const scopesSchema = z
+  .array(z.enum(API_KEY_GRANULAR_PERMISSIONS))
+  .min(1, "Select at least one permission");
 
 export const createApiKeySchema = z.object({
   name: z.string().min(1, "Name is required").max(100).trim(),
-  permission: z.enum(API_KEY_PERMISSIONS),
+  scopes: scopesSchema,
   expiration: z.enum(API_KEY_EXPIRATION_VALUES),
 });
 
 export const updateApiKeySchema = z.object({
   keyId: z.string().min(1, "Key ID is required"),
   name: z.string().min(1, "Name is required").max(100).trim(),
-  permission: z.enum(API_KEY_PERMISSIONS),
+  scopes: scopesSchema,
   expiration: z.enum(API_KEY_EXPIRATION_VALUES),
 });
 

--- a/apps/dashboard/src/schemas/oauth.ts
+++ b/apps/dashboard/src/schemas/oauth.ts
@@ -1,9 +1,11 @@
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 import {
+  OAUTH_ACCEPTED_SCOPES,
   OAUTH_SUPPORTED_RESOURCES,
   OAUTH_SUPPORTED_SCOPES,
 } from "@/constants/oauth";
+import { expandLegacyOAuthScopes } from "@/utils/oauth-scopes";
 
 const SCOPE_SEPARATOR_REGEX = /\s+/;
 
@@ -12,7 +14,8 @@ const scopeSchema = z
   .trim()
   .min(1)
   .transform((value) => value.split(SCOPE_SEPARATOR_REGEX))
-  .pipe(z.array(z.enum(OAUTH_SUPPORTED_SCOPES)).min(1))
+  .pipe(z.array(z.enum(OAUTH_ACCEPTED_SCOPES)).min(1))
+  .transform(expandLegacyOAuthScopes)
   .transform((value) => value.join(" "));
 
 const consentScopeSchema = z

--- a/apps/dashboard/src/types/api-keys.ts
+++ b/apps/dashboard/src/types/api-keys.ts
@@ -1,11 +1,14 @@
 import type { IconSvgElement } from "@hugeicons/react";
+import type { PermissionTone } from "@notra/ui/components/ui/permission-selector";
 import type {
   API_KEY_EXPIRATION_VALUES,
+  API_KEY_GRANULAR_PERMISSIONS,
   API_KEY_PERMISSIONS,
   API_KEY_PRESET_IDS,
 } from "@/constants/api-keys";
 
 export type ApiKeyPermission = (typeof API_KEY_PERMISSIONS)[number];
+export type ApiKeyGranularScope = (typeof API_KEY_GRANULAR_PERMISSIONS)[number];
 export type ApiKeyPresetId = (typeof API_KEY_PRESET_IDS)[number];
 export type ApiKeyExpiration = (typeof API_KEY_EXPIRATION_VALUES)[number];
 
@@ -16,6 +19,43 @@ export interface ApiKeyPreset {
   description: string;
   docsHref: string;
   defaultName: string;
-  permission: ApiKeyPermission;
+  scopes: ApiKeyGranularScope[];
   expiration: ApiKeyExpiration;
 }
+
+export interface ApiKeyScopeLevel {
+  value: string;
+  label: string;
+  tone: PermissionTone;
+  scopes: ApiKeyGranularScope[];
+}
+
+export interface ApiKeyScopeGroup {
+  id: string;
+  label: string;
+  description: string;
+  readScope: ApiKeyGranularScope;
+  writeScope: ApiKeyGranularScope;
+  levels: ApiKeyScopeLevel[];
+}
+
+export interface ApiKeyRevealFieldProps {
+  value: string;
+  className?: string;
+}
+
+export interface ApiKeyPermissionSelectorProps {
+  value: string[];
+  onValueChange: (scopes: string[]) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export interface ApiKeyFormValues {
+  keyId: string;
+  name: string;
+  scopes: string[];
+  expiration: ApiKeyExpiration;
+}
+
+export type ApiKeyCreateConfig = Omit<ApiKeyFormValues, "keyId">;

--- a/apps/dashboard/src/utils/oauth-scopes.ts
+++ b/apps/dashboard/src/utils/oauth-scopes.ts
@@ -1,0 +1,19 @@
+import { OAUTH_DEFAULT_SCOPES, OAUTH_LEGACY_SCOPES } from "@/constants/oauth";
+
+const LEGACY_SCOPE_SET: ReadonlySet<string> = new Set(OAUTH_LEGACY_SCOPES);
+
+export function expandLegacyOAuthScopes(scopes: readonly string[]) {
+  if (!scopes.some((scope) => LEGACY_SCOPE_SET.has(scope))) {
+    return [...scopes];
+  }
+
+  const next = new Set(scopes);
+  for (const scope of OAUTH_LEGACY_SCOPES) {
+    next.delete(scope);
+  }
+  for (const scope of OAUTH_DEFAULT_SCOPES) {
+    next.add(scope);
+  }
+
+  return [...next];
+}

--- a/apps/dashboard/src/utils/oauth-scopes.ts
+++ b/apps/dashboard/src/utils/oauth-scopes.ts
@@ -5,6 +5,7 @@ import {
 } from "@/constants/oauth";
 
 const LEGACY_SCOPE_SET: ReadonlySet<string> = new Set(OAUTH_LEGACY_SCOPES);
+const OFFLINE_ACCESS_SCOPE = "offline_access";
 
 export function expandLegacyOAuthScopes(scopes: readonly string[]) {
   if (!scopes.some((scope) => LEGACY_SCOPE_SET.has(scope))) {
@@ -15,8 +16,8 @@ export function expandLegacyOAuthScopes(scopes: readonly string[]) {
   for (const scope of OAUTH_LEGACY_SCOPES) {
     next.delete(scope);
   }
-  const expandedScopes = scopes.includes("api.write")
-    ? OAUTH_SUPPORTED_SCOPES
+  const expandedScopes: readonly string[] = scopes.includes("api.write")
+    ? OAUTH_SUPPORTED_SCOPES.filter((scope) => scope !== OFFLINE_ACCESS_SCOPE)
     : OAUTH_DEFAULT_SCOPES;
   for (const scope of expandedScopes) {
     next.add(scope);

--- a/apps/dashboard/src/utils/oauth-scopes.ts
+++ b/apps/dashboard/src/utils/oauth-scopes.ts
@@ -1,4 +1,8 @@
-import { OAUTH_DEFAULT_SCOPES, OAUTH_LEGACY_SCOPES } from "@/constants/oauth";
+import {
+  OAUTH_DEFAULT_SCOPES,
+  OAUTH_LEGACY_SCOPES,
+  OAUTH_SUPPORTED_SCOPES,
+} from "@/constants/oauth";
 
 const LEGACY_SCOPE_SET: ReadonlySet<string> = new Set(OAUTH_LEGACY_SCOPES);
 
@@ -11,7 +15,10 @@ export function expandLegacyOAuthScopes(scopes: readonly string[]) {
   for (const scope of OAUTH_LEGACY_SCOPES) {
     next.delete(scope);
   }
-  for (const scope of OAUTH_DEFAULT_SCOPES) {
+  const expandedScopes = scopes.includes("api.write")
+    ? OAUTH_SUPPORTED_SCOPES
+    : OAUTH_DEFAULT_SCOPES;
+  for (const scope of expandedScopes) {
     next.add(scope);
   }
 

--- a/apps/docs/api/authentication.mdx
+++ b/apps/docs/api/authentication.mdx
@@ -45,7 +45,7 @@ console.log(result);
 1. Open your workspace dashboard.
 2. Go to **API Keys** under **Developer**.
 3. Click **Create API Key**.
-4. Choose a name, permission, and optional expiration.
+4. Choose a name, resource permissions, and optional expiration.
 5. Copy the key and store it securely.
 
 <img
@@ -60,6 +60,24 @@ console.log(result);
 />
 
 API keys are powered by [Unkey](https://unkey.dev).
+
+## Permissions
+
+API keys can be scoped per resource. Grant **Read** when a key only needs to
+fetch data, **Write** when it needs to create, update, or delete that resource,
+and **None** when the key should not access the resource.
+
+Available resources:
+
+- Posts
+- Brand identities
+- Integrations
+- Schedules
+- Chats
+- Skills
+
+Legacy keys with the older `api.read` and `api.write` permissions continue to
+work. New keys use the resource-specific scopes.
 
 ## Error Handling
 

--- a/apps/docs/devtools/mcp.mdx
+++ b/apps/docs/devtools/mcp.mdx
@@ -40,9 +40,9 @@ Create and manage API keys in [Authentication](/api/authentication).
 />
 
 <Tip>
-  For manual API-key connections, use an API key with both read and write
-  permissions so the MCP server can complete the full set of actions your client
-  requests.
+  For manual API-key connections, grant read and write access for the resources
+  your MCP client should manage, such as posts, brand identities, integrations,
+  schedules, chats, and skills.
 </Tip>
 
 ## Install

--- a/apps/docs/devtools/raycast.mdx
+++ b/apps/docs/devtools/raycast.mdx
@@ -21,8 +21,8 @@ The Notra Raycast extension brings your workspace into Raycast so you can browse
     Open the Raycast Store, search for **Notra**, and install the extension.
   </Step>
 
-  <Step title="Create a read and write API key">
-    Head to **API Keys** in your dashboard, create a new key with read and write permissions, and copy it.
+  <Step title="Create an API key">
+    Head to **API Keys** in your dashboard, create a new key, grant read and write access for the resources you want to use in Raycast, and copy it.
 
     See [Authentication](/api/authentication) for details on creating and managing keys.
   </Step>
@@ -37,7 +37,7 @@ The Notra Raycast extension brings your workspace into Raycast so you can browse
 </Steps>
 
 <Tip>
-  Use a read and write key so the extension can perform the full set of actions, like updating drafts and triggering generation.
+  Grant write access for resources Raycast should update, like posts or schedules. Read-only access is enough for browsing and copying existing content.
 </Tip>
 
 ## Notes

--- a/apps/docs/integrations/framer.mdx
+++ b/apps/docs/integrations/framer.mdx
@@ -8,7 +8,7 @@ This guide shows how to connect Notra to [Framer](https://www.framer.com/) and p
 ## Prerequisites
 
 - Access to a Framer project.
-- A read-only Notra API key.
+- A Notra API key with read access to posts.
 - Posts in Notra that you want to import.
 
 ## Install
@@ -27,7 +27,7 @@ Install the official Notra plugin from the [Framer Marketplace](https://www.fram
 ## Connect Notra to Framer
 
 1. In Notra, go to **Developer** > **API Keys**.
-2. Create a new API key with **read-only** permissions.
+2. Create a new API key with **Read** access for posts.
 
 <img
   src="/images/api/api-keys-light.webp"

--- a/apps/web/src/app/auth.md/route.ts
+++ b/apps/web/src/app/auth.md/route.ts
@@ -14,7 +14,7 @@ The \`agent_auth\` block documents \`anonymous\` and \`identity_assertion\` requ
 
 ## Register
 
-Call \`POST /agent/auth/register\` to confirm the supported registration metadata. Production API keys are created in the Notra dashboard. Agents should request the least privileged scopes: \`api.read\` for reads, \`posts.write\` for content updates, and \`skills.write\` only when modifying reusable writing skills.
+Call \`POST /agent/auth/register\` to confirm the supported registration metadata. Production API keys are created in the Notra dashboard. Agents should request the least privileged resource scopes, such as \`posts.read\`, \`posts.write\`, \`skills.read\`, \`skills.write\`, \`integrations.read\`, and \`integrations.write\`.
 
 ## Claim
 

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -26,10 +26,16 @@ export const NOTRA_SAME_AS = [
 ] as const;
 
 const PUBLIC_API_SCOPES = [
-  "api.read",
-  "api.write",
   "posts.read",
   "posts.write",
+  "brand-identities.read",
+  "brand-identities.write",
+  "integrations.read",
+  "integrations.write",
+  "schedules.read",
+  "schedules.write",
+  "chats.read",
+  "chats.write",
   "skills.read",
   "skills.write",
 ] as const;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds granular, resource-scoped permissions for API keys and OAuth with route-level enforcement and legacy compatibility. Updates the dashboard API key UX and centralizes scope resources used across the API, OAuth, and docs.

- **New Features**
  - API: Route-level scope mapping for all `/v1` endpoints (incl. legacy org routes); auth middleware and Unkey verification try granular scopes first, then legacy `api.read`/`api.write`; scope resources are centralized and reused for enforcement and metadata.
  - Dashboard: Permission selector with Read/Write/None per resource; presets grant resource scopes; create/edit accept multiple scopes; key list shows a read/write/custom/none summary; one-time key reveal with clipboard error handling; editing preserves unknown external scopes; fixed React Doctor warnings.
  - OAuth: Accepts legacy scopes but expands them to resource scopes during auth/consent; default scopes are read-only per resource; supported scopes include legacy for compatibility; public resource metadata advertises granular scopes; does not auto-add `offline_access` when expanding legacy scopes (must be requested explicitly).

- **Migration**
  - No action required. Existing API keys and OAuth apps using `api.read`/`api.write` keep working.
  - Recommended: create new keys/apps with resource scopes and migrate over time for least-privilege access.

<sup>Written for commit 2e1a3fb92ab23e5c8945a33a9ede9f70b2ecdf81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

