### PR TITLE
fix(api): align api schemas with database

### DIFF
--- a/apps/api/src/routes/brand-identities.ts
+++ b/apps/api/src/routes/brand-identities.ts
@@ -26,7 +26,10 @@ import {
   isBrandAnalysisConfigured,
   triggerBrandAnalysisWorkflow,
 } from "../utils/brand-analysis";
-import { selectBrandIdentityColumns } from "../utils/brand-identities";
+import {
+  selectBrandIdentityColumns,
+  serializeBrandIdentity,
+} from "../utils/brand-identities";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
@@ -39,30 +42,6 @@ import {
 } from "../utils/triggers";
 
 export const brandIdentitiesRoutes = createOpenApiApp();
-
-interface BrandIdentityRow {
-  id: string;
-  name: string;
-  isDefault: boolean;
-  websiteUrl: string;
-  companyName: string | null;
-  companyDescription: string | null;
-  toneProfile: string | null;
-  customTone: string | null;
-  customInstructions: string | null;
-  audience: string | null;
-  language: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-function serializeBrandIdentity(brandIdentity: BrandIdentityRow) {
-  return {
-    ...brandIdentity,
-    createdAt: brandIdentity.createdAt.toISOString(),
-    updatedAt: brandIdentity.updatedAt.toISOString(),
-  };
-}
 
 const getBrandIdentitiesRoute = createRoute({
   method: "get",

--- a/apps/api/src/routes/brand-identities.ts
+++ b/apps/api/src/routes/brand-identities.ts
@@ -40,6 +40,30 @@ import {
 
 export const brandIdentitiesRoutes = createOpenApiApp();
 
+interface BrandIdentityRow {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  websiteUrl: string;
+  companyName: string | null;
+  companyDescription: string | null;
+  toneProfile: string | null;
+  customTone: string | null;
+  customInstructions: string | null;
+  audience: string | null;
+  language: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function serializeBrandIdentity(brandIdentity: BrandIdentityRow) {
+  return {
+    ...brandIdentity,
+    createdAt: brandIdentity.createdAt.toISOString(),
+    updatedAt: brandIdentity.updatedAt.toISOString(),
+  };
+}
+
 const getBrandIdentitiesRoute = createRoute({
   method: "get",
   path: "/brand-identities",
@@ -280,7 +304,13 @@ brandIdentitiesRoutes.openapi(getBrandIdentitiesRoute, async (c) => {
     },
   });
 
-  return c.json({ brandIdentities, organization }, 200);
+  return c.json(
+    {
+      brandIdentities: brandIdentities.map(serializeBrandIdentity),
+      organization,
+    },
+    200
+  );
 });
 
 brandIdentitiesRoutes.openapi(createBrandIdentityRoute, async (c) => {
@@ -514,7 +544,15 @@ brandIdentitiesRoutes.openapi(getBrandIdentityRoute, async (c) => {
     },
   });
 
-  return c.json({ brandIdentity: brandIdentity ?? null, organization }, 200);
+  return c.json(
+    {
+      brandIdentity: brandIdentity
+        ? serializeBrandIdentity(brandIdentity)
+        : null,
+      organization,
+    },
+    200
+  );
 });
 
 brandIdentitiesRoutes.openapi(patchBrandIdentityRoute, async (c) => {
@@ -645,7 +683,10 @@ brandIdentitiesRoutes.openapi(patchBrandIdentityRoute, async (c) => {
       return c.json({ error: "Brand identity not found" }, 404);
     }
 
-    return c.json({ brandIdentity, organization }, 200);
+    return c.json(
+      { brandIdentity: serializeBrandIdentity(brandIdentity), organization },
+      200
+    );
   } catch (error) {
     if (isPgUniqueViolation(error)) {
       return c.json(

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -41,6 +41,23 @@ export const schedulesRoutes = createOpenApiApp();
 type DbClient = ReturnType<typeof createDb>;
 type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;
 type ScheduleLookbackWindow = CreateScheduleBody["lookbackWindow"];
+interface ScheduleTriggerRow {
+  id: string;
+  organizationId: string;
+  name: string;
+  sourceType: string;
+  sourceConfig: unknown;
+  targets: unknown;
+  outputType: string;
+  outputConfig: unknown;
+  enabled: boolean;
+  autoPublish: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+type ScheduleTriggerWithLookbackWindow = ScheduleTriggerRow & {
+  lookbackWindow: ScheduleLookbackWindow;
+};
 
 const DEFAULT_SCHEDULE_NAME = "Untitled Schedule";
 
@@ -130,21 +147,7 @@ async function ensureScheduleTargetsExist(
   return null;
 }
 
-function serializeSchedule(trigger: {
-  id: string;
-  organizationId: string;
-  name: string;
-  sourceType: string;
-  sourceConfig: unknown;
-  targets: unknown;
-  outputType: string;
-  outputConfig: unknown;
-  enabled: boolean;
-  autoPublish: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-  lookbackWindow: ScheduleLookbackWindow;
-}) {
+function serializeSchedule(trigger: ScheduleTriggerWithLookbackWindow) {
   return {
     id: trigger.id,
     organizationId: trigger.organizationId,
@@ -181,7 +184,7 @@ function mapQstashError(error: unknown) {
   return { error: "Failed to configure schedule", status: 500 as const };
 }
 
-function filterByRepositoryIds<T extends { targets: unknown }>(
+function filterByRepositoryIds<T extends ScheduleTriggerRow>(
   triggers: T[],
   repositoryIds: string[]
 ) {

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -21,6 +21,10 @@ import {
   scheduleSourceConfigSchema,
   scheduleTargetsSchema,
 } from "../schemas/schedules";
+import type {
+  ScheduleTriggerRow,
+  ScheduleTriggerWithLookbackWindow,
+} from "../types/schedules";
 import { getOrganizationId } from "../utils/auth";
 import { logError } from "../utils/logging";
 import { createOpenApiApp } from "../utils/openapi-app";
@@ -40,24 +44,6 @@ export const schedulesRoutes = createOpenApiApp();
 
 type DbClient = ReturnType<typeof createDb>;
 type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;
-type ScheduleLookbackWindow = CreateScheduleBody["lookbackWindow"];
-interface ScheduleTriggerRow {
-  id: string;
-  organizationId: string;
-  name: string;
-  sourceType: string;
-  sourceConfig: unknown;
-  targets: unknown;
-  outputType: string;
-  outputConfig: unknown;
-  enabled: boolean;
-  autoPublish: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-}
-type ScheduleTriggerWithLookbackWindow = ScheduleTriggerRow & {
-  lookbackWindow: ScheduleLookbackWindow;
-};
 
 const DEFAULT_SCHEDULE_NAME = "Untitled Schedule";
 
@@ -463,8 +449,8 @@ schedulesRoutes.openapi(getSchedulesRoute, async (c) => {
   const schedules = filteredTriggers.map((trigger) =>
     serializeSchedule({
       ...trigger,
-      lookbackWindow: (lookbackWindowByTriggerId.get(trigger.id) ??
-        "last_7_days") as ScheduleLookbackWindow,
+      lookbackWindow:
+        lookbackWindowByTriggerId.get(trigger.id) ?? "last_7_days",
     })
   );
 

--- a/apps/api/src/schemas/content.ts
+++ b/apps/api/src/schemas/content.ts
@@ -14,17 +14,15 @@ import {
 } from "@notra/ai/schemas/limits";
 import { POST_SLUG_MAX_LENGTH, POST_SLUG_REGEX } from "@notra/ai/schemas/post";
 import { toneProfileSchema } from "@notra/ai/schemas/tone";
-import {
-  LOOKBACK_WINDOWS,
-  SUPPORTED_CONTENT_GENERATION_TYPES,
-} from "@notra/content-generation/schemas";
+import { SUPPORTED_CONTENT_GENERATION_TYPES } from "@notra/content-generation/schemas";
+import { lookbackWindowEnum, postStatusEnum } from "@notra/db/schema";
 import { assertPublicHttpUrl } from "@notra/utils/url";
 import { resourceIdSchema } from "./ids";
 
 const HTTP_PROTOCOL_REGEX = /^https?:\/\//i;
 export const getPostsParamsSchema = z.object({});
 
-const postStatusSchema = z.enum(["draft", "published"]);
+const postStatusSchema = z.enum(postStatusEnum.enumValues);
 const postContentTypeSchema = z.enum([
   "changelog",
   "linkedin_post",
@@ -621,7 +619,9 @@ const contentGenerationStatusSchema = z.enum([
   "skipped",
 ]);
 
-const contentGenerationLookbackWindowSchema = z.enum(LOOKBACK_WINDOWS);
+const contentGenerationLookbackWindowSchema = z.enum(
+  lookbackWindowEnum.enumValues
+);
 
 const contentGenerationTypeSchema = z.enum(SUPPORTED_CONTENT_GENERATION_TYPES);
 

--- a/apps/api/src/schemas/schedules.ts
+++ b/apps/api/src/schemas/schedules.ts
@@ -1,8 +1,6 @@
 import { z } from "@hono/zod-openapi";
-import {
-  LOOKBACK_WINDOWS,
-  SUPPORTED_CONTENT_GENERATION_TYPES,
-} from "@notra/content-generation/schemas";
+import { SUPPORTED_CONTENT_GENERATION_TYPES } from "@notra/content-generation/schemas";
+import { lookbackWindowEnum } from "@notra/db/schema";
 import { resourceIdSchema } from "./ids";
 
 const CRON_FREQUENCIES = ["daily", "weekly", "monthly"] as const;
@@ -94,7 +92,7 @@ export const createScheduleRequestSchema = z.object({
   outputConfig: scheduleOutputConfigSchema,
   enabled: z.boolean(),
   autoPublish: z.boolean().default(false),
-  lookbackWindow: z.enum(LOOKBACK_WINDOWS).default("last_7_days"),
+  lookbackWindow: z.enum(lookbackWindowEnum.enumValues).default("last_7_days"),
 });
 
 export const patchScheduleRequestSchema = createScheduleRequestSchema.openapi(
@@ -114,7 +112,7 @@ const scheduleSchema = z.object({
   autoPublish: z.boolean(),
   createdAt: z.string(),
   updatedAt: z.string(),
-  lookbackWindow: z.enum(LOOKBACK_WINDOWS),
+  lookbackWindow: z.enum(lookbackWindowEnum.enumValues),
 });
 
 const organizationSchema = z.object({

--- a/apps/api/src/types/brand-identities.ts
+++ b/apps/api/src/types/brand-identities.ts
@@ -1,0 +1,18 @@
+import type { brandSettings } from "@notra/db/schema";
+
+export type BrandIdentityRow = Pick<
+  typeof brandSettings.$inferSelect,
+  | "id"
+  | "name"
+  | "isDefault"
+  | "websiteUrl"
+  | "companyName"
+  | "companyDescription"
+  | "toneProfile"
+  | "customTone"
+  | "customInstructions"
+  | "audience"
+  | "language"
+  | "createdAt"
+  | "updatedAt"
+>;

--- a/apps/api/src/types/schedules.ts
+++ b/apps/api/src/types/schedules.ts
@@ -1,0 +1,9 @@
+import type { contentTriggers, lookbackWindowEnum } from "@notra/db/schema";
+
+type ScheduleLookbackWindow = (typeof lookbackWindowEnum.enumValues)[number];
+
+export type ScheduleTriggerRow = typeof contentTriggers.$inferSelect;
+
+export type ScheduleTriggerWithLookbackWindow = ScheduleTriggerRow & {
+  lookbackWindow: ScheduleLookbackWindow;
+};

--- a/apps/api/src/utils/brand-identities.ts
+++ b/apps/api/src/utils/brand-identities.ts
@@ -1,4 +1,5 @@
 import { brandSettings } from "@notra/db/schema";
+import type { BrandIdentityRow } from "../types/brand-identities";
 
 export function selectBrandIdentityColumns() {
   return {
@@ -15,5 +16,13 @@ export function selectBrandIdentityColumns() {
     language: brandSettings.language,
     createdAt: brandSettings.createdAt,
     updatedAt: brandSettings.updatedAt,
+  };
+}
+
+export function serializeBrandIdentity(brandIdentity: BrandIdentityRow) {
+  return {
+    ...brandIdentity,
+    createdAt: brandIdentity.createdAt.toISOString(),
+    updatedAt: brandIdentity.updatedAt.toISOString(),
   };
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns API schemas and responses with database enums and normalizes date serialization to eliminate mismatches between OpenAPI, API responses, and stored values.

- **Bug Fixes**
  - Use `postStatusEnum` and `lookbackWindowEnum` from `@notra/db/schema` in `content` and `schedules` schemas; default `lookbackWindow` stays `last_7_days`.
  - Replace all `LOOKBACK_WINDOWS` references from `@notra/content-generation/schemas`.
  - Serialize `createdAt`/`updatedAt` as ISO strings for `brand-identities` (list/get/patch) via `serializeBrandIdentity`.

- **Refactors**
  - Derive `BrandIdentityRow`, `ScheduleTriggerRow`, and `ScheduleTriggerWithLookbackWindow` from `@notra/db/schema` and move them to `apps/api/src/types/*`.
  - Simplify `serializeSchedule` and tighten repository filtering generics to `ScheduleTriggerRow`.

<sup>Written for commit 61aeb6a97640c3b8f811ca2348622ac8ab0094db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

