### PR TITLE
feat(automation): add pre-release toggle for release event triggers

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
@@ -130,6 +130,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         sourceType: "github_webhook",
         sourceConfig: {
           eventTypes: trigger.sourceConfig.eventTypes ?? [values.eventType],
+          includePreReleases: trigger.sourceConfig.includePreReleases ?? true,
         },
         targets: trigger.targets,
         outputType,

--- a/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
+++ b/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
@@ -1,54 +1,24 @@
 "use client";
 
 import {
-  Add01Icon,
-  AlertCircleIcon,
-  Loading03Icon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import {
   ResponsiveDialog,
   ResponsiveDialogContent,
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
   ResponsiveDialogTrigger,
 } from "@notra/ui/components/shared/responsive-dialog";
-import {
-  Combobox,
-  ComboboxChip,
-  ComboboxChips,
-  ComboboxChipsInput,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxItem,
-  ComboboxList,
-  useComboboxAnchor,
-} from "@notra/ui/components/ui/combobox";
-import { Skeleton } from "@notra/ui/components/ui/skeleton";
-import { Github } from "@notra/ui/components/ui/svgs/github";
-import { useForm, useStore } from "@tanstack/react-form";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
-import { BrandIdentityRadioGroup } from "@/components/brand-identity-radio-group";
-import { Button } from "@/components/button";
-import { FormatCard } from "@/components/content/create/format-card";
-import { AddRepositoryButton } from "@/components/integrations/add-repository-button";
-import { AddRepositoryDialog } from "@/components/integrations/add-repository-dialog";
-import { LegacyAddIntegrationDialog as AddIntegrationDialog } from "@/components/integrations/legacy/add-integration-dialog";
-import { FORMAT_CARD_META, FORMAT_ORDER } from "@/constants/content-formats";
-import { EVENT_TYPE_ORDER } from "@/constants/event-triggers";
-import { supportsAutoPublish } from "@/constants/schedule-output-types";
+import { useStore } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useEventTriggerForm } from "@/lib/hooks/use-event-trigger-form";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import {
-  type EventTriggerFormValues,
-  eventTriggerFormSchema,
-} from "@/schemas/automation/event-trigger-form";
 import type { CreateEventTriggerDialogProps } from "@/types/automation/event-trigger";
