### PR TITLE
fix(dashboard): preserve svg brand asset uploads

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/guidelines-asset-edit-dialog.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/guidelines-asset-edit-dialog.tsx
@@ -18,8 +18,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@notra/ui/components/ui/select";
-import type { ChangeEvent, DragEvent } from "react";
-import { useReducer, useRef } from "react";
+import type { ChangeEvent, DragEvent, RefObject } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import {
@@ -45,7 +45,7 @@ import type {
 import {
   formatBrandGuidelineAssetFileSize,
   getBrandGuidelineAssetFormat,
-  getBrandGuidelineAssetName,
+  getBrandGuidelineAssetTypeLabel,
   getBrandGuidelineImageDimensions,
 } from "@/utils/brand-guideline-assets";
 
@@ -54,6 +54,7 @@ interface AssetDialogState {
   file: File | null;
   fileError: string | null;
   kind: BrandGuidelineAssetKind;
+  previewUrl: string | null;
   saving: boolean;
   variant: BrandGuidelineAssetVariant;
 }
@@ -63,6 +64,84 @@ function updateAssetDialogState(
   next: Partial<AssetDialogState>
 ) {
   return { ...state, ...next };
+}
+
+interface AssetFileFieldProps {
+  dragging: boolean;
+  file: File | null;
+  fileError: string | null;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  onDraggingChange: (dragging: boolean) => void;
+  onDrop: (event: DragEvent<HTMLButtonElement>) => void;
+  onInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  previewUrl: string | null;
+}
+
+function AssetFileField({
+  dragging,
+  file,
+  fileError,
+  fileInputRef,
+  onDraggingChange,
+  onDrop,
+  onInputChange,
+  previewUrl,
+}: AssetFileFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label>Asset file</Label>
+      <button
+        className={cn(
+          "flex w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-6 text-center transition-colors",
+          dragging
+            ? "border-primary bg-primary/5"
+            : "border-border hover:bg-muted/40"
+        )}
+        onClick={() => fileInputRef.current?.click()}
+        onDragLeave={() => onDraggingChange(false)}
+        onDragOver={(event) => {
+          event.preventDefault();
+          onDraggingChange(true);
+        }}
+        onDrop={onDrop}
+        type="button"
+      >
+        {previewUrl ? (
+          <span
+            aria-hidden="true"
+            className="h-14 w-full max-w-48 bg-center bg-contain bg-no-repeat"
+            style={{ backgroundImage: `url("${previewUrl}")` }}
+          />
+        ) : (
+          <HugeiconsIcon
+            className="size-5 text-muted-foreground"
+            icon={Image01Icon}
+          />
+        )}
+        <span className="font-medium text-sm">
+          {file
+            ? `Selected ${getBrandGuidelineAssetTypeLabel(file)}`
+            : "Drag and drop or click to upload"}
+        </span>
+        <span className="text-muted-foreground text-xs">
+          {file
+            ? `${getBrandGuidelineAssetTypeLabel(file)} · ${formatBrandGuidelineAssetFileSize(file.size)}`
+            : `${ACCEPTED_BRAND_ASSET_TYPES_LABEL}, max 5MB`}
+        </span>
+      </button>
+      <input
+        accept={ALLOWED_MIME_TYPES.join(",")}
+        aria-label="Upload asset file"
+        className="sr-only"
+        onChange={onInputChange}
+        ref={fileInputRef}
+        type="file"
+      />
+      {fileError ? (
+        <p className="text-destructive text-xs">{fileError}</p>
+      ) : null}
+    </div>
+  );
 }
 
 export function GuidelinesAssetEditDialog({
@@ -83,24 +162,33 @@ export function GuidelinesAssetEditDialog({
     file: null,
     fileError: null,
     kind: asset?.kind ?? presetKind ?? "logo",
+    previewUrl: null,
     saving: false,
     variant: asset?.variant ?? presetVariant ?? "light",
   });
-  const { dragging, file, fileError, kind, saving, variant } = state;
+  const { dragging, file, fileError, kind, previewUrl, saving, variant } =
+    state;
 
   const extension =
     (file ? getBrandGuidelineAssetFormat(file) : null) ??
     asset?.format ??
     "svg";
-  const fileName = getBrandGuidelineAssetName({
-    format: extension,
-    kind,
-    variant,
-  });
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
 
   const handleFile = (nextFile: File | null) => {
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+
     if (!nextFile) {
-      setState({ file: null, fileError: null });
+      setState({ file: null, fileError: null, previewUrl: null });
       return;
     }
 
@@ -108,6 +196,7 @@ export function GuidelinesAssetEditDialog({
       setState({
         file: null,
         fileError: `Use ${ACCEPTED_BRAND_ASSET_TYPES_LABEL}.`,
+        previewUrl: null,
       });
       return;
     }
@@ -116,11 +205,16 @@ export function GuidelinesAssetEditDialog({
       setState({
         file: null,
         fileError: "Brand assets must be 5MB or smaller.",
+        previewUrl: null,
       });
       return;
     }
 
-    setState({ file: nextFile, fileError: null });
+    setState({
+      file: nextFile,
+      fileError: null,
+      previewUrl: URL.createObjectURL(nextFile),
+    });
   };
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -222,59 +316,18 @@ export function GuidelinesAssetEditDialog({
         </ResponsiveDialogHeader>
 
         <div className="space-y-4 py-2">
-          <div className="space-y-2">
-            <Label>Asset file</Label>
-            <button
-              className={cn(
-                "flex w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-6 text-center transition-colors",
-                dragging
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:bg-muted/40"
-              )}
-              onClick={() => fileInputRef.current?.click()}
-              onDragLeave={() => setState({ dragging: false })}
-              onDragOver={(event) => {
-                event.preventDefault();
-                setState({ dragging: true });
-              }}
-              onDrop={handleDrop}
-              type="button"
-            >
-              <HugeiconsIcon
-                className="size-5 text-muted-foreground"
-                icon={Image01Icon}
-              />
-              <span className="font-medium text-sm">
-                {file ? file.name : "Drag and drop or click to upload"}
-              </span>
-              <span className="text-muted-foreground text-xs">
-                {file
-                  ? `${file.type || "image"} · ${formatBrandGuidelineAssetFileSize(file.size)}`
-                  : `${ACCEPTED_BRAND_ASSET_TYPES_LABEL}, max 5MB`}
-              </span>
-            </button>
-            <input
-              accept={ALLOWED_MIME_TYPES.join(",")}
-              aria-label="Upload asset file"
-              className="sr-only"
-              onChange={handleInputChange}
-              ref={fileInputRef}
-              type="file"
-            />
-            {fileError ? (
-              <p className="text-destructive text-xs">{fileError}</p>
-            ) : null}
-          </div>
-
-          <div className="space-y-2">
-            <Label>Filename</Label>
-            <div className="rounded-lg border bg-muted/30 px-3 py-2">
-              <p className="truncate font-medium text-sm">{fileName}</p>
-              <p className="text-muted-foreground text-xs">
-                Generated from the asset kind, variant, and file type.
-              </p>
-            </div>
-          </div>
+          <AssetFileField
+            dragging={dragging}
+            file={file}
+            fileError={fileError}
+            fileInputRef={fileInputRef}
+            onDraggingChange={(nextDragging) =>
+              setState({ dragging: nextDragging })
+            }
+            onDrop={handleDrop}
+            onInputChange={handleInputChange}
+            previewUrl={previewUrl}
+          />
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">

--- a/apps/dashboard/src/lib/orpc/routers/upload.ts
+++ b/apps/dashboard/src/lib/orpc/routers/upload.ts
@@ -97,7 +97,8 @@ export const uploadRouter = {
           Key: key,
           Body: sanitized,
           ContentType: SVG_MIME_TYPE,
-          ContentDisposition: "attachment",
+          ContentDisposition:
+            input.type === "brand_asset" ? "inline" : "attachment",
           CacheControl: "no-store",
         })
       );

--- a/apps/dashboard/src/lib/upload/sanitize-svg.ts
+++ b/apps/dashboard/src/lib/upload/sanitize-svg.ts
@@ -3,6 +3,12 @@ import "server-only";
 import sanitizeHtml, { type IOptions } from "sanitize-html";
 
 const SVG_ROOT_TAG_REGEX = /<svg[\s>]/i;
+const SVG_ROOT_OPEN_TAG_REGEX = /^(\s*<svg\b)([^>]*)(>)/i;
+const SVG_XMLNS = 'xmlns="http://www.w3.org/2000/svg"';
+const SVG_XLINK_XMLNS = 'xmlns:xlink="http://www.w3.org/1999/xlink"';
+const SVG_XMLNS_ATTRIBUTE_REGEX = /\sxmlns=(["'])[^"']*\1/i;
+const SVG_XLINK_ATTRIBUTE_REGEX = /\sxlink:href=(["'])[^"']*\1/i;
+const SVG_XLINK_XMLNS_ATTRIBUTE_REGEX = /\sxmlns:xlink=(["'])[^"']*\1/i;
 
 export class SvgSanitizationError extends Error {
   constructor(message: string) {
@@ -30,6 +36,7 @@ const SVG_SANITIZE_OPTIONS = {
     "feOffset",
     "filter",
     "g",
+    "image",
     "line",
     "linearGradient",
     "marker",
@@ -112,18 +119,44 @@ const SVG_SANITIZE_OPTIONS = {
       "x",
       "x1",
       "x2",
+      "xmlns",
+      "xmlns:xlink",
       "y",
       "y1",
       "y2",
     ],
+    image: ["href", "xlink:href"],
+    use: ["href", "xlink:href"],
   },
-  allowedSchemes: [],
+  allowedSchemes: ["data"],
+  allowedSchemesAppliedToAttributes: ["href", "xlink:href"],
   disallowedTagsMode: "discard",
   parser: {
     lowerCaseAttributeNames: false,
     lowerCaseTags: false,
   },
 } satisfies IOptions;
+
+function ensureRootNamespaces(svg: string) {
+  return svg.replace(
+    SVG_ROOT_OPEN_TAG_REGEX,
+    (match, start: string, attributes: string, end: string) => {
+      const namespaces = [
+        SVG_XMLNS_ATTRIBUTE_REGEX.test(attributes) ? null : SVG_XMLNS,
+        SVG_XLINK_ATTRIBUTE_REGEX.test(svg) &&
+        !SVG_XLINK_XMLNS_ATTRIBUTE_REGEX.test(attributes)
+          ? SVG_XLINK_XMLNS
+          : null,
+      ].filter(Boolean);
+
+      if (namespaces.length === 0) {
+        return match;
+      }
+
+      return `${start} ${namespaces.join(" ")}${attributes}${end}`;
+    }
+  );
+}
 
 export async function sanitizeSvg(input: string): Promise<string> {
   if (!SVG_ROOT_TAG_REGEX.test(input)) {
@@ -136,5 +169,5 @@ export async function sanitizeSvg(input: string): Promise<string> {
     throw new SvgSanitizationError("SVG is empty after sanitization");
   }
 
-  return sanitized;
+  return ensureRootNamespaces(sanitized);
 }

--- a/apps/dashboard/src/utils/brand-guideline-assets.ts
+++ b/apps/dashboard/src/utils/brand-guideline-assets.ts
@@ -40,7 +40,29 @@ export function getBrandGuidelineAssetFormat(file: File) {
 }
 
 export function formatBrandGuidelineAssetFileSize(bytes: number) {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+
   return `${(bytes / 1024 / 1024).toFixed(2)}MB`;
+}
+
+export function getBrandGuidelineAssetTypeLabel(file: File) {
+  const format = getBrandGuidelineAssetFormat(file);
+
+  if (format === "svg") {
+    return "SVG";
+  }
+
+  if (format) {
+    return format.toUpperCase();
+  }
+
+  return "image";
 }
 
 export function getBrandGuidelineImageDimensions(file: File) {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "seed:brand-identity": "bun run src/scripts/seed-brand-identity.ts"
   },
   "exports": {
     "./drizzle": "./src/drizzle.ts",

--- a/packages/db/src/scripts/seed-brand-identity.ts
+++ b/packages/db/src/scripts/seed-brand-identity.ts
@@ -1,0 +1,228 @@
+import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { db } from "../drizzle";
+import {
+  brandGuidelineColors,
+  brandGuidelines,
+  brandSettings,
+  organizations,
+  sessions,
+} from "../schema";
+
+const DEFAULT_BRAND_NAME = "Upload QA Brand";
+const DEFAULT_COMPANY_NAME = "Notra Upload QA";
+const DEFAULT_WEBSITE_URL = "https://notra.sh";
+const SEEDED_COLOR_NAME = "QA Purple";
+
+function getArgValue(name: string) {
+  const prefix = `--${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(prefix));
+
+  if (inline) {
+    return inline.slice(prefix.length).trim() || null;
+  }
+
+  const index = process.argv.indexOf(`--${name}`);
+  const value = index >= 0 ? process.argv[index + 1] : undefined;
+  return value && !value.startsWith("--") ? value.trim() : null;
+}
+
+async function getOrganizationIdFromSlug(slug: string) {
+  const organization = await db.query.organizations.findFirst({
+    where: eq(organizations.slug, slug),
+    columns: { id: true },
+  });
+
+  if (!organization) {
+    throw new Error(`No organization found for slug "${slug}"`);
+  }
+
+  return organization.id;
+}
+
+async function getFallbackOrganizationId() {
+  const activeSession = await db.query.sessions.findFirst({
+    where: isNotNull(sessions.activeOrganizationId),
+    orderBy: [desc(sessions.updatedAt)],
+    columns: { activeOrganizationId: true },
+  });
+
+  if (activeSession?.activeOrganizationId) {
+    return activeSession.activeOrganizationId;
+  }
+
+  const organization = await db.query.organizations.findFirst({
+    orderBy: [desc(organizations.createdAt)],
+    columns: { id: true },
+  });
+
+  return organization?.id ?? null;
+}
+
+async function resolveOrganizationId() {
+  const explicitOrgId =
+    getArgValue("org-id") ?? process.env.SEED_ORGANIZATION_ID?.trim();
+
+  if (explicitOrgId) {
+    return explicitOrgId;
+  }
+
+  const slug = getArgValue("org-slug") ?? process.env.SEED_ORGANIZATION_SLUG;
+
+  if (slug) {
+    return getOrganizationIdFromSlug(slug);
+  }
+
+  const organizationId = await getFallbackOrganizationId();
+
+  if (!organizationId) {
+    throw new Error(
+      "No organization found. Create an organization first or pass --org-id."
+    );
+  }
+
+  return organizationId;
+}
+
+async function seedBrandIdentity() {
+  const organizationId = await resolveOrganizationId();
+  const name =
+    getArgValue("name") ?? process.env.SEED_BRAND_NAME ?? DEFAULT_BRAND_NAME;
+  const websiteUrl =
+    getArgValue("website-url") ??
+    process.env.SEED_BRAND_WEBSITE_URL ??
+    DEFAULT_WEBSITE_URL;
+  const companyName =
+    getArgValue("company-name") ??
+    process.env.SEED_BRAND_COMPANY_NAME ??
+    DEFAULT_COMPANY_NAME;
+
+  const existingBrandIdentity = await db.query.brandSettings.findFirst({
+    where: and(
+      eq(brandSettings.organizationId, organizationId),
+      eq(brandSettings.name, name)
+    ),
+    columns: { id: true },
+  });
+  const hasAnyBrandIdentity = await db.query.brandSettings.findFirst({
+    where: eq(brandSettings.organizationId, organizationId),
+    columns: { id: true },
+  });
+  const now = new Date();
+
+  const brandIdentityId = existingBrandIdentity?.id ?? crypto.randomUUID();
+
+  if (existingBrandIdentity) {
+    await db
+      .update(brandSettings)
+      .set({
+        audience:
+          "Product teams validating brand guideline uploads and asset handling.",
+        companyDescription:
+          "A local QA brand identity for testing brand guideline asset uploads.",
+        companyName,
+        customInstructions:
+          "Use this identity for local upload QA. It can be deleted safely.",
+        customTone: "Clear, direct, and product-focused.",
+        language: "English",
+        toneProfile: "Pragmatic, concise, and precise.",
+        updatedAt: now,
+        websiteUrl,
+      })
+      .where(eq(brandSettings.id, brandIdentityId));
+  } else {
+    await db.insert(brandSettings).values({
+      id: brandIdentityId,
+      organizationId,
+      name,
+      isDefault: !hasAnyBrandIdentity,
+      websiteUrl,
+      companyName,
+      companyDescription:
+        "A local QA brand identity for testing brand guideline asset uploads.",
+      toneProfile: "Pragmatic, concise, and precise.",
+      customTone: "Clear, direct, and product-focused.",
+      customInstructions:
+        "Use this identity for local upload QA. It can be deleted safely.",
+      audience:
+        "Product teams validating brand guideline uploads and asset handling.",
+      language: "English",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  const existingGuideline = await db.query.brandGuidelines.findFirst({
+    where: eq(brandGuidelines.brandSettingsId, brandIdentityId),
+    columns: { id: true },
+  });
+  const guidelineId = existingGuideline?.id ?? crypto.randomUUID();
+
+  if (existingGuideline) {
+    await db
+      .update(brandGuidelines)
+      .set({
+        status: "ready",
+        lastGenerationError: null,
+        updatedAt: now,
+      })
+      .where(eq(brandGuidelines.id, guidelineId));
+  } else {
+    await db.insert(brandGuidelines).values({
+      id: guidelineId,
+      brandSettingsId: brandIdentityId,
+      status: "ready",
+      contextDevMeta: { seed: "seed-brand-identity" },
+      lastGeneratedAt: null,
+      lastGenerationError: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  const existingSeededColor = await db.query.brandGuidelineColors.findFirst({
+    where: and(
+      eq(brandGuidelineColors.guidelineId, guidelineId),
+      eq(brandGuidelineColors.name, SEEDED_COLOR_NAME)
+    ),
+    columns: { id: true },
+  });
+
+  if (existingSeededColor) {
+    await db
+      .update(brandGuidelineColors)
+      .set({
+        lightValue: "#c8b2ee",
+        darkValue: "#9d7ad9",
+        usage: "Seed color to keep guideline sections visible for upload QA.",
+        updatedAt: now,
+      })
+      .where(eq(brandGuidelineColors.id, existingSeededColor.id));
+  } else {
+    await db.insert(brandGuidelineColors).values({
+      id: crypto.randomUUID(),
+      guidelineId,
+      role: "primary",
+      name: SEEDED_COLOR_NAME,
+      lightValue: "#c8b2ee",
+      darkValue: "#9d7ad9",
+      usage: "Seed color to keep guideline sections visible for upload QA.",
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  console.info("Seeded brand identity for upload QA", {
+    brandIdentityId,
+    guidelineId,
+    name,
+    organizationId,
+  });
+}
+
+seedBrandIdentity()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SVG brand asset uploads so sanitized SVGs render inline and can be previewed in the dashboard. Also adds a seed script to set up a QA brand identity for testing uploads.

- **Bug Fixes**
  - Serve brand asset SVGs inline (`Content-Disposition: inline` for `brand_asset`) so logos render and preview correctly.
  - Sanitize SVGs without stripping needed tags/attrs; add missing `xmlns`/`xmlns:xlink`, and allow `image`/`use` with `href`/`xlink:href` and `data:` URLs.

- **New Features**
  - Add live preview in the asset dialog and clearer file info (type label + B/KB/MB size).
  - Add `packages/db` script `seed:brand-identity` to create a local QA brand identity and guideline; supports `--org-id`/`--org-slug` and name/company/website overrides.

<sup>Written for commit 07b5cf50d3b215386ae99c373aa7e298a2ab31bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

