### PR TITLE
fix(auth): point OAuth discovery at app auth server

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -188,7 +188,7 @@ app.get("/ping", (c) => {
 });
 
 app.get("/.well-known/oauth-protected-resource", (c) => {
-  return c.json(buildProtectedResourceMetadata());
+  return c.json(buildProtectedResourceMetadata(new URL(c.req.url).origin));
 });
 
 app.get("/.well-known/oauth-authorization-server", (c) => {

--- a/apps/api/src/utils/agent-discovery.ts
+++ b/apps/api/src/utils/agent-discovery.ts
@@ -1,15 +1,32 @@
 import { PUBLIC_API_SCOPES } from "../constants/oauth-scopes";
 
 export const API_URL = "https://api.usenotra.com";
+const AUTH_SERVER_URL = "https://app.usenotra.com";
+const AUTH_ISSUER_URL = `${AUTH_SERVER_URL}/api/auth`;
+const MCP_ORIGIN_URL = "https://mcp.usenotra.com";
+const MCP_RESOURCE_URL = `${MCP_ORIGIN_URL}/mcp`;
+const SUPPORTED_RESOURCE_URLS = new Set([
+  API_URL,
+  MCP_ORIGIN_URL,
+  MCP_RESOURCE_URL,
+]);
 export const SITE_URL = "https://www.usenotra.com";
 
 export const RESOURCE_METADATA_URL = `${API_URL}/.well-known/oauth-protected-resource`;
 export const AUTH_GUIDE_URL = `${SITE_URL}/auth.md`;
 
+function normalizeProtectedResource(resource: string) {
+  if (resource === MCP_ORIGIN_URL) {
+    return MCP_RESOURCE_URL;
+  }
+
+  return SUPPORTED_RESOURCE_URLS.has(resource) ? resource : API_URL;
+}
+
 const AGENT_AUTH_METADATA = {
-  register_uri: `${SITE_URL}/agent/auth/register`,
+  register_uri: `${AUTH_SERVER_URL}/agent/auth/register`,
   claim_uri: `${SITE_URL}/agent/auth/claim`,
-  revocation_uri: `${SITE_URL}/agent/auth/revoke`,
+  revocation_uri: `${AUTH_SERVER_URL}/agent/auth/revoke`,
   skill: AUTH_GUIDE_URL,
   identity_types_supported: ["anonymous", "identity_assertion"],
   anonymous: {
@@ -24,10 +41,10 @@ const AGENT_AUTH_METADATA = {
   },
 } as const;
 
-export function buildProtectedResourceMetadata() {
+export function buildProtectedResourceMetadata(resource = API_URL) {
   return {
-    resource: API_URL,
-    authorization_servers: [SITE_URL],
+    resource: normalizeProtectedResource(resource),
+    authorization_servers: [AUTH_ISSUER_URL],
     scopes_supported: PUBLIC_API_SCOPES,
     bearer_methods_supported: ["header"],
     resource_documentation: AUTH_GUIDE_URL,
@@ -36,11 +53,11 @@ export function buildProtectedResourceMetadata() {
 
 export function buildAuthorizationServerMetadata() {
   return {
-    issuer: SITE_URL,
-    authorization_endpoint: `${SITE_URL}/agent/auth/authorize`,
-    token_endpoint: `${SITE_URL}/agent/auth/token`,
-    registration_endpoint: `${SITE_URL}/agent/auth/register`,
-    revocation_endpoint: `${SITE_URL}/agent/auth/revoke`,
+    issuer: AUTH_ISSUER_URL,
+    authorization_endpoint: `${AUTH_SERVER_URL}/agent/auth/authorize`,
+    token_endpoint: `${AUTH_SERVER_URL}/agent/auth/token`,
+    registration_endpoint: `${AUTH_SERVER_URL}/agent/auth/register`,
+    revocation_endpoint: `${AUTH_SERVER_URL}/agent/auth/revoke`,
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code"],
     token_endpoint_auth_methods_supported: ["none"],

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -38,6 +38,21 @@ export const OAUTH_DEFAULT_SCOPES = [
   "skills.read",
 ] as const;
 
+export const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = [
+  "posts.read",
+  "posts.write",
+  "brand-identities.read",
+  "brand-identities.write",
+  "integrations.read",
+  "integrations.write",
+  "schedules.read",
+  "schedules.write",
+  "chats.read",
+  "chats.write",
+  "skills.read",
+  "skills.write",
+] as const;
+
 export const OAUTH_GRANT_QUERY_PARAM = "grant";
 
 export const OAUTH_SCOPE_LEVEL = {

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -25,7 +25,7 @@ import {
   OAUTH_ACCEPTED_SCOPES,
   OAUTH_ACCESS_TOKEN_TTL_SECONDS,
   OAUTH_AUTH_CODE_TTL_MS,
-  OAUTH_DEFAULT_SCOPES,
+  OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
   OAUTH_REFRESH_TOKEN_TTL_MS,
   OAUTH_SUPPORTED_RESOURCES,
   OAUTH_SUPPORTED_SCOPES,
@@ -309,7 +309,9 @@ export const auth = betterAuth({
       allowPublicClientPrelogin: true,
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
-      clientRegistrationDefaultScopes: [...OAUTH_DEFAULT_SCOPES],
+      clientRegistrationDefaultScopes: [
+        ...OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
+      ],
       clientRegistrationAllowedScopes: [...OAUTH_SUPPORTED_SCOPES],
       customAccessTokenClaims: ({ referenceId }) =>
         referenceId ? { organizationId: referenceId } : {},

--- a/apps/web/src/app/.well-known/mcp/route.ts
+++ b/apps/web/src/app/.well-known/mcp/route.ts
@@ -1,5 +1,9 @@
 import { jsonResponse } from "@/utils/http";
-import { DOCS_URL, MCP_URL } from "@/utils/urls";
+import {
+  DOCS_URL,
+  MCP_PROTECTED_RESOURCE_METADATA_URL,
+  MCP_URL,
+} from "@/utils/urls";
 
 export function GET() {
   return jsonResponse(
@@ -10,11 +14,10 @@ export function GET() {
       endpoint: MCP_URL,
       documentation: `${DOCS_URL}/devtools/mcp`,
       instructions:
-        "Use Notra MCP after authenticating with a Notra API key. The server exposes tools for reading organization content, generating drafts, and applying saved brand voice guidance.",
+        "Use Notra MCP after authenticating with OAuth or a Notra API key. The server exposes tools for reading organization content, generating drafts, and applying saved brand voice guidance.",
       authentication: {
         type: "bearer",
-        resource_metadata:
-          "https://api.usenotra.com/.well-known/oauth-protected-resource",
+        resource_metadata: MCP_PROTECTED_RESOURCE_METADATA_URL,
       },
     },
     {

--- a/apps/web/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/web/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,6 +1,0 @@
-import { buildAuthorizationServerMetadata } from "@/utils/agent-metadata";
-import { jsonResponse } from "@/utils/http";
-
-export function GET() {
-  return jsonResponse(buildAuthorizationServerMetadata());
-}

--- a/apps/web/src/app/auth.md/route.ts
+++ b/apps/web/src/app/auth.md/route.ts
@@ -2,7 +2,7 @@ import { markdownResponse } from "@/utils/http";
 
 const AUTH_MD = `# Notra Agent Authentication
 
-Notra exposes an authenticated API and MCP server for agents that generate, read, and manage product content. Use this guide to discover the supported auth metadata, request an API credential, and recover from common errors.
+Notra exposes an authenticated API and MCP server for agents that generate, read, and manage product content. Use this guide to discover the supported auth metadata, request an OAuth or API-key credential, and recover from common errors.
 
 ## Discover
 
@@ -10,11 +10,11 @@ Start at \`/.well-known/agent.json\`, \`/.well-known/agent-card.json\`, and \`/.
 
 ## Pick a method
 
-The \`agent_auth\` block documents \`anonymous\` and \`identity_assertion\` request shapes for agents. Notra currently issues API keys through the dashboard rather than an automatic OAuth token exchange. For identity assertions, Notra accepts verified email claims and \`urn:ietf:params:oauth:token-type:id-jag\` assertions when configured for the organization.
+OAuth-capable clients should follow the authorization server advertised by the protected resource metadata. The production authorization server is \`https://app.usenotra.com\`, with authorization, token, registration, and revocation endpoints under \`/agent/auth/*\`. Manual clients can use API keys created in the Notra dashboard.
 
 ## Register
 
-Call \`POST /agent/auth/register\` to confirm the supported registration metadata. Production API keys are created in the Notra dashboard. Agents should request the least privileged resource scopes, such as \`posts.read\`, \`posts.write\`, \`skills.read\`, \`skills.write\`, \`integrations.read\`, and \`integrations.write\`.
+Call \`POST https://app.usenotra.com/agent/auth/register\` for dynamic OAuth client registration. Agents should request the least privileged resource scopes, such as \`posts.read\`, \`posts.write\`, \`skills.read\`, \`skills.write\`, \`integrations.read\`, and \`integrations.write\`.
 
 ## Claim
 
@@ -22,7 +22,7 @@ Call \`POST /agent/auth/claim\` to check the claim endpoint shape. It returns ma
 
 ## Use the credential
 
-Send the credential as \`Authorization: Bearer <NOTRA_API_KEY>\`. For MCP clients that support OAuth discovery, start at \`https://mcp.usenotra.com/.well-known/oauth-protected-resource\`; for manual clients, use the same bearer credential when connecting to \`https://mcp.usenotra.com/mcp\`.
+Send the credential as \`Authorization: Bearer <TOKEN>\`. For MCP clients that support OAuth discovery, start at \`https://mcp.usenotra.com/.well-known/oauth-protected-resource\`; for manual clients, use a Notra API key as the bearer credential when connecting to \`https://mcp.usenotra.com/mcp\`.
 
 ## Errors
 
@@ -30,7 +30,7 @@ Send the credential as \`Authorization: Bearer <NOTRA_API_KEY>\`. For MCP client
 
 ## Revocation
 
-Call \`POST /agent/auth/revoke\` or revoke the API key in the Notra dashboard. Agents should discard revoked credentials immediately and repeat discovery before requesting a replacement.
+Call \`POST https://app.usenotra.com/agent/auth/revoke\` for OAuth tokens, or revoke API keys in the Notra dashboard. Agents should discard revoked credentials immediately and repeat discovery before requesting a replacement.
 `;
 
 export function GET() {

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -1,6 +1,6 @@
 import { SITE_DESCRIPTION } from "@/utils/metadata";
 import { SOCIAL_LINKS } from "@/utils/social-links";
-import { API_URL, DOCS_URL, MCP_URL, SITE_URL } from "@/utils/urls";
+import { API_URL, APP_URL, DOCS_URL, MCP_URL, SITE_URL } from "@/utils/urls";
 
 const AGENT_DISCOVERY_PATHS = {
   agentJson: "/.well-known/agent.json",
@@ -9,7 +9,6 @@ const AGENT_DISCOVERY_PATHS = {
   authMarkdown: "/auth.md",
   botAuthDirectory: "/.well-known/http-message-signatures-directory",
   mcp: "/.well-known/mcp",
-  oauthAuthorizationServer: "/.well-known/oauth-authorization-server",
   oauthProtectedResource: "/.well-known/oauth-protected-resource",
   schemaMap: "/schema-map.xml",
 } as const;
@@ -55,11 +54,19 @@ export function apiUrl(path = "") {
   return `${API_URL}${path}`;
 }
 
+function appUrl(path = "") {
+  return `${APP_URL}${path}`;
+}
+
+function authIssuerUrl() {
+  return appUrl("/api/auth");
+}
+
 export function buildAgentAuthMetadata() {
   return {
-    register_uri: siteUrl("/agent/auth/register"),
+    register_uri: appUrl("/agent/auth/register"),
     claim_uri: siteUrl("/agent/auth/claim"),
-    revocation_uri: siteUrl("/agent/auth/revoke"),
+    revocation_uri: appUrl("/agent/auth/revoke"),
     skill: siteUrl(AGENT_DISCOVERY_PATHS.authMarkdown),
     identity_types_supported: ["anonymous", "identity_assertion"],
     anonymous: {
@@ -78,26 +85,10 @@ export function buildAgentAuthMetadata() {
 export function buildProtectedResourceMetadata() {
   return {
     resource: apiUrl(),
-    authorization_servers: [siteUrl()],
+    authorization_servers: [authIssuerUrl()],
     scopes_supported: PUBLIC_API_SCOPES,
     bearer_methods_supported: ["header"],
     resource_documentation: siteUrl(AGENT_DISCOVERY_PATHS.authMarkdown),
-  };
-}
-
-export function buildAuthorizationServerMetadata() {
-  return {
-    issuer: siteUrl(),
-    authorization_endpoint: siteUrl("/agent/auth/authorize"),
-    token_endpoint: siteUrl("/agent/auth/token"),
-    registration_endpoint: siteUrl("/agent/auth/register"),
-    revocation_endpoint: siteUrl("/agent/auth/revoke"),
-    response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code"],
-    token_endpoint_auth_methods_supported: ["none"],
-    code_challenge_methods_supported: ["S256"],
-    scopes_supported: PUBLIC_API_SCOPES,
-    agent_auth: buildAgentAuthMetadata(),
   };
 }
 

--- a/apps/web/src/utils/urls.ts
+++ b/apps/web/src/utils/urls.ts
@@ -1,5 +1,7 @@
 export const SITE_URL = "https://www.usenotra.com";
 
+export const APP_URL = "https://app.usenotra.com";
+
 export const API_URL = "https://api.usenotra.com";
 
 export const DOCS_URL = "https://docs.usenotra.com";


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point OAuth discovery to the app auth server at https://app.usenotra.com and scope protected resource metadata by request origin for API and MCP. Refresh MCP discovery/docs to support OAuth and API keys, and set clearer default scopes for dynamic client registration.

- **Bug Fixes**
  - Advertise `issuer` as https://app.usenotra.com/api/auth and move `authorize`, `token`, `register`, `revoke` under https://app.usenotra.com/agent/auth/*; remove the web `/.well-known/oauth-authorization-server` route.
  - Protected resource metadata now uses the request origin and only returns supported resources (https://api.usenotra.com, https://mcp.usenotra.com, https://mcp.usenotra.com/mcp), falling back to API if unknown.
  - MCP discovery now links to the MCP resource metadata URL; `auth.md` documents OAuth flows (dynamic client registration and revocation) and API-key usage.
  - Dashboard: use `OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES` as the default for dynamic client registration (read/write scopes for posts, skills, integrations, schedules, chats).

<sup>Written for commit d127204e76c7582cea3b4bef1e08da5960ada2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

