### PR TITLE
fix(api): align OpenAPI spec with handlers and normalize validation errors

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -57,6 +57,7 @@ const publicStatusRoute = createRoute({
   tags: ["Discovery"],
   operationId: "getPublicApiStatus",
   summary: "Check public API reachability",
+  security: [],
   responses: {
     200: {
       description:

--- a/apps/api/src/routes/brand-identities.ts
+++ b/apps/api/src/routes/brand-identities.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import {
   createBrandAnalysisJob,
   createBrandAnalysisJobId,
@@ -27,6 +27,7 @@ import {
   triggerBrandAnalysisWorkflow,
 } from "../utils/brand-analysis";
 import { selectBrandIdentityColumns } from "../utils/brand-identities";
+import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
 import { isConstraintViolation, isPgUniqueViolation } from "../utils/pg-errors";
@@ -37,7 +38,7 @@ import {
   getTriggersForBrandIdentity,
 } from "../utils/triggers";
 
-export const brandIdentitiesRoutes = new OpenAPIHono();
+export const brandIdentitiesRoutes = createOpenApiApp();
 
 const getBrandIdentitiesRoute = createRoute({
   method: "get",

--- a/apps/api/src/routes/chats.ts
+++ b/apps/api/src/routes/chats.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import {
   getChatSession,
   getChatSessionByExternalChannel,
@@ -19,9 +19,10 @@ import {
   sendChatParamsSchema,
 } from "../schemas/chats";
 import { getOrganizationId } from "../utils/auth";
+import { createOpenApiApp, formatValidationError } from "../utils/openapi-app";
 import { errorResponse } from "../utils/openapi-responses";
 
-export const chatsRoutes = new OpenAPIHono();
+export const chatsRoutes = createOpenApiApp();
 
 const listChatsRoute = createRoute({
   method: "get",
@@ -158,10 +159,7 @@ async function handleSend(
     const parseResult = sendChatMessageRequestSchema.safeParse(body);
 
     if (!parseResult.success) {
-      return c.json(
-        { error: "Invalid request body", details: parseResult.error.issues },
-        400
-      );
+      return c.json({ error: formatValidationError(parseResult.error) }, 400);
     }
 
     return await runChatMessage({

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import {
   githubIntegrations,
   linearIntegrations,
@@ -25,6 +25,7 @@ import {
   validateGitHubRepositoryAccess,
 } from "../utils/github-integrations";
 import { logError } from "../utils/logging";
+import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
 import { isConstraintViolation, isPgUniqueViolation } from "../utils/pg-errors";
@@ -35,7 +36,7 @@ import {
   getTriggersForIntegration,
 } from "../utils/triggers";
 
-export const integrationsRoutes = new OpenAPIHono();
+export const integrationsRoutes = createOpenApiApp();
 
 const getIntegrationsRoute = createRoute({
   method: "get",
@@ -119,6 +120,7 @@ const deleteIntegrationRoute = createRoute({
         },
       },
     },
+    400: errorResponse("Invalid path params"),
     401: errorResponse("Missing or invalid API key"),
     403: errorResponse("Forbidden"),
     404: errorResponse("Integration not found"),

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { supportsPostSlug } from "@notra/ai/schemas/post";
 import {
   appendContentGenerationJobEvent,
@@ -45,13 +45,14 @@ import {
   extractTitleFromMarkdown,
   renderMarkdownToHtml,
 } from "../utils/markdown";
+import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
 import { isConstraintViolation, isPgUniqueViolation } from "../utils/pg-errors";
 import { enforceRatelimit, RATE_LIMITS, ratelimit } from "../utils/ratelimit";
 import { getRedis } from "../utils/redis";
 
-export const postsRoutes = new OpenAPIHono();
+export const postsRoutes = createOpenApiApp();
 
 function shouldApplyFilter(
   selectedValues: readonly string[],
@@ -189,7 +190,6 @@ const deletePostRoute = createRoute({
     401: errorResponse("Missing or invalid API key"),
     403: errorResponse("Forbidden"),
     404: errorResponse("Post not found"),
-    409: errorResponse("Post slug already exists"),
     503: errorResponse("Authentication service unavailable"),
   },
 });
@@ -295,6 +295,7 @@ const getPostGenerationRoute = createRoute({
         },
       },
     },
+    400: errorResponse("Invalid path params"),
     401: errorResponse("Missing or invalid API key"),
     403: errorResponse("Forbidden"),
     404: errorResponse("Generation job not found"),
@@ -358,6 +359,7 @@ postsRoutes.openapi(getPostsRoute, async (c) => {
       title: true,
       slug: true,
       content: true,
+      htmlUrl: true,
       markdown: true,
       recommendations: true,
       contentType: true,
@@ -409,6 +411,7 @@ postsRoutes.openapi(getPostRoute, async (c) => {
       title: true,
       slug: true,
       content: true,
+      htmlUrl: true,
       markdown: true,
       recommendations: true,
       contentType: true,
@@ -561,6 +564,7 @@ postsRoutes.openapi(patchPostRoute, async (c) => {
         title: posts.title,
         slug: posts.slug,
         content: posts.content,
+        htmlUrl: posts.htmlUrl,
         markdown: posts.markdown,
         recommendations: posts.recommendations,
         contentType: posts.contentType,

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -314,6 +314,7 @@ const getSchedulesRoute = createRoute({
         },
       },
     },
+    400: errorResponse("Invalid query params"),
     401: errorResponse("Missing or invalid API key"),
     403: errorResponse("Forbidden"),
     404: errorResponse("Organization not found"),

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import type { createDb } from "@notra/db/drizzle";
 import {
   contentTriggerLookbackWindows,
@@ -23,6 +23,7 @@ import {
 } from "../schemas/schedules";
 import { getOrganizationId } from "../utils/auth";
 import { logError } from "../utils/logging";
+import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
 import {
@@ -35,7 +36,7 @@ import {
   ORGANIZATION_SCHEDULES_PATH_REGEX,
 } from "../utils/regex";
 
-export const schedulesRoutes = new OpenAPIHono();
+export const schedulesRoutes = createOpenApiApp();
 
 type DbClient = ReturnType<typeof createDb>;
 type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;
@@ -316,6 +317,7 @@ const getSchedulesRoute = createRoute({
     401: errorResponse("Missing or invalid API key"),
     403: errorResponse("Forbidden"),
     404: errorResponse("Organization not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -350,6 +352,7 @@ const createScheduleRoute = createRoute({
     404: errorResponse("Organization not found"),
     409: errorResponse("Duplicate schedule"),
     500: errorResponse("Failed to create schedule"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -385,6 +388,7 @@ const patchScheduleRoute = createRoute({
     404: errorResponse("Schedule or organization not found"),
     409: errorResponse("Duplicate schedule"),
     500: errorResponse("Failed to update schedule"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 
@@ -406,9 +410,11 @@ const deleteScheduleRoute = createRoute({
         },
       },
     },
+    400: errorResponse("Invalid path params"),
     401: errorResponse("Missing or invalid API key"),
     403: errorResponse("Forbidden"),
     404: errorResponse("Schedule or organization not found"),
+    503: errorResponse("Authentication service unavailable"),
   },
 });
 

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { skills } from "@notra/db/schema";
 import { and, asc, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -18,6 +18,7 @@ import {
   skillParamsSchema,
   skillResponseSchema,
 } from "../schemas/skills";
+import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse } from "../utils/openapi-responses";
 import { isPgUniqueViolation } from "../utils/pg-errors";
 import {
@@ -26,7 +27,7 @@ import {
   serializeSkillSummary,
 } from "../utils/skills";
 
-export const skillsRoutes = new OpenAPIHono();
+export const skillsRoutes = createOpenApiApp();
 
 const listSkillsRoute = createRoute({
   method: "get",
@@ -73,6 +74,7 @@ const createSkillRoute = createRoute({
   summary: "Create a skill",
   request: {
     body: {
+      required: true,
       content: { "application/json": { schema: createSkillRequestSchema } },
     },
   },
@@ -98,6 +100,7 @@ const patchSkillRoute = createRoute({
   request: {
     params: skillParamsSchema,
     body: {
+      required: true,
       content: { "application/json": { schema: patchSkillRequestSchema } },
     },
   },

--- a/apps/api/src/schemas/content.ts
+++ b/apps/api/src/schemas/content.ts
@@ -118,14 +118,6 @@ function createBaseEnumFilterSchema<T extends string>(
     });
 }
 
-function createQueryEnumFilterSchema<T extends string>(
-  valueSchema: z.ZodType<T>,
-  defaultValues: readonly T[],
-  maxItems: number
-) {
-  return createBaseEnumFilterSchema(valueSchema, defaultValues, maxItems);
-}
-
 function createOpenApiEnumFilterSchema<T extends string>(
   valueSchema: z.ZodType<T>,
   defaultValues: readonly T[],
@@ -153,39 +145,12 @@ function createBaseStringFilterSchema(maxItems: number) {
     });
 }
 
-function createQueryStringFilterSchema(maxItems: number) {
-  return createBaseStringFilterSchema(maxItems);
-}
-
 function createOpenApiStringFilterSchema(
   maxItems: number,
   description: string
 ) {
   return createBaseStringFilterSchema(maxItems).openapi({ description });
 }
-
-const statusFilterSchema = createQueryEnumFilterSchema(
-  postStatusSchema,
-  ["published"],
-  ALL_POST_STATUSES.length
-);
-
-const contentTypeFilterSchema = createQueryEnumFilterSchema(
-  postContentTypeSchema,
-  ALL_POST_CONTENT_TYPES,
-  ALL_POST_CONTENT_TYPES.length
-);
-
-const brandIdentityIdFilterSchema = createQueryStringFilterSchema(100);
-
-const getPostsQuerySchema = z.object({
-  sort: z.enum(["asc", "desc"]).default("desc"),
-  limit: z.coerce.number().int().min(1).max(100).default(10),
-  page: z.coerce.number().int().min(1).default(1),
-  status: statusFilterSchema,
-  contentType: contentTypeFilterSchema,
-  brandIdentityId: brandIdentityIdFilterSchema,
-});
 
 const openApiStatusFilterSchema = createOpenApiEnumFilterSchema(
   postStatusSchema,
@@ -257,6 +222,8 @@ export const getIntegrationParamsSchema = z.object({
 export const errorResponseSchema = z
   .object({
     error: z.string(),
+    code: z.string().optional(),
+    recovery: z.string().optional(),
   })
   .openapi("ErrorResponse");
 

--- a/apps/api/src/utils/openapi-app.ts
+++ b/apps/api/src/utils/openapi-app.ts
@@ -1,0 +1,22 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import type { ZodError } from "zod";
+
+export function formatValidationError(error: ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) {
+    return "Invalid request";
+  }
+
+  const path = issue.path.map(String).join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+export function createOpenApiApp() {
+  return new OpenAPIHono({
+    defaultHook: (result, c) => {
+      if (!result.success) {
+        return c.json({ error: formatValidationError(result.error) }, 400);
+      }
+    },
+  });
+}


### PR DESCRIPTION
### Description
Aligns the public API's generated OpenAPI document with what the handlers actually do, across all 19 endpoints.

Spec-accuracy fixes (no behavior change): documents the `code`/`recovery` fields auth errors already return; adds the missing `503` to all schedule routes and `400` to delete/get routes with validated path params; removes an unreachable `409` from delete-post; marks `GET /v1/status` public (`security: []`); requires the skill create/update request bodies; and removes a dead duplicate query schema that was a spec/validation drift hazard.

Behavior changes: a shared validation `defaultHook` now returns a clean `{ error: "<message>" }` on 400 instead of leaking the raw Zod object (the status code already conveys success/failure); and image posts now return their documented `htmlUrl` (the column was never selected, so it was always `null`).

Verified with `tsc`, `biome`, `bun run build`, a regenerated `openapi.json` (cross-checked so every authenticated op exposes 401/403/503 and 400 appears only where validation can fail), and a runtime test of the new 400 shape.

### Screenshot/Recording (if applicable)
N/A — API contract / OpenAPI spec change, no UI.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the OpenAPI spec with the actual handlers across all 19 endpoints, and fixes image post responses to include the documented htmlUrl.

- **Refactors**
  - Spec alignment: adds missing 503s and 400s where validation applies (including list schedules), removes unreachable 409 on delete post, marks GET `/v1/status` public, requires bodies for skill create/update, and removes a duplicate query schema.
  - Introduces a shared app using `@hono/zod-openapi` with a validation defaultHook; `ErrorResponse` now supports optional `code` and `recovery`.

- **Migration**
  - 400 responses now return `{ error: string }` only (no Zod details). Update client error handling accordingly.

<sup>Written for commit ac2dea520ce163361737c9d76ff763bf9d281ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

