### PR TITLE
fix(oauth): use Codex icon for ChatGPT client

### DIFF
--- a/apps/dashboard/src/constants/oauth-clients.ts
+++ b/apps/dashboard/src/constants/oauth-clients.ts
@@ -1,5 +1,5 @@
 export const OAUTH_CLIENT_BRANDS = [
-  { id: "codex", label: "Codex", keywords: ["codex"] },
+  { id: "codex", label: "Codex", keywords: ["codex", "chatgpt"] },
   { id: "claude", label: "Claude", keywords: ["claude"] },
   { id: "hermes", label: "Hermes", keywords: ["hermes"] },
   { id: "openclaw", label: "OpenClaw", keywords: ["openclaw", "open claw"] },


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map the ChatGPT OAuth client to the Codex brand so the dashboard shows the Codex icon for ChatGPT connections.

- **Bug Fixes**
  - Add "chatgpt" keyword to the Codex entry in `OAUTH_CLIENT_BRANDS` to correctly map ChatGPT to Codex.

<sup>Written for commit 274c80b082d654e4259b2d1877de2ff239df0b23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

