### PR TITLE
feat: add event trigger editing

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
@@ -40,6 +40,7 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
 import type { Trigger } from "@/types/triggers/triggers";
+import { getDefaultEventTriggerValues } from "@/utils/event-trigger-form";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 
 function formatEventList(events?: string[]) {
@@ -71,6 +72,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     false | "asc" | "desc"
   >(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
 
   useHotkey("C", () => setCreateOpen(true), { enabled: !createOpen });
 
@@ -105,14 +107,17 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
       if (!organizationId) {
         throw new Error("Organization ID is required");
       }
+      const values = getDefaultEventTriggerValues(trigger);
 
       return dashboardOrpc.automation.events.update.call({
         organizationId,
         triggerId: trigger.id,
-        sourceType: trigger.sourceType,
-        sourceConfig: trigger.sourceConfig,
+        sourceType: "github_webhook",
+        sourceConfig: {
+          eventTypes: trigger.sourceConfig.eventTypes ?? [values.eventType],
+        },
         targets: trigger.targets,
-        outputType: trigger.outputType,
+        outputType: values.outputType,
         outputConfig: trigger.outputConfig ?? {},
         enabled: !trigger.enabled,
         autoPublish: trigger.autoPublish,
@@ -187,6 +192,13 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const handleDelete = useCallback(
     (id: string) => deleteMutation.mutate(id),
     [deleteMutation]
+  );
+
+  const handleEdit = useCallback(
+    (trigger: Trigger) => {
+      setEditTrigger(trigger);
+    },
+    [setEditTrigger]
   );
 
   return (
@@ -270,6 +282,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 createdSortOrder={createdSortOrder}
                 defaultBrandVoice={defaultBrandVoice}
                 onDelete={handleDelete}
+                onEdit={handleEdit}
                 onSortCreatedChange={setCreatedSortOrder}
                 onToggle={handleToggle}
                 triggers={filteredTriggers}
@@ -282,6 +295,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 createdSortOrder={createdSortOrder}
                 defaultBrandVoice={defaultBrandVoice}
                 onDelete={handleDelete}
+                onEdit={handleEdit}
                 onSortCreatedChange={setCreatedSortOrder}
                 onToggle={handleToggle}
                 triggers={filteredTriggers}
@@ -290,6 +304,22 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           </Tabs>
         )}
       </div>
+      {editTrigger && (
+        <CreateEventTriggerDialog
+          editTrigger={editTrigger}
+          onOpenChange={(open) => !open && setEditTrigger(null)}
+          onSuccess={() => {
+            setEditTrigger(null);
+            queryClient.invalidateQueries({
+              queryKey: dashboardOrpc.automation.events.list.queryKey({
+                input: { organizationId: organizationId ?? "" },
+              }),
+            });
+          }}
+          open={!!editTrigger}
+          organizationId={organizationId ?? ""}
+        />
+      )}
     </PageContainer>
   );
 }
@@ -302,6 +332,7 @@ function EventTable({
   onSortCreatedChange,
   onToggle,
   onDelete,
+  onEdit,
 }: {
   triggers: Trigger[];
   brandVoiceMap: Record<string, BrandSettings>;
@@ -310,6 +341,7 @@ function EventTable({
   onSortCreatedChange: (next: false | "asc" | "desc") => void;
   onToggle: (trigger: Trigger) => void;
   onDelete: (triggerId: string) => void;
+  onEdit: (trigger: Trigger) => void;
 }) {
   const sortedTriggers = useMemo(() => {
     if (createdSortOrder === false) {
@@ -419,6 +451,7 @@ function EventTable({
                 <TableCell>
                   <TriggerRowActions
                     onDelete={onDelete}
+                    onEdit={onEdit}
                     onToggle={onToggle}
                     trigger={trigger}
                   />

--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
@@ -25,7 +25,7 @@ import {
 } from "@notra/ui/components/ui/tabs";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { BrandVoiceCell } from "@/components/automation/brand-voice-cell";
 import { CreateEventTriggerDialog } from "@/components/automation/events/create-event-trigger-dialog";
@@ -46,6 +46,12 @@ import {
 } from "@/utils/event-trigger-form";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 
+const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
 function formatEventList(events?: string[]) {
   if (!events || events.length === 0) {
     return "All events";
@@ -54,11 +60,17 @@ function formatEventList(events?: string[]) {
 }
 
 function formatDate(dateString: string) {
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date(dateString));
+  return DATE_FORMATTER.format(new Date(dateString));
+}
+
+function getSortIcon(isSorted: false | "asc" | "desc") {
+  if (isSorted === "asc") {
+    return ArrowUp01Icon;
+  }
+  if (isSorted === "desc") {
+    return ArrowDown01Icon;
+  }
+  return ArrowUpDownIcon;
 }
 
 interface PageClientProps {
@@ -93,17 +105,14 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     })
   );
 
-  const { brandVoiceMap, defaultBrandVoice } = useMemo(() => {
-    const map: Record<string, BrandSettings> = {};
-    let defaultVoice: BrandSettings | undefined;
-    for (const voice of brandResponse?.voices ?? []) {
-      map[voice.id] = voice;
-      if (voice.isDefault) {
-        defaultVoice = voice;
-      }
+  const brandVoiceMap: Record<string, BrandSettings> = {};
+  let defaultBrandVoice: BrandSettings | undefined;
+  for (const voice of brandResponse?.voices ?? []) {
+    brandVoiceMap[voice.id] = voice;
+    if (voice.isDefault) {
+      defaultBrandVoice = voice;
     }
-    return { brandVoiceMap: map, defaultBrandVoice: defaultVoice };
-  }, [brandResponse]);
+  }
 
   const updateMutation = useMutation({
     mutationFn: async (trigger: Trigger) => {
@@ -165,40 +174,31 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     },
   });
 
-  const triggers = data?.triggers ?? [];
-  const eventTriggers = useMemo(
-    () => triggers.filter((trigger) => trigger.sourceType === "github_webhook"),
-    [triggers]
+  const eventTriggers =
+    data?.triggers.filter(
+      (trigger) => trigger.sourceType === "github_webhook"
+    ) ?? [];
+  const filteredTriggers = eventTriggers.filter((trigger) =>
+    activeTab === "active" ? trigger.enabled : !trigger.enabled
   );
 
-  const filteredTriggers = useMemo(() => {
-    return eventTriggers.filter((t) =>
-      activeTab === "active" ? t.enabled : !t.enabled
-    );
-  }, [eventTriggers, activeTab]);
-
-  const activeCounts = useMemo(() => {
-    let active = 0;
-    let paused = 0;
-    for (const t of eventTriggers) {
-      if (t.enabled) {
-        active++;
-      } else {
-        paused++;
-      }
+  let active = 0;
+  let paused = 0;
+  for (const trigger of eventTriggers) {
+    if (trigger.enabled) {
+      active++;
+    } else {
+      paused++;
     }
-    return { active, paused };
-  }, [eventTriggers]);
+  }
 
-  const handleToggle = useCallback(
-    (trigger: Trigger) => updateMutation.mutate(trigger),
-    [updateMutation]
-  );
+  const handleToggle = (trigger: Trigger) => {
+    updateMutation.mutate(trigger);
+  };
 
-  const handleDelete = useCallback(
-    (id: string) => deleteMutation.mutate(id),
-    [deleteMutation]
-  );
+  const handleDelete = (id: string) => {
+    deleteMutation.mutate(id);
+  };
 
   const handleEdit = (trigger: Trigger) => {
     setEditTrigger(trigger);
@@ -271,12 +271,8 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             }
           >
             <TabsList variant="line">
-              <TabsTrigger value="active">
-                Active ({activeCounts.active})
-              </TabsTrigger>
-              <TabsTrigger value="paused">
-                Paused ({activeCounts.paused})
-              </TabsTrigger>
+              <TabsTrigger value="active">Active ({active})</TabsTrigger>
+              <TabsTrigger value="paused">Paused ({paused})</TabsTrigger>
             </TabsList>
 
             <TabsContent className="mt-4" value="active">
@@ -346,28 +342,17 @@ function EventTable({
   onDelete: (triggerId: string) => void;
   onEdit: (trigger: Trigger) => void;
 }) {
-  const sortedTriggers = useMemo(() => {
-    if (createdSortOrder === false) {
-      return triggers;
-    }
-    return [...triggers].sort((a, b) => {
-      const createdAtA = new Date(a.createdAt).getTime();
-      const createdAtB = new Date(b.createdAt).getTime();
-      return createdSortOrder === "desc"
-        ? createdAtB - createdAtA
-        : createdAtA - createdAtB;
-    });
-  }, [triggers, createdSortOrder]);
+  const sortedTriggers =
+    createdSortOrder === false
+      ? triggers
+      : Array.from(triggers).sort((a, b) => {
+          const createdAtA = new Date(a.createdAt).getTime();
+          const createdAtB = new Date(b.createdAt).getTime();
+          return createdSortOrder === "desc"
+            ? createdAtB - createdAtA
+            : createdAtA - createdAtB;
+        });
 
-  function getSortIcon(isSorted: false | "asc" | "desc") {
-    if (isSorted === "asc") {
-      return ArrowUp01Icon;
-    }
-    if (isSorted === "desc") {
-      return ArrowDown01Icon;
-    }
-    return ArrowUpDownIcon;
-  }
   const sortIcon = getSortIcon(createdSortOrder);
 
   if (triggers.length === 0) {

--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
@@ -40,7 +40,10 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
 import type { Trigger } from "@/types/triggers/triggers";
-import { getDefaultEventTriggerValues } from "@/utils/event-trigger-form";
+import {
+  getDefaultEventTriggerValues,
+  isAutomationOutputType,
+} from "@/utils/event-trigger-form";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
 
 function formatEventList(events?: string[]) {
@@ -108,6 +111,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         throw new Error("Organization ID is required");
       }
       const values = getDefaultEventTriggerValues(trigger);
+      const outputType = isAutomationOutputType(trigger.outputType)
+        ? trigger.outputType
+        : values.outputType;
 
       return dashboardOrpc.automation.events.update.call({
         organizationId,
@@ -117,7 +123,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           eventTypes: trigger.sourceConfig.eventTypes ?? [values.eventType],
         },
         targets: trigger.targets,
-        outputType: values.outputType,
+        outputType,
         outputConfig: trigger.outputConfig ?? {},
         enabled: !trigger.enabled,
         autoPublish: trigger.autoPublish,
@@ -194,12 +200,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     [deleteMutation]
   );
 
-  const handleEdit = useCallback(
-    (trigger: Trigger) => {
-      setEditTrigger(trigger);
-    },
-    [setEditTrigger]
-  );
+  const handleEdit = (trigger: Trigger) => {
+    setEditTrigger(trigger);
+  };
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">

--- a/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
+++ b/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
@@ -36,7 +36,7 @@ import {
 } from "@notra/ui/components/ui/tooltip";
 import { useForm, useStore } from "@tanstack/react-form";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { BrandIdentityRadioGroup } from "@/components/brand-identity-radio-group";
 import { Button } from "@/components/button";
@@ -69,16 +69,16 @@ export function CreateEventTriggerDialog({
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
-  const setOpen = useCallback(
-    (next: boolean) => {
-      if (isControlled) {
-        controlledOnOpenChange?.(next);
-      } else {
-        setInternalOpen(next);
-      }
-    },
-    [controlledOnOpenChange, isControlled]
-  );
+  const setOpen = (next: boolean) => {
+    if (next) {
+      form.reset(getDefaultEventTriggerValues(editTrigger));
+    }
+    if (isControlled) {
+      controlledOnOpenChange?.(next);
+    } else {
+      setInternalOpen(next);
+    }
+  };
   const [addRepoOpen, setAddRepoOpen] = useState(false);
   const comboboxAnchor = useComboboxAnchor();
 
@@ -144,12 +144,6 @@ export function CreateEventTriggerDialog({
     },
   });
 
-  useEffect(() => {
-    if (open) {
-      form.reset(getDefaultEventTriggerValues(editTrigger));
-    }
-  }, [open, editTrigger, form]);
-
   const outputType = useStore(form.store, (s) => s.values.outputType);
   const repositoryCount = useStore(
     form.store,
@@ -179,27 +173,20 @@ export function CreateEventTriggerDialog({
     ? `${defaultBrandVoiceName} (Default)`
     : "Default brand voice";
 
-  const { integrationOptions, githubIntegrationId } = useMemo(() => {
-    const githubIntegrations =
-      integrationsResponse?.integrations.filter(
-        (i) => i.type === "github" && i.enabled
-      ) ?? [];
-    const repos = githubIntegrations.flatMap((i) =>
-      i.repositories.filter((r) => r.enabled)
-    );
-
-    const options = repos.map((r) => ({
-      value: r.id,
-      label: r.defaultBranch
-        ? `${r.owner}/${r.repo} · ${r.defaultBranch}`
-        : `${r.owner}/${r.repo}`,
-    }));
-
-    return {
-      integrationOptions: options,
-      githubIntegrationId: githubIntegrations[0]?.id,
-    };
-  }, [integrationsResponse]);
+  const githubIntegrations =
+    integrationsResponse?.integrations.filter(
+      (integration) => integration.type === "github" && integration.enabled
+    ) ?? [];
+  const repos = githubIntegrations.flatMap((integration) =>
+    integration.repositories.filter((repository) => repository.enabled)
+  );
+  const integrationOptions = repos.map((repository) => ({
+    value: repository.id,
+    label: repository.defaultBranch
+      ? `${repository.owner}/${repository.repo} · ${repository.defaultBranch}`
+      : `${repository.owner}/${repository.repo}`,
+  }));
+  const githubIntegrationId = githubIntegrations[0]?.id;
 
   const formError = useStore(form.store, (state) => {
     if (state.submissionAttempts === 0) {
@@ -223,12 +210,12 @@ export function CreateEventTriggerDialog({
     return null;
   });
 
-  const handleOpenAddRepoFlow = useCallback(() => {
+  const handleOpenAddRepoFlow = () => {
     setAddRepoOpen(true);
     if (!isEditMode) {
       setOpen(false);
     }
-  }, [isEditMode, setOpen]);
+  };
 
   return (
     <>
@@ -450,69 +437,117 @@ export function CreateEventTriggerDialog({
               </div>
             </div>
 
-            <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
-              <div className="flex items-center justify-between gap-3">
-                <FooterStatus
-                  errorMessage={formError}
-                  repositoryCount={repositoryCount}
-                />
-                <div className="flex items-center gap-2">
-                  <Button
-                    disabled={mutation.isPending}
-                    onClick={() => setOpen(false)}
-                    size="sm"
-                    type="button"
-                    variant="ghost"
-                  >
-                    Cancel
-                  </Button>
-                  <Button disabled={mutation.isPending} type="submit">
-                    {mutation.isPending ? (
-                      <>
-                        <HugeiconsIcon
-                          className="size-4 animate-spin"
-                          icon={Loading03Icon}
-                        />
-                        {isEditMode ? "Saving..." : "Adding..."}
-                      </>
-                    ) : (
-                      <>
-                        <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                        {isEditMode ? "Save changes" : "Add trigger"}
-                      </>
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </div>
+            <DialogFooter
+              errorMessage={formError}
+              isEditMode={isEditMode}
+              isPending={mutation.isPending}
+              onCancel={() => setOpen(false)}
+              repositoryCount={repositoryCount}
+            />
           </form>
         </ResponsiveDialogContent>
       </ResponsiveDialog>
-      {githubIntegrationId ? (
-        <AddRepositoryDialog
-          integrationId={githubIntegrationId}
-          onOpenChange={(isOpen) => {
-            setAddRepoOpen(isOpen);
-            if (!(isOpen || isEditMode)) {
-              setOpen(true);
-            }
-          }}
-          open={addRepoOpen}
-          organizationId={organizationId}
-        />
-      ) : (
-        <AddIntegrationDialog
-          onOpenChange={(isOpen) => {
-            setAddRepoOpen(isOpen);
-            if (!(isOpen || isEditMode)) {
-              setOpen(true);
-            }
-          }}
-          open={addRepoOpen}
-          organizationId={organizationId}
-        />
-      )}
+      <RepositoryConnectionDialogs
+        githubIntegrationId={githubIntegrationId}
+        isEditMode={isEditMode}
+        onOpenChange={(isOpen) => {
+          setAddRepoOpen(isOpen);
+          if (!(isOpen || isEditMode)) {
+            setOpen(true);
+          }
+        }}
+        open={addRepoOpen}
+        organizationId={organizationId}
+      />
     </>
+  );
+}
+
+interface DialogFooterProps {
+  errorMessage: string | null;
+  isEditMode: boolean;
+  isPending: boolean;
+  onCancel: () => void;
+  repositoryCount: number;
+}
+
+function DialogFooter({
+  errorMessage,
+  isEditMode,
+  isPending,
+  onCancel,
+  repositoryCount,
+}: DialogFooterProps) {
+  return (
+    <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <FooterStatus
+          errorMessage={errorMessage}
+          repositoryCount={repositoryCount}
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            disabled={isPending}
+            onClick={onCancel}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+          <Button disabled={isPending} type="submit">
+            {isPending ? (
+              <>
+                <HugeiconsIcon
+                  className="size-4 animate-spin"
+                  icon={Loading03Icon}
+                />
+                {isEditMode ? "Saving..." : "Adding..."}
+              </>
+            ) : (
+              <>
+                <HugeiconsIcon className="size-4" icon={Add01Icon} />
+                {isEditMode ? "Save changes" : "Add trigger"}
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface RepositoryConnectionDialogsProps {
+  githubIntegrationId?: string;
+  isEditMode: boolean;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  organizationId: string;
+}
+
+function RepositoryConnectionDialogs({
+  githubIntegrationId,
+  onOpenChange,
+  open,
+  organizationId,
+}: RepositoryConnectionDialogsProps) {
+  if (githubIntegrationId) {
+    return (
+      <AddRepositoryDialog
+        integrationId={githubIntegrationId}
+        onOpenChange={onOpenChange}
+        open={open}
+        organizationId={organizationId}
+      />
+    );
+  }
+
+  return (
+    <AddIntegrationDialog
+      onOpenChange={onOpenChange}
+      open={open}
+      organizationId={organizationId}
+    />
   );
 }
 

--- a/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
+++ b/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
@@ -54,23 +54,18 @@ import {
 } from "@/schemas/automation/event-trigger-form";
 import type { CreateEventTriggerDialogProps } from "@/types/automation/event-trigger";
 import type { Trigger } from "@/types/triggers/triggers";
+import { getDefaultEventTriggerValues } from "@/utils/event-trigger-form";
 import { EventTypeCard } from "./event-type-card";
-
-const DEFAULT_VALUES: EventTriggerFormValues = {
-  eventType: "release",
-  outputType: "changelog",
-  repositoryIds: [],
-  brandVoiceId: "",
-  autoPublish: false,
-};
 
 export function CreateEventTriggerDialog({
   organizationId,
   onSuccess,
   trigger,
+  editTrigger,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
 }: CreateEventTriggerDialogProps) {
+  const isEditMode = !!editTrigger;
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
@@ -109,6 +104,13 @@ export function CreateEventTriggerDialog({
       };
 
       try {
+        if (isEditMode) {
+          return await dashboardOrpc.automation.events.update.call({
+            triggerId: editTrigger.id,
+            ...payload,
+            enabled: editTrigger.enabled,
+          });
+        }
         return await dashboardOrpc.automation.events.create.call(payload);
       } catch (error) {
         if (error instanceof Error && error.message === "Duplicate trigger") {
@@ -117,11 +119,13 @@ export function CreateEventTriggerDialog({
         if (error instanceof Error && error.message) {
           throw error;
         }
-        throw new Error("Failed to create trigger");
+        throw new Error(
+          isEditMode ? "Failed to update trigger" : "Failed to create trigger"
+        );
       }
     },
     onSuccess: (data) => {
-      toast.success("Trigger added");
+      toast.success(isEditMode ? "Trigger updated" : "Trigger added");
       onSuccess?.(data.trigger);
       setOpen(false);
     },
@@ -131,7 +135,7 @@ export function CreateEventTriggerDialog({
   });
 
   const form = useForm({
-    defaultValues: DEFAULT_VALUES,
+    defaultValues: getDefaultEventTriggerValues(editTrigger),
     validators: {
       onSubmit: eventTriggerFormSchema,
     },
@@ -142,9 +146,9 @@ export function CreateEventTriggerDialog({
 
   useEffect(() => {
     if (open) {
-      form.reset();
+      form.reset(getDefaultEventTriggerValues(editTrigger));
     }
-  }, [open, form]);
+  }, [open, editTrigger, form]);
 
   const outputType = useStore(form.store, (s) => s.values.outputType);
   const repositoryCount = useStore(
@@ -231,7 +235,7 @@ export function CreateEventTriggerDialog({
         <ResponsiveDialogContent className="flex h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
           <ResponsiveDialogHeader className="shrink-0 border-b p-4 pr-14">
             <ResponsiveDialogTitle className="text-base">
-              New event trigger
+              {isEditMode ? "Edit event trigger" : "New event trigger"}
             </ResponsiveDialogTitle>
             <p className="text-muted-foreground text-sm">
               React to GitHub activity and generate content automatically.
@@ -467,12 +471,12 @@ export function CreateEventTriggerDialog({
                           className="size-4 animate-spin"
                           icon={Loading03Icon}
                         />
-                        Adding...
+                        {isEditMode ? "Saving..." : "Adding..."}
                       </>
                     ) : (
                       <>
                         <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                        Add trigger
+                        {isEditMode ? "Save changes" : "Add trigger"}
                       </>
                     )}
                   </Button>

--- a/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
+++ b/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
@@ -224,9 +224,11 @@ export function CreateEventTriggerDialog({
   });
 
   const handleOpenAddRepoFlow = useCallback(() => {
-    setOpen(false);
     setAddRepoOpen(true);
-  }, [setOpen]);
+    if (!isEditMode) {
+      setOpen(false);
+    }
+  }, [isEditMode, setOpen]);
 
   return (
     <>
@@ -491,7 +493,7 @@ export function CreateEventTriggerDialog({
           integrationId={githubIntegrationId}
           onOpenChange={(isOpen) => {
             setAddRepoOpen(isOpen);
-            if (!isOpen) {
+            if (!(isOpen || isEditMode)) {
               setOpen(true);
             }
           }}
@@ -502,7 +504,7 @@ export function CreateEventTriggerDialog({
         <AddIntegrationDialog
           onOpenChange={(isOpen) => {
             setAddRepoOpen(isOpen);
-            if (!isOpen) {
+            if (!(isOpen || isEditMode)) {
               setOpen(true);
             }
           }}

--- a/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
+++ b/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
@@ -36,7 +36,7 @@ import {
 } from "@notra/ui/components/ui/tooltip";
 import { useForm, useStore } from "@tanstack/react-form";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BrandIdentityRadioGroup } from "@/components/brand-identity-radio-group";
 import { Button } from "@/components/button";
@@ -67,12 +67,10 @@ export function CreateEventTriggerDialog({
 }: CreateEventTriggerDialogProps) {
   const isEditMode = !!editTrigger;
   const [internalOpen, setInternalOpen] = useState(false);
+  const lastResetKeyRef = useRef<string | null>(null);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
   const setOpen = (next: boolean) => {
-    if (next) {
-      form.reset(getDefaultEventTriggerValues(editTrigger));
-    }
     if (isControlled) {
       controlledOnOpenChange?.(next);
     } else {
@@ -143,6 +141,21 @@ export function CreateEventTriggerDialog({
       await mutation.mutateAsync(value);
     },
   });
+
+  useEffect(() => {
+    if (!open) {
+      lastResetKeyRef.current = null;
+      return;
+    }
+
+    const resetKey = editTrigger?.id ?? "create";
+    if (lastResetKeyRef.current === resetKey) {
+      return;
+    }
+
+    form.reset(getDefaultEventTriggerValues(editTrigger));
+    lastResetKeyRef.current = resetKey;
+  }, [editTrigger, form, open]);
 
   const outputType = useStore(form.store, (s) => s.values.outputType);
   const repositoryCount = useStore(

--- a/apps/dashboard/src/components/automation/triggers/trigger-row-actions.tsx
+++ b/apps/dashboard/src/components/automation/triggers/trigger-row-actions.tsx
@@ -1,5 +1,6 @@
 import {
   Delete02Icon,
+  Edit02Icon,
   MoreVerticalIcon,
   PauseIcon,
   PlayIcon,
@@ -19,12 +20,14 @@ interface TriggerRowActionsProps {
   trigger: Trigger;
   onToggle: (trigger: Trigger) => void;
   onDelete: (triggerId: string) => void;
+  onEdit?: (trigger: Trigger) => void;
 }
 
 export function TriggerRowActions({
   trigger,
   onToggle,
   onDelete,
+  onEdit,
 }: TriggerRowActionsProps) {
   return (
     <DropdownMenu>
@@ -35,6 +38,12 @@ export function TriggerRowActions({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {onEdit && (
+          <DropdownMenuItem onClick={() => onEdit(trigger)}>
+            <HugeiconsIcon className="size-4" icon={Edit02Icon} />
+            Edit
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onClick={() => onToggle(trigger)}>
           <HugeiconsIcon
             className="size-4"

--- a/apps/dashboard/src/lib/orpc/routers/automation.ts
+++ b/apps/dashboard/src/lib/orpc/routers/automation.ts
@@ -24,8 +24,8 @@ import {
   triggerManualAutomationRun,
 } from "@/lib/triggers/manual-run";
 import {
+  configureEventTriggerBodySchema,
   configureScheduleBodySchema,
-  configureTriggerBodySchema,
   getSchedulesQuerySchema,
   type LookbackWindow,
   triggerTargetsSchema,
@@ -257,7 +257,7 @@ export const automationRouter = {
         };
       }),
     create: baseProcedure
-      .input(organizationIdInputSchema.and(configureTriggerBodySchema))
+      .input(organizationIdInputSchema.and(configureEventTriggerBodySchema))
       .handler(async ({ context, input }) => {
         await assertOrganizationAccess({
           headers: context.headers,
@@ -314,7 +314,7 @@ export const automationRouter = {
         return { trigger: serializeTrigger(trigger) };
       }),
     update: baseProcedure
-      .input(triggerInputSchema.and(configureTriggerBodySchema))
+      .input(triggerInputSchema.and(configureEventTriggerBodySchema))
       .handler(async ({ context, input }) => {
         await assertOrganizationAccess({
           headers: context.headers,

--- a/apps/dashboard/src/schemas/automation/event-trigger-form.ts
+++ b/apps/dashboard/src/schemas/automation/event-trigger-form.ts
@@ -1,13 +1,13 @@
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 import {
-  SUPPORTED_SCHEDULE_OUTPUT_TYPES,
+  SUPPORTED_AUTOMATION_OUTPUT_TYPES,
   WEBHOOK_EVENT_TYPES,
 } from "@/schemas/integrations";
 
 export const eventTriggerFormSchema = z.object({
   eventType: z.enum(WEBHOOK_EVENT_TYPES),
-  outputType: z.enum(SUPPORTED_SCHEDULE_OUTPUT_TYPES),
+  outputType: z.enum(SUPPORTED_AUTOMATION_OUTPUT_TYPES),
   repositoryIds: z.array(z.string()).min(1, "Select at least one repository"),
   brandVoiceId: z.string(),
   autoPublish: z.boolean(),

--- a/apps/dashboard/src/schemas/automation/schedule-form.ts
+++ b/apps/dashboard/src/schemas/automation/schedule-form.ts
@@ -4,7 +4,7 @@ import {
   CRON_FREQUENCIES,
   LOOKBACK_WINDOWS,
   MAX_SCHEDULE_NAME_LENGTH,
-  SUPPORTED_SCHEDULE_OUTPUT_TYPES,
+  SUPPORTED_AUTOMATION_OUTPUT_TYPES,
 } from "@/schemas/integrations";
 
 export const scheduleCronSchema = z.object({
@@ -23,7 +23,7 @@ export const scheduleFormSchema = z.object({
     .trim()
     .min(1, "Give this schedule a name")
     .max(MAX_SCHEDULE_NAME_LENGTH),
-  outputType: z.enum(SUPPORTED_SCHEDULE_OUTPUT_TYPES),
+  outputType: z.enum(SUPPORTED_AUTOMATION_OUTPUT_TYPES),
   schedule: scheduleCronSchema,
   repositoryIds: z
     .array(z.string())

--- a/apps/dashboard/src/schemas/content.ts
+++ b/apps/dashboard/src/schemas/content.ts
@@ -10,7 +10,7 @@ import { createContentGenerationRequestSchema } from "@notra/content-generation/
 import * as z from "zod";
 import {
   LOOKBACK_WINDOWS,
-  SUPPORTED_SCHEDULE_OUTPUT_TYPES,
+  SUPPORTED_AUTOMATION_OUTPUT_TYPES,
 } from "./integrations";
 
 export const postStatusSchema = z.enum(["draft", "published"]);
@@ -292,7 +292,7 @@ export const updateContentSchema = z
 export type UpdateContentInput = z.infer<typeof updateContentSchema>;
 
 export const onDemandContentTypeSchema = z.enum([
-  ...SUPPORTED_SCHEDULE_OUTPUT_TYPES,
+  ...SUPPORTED_AUTOMATION_OUTPUT_TYPES,
   "image",
 ] as const);
 export type OnDemandContentType = z.infer<typeof onDemandContentTypeSchema>;

--- a/apps/dashboard/src/schemas/integrations.ts
+++ b/apps/dashboard/src/schemas/integrations.ts
@@ -288,6 +288,18 @@ export const SUPPORTED_SCHEDULE_OUTPUT_TYPES = [
 export type ScheduleOutputType =
   (typeof SUPPORTED_SCHEDULE_OUTPUT_TYPES)[number];
 
+export const configureEventTriggerBodySchema =
+  configureTriggerBodySchema.extend({
+    sourceType: z.literal("github_webhook"),
+    sourceConfig: z.object({
+      eventTypes: z.array(z.enum(WEBHOOK_EVENT_TYPES)).min(1),
+    }),
+    outputType: z.enum(SUPPORTED_SCHEDULE_OUTPUT_TYPES),
+  });
+export type ConfigureEventTriggerBody = z.infer<
+  typeof configureEventTriggerBodySchema
+>;
+
 export const configureScheduleBodySchema = configureTriggerBodySchema.extend({
   name: z.string().trim().min(1).max(MAX_SCHEDULE_NAME_LENGTH),
   sourceType: z.literal("cron"),

--- a/apps/dashboard/src/schemas/integrations.ts
+++ b/apps/dashboard/src/schemas/integrations.ts
@@ -278,15 +278,18 @@ export const configureTriggerBodySchema = z.object({
 });
 export type ConfigureTriggerBody = z.infer<typeof configureTriggerBodySchema>;
 
-export const SUPPORTED_SCHEDULE_OUTPUT_TYPES = [
+export const SUPPORTED_AUTOMATION_OUTPUT_TYPES = [
   "changelog",
   "blog_post",
   "linkedin_post",
   "twitter_post",
   "image",
 ] as const;
+export type AutomationOutputType =
+  (typeof SUPPORTED_AUTOMATION_OUTPUT_TYPES)[number];
+
 export type ScheduleOutputType =
-  (typeof SUPPORTED_SCHEDULE_OUTPUT_TYPES)[number];
+  (typeof SUPPORTED_AUTOMATION_OUTPUT_TYPES)[number];
 
 export const configureEventTriggerBodySchema =
   configureTriggerBodySchema.extend({
@@ -294,7 +297,7 @@ export const configureEventTriggerBodySchema =
     sourceConfig: z.object({
       eventTypes: z.array(z.enum(WEBHOOK_EVENT_TYPES)).min(1),
     }),
-    outputType: z.enum(SUPPORTED_SCHEDULE_OUTPUT_TYPES),
+    outputType: z.enum(SUPPORTED_AUTOMATION_OUTPUT_TYPES),
   });
 export type ConfigureEventTriggerBody = z.infer<
   typeof configureEventTriggerBodySchema
@@ -312,7 +315,7 @@ export const configureScheduleBodySchema = configureTriggerBodySchema.extend({
       dayOfMonth: z.number().min(1).max(31).optional(),
     }),
   }),
-  outputType: z.enum(SUPPORTED_SCHEDULE_OUTPUT_TYPES),
+  outputType: z.enum(SUPPORTED_AUTOMATION_OUTPUT_TYPES),
   lookbackWindow: z.enum(LOOKBACK_WINDOWS).default("last_7_days"),
 });
 export type ConfigureScheduleBody = z.infer<typeof configureScheduleBodySchema>;

--- a/apps/dashboard/src/types/automation/event-trigger.ts
+++ b/apps/dashboard/src/types/automation/event-trigger.ts
@@ -1,10 +1,13 @@
 import type { WebhookEventType } from "@/schemas/integrations";
 import type { Trigger } from "@/types/triggers/triggers";
 
+export type { EventTriggerFormValues } from "@/schemas/automation/event-trigger-form";
+
 export interface CreateEventTriggerDialogProps {
   organizationId: string;
   onSuccess?: (trigger: Trigger) => void;
   trigger?: React.ReactElement;
+  editTrigger?: Trigger;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }

--- a/apps/dashboard/src/utils/event-trigger-form.ts
+++ b/apps/dashboard/src/utils/event-trigger-form.ts
@@ -1,0 +1,38 @@
+import {
+  SUPPORTED_SCHEDULE_OUTPUT_TYPES,
+  WEBHOOK_EVENT_TYPES,
+} from "@/schemas/integrations";
+import type { EventTriggerFormValues } from "@/types/automation/event-trigger";
+import type { Trigger } from "@/types/triggers/triggers";
+
+export const DEFAULT_EVENT_TRIGGER_VALUES: EventTriggerFormValues = {
+  eventType: "release",
+  outputType: "changelog",
+  repositoryIds: [],
+  brandVoiceId: "",
+  autoPublish: false,
+};
+
+export function getDefaultEventTriggerValues(
+  trigger?: Trigger
+): EventTriggerFormValues {
+  if (!trigger) {
+    return DEFAULT_EVENT_TRIGGER_VALUES;
+  }
+
+  const eventType = trigger.sourceConfig.eventTypes?.find((type) =>
+    WEBHOOK_EVENT_TYPES.includes(type)
+  );
+
+  const outputType = SUPPORTED_SCHEDULE_OUTPUT_TYPES.find(
+    (type) => type === trigger.outputType
+  );
+
+  return {
+    eventType: eventType ?? DEFAULT_EVENT_TRIGGER_VALUES.eventType,
+    outputType: outputType ?? DEFAULT_EVENT_TRIGGER_VALUES.outputType,
+    repositoryIds: trigger.targets.repositoryIds,
+    brandVoiceId: trigger.outputConfig?.brandVoiceId ?? "",
+    autoPublish: trigger.autoPublish,
+  };
+}

--- a/apps/dashboard/src/utils/event-trigger-form.ts
+++ b/apps/dashboard/src/utils/event-trigger-form.ts
@@ -1,5 +1,6 @@
 import {
-  SUPPORTED_SCHEDULE_OUTPUT_TYPES,
+  type AutomationOutputType,
+  SUPPORTED_AUTOMATION_OUTPUT_TYPES,
   WEBHOOK_EVENT_TYPES,
 } from "@/schemas/integrations";
 import type { EventTriggerFormValues } from "@/types/automation/event-trigger";
@@ -13,6 +14,16 @@ export const DEFAULT_EVENT_TRIGGER_VALUES: EventTriggerFormValues = {
   autoPublish: false,
 };
 
+export function isAutomationOutputType(
+  outputType: string
+): outputType is AutomationOutputType {
+  return SUPPORTED_AUTOMATION_OUTPUT_TYPES.some((type) => type === outputType);
+}
+
+function normalizeBrandVoiceId(brandVoiceId?: string): string {
+  return brandVoiceId && brandVoiceId !== "__default__" ? brandVoiceId : "";
+}
+
 export function getDefaultEventTriggerValues(
   trigger?: Trigger
 ): EventTriggerFormValues {
@@ -24,7 +35,7 @@ export function getDefaultEventTriggerValues(
     WEBHOOK_EVENT_TYPES.includes(type)
   );
 
-  const outputType = SUPPORTED_SCHEDULE_OUTPUT_TYPES.find(
+  const outputType = SUPPORTED_AUTOMATION_OUTPUT_TYPES.find(
     (type) => type === trigger.outputType
   );
 
@@ -32,7 +43,7 @@ export function getDefaultEventTriggerValues(
     eventType: eventType ?? DEFAULT_EVENT_TRIGGER_VALUES.eventType,
     outputType: outputType ?? DEFAULT_EVENT_TRIGGER_VALUES.outputType,
     repositoryIds: trigger.targets.repositoryIds,
-    brandVoiceId: trigger.outputConfig?.brandVoiceId ?? "",
+    brandVoiceId: normalizeBrandVoiceId(trigger.outputConfig?.brandVoiceId),
     autoPublish: trigger.autoPublish,
   };
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ability to edit GitHub event triggers using the existing dialog with pre-filled values. Also tightens validation and unifies supported automation output types across automations.

- New Features
  - Edit existing triggers from the row actions menu; dialog shows current values with updated title, footer copy (Save changes/Saving...), and toasts.
  - Saves via `automation.events.update` in edit mode; create flow unchanged; list refreshes after save.

- Bug Fixes
  - Reliable defaults: form resets on controlled open and populates via `getDefaultEventTriggerValues`; keep the dialog open when adding repositories in edit mode; dedicated repository/integration dialogs handle the connection flow.
  - Schema-compliant updates: toggle now sends `sourceType: "github_webhook"` with `sourceConfig.eventTypes` and a validated `outputType` (via `isAutomationOutputType`); create/update use `configureEventTriggerBodySchema`; `SUPPORTED_AUTOMATION_OUTPUT_TYPES` is used across triggers, schedules, and on-demand content.

<sup>Written for commit a14cbe5147a6e55de9e535089dce54617d8cc0f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

