### PR TITLE
feat(ai): tighten prompt scoping, adopt adaptive thinking, add Sonnet 5

### DIFF
--- a/apps/dashboard/src/components/chat/assistant-metadata-hover.tsx
+++ b/apps/dashboard/src/components/chat/assistant-metadata-hover.tsx
@@ -21,6 +21,7 @@ import { useShowAgentStats } from "@/lib/hooks/use-privacy-preferences";
 const MODEL_LABELS = {
   auto: "Auto",
   "anthropic/claude-opus-4.8": "Claude Opus 4.8",
+  "anthropic/claude-sonnet-5": "Claude Sonnet 5",
   "anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
   "anthropic/claude-haiku-4.5": "Claude Haiku 4.5",
   "openai/gpt-5.4": "GPT-5.4",
@@ -30,6 +31,7 @@ const MODEL_LABELS = {
 const MODEL_CONTEXT_WINDOWS = {
   auto: 1_000_000,
   "anthropic/claude-opus-4.8": 1_000_000,
+  "anthropic/claude-sonnet-5": 1_000_000,
   "anthropic/claude-sonnet-4.6": 1_000_000,
   "anthropic/claude-haiku-4.5": 200_000,
   "openai/gpt-5.4": 1_100_000,

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -129,6 +129,13 @@ export const AVAILABLE_MODELS = [
     provider: "anthropic",
   },
   {
+    id: "anthropic/claude-sonnet-5",
+    label: "Sonnet 5",
+    description: "Near-Opus quality at Sonnet speed",
+    pricing: "$2 input / $10 output per 1M",
+    provider: "anthropic",
+  },
+  {
     id: "anthropic/claude-sonnet-4.6",
     label: "Sonnet 4.6",
     description: "Best everyday default",

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -159,7 +159,7 @@ export async function runBackgroundGen(
     providerOptions: withGatewayDefaults(
       {
         anthropic: {
-          thinking: { type: "enabled", budgetTokens: 4096 },
+          thinking: { type: "adaptive" },
         },
       },
       { modelId: AGENT_DEFAULT_MODEL }

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -189,7 +189,7 @@ export async function runBackgroundGen(
       fail: createFailTool(postToolsResult),
     },
     instructions,
-    stopWhen: stepCountIs(35),
+    stopWhen: stepCountIs(50),
     experimental_telemetry: buildExperimentalTelemetry(telemetryMetadata),
   });
 

--- a/packages/ai/src/agents/chat.ts
+++ b/packages/ai/src/agents/chat.ts
@@ -136,6 +136,7 @@ Triggers: the user wants the document changed (rewrite, shorten, tone change, cl
 ## Guidelines
 - Always assume the user wants to edit this specific document, not some pasted markdown
 - Make minimal edits
+- Only make the changes the user asked for. Never rewrite, reformat, or "improve" parts of the document the request does not cover, and only mention the changes you actually made
 - Line numbers are 1-indexed
 - For multi-line content use \\n in content string
 - When user selects text, focus only on that section

--- a/packages/ai/src/billing/token-pricing.ts
+++ b/packages/ai/src/billing/token-pricing.ts
@@ -9,6 +9,13 @@ const CLAUDE_SONNET_4_6_PRICING: ModelPricing = {
   cacheWritePerMillionTokens: 3.75,
 };
 
+const CLAUDE_SONNET_5_PRICING: ModelPricing = {
+  inputPerMillionTokens: 2.0,
+  outputPerMillionTokens: 10.0,
+  cacheReadPerMillionTokens: 0.2,
+  cacheWritePerMillionTokens: 2.5,
+};
+
 const CLAUDE_OPUS_4_8_PRICING: ModelPricing = {
   inputPerMillionTokens: 5.0,
   outputPerMillionTokens: 25.0,
@@ -22,6 +29,9 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "vercel/anthropic/claude-opus-4.8": CLAUDE_OPUS_4_8_PRICING,
   "opencode/claude-sonnet-4-6": CLAUDE_SONNET_4_6_PRICING,
   "anthropic/claude-sonnet-4.6": CLAUDE_SONNET_4_6_PRICING,
+  "opencode/claude-sonnet-5": CLAUDE_SONNET_5_PRICING,
+  "anthropic/claude-sonnet-5": CLAUDE_SONNET_5_PRICING,
+  "vercel/anthropic/claude-sonnet-5": CLAUDE_SONNET_5_PRICING,
   "anthropic/claude-haiku-4.5": {
     inputPerMillionTokens: 0.8,
     outputPerMillionTokens: 4.0,

--- a/packages/ai/src/constants/models.ts
+++ b/packages/ai/src/constants/models.ts
@@ -1,1 +1,1 @@
-export const AGENT_DEFAULT_MODEL = "anthropic/claude-sonnet-4.6";
+export const AGENT_DEFAULT_MODEL = "anthropic/claude-sonnet-5";

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -710,7 +710,10 @@ function getThinkingProviderOptions(
 }
 
 function usesAdaptiveThinking(modelId: string): boolean {
-  return modelId.startsWith("anthropic/claude-opus-");
+  return (
+    modelId.startsWith("anthropic/claude-opus-") ||
+    modelId.startsWith("anthropic/claude-sonnet-")
+  );
 }
 
 function getAnthropicThinkingBudget(

--- a/packages/ai/src/prompts/_shared/index.ts
+++ b/packages/ai/src/prompts/_shared/index.ts
@@ -12,6 +12,7 @@ export const factualityRules = dedent`
   - Do not interpret unclear implementation details into stronger claims. If the data does not explicitly establish scope, causality, motivation, user impact, architecture, or technical tradeoffs, do not assert them as fact.
   - Do not turn code changes into product promises. Only describe what is factually supported by the provided data.
   - Treat the provided lookback window as the source of truth.
+  - Only mention changes that fall inside the provided lookback window and come from the selected sources. Never bring in other work, earlier releases, unrelated features, or future plans that are outside that scope, even if you know about them from repository context.
 `;
 
 export const prohibitedLanguage = dedent`

--- a/packages/ai/src/prompts/changelog/shared.ts
+++ b/packages/ai/src/prompts/changelog/shared.ts
@@ -52,7 +52,7 @@ export function buildChangelogPrompt(options: ChangelogPromptOptions): string {
     - Do not number highlight items. Do not name the section "Top 5".
     - Each highlight item: title plus a short, concise description. One sentence is ideal, two maximum.
     - Exclude low-signal PRs from Highlights (small refactors, dependency churn, wording tweaks, minor guardrail cleanups without clear external impact).
-    - Every PR appears exactly once in either Highlights or More Updates.
+    - Every PR that passes audience filtering appears exactly once in either Highlights or More Updates. Filtered-out PRs appear nowhere.
     - More Updates contains bullet lists only under each category, with no paragraph prose.
     - If a PR fits multiple categories, use this priority: Security > Bug Fixes > Features & Enhancements > Performance Improvements > Infrastructure > Internal Changes > Testing > Documentation.
     - Avoid unnecessary product or vendor namedropping in highlight copy unless required for technical clarity.

--- a/packages/ai/src/prompts/content-editor.ts
+++ b/packages/ai/src/prompts/content-editor.ts
@@ -57,6 +57,7 @@ export function getContentEditorChatPrompt(
 
     ## Guidelines
     - Make minimal edits
+    - Only make the changes the user asked for. Never rewrite, reformat, or "improve" parts of the document the request does not cover, and only mention the changes you actually made
     - Line numbers are 1-indexed
     - For multi-line content use \\n in content string
     - When user selects text, focus only on that section

--- a/packages/ai/src/prompts/marketing-assets.ts
+++ b/packages/ai/src/prompts/marketing-assets.ts
@@ -62,6 +62,8 @@ Use the Write tool to create it. After the file exists, stop. No other output is
 
 <subject>
 ${describeSource(source)}
+
+The image is about this subject only. Use the wider repository for visual style, design tokens, and brand assets, but do not depict, mention, or hint at other changes, features, releases, or milestones that are not part of this subject.
 </subject>
 
 <research>

--- a/packages/ai/src/schemas/chat.ts
+++ b/packages/ai/src/schemas/chat.ts
@@ -7,6 +7,7 @@ import { standaloneChatContextSchema } from "./standalone-chat";
 export const chatModelSchema = z.enum([
   "auto",
   "anthropic/claude-opus-4.8",
+  "anthropic/claude-sonnet-5",
   "anthropic/claude-sonnet-4.6",
   "anthropic/claude-haiku-4.5",
   "openai/gpt-5.4",


### PR DESCRIPTION
## Summary

### Prompt scoping (agents only mention/use the changes they were told to)
- **Shared factuality rules** (`prompts/_shared/index.ts`): agents may only cover changes inside the provided lookback window and selected sources; never bring in outside work, earlier releases, or future plans. Applies to changelog, blog, Twitter, and LinkedIn generation.
- **Image gen** (`prompts/marketing-assets.ts`): the image must be about the given subject only; the wider repo is for visual style, tokens, and assets, not extra content.
- **Editor chat agents** (`agents/chat.ts`, `prompts/content-editor.ts`): only make the requested changes, never rewrite uncovered parts, and only mention changes actually made.
- **Changelog prompt fix**: resolved a contradiction where "every PR appears exactly once" conflicted with the audience-filtering rules that omit low-signal PRs.

### Adaptive thinking (Anthropic migration guidance)
- `agents/background-gen.ts`: replaced deprecated `thinking: {type: "enabled", budgetTokens: 4096}` with `thinking: {type: "adaptive"}`.
- `orchestration/orchestrate-standalone.ts`: Sonnet models now use adaptive thinking + `output_config.effort` instead of the deprecated `budget_tokens` path (Haiku 4.5 keeps the budget path since it doesn't support adaptive).

### Sonnet 5
- Background content generation now runs on `anthropic/claude-sonnet-5` (`AGENT_DEFAULT_MODEL`).
- Added Sonnet 5 pricing ($2/M input, $10/M output, $0.20/M cache read, $2.50/M cache write) in `billing/token-pricing.ts`. Note: these are the intro prices valid through 2026-08-31.
- Added Sonnet 5 to the standalone chat model picker (schema, `AVAILABLE_MODELS`, labels, context windows) alongside the existing Sonnet 4.6.

https://claude.ai/code/session_015iwYxEhXycWA8iDmXN91Ds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes prompts to only in-range changes, switches Anthropic flows to adaptive thinking, makes `anthropic/claude-sonnet-5` the default, and raises background-gen step cap to 50.

- **New Features**
  - Default model set to `anthropic/claude-sonnet-5` for background generation; added to chat picker, dashboard labels/context windows, and schemas.
  - Added Sonnet 5 pricing: $2/M input, $10/M output, $0.20/M cache read, $2.50/M cache write.

- **Refactors**
  - Adopted adaptive thinking for `anthropic/claude-sonnet-*` and `anthropic/claude-opus-*` (Haiku 4.5 stays on token budget); increased background-gen step cap from 35 to 50.
  - Tightened prompt scope across agents: factuality limited to lookback/sources; editor chat only edits requested parts; marketing images depict only the given subject; changelog rule fixed so only audience-approved PRs appear once.

<sup>Written for commit a2871ddedc2e8c5d692fdc7258e9516eafa7c075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

