### PR TITLE
docs: add docolin frontmatter to all documentation pages

### DIFF
--- a/apps/docs/api/authentication.mdx
+++ b/apps/docs/api/authentication.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Authentication"
 description: "Authenticate requests to the Notra API using API keys."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/authentication
+  type: reference
+  applies_to:
+    - notra-api
+    - typescript
+  language: en
+  difficulty: beginner
+  time_estimate: 6m
+  status: stable
+  aliases:
+    - API authentication
+    - API keys
+    - bearer token
+  prev: ./getting-started.mdx
+  next: ./rate-limits.mdx
 ---
 
 Notra API requests are authenticated with API keys.

--- a/apps/docs/api/caching.mdx
+++ b/apps/docs/api/caching.mdx
@@ -1,6 +1,29 @@
 ---
 title: "Caching"
 description: "Cache paginated Notra post data safely, including sorting and invalidation patterns."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/caching
+  type: how-to
+  applies_to:
+    - notra-api
+    - typescript
+    - react
+    - nextjs
+  language: en
+  difficulty: intermediate
+  time_estimate: 10m
+  status: stable
+  aliases:
+    - API caching
+    - cache invalidation
+    - cache key design
+    - TanStack Query
+  prev: ./rust-sdk.mdx
+  next: ./common-tasks.mdx
 ---
 
 When caching Notra post data, include every query input that changes the result set in the cache key.

--- a/apps/docs/api/common-tasks.mdx
+++ b/apps/docs/api/common-tasks.mdx
@@ -1,6 +1,27 @@
 ---
 title: "Common Tasks"
 description: "Practical Notra API examples for common implementation questions."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/common-tasks
+  type: how-to
+  applies_to:
+    - notra-api
+    - typescript
+  language: en
+  difficulty: beginner
+  time_estimate: 6m
+  status: stable
+  aliases:
+    - common tasks
+    - update post
+    - create post
+    - API examples
+  prev: ./caching.mdx
+  next: ./pagination.mdx
 ---
 
 ## Update an existing post

--- a/apps/docs/api/getting-started.mdx
+++ b/apps/docs/api/getting-started.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Getting Started"
 description: "Get started with the Notra API."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/getting-started
+  type: tutorial
+  applies_to:
+    - notra-api
+    - typescript
+  language: en
+  difficulty: beginner
+  time_estimate: 8m
+  status: stable
+  aliases:
+    - API getting started
+    - Notra API setup
+    - REST API
+    - TypeScript SDK
+  next: ./authentication.mdx
 ---
 
 We provide two ways to interact with Notra:

--- a/apps/docs/api/pagination.mdx
+++ b/apps/docs/api/pagination.mdx
@@ -1,6 +1,27 @@
 ---
 title: "Pagination"
 description: "Learn how to use pagination in the Notra API."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/pagination
+  type: how-to
+  applies_to:
+    - notra-api
+    - typescript
+  language: en
+  difficulty: beginner
+  time_estimate: 10m
+  status: stable
+  aliases:
+    - API pagination
+    - offset pagination
+    - page and limit
+    - paginate posts
+  prev: ./common-tasks.mdx
+  next: ./types.mdx
 ---
 
 Notra uses offset-based pagination for list endpoints. Each response includes a

--- a/apps/docs/api/rate-limits.mdx
+++ b/apps/docs/api/rate-limits.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Rate Limits"
 description: "Per-key rate limits on generation, integration, and update endpoints."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/rate-limits
+  type: reference
+  applies_to:
+    - notra-api
+  language: en
+  difficulty: beginner
+  time_estimate: 6m
+  status: stable
+  aliases:
+    - rate limits
+    - 429 errors
+    - API throttling
+    - retry-after
+  prev: ./authentication.mdx
 ---
 
 The Notra API enforces rate limits on a small set of write-heavy endpoints to protect the service. Read endpoints (listing posts, fetching brand identities, etc.) are not currently rate limited.

--- a/apps/docs/api/rust-sdk.mdx
+++ b/apps/docs/api/rust-sdk.mdx
@@ -2,6 +2,25 @@
 title: "Rust SDK (Community)"
 sidebarTitle: "Rust SDK"
 description: "Use the community-maintained notra crate for a type-safe Rust integration."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/rust-sdk
