### PR TITLE
fix(auth): seed system skills and autumn customer via organizationHooks

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -11,7 +11,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "backfill:system-skills": "bun run scripts/backfill-system-skills.ts"
   },
   "dependencies": {
     "@ai-sdk/react": "3.0.208",

--- a/apps/dashboard/scripts/backfill-system-skills.ts
+++ b/apps/dashboard/scripts/backfill-system-skills.ts
@@ -1,0 +1,32 @@
+import { db } from "@notra/db/drizzle";
+import { organizations, skills } from "@notra/db/schema";
+import { count, eq } from "drizzle-orm";
+import { seedSystemSkills } from "../src/lib/skills/seed";
+
+async function main() {
+  const orgs = await db.select({ id: organizations.id }).from(organizations);
+  const [before] = await db
+    .select({ value: count() })
+    .from(skills)
+    .where(eq(skills.isSystem, true));
+
+  for (const org of orgs) {
+    await seedSystemSkills(org.id);
+  }
+
+  const [after] = await db
+    .select({ value: count() })
+    .from(skills)
+    .where(eq(skills.isSystem, true));
+
+  console.log(
+    `Backfilled ${orgs.length} organizations: system skills ${before?.value ?? 0} -> ${after?.value ?? 0}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/apps/dashboard/scripts/backfill-system-skills.ts
+++ b/apps/dashboard/scripts/backfill-system-skills.ts
@@ -10,9 +10,28 @@ async function main() {
     .from(skills)
     .where(eq(skills.isSystem, true));
 
+  let seeded = 0;
+  let skipped = 0;
+  let failed = 0;
+
   for (const org of orgs) {
-    await seedSystemSkills(org.id);
+    try {
+      const insertedCount = await seedSystemSkills(org.id);
+      if (insertedCount > 0) {
+        seeded += 1;
+        console.log(`[${org.id}] seeded ${insertedCount} system skills`);
+      } else {
+        skipped += 1;
+      }
+    } catch (error) {
+      failed += 1;
+      console.error(`[${org.id}] failed to seed system skills:`, error);
+    }
   }
+
+  console.log(
+    `Organizations: ${seeded} seeded, ${skipped} already seeded, ${failed} failed`
+  );
 
   const [after] = await db
     .select({ value: count() })

--- a/apps/dashboard/scripts/backfill-system-skills.ts
+++ b/apps/dashboard/scripts/backfill-system-skills.ts
@@ -33,6 +33,10 @@ async function main() {
     `Organizations: ${seeded} seeded, ${skipped} already seeded, ${failed} failed`
   );
 
+  if (failed > 0) {
+    throw new Error(`Failed to seed ${failed} organizations`);
+  }
+
   const [after] = await db
     .select({ value: count() })
     .from(skills)

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -270,6 +270,33 @@ export const auth = betterAuth({
         beforeCreateOrganization: async ({ organization }) => {
           return validateAndNormalizeOrganizationSlug(organization);
         },
+        afterCreateOrganization: async ({ organization }) => {
+          try {
+            await seedSystemSkills(organization.id);
+          } catch (error) {
+            console.error(
+              "[Skills] Failed to seed system skills for new org:",
+              {
+                organizationId: organization.id,
+                error,
+              }
+            );
+          }
+
+          if (!autumn) {
+            console.warn(
+              "[Autumn] Skipping customer creation - AUTUMN_SECRET_KEY not configured"
+            );
+            return;
+          }
+          await autumn.customers.getOrCreate({
+            customerId: organization.id,
+            name: organization.name,
+            metadata: {
+              orgId: organization.id,
+            },
+          });
+        },
         beforeCreateInvitation: async ({ invitation, organization }) => {
           if (!isNotDisposableEmail(invitation.email)) {
             throw new APIError("BAD_REQUEST", {
@@ -416,37 +443,6 @@ export const auth = betterAuth({
         },
         after: async (user) => {
           sendWelcomeEmailAction({ userEmail: user.email ?? "" });
-        },
-      },
-    },
-    organization: {
-      create: {
-        after: async (org: { id: string; name: string }) => {
-          try {
-            await seedSystemSkills(org.id);
-          } catch (error) {
-            console.error(
-              "[Skills] Failed to seed system skills for new org:",
-              {
-                organizationId: org.id,
-                error,
-              }
-            );
-          }
-
-          if (!autumn) {
-            console.warn(
-              "[Autumn] Skipping customer creation - AUTUMN_SECRET_KEY not configured"
-            );
-            return;
-          }
-          await autumn.customers.getOrCreate({
-            customerId: org.id,
-            name: org.name,
-            metadata: {
-              orgId: org.id,
-            },
-          });
         },
       },
     },

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -289,13 +289,20 @@ export const auth = betterAuth({
             );
             return;
           }
-          await autumn.customers.getOrCreate({
-            customerId: organization.id,
-            name: organization.name,
-            metadata: {
-              orgId: organization.id,
-            },
-          });
+          try {
+            await autumn.customers.getOrCreate({
+              customerId: organization.id,
+              name: organization.name,
+              metadata: {
+                orgId: organization.id,
+              },
+            });
+          } catch (error) {
+            console.error("[Autumn] Failed to create customer for new org:", {
+              organizationId: organization.id,
+              error,
+            });
+          }
         },
         beforeCreateInvitation: async ({ invitation, organization }) => {
           if (!isNotDisposableEmail(invitation.email)) {

--- a/apps/dashboard/src/lib/skills/seed.ts
+++ b/apps/dashboard/src/lib/skills/seed.ts
@@ -48,7 +48,9 @@ function buildSystemSkills(): SystemSkillDefinition[] {
   ];
 }
 
-export async function seedSystemSkills(organizationId: string): Promise<void> {
+export async function seedSystemSkills(
+  organizationId: string
+): Promise<number> {
   const definitions = buildSystemSkills();
 
   const rows = definitions.map((def) => ({
@@ -60,10 +62,13 @@ export async function seedSystemSkills(organizationId: string): Promise<void> {
     isSystem: true,
   }));
 
-  await db
+  const inserted = await db
     .insert(skills)
     .values(rows)
     .onConflictDoNothing({
       target: [skills.organizationId, skills.name],
-    });
+    })
+    .returning({ id: skills.id });
+
+  return inserted.length;
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seed system skills and create the `autumn` customer when a new organization is created via `organizationHooks.afterCreateOrganization`. Added a backfill script (`backfill:system-skills`) with clearer logging and a non-zero exit when any org seeding fails.

- **Refactors**
  - Moved org setup from `organization.create.after` to `afterCreateOrganization`.
  - Improved reliability: added try/catch and logs for seeding and `autumn` customer creation (skip and warn if `AUTUMN_SECRET_KEY` is missing); `seedSystemSkills` returns inserted count; backfill exits non-zero on failures.

- **Migration**
  - Run `bun run backfill:system-skills` once to seed system skills for all existing organizations.

<sup>Written for commit 1e54a6dd7ef6432302ef32a2781445d31042528c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

