### PR TITLE
fix(auth): allow write scopes during oauth consent

### DIFF
--- a/apps/dashboard/src/utils/oauth-proxy.ts
+++ b/apps/dashboard/src/utils/oauth-proxy.ts
@@ -1,11 +1,13 @@
+import { OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES } from "@/constants/oauth";
 import { auth } from "@/lib/auth/server";
 
 const AUTH_ROUTE_PREFIX = "/api/auth";
 const INTERNAL_AUTH_ORIGIN = "http://notra.internal";
 const TOKEN_PATH = "/oauth2/token";
+const REGISTER_PATH = "/oauth2/register";
 const ALLOWED_OAUTH_PROXY_PATHS = new Set([
   TOKEN_PATH,
-  "/oauth2/register",
+  REGISTER_PATH,
   "/oauth2/revoke",
 ]);
 const FORWARDED_HEADER_NAMES = [
@@ -40,6 +42,29 @@ export function buildOAuthForwardedHeaders(
   return headers;
 }
 
+function withDefaultRegistrationScopes(body: ArrayBuffer) {
+  try {
+    const payload = JSON.parse(new TextDecoder().decode(body));
+
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return body;
+    }
+
+    if ("scope" in payload && typeof payload.scope === "string") {
+      return body;
+    }
+
+    return new TextEncoder().encode(
+      JSON.stringify({
+        ...payload,
+        scope: OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES.join(" "),
+      })
+    ).buffer;
+  } catch {
+    return body;
+  }
+}
+
 export async function proxyOAuthRequest(request: Request, pathname: string) {
   if (!ALLOWED_OAUTH_PROXY_PATHS.has(pathname)) {
     return Response.json({ error: "not_found" }, { status: 404 });
@@ -51,10 +76,14 @@ export async function proxyOAuthRequest(request: Request, pathname: string) {
   );
   targetUrl.search = new URL(request.url).search;
 
-  const body =
+  const rawBody =
     request.method === "GET" || request.method === "HEAD"
       ? undefined
       : await request.arrayBuffer();
+  const body =
+    rawBody && pathname === REGISTER_PATH
+      ? withDefaultRegistrationScopes(rawBody)
+      : rawBody;
 
   const response = await auth.handler(
     new Request(targetUrl, {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables granting write scopes during OAuth consent and sets default scopes during client registration. Users now see both read and write options, and the server accepts them.

- **Bug Fixes**
  - Consent API: removed validation that forced granted scopes to be a subset of requested scopes.
  - Consent UI: shows all resources with both read and write levels, not only those in the scope query.
  - OAuth proxy: injects `OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES` on `/oauth2/register` only when `scope` is missing.

<sup>Written for commit 91d1713e8a18807a11d1504831fee2aefeca553b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