+  type: reference
+  applies_to:
+    - notra-api
+    - rust
+  language: en
+  difficulty: intermediate
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - Rust SDK
+    - notra crate
+    - Rust integration
+  next: ./caching.mdx
 ---
 
 The `notra` crate is a community-maintained Rust SDK for the Notra API. It provides typed request builders, response structs, and async support via `tokio`.

--- a/apps/docs/api/types.mdx
+++ b/apps/docs/api/types.mdx
@@ -1,6 +1,26 @@
 ---
 title: "TypeScript Types"
 description: "TypeScript type definitions for Notra API responses."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/types
+  type: reference
+  applies_to:
+    - notra-api
+    - typescript
+  language: en
+  difficulty: beginner
+  time_estimate: 6m
+  status: stable
+  aliases:
+    - TypeScript types
+    - type definitions
+    - Zod schemas
+    - API types
+  prev: ./pagination.mdx
 ---
 
 ## Using the SDK

--- a/apps/docs/api/webhooks/events.mdx
+++ b/apps/docs/api/webhooks/events.mdx
@@ -1,6 +1,27 @@
 ---
 title: "Webhook Events"
 description: "Reference for all webhook event types and their payload structures"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/webhooks/events
+  type: reference
+  applies_to:
+    - notra-api
+    - github-account
+    - typescript
+  language: en
+  difficulty: intermediate
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - webhook events
+    - push event
+    - release event
+    - event payloads
+  prev: ./overview.mdx
 ---
 
 Notra processes specific events from connected integrations and transforms them into actionable data for your workflows.

--- a/apps/docs/api/webhooks/overview.mdx
+++ b/apps/docs/api/webhooks/overview.mdx
@@ -1,6 +1,27 @@
 ---
 title: "Webhooks Overview"
 description: "Learn how to receive real-time notifications from GitHub using webhooks"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/api/webhooks/overview
+  type: explanation
+  applies_to:
+    - notra-api
+    - github-account
+    - typescript
+  language: en
+  difficulty: intermediate
+  time_estimate: 8m
+  status: stable
+  aliases:
+    - webhooks overview
+    - webhook setup
+    - signature verification
+    - webhook security
+  next: ./events.mdx
 ---
 
 Webhooks allow Notra to receive real-time notifications when events occur in your connected integrations. Instead of polling for changes, webhooks push data to Notra immediately when events happen.

--- a/apps/docs/automation/event-based.mdx
+++ b/apps/docs/automation/event-based.mdx
@@ -1,6 +1,27 @@
 ---
 title: "Event-Based Automation"
 description: "Trigger content generation automatically when events occur in your repositories"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/automation/event-based
+  type: how-to
+  applies_to:
+    - notra
+    - github-account
+  language: en
+  difficulty: intermediate
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - event-based automation
+    - GitHub webhook triggers
+    - release triggers
+    - push triggers
+  prev: ./overview.mdx
+  next: ./scheduled.mdx
 ---
 
 Event-based automation generates content in response to specific GitHub events like releases, pushes to production, or other repository activities. This enables real-time content creation that keeps your audience informed as changes happen.

--- a/apps/docs/automation/overview.mdx
+++ b/apps/docs/automation/overview.mdx
@@ -1,6 +1,24 @@
 ---
 title: "Automation Overview"
 description: "Learn how Notra automates content generation with event-based and scheduled workflows"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/automation/overview
+  type: explanation
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 6m
+  status: stable
+  aliases:
+    - automation overview
+    - event-based vs scheduled
+    - automated workflows
+  next: ./event-based.mdx
 ---
 
 Notra offers two powerful automation modes to turn your development work into content: **event-based** and **scheduled** automation. Each mode serves different use cases and content strategies.

--- a/apps/docs/automation/scheduled.mdx
+++ b/apps/docs/automation/scheduled.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Scheduled Automation"
 description: "Generate content automatically on a regular schedule with customizable frequency and lookback windows"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/automation/scheduled
