### PR TITLE
fix(github): store app installation record ids

### DIFF
--- a/apps/dashboard/src/lib/orpc/routers/github.ts
+++ b/apps/dashboard/src/lib/orpc/routers/github.ts
@@ -195,7 +195,7 @@ export const githubRouter = {
                 listGitHubAppRepositories(input.organizationId),
                 getSelectedGitHubAppRepositoryIds(
                   input.organizationId,
-                  installation.installationId
+                  installation.id
                 ),
               ]);
 

--- a/bun.lock
+++ b/bun.lock
@@ -2923,7 +2923,7 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
-    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "immer": ["immer@9.0.21", "", {}, "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="],
 
@@ -4437,6 +4437,8 @@
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
+    "@dotenvx/dotenvx/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "@dotenvx/dotenvx/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
@@ -4533,8 +4535,6 @@
 
     "@mintlify/common/hex-rgb": ["hex-rgb@5.0.0", "", {}, "sha512-NQO+lgVUCtHxZ792FodgW0zflK+ozS9X9dwGp9XvvmPlH7pyxd588cn24TD3rmPm/N0AIRXF10Otah8yKqGw4w=="],
 
-    "@mintlify/common/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
     "@mintlify/common/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "@mintlify/common/mdast-util-gfm": ["mdast-util-gfm@3.0.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw=="],
@@ -4620,8 +4620,6 @@
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@notra/email/@types/node": ["@types/node@22.9.0", "", { "dependencies": { "undici-types": "~6.19.8" } }, "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ=="],
-
-    "@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@oclif/core/ansis": ["ansis@3.17.0", "", {}, "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg=="],
 
@@ -4966,6 +4964,8 @@
     "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "global-directory/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "got/form-data-encoder": ["form-data-encoder@2.1.4", "", {}, "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw=="],
 

--- a/packages/ai/src/integrations/github.ts
+++ b/packages/ai/src/integrations/github.ts
@@ -108,6 +108,21 @@ async function createGitHubAppInstallationToken(installationId: string) {
   return data.token;
 }
 
+async function createGitHubAppInstallationTokenForRecord(recordId: string) {
+  const installation = await db.query.githubAppInstallations.findFirst({
+    where: eq(githubAppInstallations.id, recordId),
+    columns: {
+      installationId: true,
+    },
+  });
+
+  if (!installation) {
+    throw new Error("GitHub App installation not found");
+  }
+
+  return createGitHubAppInstallationToken(installation.installationId);
+}
+
 async function getGitHubAppInstallation(installationId: string) {
   const octokit = createOctokit(createGitHubAppJwt());
   const { data } = await octokit.request(
@@ -555,12 +570,12 @@ export async function listGitHubAppRepositories(organizationId: string) {
 
 export async function getSelectedGitHubAppRepositoryIds(
   organizationId: string,
-  installationId: string
+  githubAppInstallationId: string
 ) {
   const selected = await db.query.githubIntegrations.findMany({
     where: and(
       eq(githubIntegrations.organizationId, organizationId),
-      eq(githubIntegrations.githubAppInstallationId, installationId),
+      eq(githubIntegrations.githubAppInstallationId, githubAppInstallationId),
       eq(githubIntegrations.enabled, true)
     ),
     columns: {
@@ -601,10 +616,7 @@ export async function setSelectedGitHubAppRepositories(params: {
   const existing = await db.query.githubIntegrations.findMany({
     where: and(
       eq(githubIntegrations.organizationId, params.organizationId),
-      eq(
-        githubIntegrations.githubAppInstallationId,
-        installation.installationId
-      )
+      eq(githubIntegrations.githubAppInstallationId, installation.id)
     ),
     columns: {
       id: true,
@@ -663,7 +675,7 @@ export async function setSelectedGitHubAppRepositories(params: {
         createdByUserId: params.userId,
         displayName: repository.fullName,
         encryptedToken: null,
-        githubAppInstallationId: installation.installationId,
+        githubAppInstallationId: installation.id,
         githubRepositoryId: repository.id,
         githubRepositoryPrivate: repository.private,
         owner: repository.owner,
@@ -708,10 +720,7 @@ export async function deleteGitHubAppInstallationForOrganization(
     .where(
       and(
         eq(githubIntegrations.organizationId, organizationId),
-        eq(
-          githubIntegrations.githubAppInstallationId,
-          installation.installationId
-        )
+        eq(githubIntegrations.githubAppInstallationId, installation.id)
       )
     );
 
@@ -1120,7 +1129,7 @@ export async function getTokenForRepository(
   }
 
   if (integration.githubAppInstallationId) {
-    return createGitHubAppInstallationToken(
+    return createGitHubAppInstallationTokenForRecord(
       integration.githubAppInstallationId
     );
   }
@@ -1138,7 +1147,7 @@ export async function getTokenForIntegrationId(integrationId: string) {
   });
 
   if (integration?.githubAppInstallationId) {
-    return createGitHubAppInstallationToken(
+    return createGitHubAppInstallationTokenForRecord(
       integration.githubAppInstallationId
     );
   }
@@ -1200,7 +1209,7 @@ export async function getGitHubToolRepositoryContextByIntegrationId(
   let token: string | undefined;
 
   if (integration.githubAppInstallationId) {
-    token = await createGitHubAppInstallationToken(
+    token = await createGitHubAppInstallationTokenForRecord(
       integration.githubAppInstallationId
     );
   } else if (integration.encryptedToken) {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch GitHub App integration linkage to use internal installation record IDs instead of GitHub installation IDs. This fixes token generation and repository selection by consistently referencing the stored record ID.

- **Bug Fixes**
  - Use `installation.id` for all reads/writes to `githubIntegrations.githubAppInstallationId`.
  - Add `createGitHubAppInstallationTokenForRecord` to resolve record ID to installation ID before creating tokens; update `getTokenForRepository`, `getTokenForIntegrationId`, and tool context to use it.
  - Update dashboard router to pass `installation.id` to `getSelectedGitHubAppRepositoryIds`.

<sup>Written for commit 8ab3cd74f0fa3614d1ff1a8dcd437f044d59b138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

