### PR TITLE
fix(auth): grant offline_access so MCP OAuth clients can refresh

### DIFF
--- a/apps/api/src/constants/oauth-scopes.ts
+++ b/apps/api/src/constants/oauth-scopes.ts
@@ -37,9 +37,13 @@ export const PUBLIC_API_SCOPE_RESOURCES = [
   },
 ] as const;
 
-export const PUBLIC_API_SCOPES = PUBLIC_API_SCOPE_RESOURCES.flatMap(
-  (resource) => [resource.readScope, resource.writeScope]
-);
+export const PUBLIC_API_SCOPES = [
+  "offline_access",
+  ...PUBLIC_API_SCOPE_RESOURCES.flatMap((resource) => [
+    resource.readScope,
+    resource.writeScope,
+  ]),
+];
 
 export const LEGACY_API_READ_SCOPE = "api.read";
 export const LEGACY_API_WRITE_SCOPE = "api.write";

--- a/apps/api/src/utils/agent-discovery.ts
+++ b/apps/api/src/utils/agent-discovery.ts
@@ -59,7 +59,7 @@ export function buildAuthorizationServerMetadata() {
     registration_endpoint: `${AUTH_SERVER_URL}/agent/auth/register`,
     revocation_endpoint: `${AUTH_SERVER_URL}/agent/auth/revoke`,
     response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
     token_endpoint_auth_methods_supported: ["none"],
     code_challenge_methods_supported: ["S256"],
     scopes_supported: PUBLIC_API_SCOPES,

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -2,6 +2,8 @@ export const OAUTH_AUTH_CODE_TTL_MS = 5 * 60 * 1000;
 export const OAUTH_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 export const OAUTH_REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
+export const OAUTH_OFFLINE_ACCESS_SCOPE = "offline_access";
+
 export const OAUTH_SUPPORTED_SCOPES = [
   "offline_access",
   "posts.read",
@@ -39,6 +41,7 @@ export const OAUTH_DEFAULT_SCOPES = [
 ] as const;
 
 export const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = [
+  "offline_access",
   "posts.read",
   "posts.write",
   "brand-identities.read",

--- a/apps/dashboard/src/utils/oauth-proxy.ts
+++ b/apps/dashboard/src/utils/oauth-proxy.ts
@@ -1,4 +1,7 @@
-import { OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES } from "@/constants/oauth";
+import {
+  OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
+  OAUTH_OFFLINE_ACCESS_SCOPE,
+} from "@/constants/oauth";
 import { auth } from "@/lib/auth/server";
 
 const AUTH_ROUTE_PREFIX = "/api/auth";
@@ -42,6 +45,19 @@ export function buildOAuthForwardedHeaders(
   return headers;
 }
 
+const REGISTRATION_SCOPE_SEPARATOR = " ";
+const REGISTRATION_SCOPE_SPLIT_REGEX = /\s+/;
+
+function ensureOfflineAccessScope(scope: string) {
+  const scopes = scope.split(REGISTRATION_SCOPE_SPLIT_REGEX).filter(Boolean);
+
+  if (!scopes.includes(OAUTH_OFFLINE_ACCESS_SCOPE)) {
+    scopes.push(OAUTH_OFFLINE_ACCESS_SCOPE);
+  }
+
+  return scopes.join(REGISTRATION_SCOPE_SEPARATOR);
+}
+
 function withDefaultRegistrationScopes(body: ArrayBuffer) {
   try {
     const payload = JSON.parse(new TextDecoder().decode(body));
@@ -50,14 +66,17 @@ function withDefaultRegistrationScopes(body: ArrayBuffer) {
       return body;
     }
 
-    if ("scope" in payload && typeof payload.scope === "string") {
-      return body;
-    }
+    const requestedScope =
+      "scope" in payload && typeof payload.scope === "string"
+        ? payload.scope
+        : OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES.join(
+            REGISTRATION_SCOPE_SEPARATOR
+          );
 
     return new TextEncoder().encode(
       JSON.stringify({
         ...payload,
-        scope: OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES.join(" "),
+        scope: ensureOfflineAccessScope(requestedScope),
       })
     ).buffer;
   } catch {

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -25,6 +25,7 @@ export const NOTRA_SAME_AS = [
 ] as const;
 
 const PUBLIC_API_SCOPES = [
+  "offline_access",
   "posts.read",
   "posts.write",
   "brand-identities.read",


### PR DESCRIPTION
### Description
MCP/OAuth clients (e.g. ChatGPT's connector) were disconnected after the 1-hour access-token expiry because they never received a refresh token. better-auth only mints a refresh token when `offline_access` is in the granted scope, and the authorize endpoint caps the grant to the registered `client.scopes` — but the dynamic client registration proxy pinned `client.scopes` to a default list that omitted `offline_access`, so it could never be granted.

This guarantees `offline_access` in the registered scope and advertises it in discovery metadata, so clients receive a refresh token (1h access token, silently refreshable for 90 days).

- `oauth-proxy`: always include `offline_access` in the registered client scope (both no-scope and client-provided-scope registrations)
- `constants/oauth`: add `offline_access` to the DCR default scopes
- `api`/`web` protected-resource metadata: advertise `offline_access` in `scopes_supported`
- `api` authorization-server metadata: add `refresh_token` to `grant_types_supported`

`offline_access` stays invisible on the consent screen (it isn't in `OAUTH_SCOPE_RESOURCES`) while still being preserved through the scope selector.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure MCP OAuth clients get refresh tokens by guaranteeing `offline_access` in registered scopes and advertising support in discovery metadata. This stops disconnects after the 1-hour access token by enabling silent refresh.

- **Bug Fixes**
  - Registration proxy always injects `offline_access` into `client.scopes` (default and client-provided).
  - Added `offline_access` to DCR default scopes and to `scopes_supported` in API/Web metadata.
  - Added `refresh_token` to `grant_types_supported` in authorization server metadata.
  - Kept `offline_access` hidden on the consent UI while preserved in the scope selector.

<sup>Written for commit 17085fbb21ac66646c291d803e25ebd7fdc6154d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