+  type: how-to
+  applies_to:
+    - notra
+    - github-account
+  language: en
+  difficulty: intermediate
+  time_estimate: 14m
+  status: stable
+  aliases:
+    - scheduled automation
+    - cron schedule
+    - recurring content
+    - lookback window
+  prev: ./event-based.mdx
 ---
 
 Scheduled automation generates content at regular intervals based on repository activity over a defined time period. This is perfect for creating consistent content like weekly updates, monthly changelogs, or regular social media posts.

--- a/apps/docs/concepts/brand-voice.mdx
+++ b/apps/docs/concepts/brand-voice.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Brand Voice"
 description: "Learn how Notra adapts generated content to match your team's tone, style, and audience preferences."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/concepts/brand-voice
+  type: explanation
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - brand voice
+    - tone profiles
+    - custom instructions
+    - target audience
+  prev: ./content-pipeline.mdx
 ---
 
 Brand voice is what makes your content sound like *you*. Notra ensures every generated draft reflects your team's unique communication style through brand settings and AI-powered adaptation.

--- a/apps/docs/concepts/content-pipeline.mdx
+++ b/apps/docs/concepts/content-pipeline.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Content Pipeline"
 description: "Explore Notra's five-step content pipeline that transforms raw engineering activity into polished, publish-ready drafts."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/concepts/content-pipeline
+  type: explanation
+  applies_to:
+    - notra
+  language: en
+  difficulty: intermediate
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - content pipeline
+    - five-step pipeline
+    - ingest analyze generate
+  prev: ./how-it-works.mdx
+  next: ./brand-voice.mdx
 ---
 
 Notra's content pipeline is the core system that converts your team's work into content. Understanding this pipeline helps you make the most of the platform and troubleshoot when needed.

--- a/apps/docs/concepts/how-it-works.mdx
+++ b/apps/docs/concepts/how-it-works.mdx
@@ -1,6 +1,24 @@
 ---
 title: "How Notra Works"
 description: "Understand how Notra transforms your team's work into ready-to-publish content through automated activity ingestion, AI analysis, and brand voice adaptation."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/concepts/how-it-works
+  type: explanation
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 8m
+  status: stable
+  aliases:
+    - how Notra works
+    - content pipeline overview
+    - AI analysis
+  next: ./content-pipeline.mdx
 ---
 
 Notra automates content creation by connecting to your team's tools, analyzing activity with AI, and generating drafts tailored to your brand voice. Here's how the system works from start to finish.

--- a/apps/docs/content/blog-posts.mdx
+++ b/apps/docs/content/blog-posts.mdx
@@ -1,6 +1,27 @@
 ---
 title: "Blog Posts"
 description: "Generate in-depth technical blog posts from your development work and product updates"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/content/blog-posts
+  type: how-to
+  applies_to:
+    - notra
+    - github-account
+  language: en
+  difficulty: beginner
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - blog posts
+    - generate blog post
+    - technical blog
+    - feature announcement
+  prev: ./changelogs.mdx
+  next: ./social-media.mdx
 ---
 
 Notra can transform significant features, architectural decisions, and product milestones into comprehensive blog posts that tell the story behind your work.

--- a/apps/docs/content/changelogs.mdx
+++ b/apps/docs/content/changelogs.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Changelogs"
 description: "Auto-generate comprehensive changelogs from your GitHub activity with AI-powered formatting and customization"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/content/changelogs
+  type: how-to
+  applies_to:
+    - notra
+    - github-account
+  language: en
+  difficulty: beginner
+  time_estimate: 10m
+  status: stable
+  aliases:
+    - changelogs
+    - generate changelog
+    - release notes
+    - lookback window
+  next: ./blog-posts.mdx
 ---
 
 Notra automatically generates changelogs from your GitHub pull requests, commits, and releases. Transform your development activity into polished, well-organized updates that keep your users informed.

--- a/apps/docs/content/social-media.mdx
+++ b/apps/docs/content/social-media.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Social Media Posts"
 description: "Turn your development activity into engaging LinkedIn and Twitter posts that build your technical brand"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/content/social-media
+  type: how-to
+  applies_to:
+    - notra
+    - github-account
+  language: en
+  difficulty: beginner
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - social media posts
+    - LinkedIn posts
+    - Twitter posts
+    - social content
+  prev: ./blog-posts.mdx
 ---
 
 Notra automatically generates social media content from your GitHub activity, helping you build a technical brand and share your work without manual writing.

