### PR TITLE
fix(docs): redirect API reference OpenAPI spec

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -25,21 +25,10 @@ npx mint dev
 
 ## OpenAPI auto-generated API pages
 
-`docs.json` is configured to auto-populate API pages from `openapi/openapi.json`.
+`docs.json` is configured to auto-populate API pages from
+`https://api.usenotra.com/openapi.json`.
 
-Refresh the local OpenAPI snapshot from the API app:
-
-```bash
-bun run openapi:pull:local
-```
-
-Or refresh from production:
-
-```bash
-bun run openapi:pull:prod
-```
-
-Validate the OpenAPI file before pushing docs changes:
+Validate the live OpenAPI spec before pushing docs changes:
 
 ```bash
 bun run openapi:check

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -31,6 +31,11 @@
       "destination": "/api/getting-started"
     },
     {
+      "source": "/api-reference/openapi.json",
+      "destination": "https://api.usenotra.com/openapi.json",
+      "permanent": false
+    },
+    {
       "source": "/sdk/getting-started",
       "destination": "/api/getting-started"
     },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "mint dev --port 3005 --no-open",
     "open": "mint dev --port 3005",
-    "openapi:check": "mint openapi-check openapi/openapi.json"
+    "openapi:check": "mint openapi-check https://api.usenotra.com/openapi.json"
   },
   "devDependencies": {
     "mint": "^4.2.536"


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the docs to the live OpenAPI spec at https://api.usenotra.com/openapi.json and add a redirect for /api-reference/openapi.json. This removes stale local snapshots and keeps the API reference and validation up to date.

- **Bug Fixes**
  - Added redirect from /api-reference/openapi.json to the live spec (non-permanent).
  - Updated the `openapi:check` script to validate the live spec URL.
  - Simplified README: removed snapshot pull steps and clarified validating against the live spec.

<sup>Written for commit a39f5c3ca8417e30befe7073e60fd934fb8900f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

