### PR TITLE
refactor(dashboard): replace manual styleguide narrowing with zod schemas

### DIFF
--- a/apps/dashboard/src/schemas/brand-guidelines.ts
+++ b/apps/dashboard/src/schemas/brand-guidelines.ts
@@ -1,5 +1,6 @@
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
+import { BRAND_GUIDELINE_HEX_COLOR_REGEX } from "@/constants/brand-guidelines";
 
 export const guidelineColorRoleSchema = z.enum([
   "primary",
@@ -131,3 +132,94 @@ export const brandGuidelinesWorkflowPayloadSchema = z.object({
   organizationId: z.string().min(1),
   sourceUrl: z.string().min(1),
 });
+
+const styleguideTextSchema = z.string().trim().min(1);
+const optionalStyleguideTextSchema = styleguideTextSchema
+  .optional()
+  .catch(undefined);
+
+const styleguideHexSchema = styleguideTextSchema.regex(
+  BRAND_GUIDELINE_HEX_COLOR_REGEX
+);
+const optionalStyleguideHexSchema = styleguideHexSchema
+  .optional()
+  .catch(undefined);
+
+const styleguideTextOrNumberSchema = z.union([
+  styleguideTextSchema,
+  z.number().transform((value) => String(value)),
+]);
+const optionalStyleguideTextOrNumberSchema = styleguideTextOrNumberSchema
+  .optional()
+  .catch(undefined);
+
+export const styleguideRecordSchema = z.record(z.string(), z.unknown());
+
+export const styleguideColorSchema = z.union([
+  styleguideHexSchema.transform((hex) => ({
+    hex,
+    name: null,
+    usage: null,
+    darkValue: null,
+  })),
+  z
+    .object({
+      hex: styleguideHexSchema,
+      name: optionalStyleguideTextSchema,
+      usage: optionalStyleguideTextSchema,
+      darkHex: optionalStyleguideHexSchema,
+      darkValue: optionalStyleguideHexSchema,
+      dark: optionalStyleguideHexSchema,
+    })
+    .transform((color) => ({
+      hex: color.hex,
+      name: color.name ?? null,
+      usage: color.usage ?? null,
+      darkValue: color.darkHex ?? color.darkValue ?? color.dark ?? null,
+    })),
+]);
+
+export const styleguideFontSchema = z.union([
+  styleguideTextSchema.transform((family) => ({
+    family,
+    weight: null,
+    size: null,
+    lineHeight: null,
+  })),
+  z
+    .object({
+      fontFamily: styleguideTextSchema,
+      fontWeight: optionalStyleguideTextOrNumberSchema,
+      weight: optionalStyleguideTextSchema,
+      fontSize: optionalStyleguideTextSchema,
+      size: optionalStyleguideTextSchema,
+      lineHeight: optionalStyleguideTextOrNumberSchema,
+    })
+    .transform((font) => ({
+      family: font.fontFamily,
+      weight: font.fontWeight ?? font.weight ?? null,
+      size: font.fontSize ?? font.size ?? null,
+      lineHeight: font.lineHeight ?? null,
+    })),
+]);
+
+export const styleguideTokenValueSchema = z.union([
+  styleguideTextSchema.transform((value) => ({ value, metadata: null })),
+  z.number().transform((value) => ({ value: String(value), metadata: null })),
+  z
+    .looseObject({
+      value: optionalStyleguideTextSchema,
+      boxShadow: optionalStyleguideTextSchema,
+      borderRadius: optionalStyleguideTextSchema,
+    })
+    .transform((token, ctx) => {
+      const value = token.value ?? token.boxShadow ?? token.borderRadius;
+
+      if (!value) {
+        ctx.addIssue({ code: "custom", message: "Token value is missing" });
+        return z.NEVER;
+      }
+
+      return { value, metadata: token };
+    }),
+]);

--- a/apps/dashboard/src/schemas/brand-guidelines.ts
+++ b/apps/dashboard/src/schemas/brand-guidelines.ts
@@ -190,7 +190,7 @@ export const styleguideFontSchema = z.union([
     .object({
       fontFamily: styleguideTextSchema,
       fontWeight: optionalStyleguideTextOrNumberSchema,
-      weight: optionalStyleguideTextSchema,
+      weight: optionalStyleguideTextOrNumberSchema,
       fontSize: optionalStyleguideTextSchema,
       size: optionalStyleguideTextSchema,
       lineHeight: optionalStyleguideTextOrNumberSchema,
@@ -208,7 +208,7 @@ export const styleguideTokenValueSchema = z.union([
   z.number().transform((value) => ({ value: String(value), metadata: null })),
   z
     .looseObject({
-      value: optionalStyleguideTextSchema,
+      value: optionalStyleguideTextOrNumberSchema,
       boxShadow: optionalStyleguideTextSchema,
       borderRadius: optionalStyleguideTextSchema,
     })

--- a/apps/dashboard/src/utils/brand-guidelines.ts
+++ b/apps/dashboard/src/utils/brand-guidelines.ts
@@ -8,6 +8,12 @@ import {
   BRAND_GUIDELINE_LEADING_WWW_REGEX,
   BRAND_GUIDELINE_TOKEN_GROUPS,
 } from "@/constants/brand-guidelines";
+import {
+  styleguideColorSchema,
+  styleguideFontSchema,
+  styleguideRecordSchema,
+  styleguideTokenValueSchema,
+} from "@/schemas/brand-guidelines";
 import type {
   NormalizedAsset,
   NormalizedColor,
@@ -20,18 +26,6 @@ import type {
   BrandGuidelineTokenType,
 } from "@/types/hooks/brand-guidelines";
 import { selectPreferredBrandGuidelineAssets } from "@/utils/brand-guideline-assets";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringValue(value: unknown) {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function objectValue(value: unknown) {
-  return isRecord(value) ? value : null;
-}
 
 export function normalizeBrandGuidelineSourceUrl(rawUrl: string) {
   return new URL(rawUrl).href;
@@ -98,58 +92,29 @@ function normalizeTokenType(type: string): BrandGuidelineTokenType {
   return "unknown";
 }
 
-function getDarkColorValue(color: Record<string, unknown>) {
-  return (
-    stringValue(color.darkHex) ??
-    stringValue(color.darkValue) ??
-    stringValue(color.dark)
-  );
-}
-
 export function extractStyleguideColors(
   styleguide: ContextDevStyleguideResponse
 ): NormalizedColor[] {
-  const colors = objectValue(styleguide.styleguide.colors);
+  const colors = styleguideRecordSchema.safeParse(styleguide.styleguide.colors);
 
-  if (!colors) {
+  if (!colors.success) {
     return [];
   }
 
-  return Object.entries(colors).flatMap(([key, value], index) => {
-    if (
-      typeof value === "string" &&
-      BRAND_GUIDELINE_HEX_COLOR_REGEX.test(value)
-    ) {
-      return [
-        {
-          role: normalizeColorRole(key),
-          name: key,
-          lightValue: value,
-          darkValue: null,
-          usage: null,
-          sortOrder: index,
-        },
-      ];
-    }
+  return Object.entries(colors.data).flatMap(([key, value], index) => {
+    const color = styleguideColorSchema.safeParse(value);
 
-    const color = objectValue(value);
-    const hex = stringValue(color?.hex);
-    const darkHex = color ? getDarkColorValue(color) : null;
-
-    if (!hex || !BRAND_GUIDELINE_HEX_COLOR_REGEX.test(hex)) {
+    if (!color.success) {
       return [];
     }
 
     return [
       {
         role: normalizeColorRole(key),
-        name: stringValue(color?.name) ?? key,
-        lightValue: hex,
-        darkValue:
-          darkHex && BRAND_GUIDELINE_HEX_COLOR_REGEX.test(darkHex)
-            ? darkHex
-            : null,
-        usage: stringValue(color?.usage),
+        name: color.data.name ?? key,
+        lightValue: color.data.hex,
+        darkValue: color.data.darkValue,
+        usage: color.data.usage,
         sortOrder: index,
       },
     ];
@@ -204,45 +169,37 @@ export function dedupeColors(colors: NormalizedColor[]) {
 export function extractFonts(
   styleguide: ContextDevStyleguideResponse
 ): NormalizedFont[] {
-  const typography = objectValue(styleguide.styleguide.typography);
+  const typography = styleguideRecordSchema.safeParse(
+    styleguide.styleguide.typography
+  );
 
-  if (!typography) {
+  if (!typography.success) {
     return [];
   }
 
-  const entries = Object.entries(typography).flatMap(([key, value]) => {
+  const entries = Object.entries(typography.data).flatMap(([key, value]) => {
     if (key === "headings") {
-      const headings = objectValue(value);
-      return headings ? Object.entries(headings) : [];
+      const headings = styleguideRecordSchema.safeParse(value);
+      return headings.success ? Object.entries(headings.data) : [];
     }
 
     return [[key, value] as const];
   });
 
   return entries.flatMap(([key, value], index) => {
-    const token = objectValue(value);
-    const family = stringValue(token?.fontFamily) ?? stringValue(value);
+    const font = styleguideFontSchema.safeParse(value);
 
-    if (!family) {
+    if (!font.success) {
       return [];
     }
 
     return [
       {
         role: normalizeFontRole(key),
-        family,
-        weight:
-          stringValue(token?.fontWeight) ??
-          stringValue(token?.weight) ??
-          (typeof token?.fontWeight === "number"
-            ? String(token.fontWeight)
-            : null),
-        size: stringValue(token?.fontSize) ?? stringValue(token?.size),
-        lineHeight:
-          stringValue(token?.lineHeight) ??
-          (typeof token?.lineHeight === "number"
-            ? String(token.lineHeight)
-            : null),
+        family: font.data.family,
+        weight: font.data.weight,
+        size: font.data.size,
+        lineHeight: font.data.lineHeight,
         source: "styleguide",
         sortOrder: index,
       },
@@ -255,26 +212,18 @@ function extractTokenGroup(
   groupName: string,
   startSortOrder: number
 ): NormalizedToken[] {
-  const group = objectValue(styleguide.styleguide[groupName]);
+  const group = styleguideRecordSchema.safeParse(
+    styleguide.styleguide[groupName]
+  );
 
-  if (!group) {
+  if (!group.success) {
     return [];
   }
 
-  return Object.entries(group).flatMap(([key, value], index) => {
-    const stringToken = stringValue(value);
-    const numericToken =
-      typeof value === "number" && Number.isFinite(value)
-        ? String(value)
-        : null;
-    const recordToken = objectValue(value);
-    const recordValue =
-      stringValue(recordToken?.value) ??
-      stringValue(recordToken?.boxShadow) ??
-      stringValue(recordToken?.borderRadius);
-    const tokenValue = stringToken ?? numericToken ?? recordValue;
+  return Object.entries(group.data).flatMap(([key, value], index) => {
+    const token = styleguideTokenValueSchema.safeParse(value);
 
-    if (!tokenValue) {
+    if (!token.success) {
       return [];
     }
 
@@ -282,9 +231,9 @@ function extractTokenGroup(
       {
         type: normalizeTokenType(groupName),
         name: key,
-        value: tokenValue,
+        value: token.data.value,
         source: "styleguide",
-        metadata: recordToken,
+        metadata: token.data.metadata,
         sortOrder: startSortOrder + index,
       },
     ];


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced manual styleguide parsing with Zod schemas to make brand guideline extraction safer and consistent across colors, fonts, and tokens. Adds support for numeric font weights and token values.

- **Refactors**
  - Added `styleguideColorSchema`, `styleguideFontSchema` (accepts numeric `fontWeight`/`weight`), `styleguideTokenValueSchema` (accepts numeric values), and `styleguideRecordSchema`, with hex validation via `BRAND_GUIDELINE_HEX_COLOR_REGEX`.
  - Switched `extractStyleguideColors`, `extractFonts`, and token group extraction to `safeParse` with schema transforms; removed custom type guards and helpers.
  - Normalizes flexible inputs and aliases (`darkHex`/`darkValue`/`dark`) into consistent shapes, converts numbers to strings, and attaches token metadata when provided.

<sup>Written for commit 04dd48583c1a75e3687e4df9137956eec8da26bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