--- a/apps/docs/devtools/cli.mdx
+++ b/apps/docs/devtools/cli.mdx
@@ -1,6 +1,26 @@
 ---
 title: "CLI"
 description: "Manage posts, brand identities, integrations, and schedules from the terminal."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/devtools/cli
+  type: reference
+  applies_to:
+    - notra
+    - notra-cli
+  language: en
+  difficulty: intermediate
+  time_estimate: 12m
+  status: draft
+  aliases:
+    - Notra CLI
+    - notra command
+    - command line
+    - terminal access
+  next: ./mcp.mdx
 ---
 
 The Notra CLI gives you scriptable access to your workspace when installed. This repository currently does not include a CLI package, so treat these commands as the intended public CLI interface rather than local monorepo commands.

--- a/apps/docs/devtools/mcp.mdx
+++ b/apps/docs/devtools/mcp.mdx
@@ -1,6 +1,27 @@
 ---
 title: "MCP Server"
 description: "Connect the Notra MCP server to AI tools using OAuth or API-key bearer authentication, with tools for posts, brand identities, integrations, and schedules."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/devtools/mcp
+  type: how-to
+  applies_to:
+    - notra
+    - notra-mcp
+  language: en
+  difficulty: intermediate
+  time_estimate: 8m
+  status: stable
+  aliases:
+    - MCP server
+    - Notra MCP
+    - Model Context Protocol
+    - AI agent access
+  prev: ./cli.mdx
+  next: ./raycast.mdx
 ---
 
 Notra provides a hosted MCP server at `https://mcp.usenotra.com/mcp` so AI agents can work with your Notra workspace directly.

--- a/apps/docs/devtools/raycast.mdx
+++ b/apps/docs/devtools/raycast.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Raycast Extension"
 description: "Search posts, copy content, and manage workflows from Raycast."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/devtools/raycast
+  type: how-to
+  applies_to:
+    - notra
+    - raycast
+    - macos
+  language: en
+  difficulty: beginner
+  time_estimate: 5m
+  status: stable
+  aliases:
+    - Raycast extension
+    - Notra Raycast
+  prev: ./mcp.mdx
 ---
 
 The Notra Raycast extension brings your workspace into Raycast so you can browse posts, copy content, and manage workflows without leaving your launcher.

--- a/apps/docs/integrations/featul.mdx
+++ b/apps/docs/integrations/featul.mdx
@@ -2,6 +2,25 @@
 title: "Featul (Community)"
 sidebarTitle: "Featul"
 description: "Import Notra changelog content into Featul."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/integrations/featul
+  type: how-to
+  applies_to:
+    - notra
+    - featul
+  language: en
+  difficulty: beginner
+  time_estimate: 5m
+  status: stable
+  aliases:
+    - Featul integration
+    - import changelog to Featul
+  prev: ./framer.mdx
+  next: ./kontentspace.mdx
 ---
 
 <Warning>

--- a/apps/docs/integrations/framer.mdx
+++ b/apps/docs/integrations/framer.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Framer"
 description: "Import Notra content into Framer with the Notra marketplace plugin."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/integrations/framer