-import type { Trigger } from "@/types/triggers/triggers";
-import { getDefaultEventTriggerValues } from "@/utils/event-trigger-form";
-import { EventTypeCard } from "./event-type-card";
-import { TriggerSwitchRow } from "./trigger-switch-row";
+import { EventTriggerDialogFooter } from "./event-trigger-dialog-footer";
+import { EventTriggerEventSection } from "./event-trigger-event-section";
+import { EventTriggerFormatSection } from "./event-trigger-format-section";
+import { EventTriggerRepositoriesSection } from "./event-trigger-repositories-section";
+import { EventTriggerRulesSection } from "./event-trigger-rules-section";
+import { RepositoryConnectionDialogs } from "./repository-connection-dialogs";
 
 export function CreateEventTriggerDialog({
   organizationId,
@@ -60,7 +30,6 @@ export function CreateEventTriggerDialog({
 }: CreateEventTriggerDialogProps) {
   const isEditMode = !!editTrigger;
   const [internalOpen, setInternalOpen] = useState(false);
-  const lastResetKeyRef = useRef<string | null>(null);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
   const setOpen = (next: boolean) => {
@@ -71,91 +40,15 @@ export function CreateEventTriggerDialog({
     }
   };
   const [addRepoOpen, setAddRepoOpen] = useState(false);
-  const comboboxAnchor = useComboboxAnchor();
 
-  const mutation = useMutation<
-    { trigger: Trigger },
-    Error,
-    EventTriggerFormValues
-  >({
-    mutationFn: async (value) => {
-      const payload = {
-        organizationId,
-        sourceType: "github_webhook" as const,
-        sourceConfig: {
-          eventTypes: [value.eventType],
-          includePreReleases:
-            value.eventType === "release" ? value.includePreReleases : true,
-        },
-        targets: { repositoryIds: value.repositoryIds },
-        outputType: value.outputType,
-        outputConfig: {
-          ...(value.brandVoiceId ? { brandVoiceId: value.brandVoiceId } : {}),
-        },
-        enabled: true,
-        autoPublish: supportsAutoPublish(value.outputType)
-          ? value.autoPublish
-          : false,
-      };
-
-      try {
-        if (isEditMode) {
-          return await dashboardOrpc.automation.events.update.call({
-            triggerId: editTrigger.id,
-            ...payload,
-            enabled: editTrigger.enabled,
-          });
-        }
-        return await dashboardOrpc.automation.events.create.call(payload);
-      } catch (error) {
-        if (error instanceof Error && error.message === "Duplicate trigger") {
-          throw new Error("Trigger already exists");
-        }
-        if (error instanceof Error && error.message) {
-          throw error;
-        }
-        throw new Error(
-          isEditMode ? "Failed to update trigger" : "Failed to create trigger"
-        );
-      }
-    },
-    onSuccess: (data) => {
-      toast.success(isEditMode ? "Trigger updated" : "Trigger added");
-      onSuccess?.(data.trigger);
-      setOpen(false);
-    },
-    onError: (error) => {
-      toast.error(error.message);
-    },
+  const { form, isPending } = useEventTriggerForm({
+    organizationId,
+    editTrigger,
+    open,
+    onSuccess,
+    onClose: () => setOpen(false),
   });
 
-  const form = useForm({
-    defaultValues: getDefaultEventTriggerValues(editTrigger),
-    validators: {
-      onSubmit: eventTriggerFormSchema,
-    },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync(value);
-    },
-  });
-
-  useEffect(() => {
-    if (!open) {
-      lastResetKeyRef.current = null;
-      return;
-    }
-
-    const resetKey = editTrigger?.id ?? "create";
-    if (lastResetKeyRef.current === resetKey) {
-      return;
-    }
-
-    form.reset(getDefaultEventTriggerValues(editTrigger));
-    lastResetKeyRef.current = resetKey;
-  }, [editTrigger, form, open]);
-
-  const outputType = useStore(form.store, (s) => s.values.outputType);
-  const eventType = useStore(form.store, (s) => s.values.eventType);
   const repositoryCount = useStore(
     form.store,
     (s) => s.values.repositoryIds.length
@@ -176,13 +69,6 @@ export function CreateEventTriggerDialog({
   );
 
   const brandVoices = brandResponse?.voices ?? [];
-  const nonDefaultBrandVoices = brandVoices.filter((voice) => !voice.isDefault);
-  const defaultBrandVoiceName = brandVoices.find(
-    (voice) => voice.isDefault
-  )?.name;
-  const defaultBrandVoiceLabel = defaultBrandVoiceName
-    ? `${defaultBrandVoiceName} (Default)`
-    : "Default brand voice";
 
   const githubIntegrations =
     integrationsResponse?.integrations.filter(
@@ -252,197 +138,25 @@ export function CreateEventTriggerDialog({
           >
             <div className="min-h-0 flex-1 overflow-y-auto">
               <div className="space-y-8 p-6">
-                <section className="space-y-3">
-                  <div className="space-y-1">
-                    <h3 className="font-semibold text-base">Content format</h3>
-                    <p className="text-muted-foreground text-sm">
-                      What should we generate?
-                    </p>
-                  </div>
-                  <form.Field name="outputType">
-                    {(field) => (
-                      <div className="grid gap-3 md:grid-cols-2">
-                        {FORMAT_ORDER.map((type) => (
-                          <FormatCard
-                            format={type}
-                            key={type}
-                            onToggle={() => field.handleChange(type)}
-                            selected={field.state.value === type}
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </form.Field>
-                </section>
-
-                <section className="space-y-3">
-                  <div className="space-y-1">
-                    <h3 className="font-semibold text-base">Trigger event</h3>
-                    <p className="text-muted-foreground text-sm">
-                      When should this fire?
-                    </p>
-                  </div>
-                  <form.Field name="eventType">
-                    {(field) => (
-                      <div className="grid gap-3 md:grid-cols-2">
-                        {EVENT_TYPE_ORDER.map((type) => (
-                          <EventTypeCard
-                            eventType={type}
-                            key={type}
-                            onSelect={() => field.handleChange(type)}
-                            selected={field.state.value === type}
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </form.Field>
-                  {eventType === "release" && (
-                    <form.Field name="includePreReleases">
-                      {(field) => (
-                        <TriggerSwitchRow
-                          checked={field.state.value}
-                          id={field.name}
-                          label="Include pre-releases"
-                          onCheckedChange={field.handleChange}
-                          tooltip="When off, releases marked as pre-release on GitHub will not fire this trigger."
-                        />
-                      )}
-                    </form.Field>
-                  )}
-                </section>
-
-                <section className="space-y-3">
-                  <div className="space-y-1">
-                    <h3 className="flex items-center gap-1 font-semibold text-base">
-                      Repositories
-                      <span aria-hidden="true" className="text-destructive">
-                        *
-                      </span>
-                    </h3>
-                    <p className="text-muted-foreground text-sm">
-                      Pick which repositories should fire this trigger.
-                    </p>
-                  </div>
-                  {isLoadingRepos && <Skeleton className="h-10 w-full" />}
-                  {!isLoadingRepos && integrationOptions.length === 0 && (
-                    <div className="flex items-center gap-2 rounded-lg border border-dashed p-3">
-                      <span className="flex-1 text-muted-foreground text-xs">
-                        No GitHub repositories connected yet.
-                      </span>
-                      <AddRepositoryButton onAdd={handleOpenAddRepoFlow} />
-                    </div>
-                  )}
-                  {!isLoadingRepos && integrationOptions.length > 0 && (
-                    <form.Field name="repositoryIds">
-                      {(field) => (
-                        <div ref={comboboxAnchor}>
-                          <Combobox
-                            items={integrationOptions.map((o) => o.value)}
-                            multiple
-                            onValueChange={(value) =>
-                              field.handleChange(
-                                Array.isArray(value) ? value : []
-                              )
-                            }
-                            value={field.state.value}
-                          >
-                            <ComboboxChips>
-                              {field.state.value.map((id) => {
-                                const opt = integrationOptions.find(
-                                  (o) => o.value === id
-                                );
-                                if (!opt) {
-                                  return null;
-                                }
-                                return (
-                                  <ComboboxChip key={opt.value}>
-                                    <span className="flex items-center gap-1.5">
-                                      <Github className="size-3 shrink-0" />
-                                      {opt.label}
-                                    </span>
-                                  </ComboboxChip>
-                                );
-                              })}
-                              <ComboboxChipsInput placeholder="Search repositories" />
-                            </ComboboxChips>
-                            <ComboboxContent anchor={comboboxAnchor.current}>
-                              <ComboboxEmpty>
-                                No repositories found.
-                              </ComboboxEmpty>
-                              <ComboboxList>
-                                {integrationOptions.map((opt) => (
-                                  <ComboboxItem
-                                    key={opt.value}
-                                    value={opt.value}
-                                  >
-                                    <span className="flex items-center gap-2">
-                                      <Github className="size-3.5 shrink-0" />
-                                      {opt.label}
-                                    </span>
-                                  </ComboboxItem>
-                                ))}
-                              </ComboboxList>
-                            </ComboboxContent>
-                          </Combobox>
-                        </div>
-                      )}
-                    </form.Field>
-                  )}
-                </section>
-
-                {(brandVoices.length > 1 ||
-                  supportsAutoPublish(outputType)) && (
-                  <section className="space-y-3">
-                    <div className="space-y-1">
-                      <h3 className="font-semibold text-base">
-                        {FORMAT_CARD_META[outputType].label} rules
-                      </h3>
-                      <p className="text-muted-foreground text-sm">
-                        Voice and publishing behaviour for this trigger.
-                      </p>
-                    </div>
-
-                    {brandVoices.length > 1 && (
-                      <form.Field name="brandVoiceId">
-                        {(field) => (
-                          <BrandIdentityRadioGroup
-                            description="Choose which brand voice to use for generated content."
-                            emptyOption={{
-                              label: defaultBrandVoiceLabel,
-                              description: "Use your default brand voice.",
-                            }}
-                            id={field.name}
-                            label="Brand voice"
-                            onChange={field.handleChange}
-                            value={field.state.value}
-                            voices={nonDefaultBrandVoices}
-                          />
-                        )}
-                      </form.Field>
-                    )}
-
-                    {supportsAutoPublish(outputType) && (
-                      <form.Field name="autoPublish">
-                        {(field) => (
-                          <TriggerSwitchRow
-                            checked={field.state.value}
-                            id={field.name}
-                            label="Auto-publish"
-                            onCheckedChange={field.handleChange}
-                            tooltip="When on, posts are published immediately instead of saved as drafts."
-                          />
-                        )}
-                      </form.Field>
-                    )}
-                  </section>
-                )}
+                <EventTriggerFormatSection form={form} />
+                <EventTriggerEventSection form={form} />
+                <EventTriggerRepositoriesSection
+                  form={form}
+                  isLoading={isLoadingRepos}
+                  onAddRepository={handleOpenAddRepoFlow}
+                  options={integrationOptions}
+                />
+                <EventTriggerRulesSection
+                  brandVoices={brandVoices}
+                  form={form}
+                />
               </div>
             </div>
 
-            <DialogFooter
+            <EventTriggerDialogFooter
               errorMessage={formError}
               isEditMode={isEditMode}
-              isPending={mutation.isPending}
+              isPending={isPending}
               onCancel={() => setOpen(false)}
               repositoryCount={repositoryCount}
             />
@@ -462,116 +176,5 @@ export function CreateEventTriggerDialog({
         organizationId={organizationId}
       />
     </>
-  );
-}
-
-interface DialogFooterProps {
-  errorMessage: string | null;
-  isEditMode: boolean;
-  isPending: boolean;
-  onCancel: () => void;
-  repositoryCount: number;
-}
-
-function DialogFooter({
-  errorMessage,
-  isEditMode,
-  isPending,
-  onCancel,
-  repositoryCount,
-}: DialogFooterProps) {
-  return (
-    <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
-      <div className="flex items-center justify-between gap-3">
-        <FooterStatus
-          errorMessage={errorMessage}
-          repositoryCount={repositoryCount}
-        />
-        <div className="flex items-center gap-2">
-          <Button
-            disabled={isPending}
-            onClick={onCancel}
-            size="sm"
-            type="button"
-            variant="ghost"
-          >
-            Cancel
-          </Button>
-          <Button disabled={isPending} type="submit">
-            {isPending ? (
-              <>
-                <HugeiconsIcon
-                  className="size-4 animate-spin"
-                  icon={Loading03Icon}
-                />
-                {isEditMode ? "Saving..." : "Adding..."}
-              </>
-            ) : (
-              <>
-                <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                {isEditMode ? "Save changes" : "Add trigger"}
-              </>
-            )}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-interface RepositoryConnectionDialogsProps {
-  githubIntegrationId?: string;
-  isEditMode: boolean;
-  onOpenChange: (open: boolean) => void;
-  open: boolean;
-  organizationId: string;
-}
-
-function RepositoryConnectionDialogs({
-  githubIntegrationId,
-  onOpenChange,
-  open,
-  organizationId,
-}: RepositoryConnectionDialogsProps) {
-  if (githubIntegrationId) {
-    return (
-      <AddRepositoryDialog
-        integrationId={githubIntegrationId}
-        onOpenChange={onOpenChange}
-        open={open}
-        organizationId={organizationId}
-      />
-    );
-  }
-
-  return (
-    <AddIntegrationDialog
-      onOpenChange={onOpenChange}
-      open={open}
-      organizationId={organizationId}
-    />
-  );
-}
-
-interface FooterStatusProps {
-  errorMessage: string | null;
-  repositoryCount: number;
-}
-
-function FooterStatus({ errorMessage, repositoryCount }: FooterStatusProps) {
-  if (errorMessage) {
-    return (
-      <span className="flex items-center gap-1.5 font-medium text-destructive text-xs">
-        <HugeiconsIcon className="size-3.5" icon={AlertCircleIcon} />
-        {errorMessage}
-      </span>
-    );
-  }
-  return (
-    <span className="flex items-center gap-1.5 text-muted-foreground text-xs">
-      {repositoryCount === 0
-        ? "No repositories selected yet"
-        : `${repositoryCount} ${repositoryCount === 1 ? "repository" : "repositories"} selected`}
-    </span>
   );
 }

--- a/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
+++ b/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
@@ -89,7 +89,11 @@ export function CreateEventTriggerDialog({
       const payload = {
         organizationId,
         sourceType: "github_webhook" as const,
-        sourceConfig: { eventTypes: [value.eventType] },
+        sourceConfig: {
+          eventTypes: [value.eventType],
+          includePreReleases:
+            value.eventType === "release" ? value.includePreReleases : true,
+        },
         targets: { repositoryIds: value.repositoryIds },
         outputType: value.outputType,
         outputConfig: {
@@ -158,6 +162,7 @@ export function CreateEventTriggerDialog({
   }, [editTrigger, form, open]);
 
   const outputType = useStore(form.store, (s) => s.values.outputType);
+  const eventType = useStore(form.store, (s) => s.values.eventType);
   const repositoryCount = useStore(
     form.store,
     (s) => s.values.repositoryIds.length
@@ -298,6 +303,41 @@ export function CreateEventTriggerDialog({
                       </div>
                     )}
                   </form.Field>
+                  {eventType === "release" && (
+                    <form.Field name="includePreReleases">
+                      {(field) => (
+                        <div className="flex items-center justify-between rounded-lg border p-3">
+                          <div className="flex items-center gap-1.5">
+                            <Label
+                              className="cursor-pointer font-medium text-sm"
+                              htmlFor={field.name}
+                            >
+                              Include pre-releases
+                            </Label>
+                            <Tooltip>
+                              <TooltipTrigger className="inline-flex cursor-help text-muted-foreground">
+                                <HugeiconsIcon
+                                  icon={InformationCircleIcon}
+                                  size={14}
+                                />
+                              </TooltipTrigger>
+                              <TooltipContent side="top">
+                                <p className="max-w-50 text-xs">
+                                  When off, releases marked as pre-release on
+                                  GitHub will not fire this trigger.
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </div>
+                          <Switch
+                            checked={field.state.value}
+                            id={field.name}
+                            onCheckedChange={field.handleChange}
+                          />
+                        </div>
+                      )}
+                    </form.Field>
+                  )}
                 </section>
 
                 <section className="space-y-3">

--- a/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
+++ b/apps/dashboard/src/components/automation/events/create-event-trigger-dialog.tsx
@@ -3,7 +3,6 @@
 import {
   Add01Icon,
   AlertCircleIcon,
-  InformationCircleIcon,
   Loading03Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -25,15 +24,8 @@ import {
   ComboboxList,
   useComboboxAnchor,
 } from "@notra/ui/components/ui/combobox";
-import { Label } from "@notra/ui/components/ui/label";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { Github } from "@notra/ui/components/ui/svgs/github";
-import { Switch } from "@notra/ui/components/ui/switch";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@notra/ui/components/ui/tooltip";
 import { useForm, useStore } from "@tanstack/react-form";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
@@ -56,6 +48,7 @@ import type { CreateEventTriggerDialogProps } from "@/types/automation/event-tri
 import type { Trigger } from "@/types/triggers/triggers";
 import { getDefaultEventTriggerValues } from "@/utils/event-trigger-form";
 import { EventTypeCard } from "./event-type-card";
+import { TriggerSwitchRow } from "./trigger-switch-row";
 
 export function CreateEventTriggerDialog({
   organizationId,
@@ -306,35 +299,13 @@ export function CreateEventTriggerDialog({
                   {eventType === "release" && (
                     <form.Field name="includePreReleases">
                       {(field) => (
-                        <div className="flex items-center justify-between rounded-lg border p-3">
-                          <div className="flex items-center gap-1.5">
-                            <Label
-                              className="cursor-pointer font-medium text-sm"
-                              htmlFor={field.name}
-                            >
-                              Include pre-releases
-                            </Label>
-                            <Tooltip>
-                              <TooltipTrigger className="inline-flex cursor-help text-muted-foreground">
-                                <HugeiconsIcon
-                                  icon={InformationCircleIcon}
-                                  size={14}
-                                />
-                              </TooltipTrigger>
-                              <TooltipContent side="top">
-                                <p className="max-w-50 text-xs">
-                                  When off, releases marked as pre-release on
-                                  GitHub will not fire this trigger.
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </div>
-                          <Switch
-                            checked={field.state.value}
-                            id={field.name}
-                            onCheckedChange={field.handleChange}
-                          />
-                        </div>
+                        <TriggerSwitchRow
+                          checked={field.state.value}
+                          id={field.name}
+                          label="Include pre-releases"
+                          onCheckedChange={field.handleChange}
+                          tooltip="When off, releases marked as pre-release on GitHub will not fire this trigger."
+                        />
                       )}
                     </form.Field>
                   )}
@@ -453,35 +424,13 @@ export function CreateEventTriggerDialog({
                     {supportsAutoPublish(outputType) && (
                       <form.Field name="autoPublish">
                         {(field) => (
-                          <div className="flex items-center justify-between rounded-lg border p-3">
-                            <div className="flex items-center gap-1.5">
-                              <Label
-                                className="cursor-pointer font-medium text-sm"
-                                htmlFor={field.name}
-                              >
-                                Auto-publish
-                              </Label>
-                              <Tooltip>
-                                <TooltipTrigger className="inline-flex cursor-help text-muted-foreground">
-                                  <HugeiconsIcon
-                                    icon={InformationCircleIcon}
-                                    size={14}
-                                  />
-                                </TooltipTrigger>
-                                <TooltipContent side="top">
-                                  <p className="max-w-50 text-xs">
-                                    When on, posts are published immediately
-                                    instead of saved as drafts.
-                                  </p>
-                                </TooltipContent>
-                              </Tooltip>
-                            </div>
-                            <Switch
-                              checked={field.state.value}
-                              id={field.name}
-                              onCheckedChange={field.handleChange}
-                            />
-                          </div>
+                          <TriggerSwitchRow
+                            checked={field.state.value}
+                            id={field.name}
+                            label="Auto-publish"
+                            onCheckedChange={field.handleChange}
+                            tooltip="When on, posts are published immediately instead of saved as drafts."
+                          />
                         )}
                       </form.Field>
                     )}

--- a/apps/dashboard/src/components/automation/events/event-trigger-dialog-footer.tsx
+++ b/apps/dashboard/src/components/automation/events/event-trigger-dialog-footer.tsx
@@ -1,0 +1,78 @@
+import {
+  Add01Icon,
+  AlertCircleIcon,
+  Loading03Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@/components/button";
+import type {
+  EventTriggerDialogFooterProps,
+  EventTriggerFooterStatusProps,
+} from "@/types/automation/event-trigger";
+
+function FooterStatus({
+  errorMessage,
+  repositoryCount,
+}: EventTriggerFooterStatusProps) {
+  if (errorMessage) {
+    return (
+      <span className="flex items-center gap-1.5 font-medium text-destructive text-xs">
+        <HugeiconsIcon className="size-3.5" icon={AlertCircleIcon} />
+        {errorMessage}
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1.5 text-muted-foreground text-xs">
+      {repositoryCount === 0
+        ? "No repositories selected yet"
+        : `${repositoryCount} ${repositoryCount === 1 ? "repository" : "repositories"} selected`}
+    </span>
+  );
+}
+
+export function EventTriggerDialogFooter({
+  errorMessage,
+  isEditMode,
+  isPending,
+  onCancel,
+  repositoryCount,
+}: EventTriggerDialogFooterProps) {
+  return (
+    <div className="shrink-0 border-t bg-muted/30 px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <FooterStatus
+          errorMessage={errorMessage}
+          repositoryCount={repositoryCount}
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            disabled={isPending}
+            onClick={onCancel}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+          <Button disabled={isPending} type="submit">
+            {isPending ? (
+              <>
+                <HugeiconsIcon
+                  className="size-4 animate-spin"
+                  icon={Loading03Icon}
+                />
+                {isEditMode ? "Saving..." : "Adding..."}
+              </>
+            ) : (
+              <>
+                <HugeiconsIcon className="size-4" icon={Add01Icon} />
+                {isEditMode ? "Save changes" : "Add trigger"}
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/automation/events/event-trigger-event-section.tsx
+++ b/apps/dashboard/src/components/automation/events/event-trigger-event-section.tsx
@@ -1,0 +1,47 @@
+import { useStore } from "@tanstack/react-form";
+import { EVENT_TYPE_ORDER } from "@/constants/event-triggers";
+import type { EventTriggerFormSectionProps } from "@/types/automation/event-trigger";
+import { EventTypeCard } from "./event-type-card";
+import { TriggerSwitchRow } from "./trigger-switch-row";
+
+export function EventTriggerEventSection({
+  form,
+}: EventTriggerFormSectionProps) {
+  const eventType = useStore(form.store, (s) => s.values.eventType);
+
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="font-semibold text-base">Trigger event</h3>
+        <p className="text-muted-foreground text-sm">When should this fire?</p>
+      </div>
+      <form.Field name="eventType">
+        {(field) => (
+          <div className="grid gap-3 md:grid-cols-2">
+            {EVENT_TYPE_ORDER.map((type) => (
+              <EventTypeCard
+                eventType={type}
+                key={type}
+                onSelect={() => field.handleChange(type)}
+                selected={field.state.value === type}
+              />
+            ))}
+          </div>
+        )}
+      </form.Field>
+      {eventType === "release" && (
+        <form.Field name="includePreReleases">
+          {(field) => (
+            <TriggerSwitchRow
+              checked={field.state.value}
+              id={field.name}
+              label="Include pre-releases"
+              onCheckedChange={field.handleChange}
+              tooltip="When off, releases marked as pre-release on GitHub will not fire this trigger."
+            />
+          )}
+        </form.Field>
+      )}
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/automation/events/event-trigger-format-section.tsx
+++ b/apps/dashboard/src/components/automation/events/event-trigger-format-section.tsx
@@ -1,0 +1,32 @@
+import { FormatCard } from "@/components/content/create/format-card";
+import { FORMAT_ORDER } from "@/constants/content-formats";
+import type { EventTriggerFormSectionProps } from "@/types/automation/event-trigger";
+
+export function EventTriggerFormatSection({
+  form,
+}: EventTriggerFormSectionProps) {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="font-semibold text-base">Content format</h3>
+        <p className="text-muted-foreground text-sm">
+          What should we generate?
+        </p>
+      </div>
+      <form.Field name="outputType">
+        {(field) => (
+          <div className="grid gap-3 md:grid-cols-2">
+            {FORMAT_ORDER.map((type) => (
+              <FormatCard
+                format={type}
+                key={type}
+                onToggle={() => field.handleChange(type)}
+                selected={field.state.value === type}
+              />
+            ))}
+          </div>
+        )}
+      </form.Field>
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/automation/events/event-trigger-repositories-section.tsx
+++ b/apps/dashboard/src/components/automation/events/event-trigger-repositories-section.tsx
@@ -1,0 +1,96 @@
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  useComboboxAnchor,
+} from "@notra/ui/components/ui/combobox";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { Github } from "@notra/ui/components/ui/svgs/github";
+import { AddRepositoryButton } from "@/components/integrations/add-repository-button";
+import type { EventTriggerRepositoriesSectionProps } from "@/types/automation/event-trigger";
+
+export function EventTriggerRepositoriesSection({
+  form,
+  isLoading,
+  options,
+  onAddRepository,
+}: EventTriggerRepositoriesSectionProps) {
+  const comboboxAnchor = useComboboxAnchor();
+
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="flex items-center gap-1 font-semibold text-base">
+          Repositories
+          <span aria-hidden="true" className="text-destructive">
+            *
+          </span>
+        </h3>
+        <p className="text-muted-foreground text-sm">
+          Pick which repositories should fire this trigger.
+        </p>
+      </div>
+      {isLoading && <Skeleton className="h-10 w-full" />}
+      {!isLoading && options.length === 0 && (
+        <div className="flex items-center gap-2 rounded-lg border border-dashed p-3">
+          <span className="flex-1 text-muted-foreground text-xs">
+            No GitHub repositories connected yet.
+          </span>
+          <AddRepositoryButton onAdd={onAddRepository} />
+        </div>
+      )}
+      {!isLoading && options.length > 0 && (
+        <form.Field name="repositoryIds">
+          {(field) => (
+            <div ref={comboboxAnchor}>
+              <Combobox
+                items={options.map((o) => o.value)}
+                multiple
+                onValueChange={(value) =>
+                  field.handleChange(Array.isArray(value) ? value : [])
+                }
+                value={field.state.value}
+              >
+                <ComboboxChips>
+                  {field.state.value.map((id) => {
+                    const opt = options.find((o) => o.value === id);
+                    if (!opt) {
+                      return null;
+                    }
+                    return (
+                      <ComboboxChip key={opt.value}>
+                        <span className="flex items-center gap-1.5">
+                          <Github className="size-3 shrink-0" />
+                          {opt.label}
+                        </span>
+                      </ComboboxChip>
+                    );
+                  })}
+                  <ComboboxChipsInput placeholder="Search repositories" />
+                </ComboboxChips>
+                <ComboboxContent anchor={comboboxAnchor.current}>
+                  <ComboboxEmpty>No repositories found.</ComboboxEmpty>
+                  <ComboboxList>
+                    {options.map((opt) => (
+                      <ComboboxItem key={opt.value} value={opt.value}>
+                        <span className="flex items-center gap-2">
+                          <Github className="size-3.5 shrink-0" />
+                          {opt.label}
+                        </span>
+                      </ComboboxItem>
+                    ))}
+                  </ComboboxList>
+                </ComboboxContent>
+              </Combobox>
+            </div>
+          )}
+        </form.Field>
+      )}
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/automation/events/event-trigger-rules-section.tsx
+++ b/apps/dashboard/src/components/automation/events/event-trigger-rules-section.tsx
@@ -1,0 +1,71 @@
+import { useStore } from "@tanstack/react-form";
+import { BrandIdentityRadioGroup } from "@/components/brand-identity-radio-group";
+import { FORMAT_CARD_META } from "@/constants/content-formats";
+import { supportsAutoPublish } from "@/constants/schedule-output-types";
+import type { EventTriggerRulesSectionProps } from "@/types/automation/event-trigger";
+import { TriggerSwitchRow } from "./trigger-switch-row";
+
+export function EventTriggerRulesSection({
+  form,
+  brandVoices,
+}: EventTriggerRulesSectionProps) {
+  const outputType = useStore(form.store, (s) => s.values.outputType);
+
+  const nonDefaultBrandVoices = brandVoices.filter((voice) => !voice.isDefault);
+  const defaultBrandVoiceName = brandVoices.find(
+    (voice) => voice.isDefault
+  )?.name;
+  const defaultBrandVoiceLabel = defaultBrandVoiceName
+    ? `${defaultBrandVoiceName} (Default)`
+    : "Default brand voice";
+
+  if (!(brandVoices.length > 1 || supportsAutoPublish(outputType))) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="font-semibold text-base">
+          {FORMAT_CARD_META[outputType].label} rules
+        </h3>
+        <p className="text-muted-foreground text-sm">
+          Voice and publishing behaviour for this trigger.
+        </p>
+      </div>
+
+      {brandVoices.length > 1 && (
+        <form.Field name="brandVoiceId">
+          {(field) => (
+            <BrandIdentityRadioGroup
+              description="Choose which brand voice to use for generated content."
+              emptyOption={{
+                label: defaultBrandVoiceLabel,
+                description: "Use your default brand voice.",
+              }}
+              id={field.name}
+              label="Brand voice"
+              onChange={field.handleChange}
+              value={field.state.value}
+              voices={nonDefaultBrandVoices}
+            />
+          )}
+        </form.Field>
+      )}
+
+      {supportsAutoPublish(outputType) && (
+        <form.Field name="autoPublish">
+          {(field) => (
+            <TriggerSwitchRow
+              checked={field.state.value}
+              id={field.name}
+              label="Auto-publish"
+              onCheckedChange={field.handleChange}
+              tooltip="When on, posts are published immediately instead of saved as drafts."
+            />
+          )}
+        </form.Field>
+      )}
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/automation/events/repository-connection-dialogs.tsx
+++ b/apps/dashboard/src/components/automation/events/repository-connection-dialogs.tsx
@@ -1,0 +1,29 @@
+import { AddRepositoryDialog } from "@/components/integrations/add-repository-dialog";
+import { LegacyAddIntegrationDialog as AddIntegrationDialog } from "@/components/integrations/legacy/add-integration-dialog";
+import type { RepositoryConnectionDialogsProps } from "@/types/automation/event-trigger";
+
+export function RepositoryConnectionDialogs({
+  githubIntegrationId,
+  onOpenChange,
+  open,
+  organizationId,
+}: RepositoryConnectionDialogsProps) {
+  if (githubIntegrationId) {
+    return (
+      <AddRepositoryDialog
+        integrationId={githubIntegrationId}
+        onOpenChange={onOpenChange}
+        open={open}
+        organizationId={organizationId}
+      />
+    );
+  }
+
+  return (
+    <AddIntegrationDialog
+      onOpenChange={onOpenChange}
+      open={open}
+      organizationId={organizationId}
+    />
+  );
+}

--- a/apps/dashboard/src/components/automation/events/trigger-switch-row.tsx
+++ b/apps/dashboard/src/components/automation/events/trigger-switch-row.tsx
@@ -1,0 +1,37 @@
+import { InformationCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Label } from "@notra/ui/components/ui/label";
+import { Switch } from "@notra/ui/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@notra/ui/components/ui/tooltip";
+import type { TriggerSwitchRowProps } from "@/types/automation/event-trigger";
+
+export function TriggerSwitchRow({
+  id,
+  label,
+  tooltip,
+  checked,
+  onCheckedChange,
+}: TriggerSwitchRowProps) {
+  return (
+    <div className="flex items-center justify-between rounded-lg border p-3">
+      <div className="flex items-center gap-1.5">
+        <Label className="cursor-pointer font-medium text-sm" htmlFor={id}>
+          {label}
+        </Label>
+        <Tooltip>
+          <TooltipTrigger className="inline-flex cursor-help text-muted-foreground">
+            <HugeiconsIcon icon={InformationCircleIcon} size={14} />
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p className="max-w-50 text-xs">{tooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <Switch checked={checked} id={id} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-event-trigger-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-event-trigger-form.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { supportsAutoPublish } from "@/constants/schedule-output-types";
+import { dashboardOrpc } from "@/lib/orpc/query";
+import {
+  type EventTriggerFormValues,
+  eventTriggerFormSchema,
+} from "@/schemas/automation/event-trigger-form";
+import type { UseEventTriggerFormProps } from "@/types/automation/event-trigger";
+import type { Trigger } from "@/types/triggers/triggers";
+import { getDefaultEventTriggerValues } from "@/utils/event-trigger-form";
+
+export function useEventTriggerForm({
+  organizationId,
+  editTrigger,
+  open,
+  onSuccess,
+  onClose,
+}: UseEventTriggerFormProps) {
+  const isEditMode = !!editTrigger;
+  const lastResetKeyRef = useRef<string | null>(null);
+
+  const mutation = useMutation<
+    { trigger: Trigger },
+    Error,
+    EventTriggerFormValues
+  >({
+    mutationFn: async (value) => {
+      const payload = {
+        organizationId,
+        sourceType: "github_webhook" as const,
+        sourceConfig: {
+          eventTypes: [value.eventType],
+          includePreReleases:
+            value.eventType === "release" ? value.includePreReleases : true,
+        },
+        targets: { repositoryIds: value.repositoryIds },
+        outputType: value.outputType,
+        outputConfig: {
+          ...(value.brandVoiceId ? { brandVoiceId: value.brandVoiceId } : {}),
+        },
+        enabled: true,
+        autoPublish: supportsAutoPublish(value.outputType)
+          ? value.autoPublish
+          : false,
+      };
+
+      try {
+        if (isEditMode) {
+          return await dashboardOrpc.automation.events.update.call({
+            triggerId: editTrigger.id,
+            ...payload,
+            enabled: editTrigger.enabled,
+          });
+        }
+        return await dashboardOrpc.automation.events.create.call(payload);
+      } catch (error) {
+        if (error instanceof Error && error.message === "Duplicate trigger") {
+          throw new Error("Trigger already exists");
+        }
+        if (error instanceof Error && error.message) {
+          throw error;
+        }
+        throw new Error(
+          isEditMode ? "Failed to update trigger" : "Failed to create trigger"
+        );
+      }
+    },
+    onSuccess: (data) => {
+      toast.success(isEditMode ? "Trigger updated" : "Trigger added");
+      onSuccess?.(data.trigger);
+      onClose();
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const form = useForm({
+    defaultValues: getDefaultEventTriggerValues(editTrigger),
+    validators: {
+      onSubmit: eventTriggerFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      await mutation.mutateAsync(value);
+    },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      lastResetKeyRef.current = null;
+      return;
+    }
+
+    const resetKey = editTrigger?.id ?? "create";
+    if (lastResetKeyRef.current === resetKey) {
+      return;
+    }
+
+    form.reset(getDefaultEventTriggerValues(editTrigger));
+    lastResetKeyRef.current = resetKey;
+  }, [editTrigger, form, open]);
+
+  return { form, isPending: mutation.isPending };
+}

--- a/apps/dashboard/src/lib/webhooks/dispatch-event-triggers.ts
+++ b/apps/dashboard/src/lib/webhooks/dispatch-event-triggers.ts
@@ -1,0 +1,92 @@
+import { triggerEventNow } from "@notra/ai/qstash/triggers";
+import { Data, Effect } from "effect";
+import { triggerSourceConfigSchema } from "@/schemas/integrations";
+import type {
+  DispatchEventTriggerProps,
+  DispatchEventTriggersProps,
+  GithubProcessedEvent,
+  MatchingEventTrigger,
+} from "@/types/webhooks/webhooks";
+
+class EventTriggerDispatchError extends Data.TaggedError(
+  "EventTriggerDispatchError"
+)<{ triggerId: string; cause: unknown }> {}
+
+function isPreReleaseEvent(processedEvent: GithubProcessedEvent) {
+  return (
+    processedEvent.type === "release" && processedEvent.data.prerelease === true
+  );
+}
+
+function shouldDispatchTrigger(
+  trigger: MatchingEventTrigger,
+  processedEvent: GithubProcessedEvent
+) {
+  const parsed = triggerSourceConfigSchema.safeParse(trigger.sourceConfig);
+  const eventTypes = parsed.success ? (parsed.data.eventTypes ?? []) : [];
+  const includePreReleases = parsed.success
+    ? (parsed.data.includePreReleases ?? true)
+    : true;
+
+  if (isPreReleaseEvent(processedEvent) && !includePreReleases) {
+    return false;
+  }
+
+  return (
+    eventTypes.length === 0 ||
+    eventTypes.some((eventType) => eventType === processedEvent.type)
+  );
+}
+
+const dispatchEventTrigger = Effect.fn("dispatchEventTrigger")(function* ({
+  trigger,
+  processedEvent,
+  repositoryId,
+  deliveryId,
+}: DispatchEventTriggerProps) {
+  yield* Effect.tryPromise({
+    try: () =>
+      triggerEventNow({
+        triggerId: trigger.id,
+        eventType: processedEvent.type,
+        eventAction: processedEvent.action,
+        eventData: processedEvent.data,
+        repositoryId,
+        deliveryId,
+      }),
+    catch: (cause) =>
+      new EventTriggerDispatchError({ triggerId: trigger.id, cause }),
+  });
+});
+
+export function dispatchEventTriggers({
+  triggers,
+  processedEvent,
+  repositoryId,
+  deliveryId,
+}: DispatchEventTriggersProps) {
+  const matching = triggers.filter((trigger) =>
+    shouldDispatchTrigger(trigger, processedEvent)
+  );
+
+  return Effect.runPromise(
+    Effect.forEach(
+      matching,
+      (trigger) =>
+        dispatchEventTrigger({
+          trigger,
+          processedEvent,
+          repositoryId,
+          deliveryId,
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logError(
+              `Failed to trigger event workflow for trigger ${error.triggerId}`,
+              error.cause
+            )
+          )
+        ),
+      { discard: true }
+    )
+  );
+}

--- a/apps/dashboard/src/lib/webhooks/dispatch-event-triggers.ts
+++ b/apps/dashboard/src/lib/webhooks/dispatch-event-triggers.ts
@@ -86,7 +86,7 @@ export function dispatchEventTriggers({
             )
           )
         ),
-      { discard: true }
+      { concurrency: "unbounded", discard: true }
     )
   );
 }

--- a/apps/dashboard/src/lib/webhooks/github.ts
+++ b/apps/dashboard/src/lib/webhooks/github.ts
@@ -1,11 +1,11 @@
 import crypto from "node:crypto";
 import { getWebhookSecretByRepositoryId } from "@notra/ai/integrations/github";
-import { triggerEventNow } from "@notra/ai/qstash/triggers";
 import { redis } from "@notra/ai/utils/redis";
 import { db } from "@notra/db/drizzle";
 import { contentTriggers } from "@notra/db/schema";
 import { and, eq, sql } from "drizzle-orm";
 import { checkLogRetention } from "@/lib/billing/check-log-retention";
+import { dispatchEventTriggers } from "@/lib/webhooks/dispatch-event-triggers";
 import { appendWebhookLog } from "@/lib/webhooks/logging";
 import {
   type GitHubEventType,
@@ -460,28 +460,12 @@ export async function handleGitHubWebhook(
       )
     );
 
-  for (const trigger of matchingTriggers) {
-    const config = trigger.sourceConfig as { eventTypes?: string[] };
-    const eventTypes = config.eventTypes ?? [];
-
-    if (eventTypes.length === 0 || eventTypes.includes(processedEvent.type)) {
-      try {
-        await triggerEventNow({
-          triggerId: trigger.id,
-          eventType: processedEvent.type,
-          eventAction: processedEvent.action,
-          eventData: processedEvent.data as Record<string, unknown>,
-          repositoryId,
-          deliveryId: delivery ?? undefined,
-        });
-      } catch (error) {
-        console.error(
-          `Failed to trigger event workflow for trigger ${trigger.id}:`,
-          error
-        );
-      }
-    }
-  }
+  await dispatchEventTriggers({
+    triggers: matchingTriggers,
+    processedEvent,
+    repositoryId,
+    deliveryId: delivery ?? undefined,
+  });
 
   if (SHOULD_DEDUPE_DELIVERIES && delivery) {
     await markDeliveryProcessed(delivery);

--- a/apps/dashboard/src/schemas/automation/event-trigger-form.ts
+++ b/apps/dashboard/src/schemas/automation/event-trigger-form.ts
@@ -11,6 +11,7 @@ export const eventTriggerFormSchema = z.object({
   repositoryIds: z.array(z.string()).min(1, "Select at least one repository"),
   brandVoiceId: z.string(),
   autoPublish: z.boolean(),
+  includePreReleases: z.boolean(),
 });
 
 export type EventTriggerFormValues = z.infer<typeof eventTriggerFormSchema>;

--- a/apps/dashboard/src/schemas/integrations.ts
+++ b/apps/dashboard/src/schemas/integrations.ts
@@ -245,6 +245,7 @@ export const triggerSourceTypeSchema = z.enum([
 
 export const triggerSourceConfigSchema = z.object({
   eventTypes: z.array(z.enum(WEBHOOK_EVENT_TYPES)).optional(),
+  includePreReleases: z.boolean().optional(),
   cron: z
     .object({
       frequency: z.enum(CRON_FREQUENCIES),
@@ -296,6 +297,7 @@ export const configureEventTriggerBodySchema =
     sourceType: z.literal("github_webhook"),
     sourceConfig: z.object({
       eventTypes: z.array(z.enum(WEBHOOK_EVENT_TYPES)).min(1),
+      includePreReleases: z.boolean().default(true),
     }),
     outputType: z.enum(SUPPORTED_AUTOMATION_OUTPUT_TYPES),
   });

--- a/apps/dashboard/src/types/automation/event-trigger.ts
+++ b/apps/dashboard/src/types/automation/event-trigger.ts
@@ -17,3 +17,11 @@ export interface EventTypeCardProps {
   selected: boolean;
   onSelect: () => void;
 }
+
+export interface TriggerSwitchRowProps {
+  id: string;
+  label: string;
+  tooltip: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}

--- a/apps/dashboard/src/types/automation/event-trigger.ts
+++ b/apps/dashboard/src/types/automation/event-trigger.ts
@@ -1,4 +1,6 @@
+import type { useEventTriggerForm } from "@/lib/hooks/use-event-trigger-form";
 import type { WebhookEventType } from "@/schemas/integrations";
+import type { BrandSettings } from "@/types/hooks/brand-analysis";
 import type { Trigger } from "@/types/triggers/triggers";
 
 export type { EventTriggerFormValues } from "@/schemas/automation/event-trigger-form";
@@ -24,4 +26,58 @@ export interface TriggerSwitchRowProps {
   tooltip: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+}
+
+export interface UseEventTriggerFormProps {
+  organizationId: string;
+  editTrigger?: Trigger;
+  open: boolean;
+  onSuccess?: (trigger: Trigger) => void;
+  onClose: () => void;
+}
+
+export type EventTriggerFormApi = ReturnType<
+  typeof useEventTriggerForm
+>["form"];
+
+export interface EventTriggerFormSectionProps {
+  form: EventTriggerFormApi;
+}
+
+export interface RepositoryOption {
+  value: string;
+  label: string;
+}
+
+export interface EventTriggerRepositoriesSectionProps {
+  form: EventTriggerFormApi;
+  isLoading: boolean;
+  options: RepositoryOption[];
+  onAddRepository: () => void;
+}
+
+export interface EventTriggerRulesSectionProps {
+  form: EventTriggerFormApi;
+  brandVoices: BrandSettings[];
+}
+
+export interface EventTriggerDialogFooterProps {
+  errorMessage: string | null;
+  isEditMode: boolean;
+  isPending: boolean;
+  onCancel: () => void;
+  repositoryCount: number;
+}
+
+export interface EventTriggerFooterStatusProps {
+  errorMessage: string | null;
+  repositoryCount: number;
+}
+
+export interface RepositoryConnectionDialogsProps {
+  githubIntegrationId?: string;
+  isEditMode: boolean;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  organizationId: string;
 }

--- a/apps/dashboard/src/types/triggers/triggers.ts
+++ b/apps/dashboard/src/types/triggers/triggers.ts
@@ -16,6 +16,7 @@ export interface TriggerTarget {
 
 export interface TriggerSourceConfig {
   eventTypes?: WebhookEventType[];
+  includePreReleases?: boolean;
   cron?: {
     frequency: "daily" | "weekly" | "monthly";
     hour: number;

--- a/apps/dashboard/src/types/webhooks/webhooks.ts
+++ b/apps/dashboard/src/types/webhooks/webhooks.ts
@@ -67,6 +67,25 @@ export interface GithubProcessedEvent {
   data: Record<string, unknown>;
 }
 
+export interface MatchingEventTrigger {
+  id: string;
+  sourceConfig: unknown;
+}
+
+export interface DispatchEventTriggerProps {
+  trigger: MatchingEventTrigger;
+  processedEvent: GithubProcessedEvent;
+  repositoryId: string;
+  deliveryId?: string;
+}
+
+export interface DispatchEventTriggersProps {
+  triggers: MatchingEventTrigger[];
+  processedEvent: GithubProcessedEvent;
+  repositoryId: string;
+  deliveryId?: string;
+}
+
 export type GithubMemoryEventType = Exclude<GitHubEventType, "ping">;
 
 export interface GithubCreateMemoryEntryProps {

--- a/apps/dashboard/src/utils/event-trigger-form.ts
+++ b/apps/dashboard/src/utils/event-trigger-form.ts
@@ -12,6 +12,7 @@ export const DEFAULT_EVENT_TRIGGER_VALUES: EventTriggerFormValues = {
   repositoryIds: [],
   brandVoiceId: "",
   autoPublish: false,
+  includePreReleases: true,
 };
 
 export function isAutomationOutputType(
@@ -45,5 +46,6 @@ export function getDefaultEventTriggerValues(
     repositoryIds: trigger.targets.repositoryIds,
     brandVoiceId: normalizeBrandVoiceId(trigger.outputConfig?.brandVoiceId),
     autoPublish: trigger.autoPublish,
+    includePreReleases: trigger.sourceConfig.includePreReleases ?? true,
   };
 }


### PR DESCRIPTION
## Summary
- Adds an "Include pre-releases" switch to the event trigger dialog, shown only when the "Release published" event is selected. Defaults to on.
- The setting lives inside the GitHub webhook `sourceConfig` jsonb (`includePreReleases`), so it is scoped to github_webhook triggers only. No schema migration needed: existing triggers have no key stored and every read falls back to `true`, preserving current behavior.
- The webhook fan-out now skips triggers with the toggle off when the incoming release event has `prerelease: true`. Push events are unaffected.

## Refactor
- Extracted the trigger fan-out from `handleGitHubWebhook` into `lib/webhooks/dispatch-event-triggers.ts`, rewritten with Effect (`Effect.fn` + `Effect.tryPromise` + tagged error), matching the existing `auto-pause.ts` idiom. Dispatch failures are logged per trigger without failing the webhook, same as before.
- Trigger source config is now parsed with the shared Zod schema instead of a type assertion.
- New prop types live in `types/webhooks/webhooks.ts` per the code organization convention.

## Testing
- `bun run build` passes (web, dashboard, api).
- Biome check clean on all touched files.

https://claude.ai/code/session_01VtLNvELCoEejXkzWurWJTu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Include pre-releases” toggle for GitHub release event triggers so teams can ignore pre-release publishes. Defaults to on and remains backward compatible; when off, prerelease release events are skipped during dispatch.

- **New Features**
  - Toggle appears only when “Release published” is selected; non-release triggers always send `includePreReleases: true`, and edit/create flows default missing values to true.
  - Stored as `includePreReleases` in `github_webhook` `sourceConfig`, with API schema default `true` (no migration).

- **Refactors**
  - Extracted webhook fan-out to `lib/webhooks/dispatch-event-triggers.ts` using `effect`, with Zod-validated source config and per-trigger error logging.
  - Split the event trigger dialog into section components and moved form/mutation logic to `use-event-trigger-form`; added standalone footer and repository connection dialogs.
  - Added `TriggerSwitchRow` to unify toggle rows; used for “Include pre-releases” and “Auto-publish”.

<sup>Written for commit f6eb5453bd3a7a8b3fccafdb3dfcdd890ea36aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

