### PR TITLE
fix(api): support transactions and chat router fallback

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import "./tcc";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { createDb } from "@notra/db/drizzle-http";
+import { createDb } from "@notra/db/drizzle";
 import { trimTrailingSlash } from "hono/trailing-slash";
 import {
   LEGACY_API_READ_SCOPE,

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-import type { createDb } from "@notra/db/drizzle-http";
+import type { createDb } from "@notra/db/drizzle";
 import { Unkey } from "@unkey/api";
 import type { Context, Next } from "hono";
 import {

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
-import type { createDb } from "@notra/db/drizzle-http";
+import type { createDb } from "@notra/db/drizzle";
 import {
   contentTriggerLookbackWindows,
   contentTriggers,

--- a/apps/api/src/utils/content-generation.ts
+++ b/apps/api/src/utils/content-generation.ts
@@ -1,5 +1,5 @@
 import type { ContentGenerationWorkflowPayload } from "@notra/content-generation/schemas";
-import type { createDb } from "@notra/db/drizzle-http";
+import type { createDb } from "@notra/db/drizzle";
 import {
   brandSettings,
   githubIntegrations,

--- a/apps/api/src/utils/github-integrations.ts
+++ b/apps/api/src/utils/github-integrations.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { createOctokit } from "@notra/ai/utils/octokit";
-import type { createDb } from "@notra/db/drizzle-http";
+import type { createDb } from "@notra/db/drizzle";
 import { githubIntegrations, members } from "@notra/db/schema";
 import {
   decodeIntegrationEncryptionKey,

--- a/apps/api/src/utils/organizations.ts
+++ b/apps/api/src/utils/organizations.ts
@@ -1,4 +1,4 @@
-import type { createDb } from "@notra/db/drizzle-http";
+import type { createDb } from "@notra/db/drizzle";
 import { organizations } from "@notra/db/schema";
 import { eq } from "drizzle-orm";
 

--- a/apps/api/src/utils/triggers.ts
+++ b/apps/api/src/utils/triggers.ts
@@ -1,4 +1,4 @@
-import type { createDb } from "@notra/db/drizzle-http";
+import type { createDb } from "@notra/db/drizzle";
 import { contentTriggers } from "@notra/db/schema";
 import { and, eq, inArray } from "drizzle-orm";
 import { logError } from "./logging";

--- a/packages/ai/src/orchestration/router.ts
+++ b/packages/ai/src/orchestration/router.ts
@@ -15,7 +15,7 @@ import {
   buildExperimentalTelemetry,
   type TccMetadata,
 } from "@notra/ai/utils/tcc";
-import { generateText, Output } from "ai";
+import { generateObject, generateText } from "ai";
 
 const MODELS = {
   router: "openai/gpt-oss-120b",
@@ -119,20 +119,81 @@ export async function routeMessage(
 
   const routerModel = wrapModelWithObservability(gateway(MODELS.router), log);
 
-  const { output } = await generateText({
-    model: routerModel,
-    output: Output.object({ schema: routingDecisionSchema }),
-    system: ROUTING_PROMPT,
-    prompt: `Classify this user message:
+  try {
+    const { object } = await generateObject({
+      model: routerModel,
+      schema: routingDecisionSchema,
+      system: ROUTING_PROMPT,
+      prompt: `Classify this user message:
 
 "${userMessage}"${contextHint}`,
-    providerOptions: withGatewayAutomaticCaching(undefined, {
-      modelId: MODELS.router,
-    }),
-    experimental_telemetry: buildExperimentalTelemetry(telemetryMetadata),
-  });
+      providerOptions: withGatewayAutomaticCaching(undefined, {
+        modelId: MODELS.router,
+      }),
+      experimental_repairText: async ({ text, error }) => {
+        try {
+          const { text: repairedText } = await generateText({
+            model: routerModel,
+            system:
+              "Repair the router output so it is valid JSON matching the required schema. Return only JSON.",
+            prompt: [
+              "Schema:",
+              JSON.stringify({
+                type: "object",
+                properties: {
+                  complexity: { enum: ["simple", "complex"] },
+                  requiresTools: { type: "boolean" },
+                  reasoningHeavy: { type: "boolean" },
+                  reasoning: { type: "string" },
+                },
+                required: [
+                  "complexity",
+                  "requiresTools",
+                  "reasoningHeavy",
+                  "reasoning",
+                ],
+                additionalProperties: false,
+              }),
+              "Invalid output:",
+              text,
+              "Validation error:",
+              error.message,
+            ].join("\n"),
+            maxOutputTokens: 200,
+            providerOptions: withGatewayAutomaticCaching(undefined, {
+              modelId: MODELS.router,
+            }),
+            experimental_telemetry:
+              buildExperimentalTelemetry(telemetryMetadata),
+          });
 
-  return output;
+          return repairedText;
+        } catch (repairError) {
+          console.error("[Chat Router] Repair failed", {
+            error:
+              repairError instanceof Error
+                ? repairError.message
+                : String(repairError),
+          });
+          return null;
+        }
+      },
+      experimental_telemetry: buildExperimentalTelemetry(telemetryMetadata),
+    });
+
+    return object;
+  } catch (error) {
+    console.error("[Chat Router] Routing failed; using fallback", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {
+      complexity: "complex",
+      requiresTools: false,
+      reasoningHeavy: false,
+      reasoning:
+        "Router structured output failed; falling back to Sonnet without tool routing.",
+    };
+  }
 }
 
 export function selectModel(decision: RoutingDecision): string {

--- a/packages/db/src/drizzle.ts
+++ b/packages/db/src/drizzle.ts
@@ -4,21 +4,40 @@ import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import * as schema from "./schema";
 
 const databaseUrl = process.env.DATABASE_URL;
-
-if (!databaseUrl) {
-  throw new Error("[ENV]: DATABASE_URL is not defined");
-}
 const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
 const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 
-export const db: NodePgDatabase<typeof schema> = drizzle(databaseUrl, {
-  cache:
-    upstashUrl && upstashToken
-      ? upstashCache({
-          url: upstashUrl,
-          token: upstashToken,
-          global: true,
-        })
-      : undefined,
-  schema,
-});
+const dbByUrl = new Map<string, NodePgDatabase<typeof schema>>();
+
+export function createDb(databaseUrl: string): NodePgDatabase<typeof schema> {
+  const cached = dbByUrl.get(databaseUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const client = drizzle(databaseUrl, {
+    cache:
+      upstashUrl && upstashToken
+        ? upstashCache({
+            url: upstashUrl,
+            token: upstashToken,
+            global: true,
+          })
+        : undefined,
+    schema,
+  });
+  dbByUrl.set(databaseUrl, client);
+  return client;
+}
+
+function createMissingDatabaseUrlProxy(): NodePgDatabase<typeof schema> {
+  return new Proxy({} as NodePgDatabase<typeof schema>, {
+    get() {
+      throw new Error("[ENV]: DATABASE_URL is not defined");
+    },
+  });
+}
+
+export const db = databaseUrl
+  ? createDb(databaseUrl)
+  : createMissingDatabaseUrlProxy();


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables real DB transactions by moving the API to Node Postgres `@notra/db/drizzle` with a reusable `createDb`, and makes the chat router resilient with schema-validated output, auto-repair, and a safe fallback.

- **Bug Fixes**
  - Chat router now uses `generateObject` with schema validation and automatic repair; adds try/catch and a default decision to keep chats working when routing fails.

- **Refactors**
  - Replaced `@notra/db/drizzle-http` with `@notra/db/drizzle`.
  - Added `createDb(databaseUrl)` with per-URL client caching and Upstash cache; exported `db` and a clear error when `DATABASE_URL` is missing. API now supports real transactions.

<sup>Written for commit 7dd16b36ef8ff0c4f8157019e36a745a6e998a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