+  type: how-to
+  applies_to:
+    - notra
+    - framer
+  language: en
+  difficulty: beginner
+  time_estimate: 5m
+  status: stable
+  aliases:
+    - Framer plugin
+    - import to Framer
+    - Framer marketplace
+  prev: ./slack.mdx
+  next: ./featul.mdx
 ---
 
 This guide shows how to connect Notra to [Framer](https://www.framer.com/) and pull your content into a Framer site with the official Notra plugin.

--- a/apps/docs/integrations/github.mdx
+++ b/apps/docs/integrations/github.mdx
@@ -1,6 +1,27 @@
 ---
 title: "GitHub Integration"
 description: "Connect GitHub repositories to automatically generate content from your development activity"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/integrations/github
+  type: how-to
+  applies_to:
+    - notra
+    - github-account
+  language: en
+  difficulty: beginner
+  time_estimate: 12m
+  status: stable
+  aliases:
+    - GitHub integration
+    - connect repository
+    - GitHub webhook setup
+    - personal access token
+  prev: ./overview.mdx
+  next: ./linear.mdx
 ---
 
 The GitHub integration pulls data from your repositories to generate changelogs, blog posts, social media updates, and more. Notra analyzes pull requests, issues, releases, and commits to create compelling content about your product.

--- a/apps/docs/integrations/kontentspace.mdx
+++ b/apps/docs/integrations/kontentspace.mdx
@@ -2,6 +2,26 @@
 title: "Kontentspace (Community)"
 sidebarTitle: "Kontentspace"
 description: "Connect your Notra MCP to Kontentspace AI-agent"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/integrations/kontentspace
+  type: how-to
+  applies_to:
+    - notra
+    - kontentspace
+    - notra-mcp
+  language: en
+  difficulty: beginner
+  time_estimate: 5m
+  status: stable
+  aliases:
+    - Kontentspace integration
+    - Kontentspace AI agent
+    - Notra MCP
+  prev: ./featul.mdx
 ---
 
 <Warning>

--- a/apps/docs/integrations/linear.mdx
+++ b/apps/docs/integrations/linear.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Linear"
 description: "Integrate Linear with Notra to pull issues, projects, and cycles into your content pipeline."
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/integrations/linear
+  type: how-to
+  applies_to:
+    - notra
+    - linear-account
+  language: en
+  difficulty: beginner
+  time_estimate: 5m
+  status: stable
+  aliases:
+    - Linear integration
+    - connect Linear
+    - Linear issues
+  prev: ./github.mdx
+  next: ./slack.mdx
 ---
 
 Connect your Linear workspace to Notra to use completed issues, projects, and development cycles as data sources for AI-powered content generation.

--- a/apps/docs/integrations/overview.mdx
+++ b/apps/docs/integrations/overview.mdx
@@ -1,6 +1,24 @@
 ---
 title: "Integrations Overview"
 description: "Connect your tools to Notra for AI-powered content automation"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/integrations/overview
+  type: explanation
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 5m
+  status: stable
+  aliases:
+    - integrations overview
+    - input sources
+    - output destinations
+  next: ./github.mdx
 ---
 
 Notra connects to your existing workflow tools to gather information for AI-generated content. Integrations are organized into input sources and planned output destinations.

--- a/apps/docs/integrations/slack.mdx
+++ b/apps/docs/integrations/slack.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Slack Integration"
 description: "Track updates and announcements from Slack to generate automated content"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/integrations/slack
+  type: explanation
+  applies_to:
+    - notra
+    - slack-workspace
+  language: en
+  difficulty: beginner
+  time_estimate: 8m
+  status: draft
+  aliases:
+    - Slack integration
+    - Slack coming soon
+    - monitor channels
+  prev: ./linear.mdx
+  next: ./framer.mdx
 ---
 
 <Note>

--- a/apps/docs/organization/billing.mdx
+++ b/apps/docs/organization/billing.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Billing & Plans"
 description: "Manage your subscription, view invoices, and track feature usage"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/organization/billing
+  type: how-to
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 10m
+  status: stable
+  aliases:
+    - billing and plans
+    - subscription
+    - invoices
+    - usage limits
+  prev: ./team-management.mdx
 ---
 
 ## Overview

--- a/apps/docs/organization/team-management.mdx
+++ b/apps/docs/organization/team-management.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Team Management"
 description: "Invite team members and manage roles and permissions in your workspace"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/organization/team-management
+  type: how-to
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 10m
+  status: stable
+  aliases:
+    - team management
+    - invite members
+    - roles and permissions
+    - RBAC
+  prev: ./workspace-setup.mdx
+  next: ./billing.mdx
 ---
 
 ## Overview

--- a/apps/docs/organization/workspace-setup.mdx
+++ b/apps/docs/organization/workspace-setup.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Workspace Setup"
 description: "Create and configure your workspace to get started with Notra"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/organization/workspace-setup
+  type: how-to
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 8m
+  status: stable
+  aliases:
+    - workspace setup
+    - create organization
+    - brand identity setup
+    - organization slug
+  next: ./team-management.mdx
 ---
 
 ## Creating Your First Workspace

--- a/apps/docs/overview.mdx
+++ b/apps/docs/overview.mdx
@@ -1,6 +1,24 @@
 ---
 title: "Welcome to Notra"
 description: "Turn your team's work into ready-to-publish content with AI-powered automation"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/overview
+  type: explanation
+  applies_to:
+    - notra
+  language: en
+  difficulty: beginner
+  time_estimate: 6m
+  status: stable
+  aliases:
+    - Notra overview
+    - What is Notra
+    - content automation
+  next: ./quickstart.mdx
 ---
 
 Notra helps teams transform daily work, including merged pull requests, releases, commits, and Linear issues, into polished content for changelogs, blog posts, and social media updates.

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Quickstart"
 description: "Generate your first AI-powered content in under 5 minutes"
+authors:
+  - handle: dominik
+
+docolin:
+  schema_version: 1
+  kind: tools/notra/quickstart
+  type: tutorial
+  applies_to:
+    - notra
+    - github-account
+  language: en
+  difficulty: beginner
+  time_estimate: 15m
+  status: stable
+  aliases:
+    - Notra quickstart
+    - getting started with Notra
+    - connect GitHub
+    - first content
+  prev: ./overview.mdx
 ---
 
 This guide walks you through setting up Notra, connecting GitHub, configuring your brand voice, and generating your first piece of content.


### PR DESCRIPTION
Add the docolin namespaced frontmatter block (schema_version, kind, type, applies_to, language, difficulty, time_estimate, status, aliases, prev/next) plus an authors entry to all 34 pages under apps/docs so the docs can be imported by docolin (Mintlify import path).

kind paths map to tools/notra/<path>; prev/next chain within each docs.json sidebar group. devtools/cli and integrations/slack are marked status: draft since the CLI package is not yet published and Slack is still "coming soon".

### Description
docolin imports a Mintlify docs set as long as each page carries a `docolin:` frontmatter block alongside the existing Mintlify frontmatter (it's additive — nothing existing is renamed or removed). This PR adds that block to every page under `apps/docs` so the whole docs site becomes importable.

Each field was set by reading the page against docolin's [frontmatter spec](https://docolin.com/docolin/docolin/authoring/frontmatter), not applied blindly:

- **kind** → `tools/notra/<path>` mirroring the file location (`tools/` is a valid top-level domain; all paths are 2–5 segments deep).
- **type** → the dominant Diátaxis intent of each page (tutorial / how-to / reference / explanation).
- **prev / next** → chained to match the `docs.json` sidebar order within each group, in both the Documentation and API Reference tabs.
- **applies_to** → factual tags matching each page's real content/prerequisites, e.g. `github-account` on the content and scheduled-automation pages (a connected GitHub repo is required), `typescript` on the TS-heavy API pages, `react`/`nextjs` on the caching page.
- **status** → `draft` for `devtools/cli` (the CLI package isn't published yet) and `integrations/slack` (feature is "coming soon / under active development"); `stable` elsewhere.

All 34 frontmatter blocks parse as valid YAML.

### Screenshot/Recording (if applicable)
N/A — frontmatter/metadata only, no rendered-output change.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally (`bun x ultracite check apps/docs` — passes; biome doesn't lint `.mdx`, so frontmatter was YAML-validated separately)
- [x] I updated docs when behavior or setup changed (this PR is docs-only)
- [x] I only added comments where the logic is not obvious (N/A — no code)
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did — **disclosure:** the docolin frontmatter blocks were generated and reviewed with Claude Code (Anthropic); every field was verified by reading each page against docolin's frontmatter spec.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `docolin:` frontmatter block and `authors` to all 34 pages in `apps/docs` so the docs can be imported by docolin via the Mintlify path. No UI changes; this is additive metadata (`schema_version`, `kind`, `type`, `applies_to`, `language`, `difficulty`, `time_estimate`, `status`, `aliases`, `prev/next`).

- **New Features**
  - Added `docolin:` block to every page with `kind` set to `tools/notra/<path>` and `prev/next` chained to the `docs.json` sidebar order.
  - Marked `devtools/cli` and `integrations/slack` as `status: draft`; all other pages `stable`.
  - Added `authors` entries; all frontmatter validated as YAML.

<sup>Written for commit 92407581f278ce1140af5c495b9f5ce5ecd1ad87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

