### PR TITLE
feat(content): generate collection titles with AI and backfill legacy names

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,7 +12,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "backfill:system-skills": "bun run scripts/backfill-system-skills.ts"
+    "backfill:system-skills": "bun run scripts/backfill-system-skills.ts",
+    "backfill:collection-titles": "bun run scripts/backfill-collection-titles.ts"
   },
   "dependencies": {
     "@ai-sdk/react": "3.0.208",

--- a/apps/dashboard/scripts/backfill-collection-titles.ts
+++ b/apps/dashboard/scripts/backfill-collection-titles.ts
@@ -2,7 +2,9 @@ import { generateCollectionTitle } from "@notra/ai/jobs/collection-title";
 import { db } from "@notra/db/drizzle";
 import { postCollections } from "@notra/db/schema";
 import { isLegacyPostCollectionName } from "@notra/db/utils/post-collections";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+const POSITIVE_INTEGER_REGEX = /^\d+$/;
 
 function hasFlag(name: string) {
   return process.argv.includes(`--${name}`);
@@ -16,15 +18,24 @@ function getArgValue(name: string) {
 
 async function main() {
   const dryRun = hasFlag("dry-run");
+  const redoBackfilled = hasFlag("redo-backfilled");
   const organizationId = getArgValue("org");
   const limitValue = getArgValue("limit");
+  if (limitValue && !POSITIVE_INTEGER_REGEX.test(limitValue)) {
+    throw new Error(`Invalid --limit value: ${limitValue}`);
+  }
+
   const limit = limitValue ? Number.parseInt(limitValue, 10) : undefined;
 
   if (limitValue && (!limit || limit <= 0)) {
     throw new Error(`Invalid --limit value: ${limitValue}`);
   }
 
-  const filters = [eq(postCollections.nameSource, "generated")];
+  const filters = [
+    redoBackfilled
+      ? inArray(postCollections.nameSource, ["generated", "backfill"])
+      : eq(postCollections.nameSource, "generated"),
+  ];
   if (organizationId) {
     filters.push(eq(postCollections.organizationId, organizationId));
   }
@@ -34,25 +45,31 @@ async function main() {
       id: postCollections.id,
       organizationId: postCollections.organizationId,
       name: postCollections.name,
+      nameSource: postCollections.nameSource,
     })
     .from(postCollections)
     .where(and(...filters))
     .orderBy(desc(postCollections.createdAt));
 
-  const legacyCollections = candidates.filter((collection) =>
-    isLegacyPostCollectionName(collection.name)
+  const eligibleCollections = candidates.filter(
+    (collection) =>
+      isLegacyPostCollectionName(collection.name) ||
+      (redoBackfilled && collection.nameSource === "backfill")
   );
-  const targets = limit ? legacyCollections.slice(0, limit) : legacyCollections;
+  const targets = limit
+    ? eligibleCollections.slice(0, limit)
+    : eligibleCollections;
 
   console.log(
-    `Found ${candidates.length} generated-name collections, ${legacyCollections.length} with legacy titles, processing ${targets.length}${dryRun ? " (dry run)" : ""}`
+    `Found ${candidates.length} candidate collections, ${eligibleCollections.length} eligible, processing ${targets.length}${dryRun ? " (dry run)" : ""}`
   );
 
   let renamed = 0;
   let skipped = 0;
   let failed = 0;
 
-  for (const collection of targets) {
+  for (const [index, collection] of targets.entries()) {
+    const progress = `(${index + 1}/${targets.length})`;
     try {
       const title = await generateCollectionTitle({
         collectionId: collection.id,
@@ -63,14 +80,21 @@ async function main() {
 
       if (title) {
         renamed += 1;
-        console.log(`[${collection.id}] "${collection.name}" -> "${title}"`);
+        console.log(
+          `${progress} [${collection.id}] "${collection.name}" -> "${title}"`
+        );
       } else {
         skipped += 1;
-        console.log(`[${collection.id}] skipped (no posts or empty title)`);
+        console.log(
+          `${progress} [${collection.id}] skipped (no posts or empty title)`
+        );
       }
     } catch (error) {
       failed += 1;
-      console.error(`[${collection.id}] failed to generate title:`, error);
+      console.error(
+        `${progress} [${collection.id}] failed to generate title:`,
+        error
+      );
     }
   }
 

--- a/apps/dashboard/scripts/backfill-collection-titles.ts
+++ b/apps/dashboard/scripts/backfill-collection-titles.ts
@@ -1,0 +1,91 @@
+import { generateCollectionTitle } from "@notra/ai/jobs/collection-title";
+import { db } from "@notra/db/drizzle";
+import { postCollections } from "@notra/db/schema";
+import { isLegacyPostCollectionName } from "@notra/db/utils/post-collections";
+import { and, desc, eq } from "drizzle-orm";
+
+function hasFlag(name: string) {
+  return process.argv.includes(`--${name}`);
+}
+
+function getArgValue(name: string) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((value) => value.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+}
+
+async function main() {
+  const dryRun = hasFlag("dry-run");
+  const organizationId = getArgValue("org");
+  const limitValue = getArgValue("limit");
+  const limit = limitValue ? Number.parseInt(limitValue, 10) : undefined;
+
+  if (limitValue && (!limit || limit <= 0)) {
+    throw new Error(`Invalid --limit value: ${limitValue}`);
+  }
+
+  const filters = [eq(postCollections.nameSource, "generated")];
+  if (organizationId) {
+    filters.push(eq(postCollections.organizationId, organizationId));
+  }
+
+  const candidates = await db
+    .select({
+      id: postCollections.id,
+      organizationId: postCollections.organizationId,
+      name: postCollections.name,
+    })
+    .from(postCollections)
+    .where(and(...filters))
+    .orderBy(desc(postCollections.createdAt));
+
+  const legacyCollections = candidates.filter((collection) =>
+    isLegacyPostCollectionName(collection.name)
+  );
+  const targets = limit ? legacyCollections.slice(0, limit) : legacyCollections;
+
+  console.log(
+    `Found ${candidates.length} generated-name collections, ${legacyCollections.length} with legacy titles, processing ${targets.length}${dryRun ? " (dry run)" : ""}`
+  );
+
+  let renamed = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const collection of targets) {
+    try {
+      const title = await generateCollectionTitle({
+        collectionId: collection.id,
+        organizationId: collection.organizationId,
+        nameSource: "backfill",
+        dryRun,
+      });
+
+      if (title) {
+        renamed += 1;
+        console.log(`[${collection.id}] "${collection.name}" -> "${title}"`);
+      } else {
+        skipped += 1;
+        console.log(`[${collection.id}] skipped (no posts or empty title)`);
+      }
+    } catch (error) {
+      failed += 1;
+      console.error(`[${collection.id}] failed to generate title:`, error);
+    }
+  }
+
+  console.log(
+    `Done: ${renamed} renamed, ${skipped} skipped, ${failed} failed${dryRun ? " (dry run, nothing saved)" : ""}`
+  );
+
+  if (failed > 0) {
+    throw new Error(`Failed to backfill ${failed} collections`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/posts/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/posts/route.ts
@@ -1,12 +1,16 @@
+import { maybeGenerateCollectionTitle } from "@notra/ai/jobs/collection-title";
 import { supportsPostSlug } from "@notra/ai/schemas/post";
 import { sanitizeMarkdownHtml } from "@notra/ai/utils/sanitize";
 import { db } from "@notra/db/drizzle";
 import { postCollections, posts } from "@notra/db/schema";
-import { buildPostCollectionName } from "@notra/db/utils/post-collections";
+import {
+  buildPostCollectionName,
+  isLegacyPostCollectionName,
+} from "@notra/db/utils/post-collections";
 import { and, eq, isNotNull, sql } from "drizzle-orm";
 import { marked } from "marked";
 import { nanoid } from "nanoid";
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { createChatPostSchema } from "@/schemas/content";
 import type { RouteContext } from "@/types/api/routes";
@@ -79,6 +83,7 @@ export async function POST(
         id: postCollections.id,
         contentTypes: postCollections.contentTypes,
         createdAt: postCollections.createdAt,
+        name: postCollections.name,
         nameSource: postCollections.nameSource,
       });
 
@@ -86,7 +91,10 @@ export async function POST(
       return null;
     }
 
-    if (collection.nameSource === "generated") {
+    if (
+      collection.nameSource === "generated" &&
+      isLegacyPostCollectionName(collection.name)
+    ) {
       await tx
         .update(postCollections)
         .set({
@@ -114,7 +122,7 @@ export async function POST(
       sourceMetadata: null,
     });
 
-    return { postId: id };
+    return { postId: id, collectionId: collection.id };
   });
 
   if (!result) {
@@ -123,6 +131,13 @@ export async function POST(
       { status: 500 }
     );
   }
+
+  after(async () => {
+    await maybeGenerateCollectionTitle({
+      collectionId: result.collectionId,
+      organizationId,
+    });
+  });
 
   return NextResponse.json({ postId: result.postId, status });
 }

--- a/apps/dashboard/src/lib/workflows/schedule/handlers/image.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/handlers/image.ts
@@ -1,4 +1,5 @@
 import { generateRepoImage } from "@notra/ai/agents/repo-image";
+import { maybeGenerateCollectionTitle } from "@notra/ai/jobs/collection-title";
 import { isGitHubRateLimitError } from "@notra/ai/tools/github";
 import {
   uploadGeneratedHtmlAsset,
@@ -82,6 +83,11 @@ export async function handleImage(
           updatedAt: new Date(),
         })
         .where(eq(postCollections.id, ctx.collectionId));
+    });
+
+    await maybeGenerateCollectionTitle({
+      collectionId: ctx.collectionId,
+      organizationId: ctx.organizationId,
     });
 
     return {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:drop": "dotenv -- bunx drizzle-kit drop --config packages/db/drizzle.config.ts",
     "db:pull": "dotenv -- bunx drizzle-kit pull --config packages/db/drizzle.config.ts",
     "email:dev": "dotenv -- bun run --filter=@notra/email dev",
+    "backfill:collection-titles": "dotenv -- bun apps/dashboard/scripts/backfill-collection-titles.ts",
     "devtools:api": "cd apps/api && bunx @ai-sdk/devtools",
     "devtools:dashboard": "cd apps/dashboard && bunx @ai-sdk/devtools",
     "check": "ultracite check",

--- a/packages/ai/src/constants/collection-title.ts
+++ b/packages/ai/src/constants/collection-title.ts
@@ -1,0 +1,3 @@
+export const COLLECTION_TITLE_MODEL_ID = "openai/gpt-5.5";
+export const COLLECTION_TITLE_MAX_POSTS = 10;
+export const COLLECTION_TITLE_EXCERPT_LENGTH = 400;

--- a/packages/ai/src/constants/collection-title.ts
+++ b/packages/ai/src/constants/collection-title.ts
@@ -1,3 +1,4 @@
 export const COLLECTION_TITLE_MODEL_ID = "openai/gpt-5.5";
 export const COLLECTION_TITLE_MAX_POSTS = 10;
 export const COLLECTION_TITLE_EXCERPT_LENGTH = 400;
+export const COLLECTION_TITLE_MAX_IMAGES = 4;

--- a/packages/ai/src/jobs/collection-title.ts
+++ b/packages/ai/src/jobs/collection-title.ts
@@ -1,0 +1,152 @@
+import {
+  COLLECTION_TITLE_EXCERPT_LENGTH,
+  COLLECTION_TITLE_MAX_POSTS,
+  COLLECTION_TITLE_MODEL_ID,
+} from "@notra/ai/constants/collection-title";
+import { gateway } from "@notra/ai/gateway";
+import { withGatewayAutomaticCaching } from "@notra/ai/provider-options";
+import {
+  COLLECTION_TITLE_MAX_LENGTH,
+  collectionTitleResultSchema,
+} from "@notra/ai/schemas/collection-title";
+import type {
+  GenerateCollectionTitleParams,
+  MaybeGenerateCollectionTitleParams,
+} from "@notra/ai/types/collection-title";
+import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
+import { db } from "@notra/db/drizzle";
+import { postCollections, posts } from "@notra/db/schema";
+import { generateObject } from "ai";
+import { and, asc, eq, ne } from "drizzle-orm";
+
+const HTML_TAG_REGEX = /<[^>]+>/g;
+const WHITESPACE_REGEX = /\s+/g;
+
+const SYSTEM_PROMPT = [
+  "You write display titles for batches of AI-generated content shown in the Notra dashboard.",
+  "Read the posts in the batch and produce one short title that captures what the batch is actually about.",
+  `Requirements: at most ${COLLECTION_TITLE_MAX_LENGTH} characters, plain text, sentence case, no dates, no surrounding quotes, no trailing punctuation.`,
+  'Do not use generic labels like "Changelog", "Blog post", or "LinkedIn post" as the title.',
+  "Focus on the concrete subject matter: the features, fixes, announcements, or themes the posts cover.",
+].join(" ");
+
+function buildPostExcerpt(markdown: string | null, content: string) {
+  const source = markdown ?? content.replace(HTML_TAG_REGEX, " ");
+  return source
+    .replace(WHITESPACE_REGEX, " ")
+    .trim()
+    .slice(0, COLLECTION_TITLE_EXCERPT_LENGTH);
+}
+
+export async function generateCollectionTitle(
+  params: GenerateCollectionTitleParams
+): Promise<string | null> {
+  const collectionPosts = await db
+    .select({
+      title: posts.title,
+      contentType: posts.contentType,
+      markdown: posts.markdown,
+      content: posts.content,
+    })
+    .from(posts)
+    .where(
+      and(
+        eq(posts.collectionId, params.collectionId),
+        eq(posts.organizationId, params.organizationId)
+      )
+    )
+    .orderBy(asc(posts.createdAt))
+    .limit(COLLECTION_TITLE_MAX_POSTS);
+
+  if (collectionPosts.length === 0) {
+    return null;
+  }
+
+  const postSummaries = collectionPosts.map((post, index) => {
+    const label = post.contentType.replaceAll("_", " ");
+    const excerpt = buildPostExcerpt(post.markdown, post.content);
+    return [`Post ${index + 1} (${label}): ${post.title}`, excerpt]
+      .filter(Boolean)
+      .join("\n");
+  });
+
+  const { object } = await generateObject({
+    model: gateway(COLLECTION_TITLE_MODEL_ID),
+    schema: collectionTitleResultSchema,
+    system: SYSTEM_PROMPT,
+    prompt: postSummaries.join("\n\n"),
+    providerOptions: withGatewayAutomaticCaching(undefined, {
+      modelId: COLLECTION_TITLE_MODEL_ID,
+    }),
+    experimental_telemetry: buildExperimentalTelemetry({
+      feature: "collection_title",
+      organizationId: params.organizationId,
+      collectionId: params.collectionId,
+    }),
+  });
+
+  const title = object.title.trim();
+  if (!title) {
+    return null;
+  }
+
+  if (!params.dryRun) {
+    await db
+      .update(postCollections)
+      .set({
+        name: title,
+        nameSource: params.nameSource ?? "generated",
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(postCollections.id, params.collectionId),
+          eq(postCollections.organizationId, params.organizationId),
+          ne(postCollections.nameSource, "user")
+        )
+      );
+  }
+
+  return title;
+}
+
+export async function maybeGenerateCollectionTitle(
+  params: MaybeGenerateCollectionTitleParams
+) {
+  try {
+    const collection = await db.query.postCollections.findFirst({
+      columns: {
+        nameSource: true,
+        expectedPostCount: true,
+        completedPostCount: true,
+      },
+      where: and(
+        eq(postCollections.id, params.collectionId),
+        eq(postCollections.organizationId, params.organizationId)
+      ),
+    });
+
+    if (!collection || collection.nameSource === "user") {
+      return;
+    }
+
+    const isComplete =
+      collection.expectedPostCount === null ||
+      collection.completedPostCount >= collection.expectedPostCount;
+    if (!isComplete) {
+      return;
+    }
+
+    await generateCollectionTitle({
+      collectionId: params.collectionId,
+      organizationId: params.organizationId,
+      nameSource: collection.nameSource,
+    });
+  } catch (error) {
+    console.error("[CollectionTitle] Failed to generate collection title", {
+      collectionId: params.collectionId,
+      organizationId: params.organizationId,
+      error,
+    });
+  }
+}

--- a/packages/ai/src/jobs/collection-title.ts
+++ b/packages/ai/src/jobs/collection-title.ts
@@ -1,5 +1,6 @@
 import {
   COLLECTION_TITLE_EXCERPT_LENGTH,
+  COLLECTION_TITLE_MAX_IMAGES,
   COLLECTION_TITLE_MAX_POSTS,
   COLLECTION_TITLE_MODEL_ID,
 } from "@notra/ai/constants/collection-title";
@@ -15,19 +16,29 @@ import type {
 } from "@notra/ai/types/collection-title";
 import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
 import { db } from "@notra/db/drizzle";
-import { postCollections, posts } from "@notra/db/schema";
-import { generateObject } from "ai";
+import { organizations, postCollections, posts } from "@notra/db/schema";
+import { isLegacyPostCollectionName } from "@notra/db/utils/post-collections";
+import { generateObject, type ImagePart, type TextPart } from "ai";
 import { and, asc, eq, ne } from "drizzle-orm";
 
 const HTML_TAG_REGEX = /<[^>]+>/g;
 const WHITESPACE_REGEX = /\s+/g;
 
+const IMAGE_CONTENT_TYPE = "image";
+
 const SYSTEM_PROMPT = [
   "You write display titles for batches of AI-generated content shown in the Notra dashboard.",
   "Read the posts in the batch and produce one short title that captures what the batch is actually about.",
   `Requirements: at most ${COLLECTION_TITLE_MAX_LENGTH} characters, plain text, sentence case, no dates, no surrounding quotes, no trailing punctuation.`,
+  "Write a concise noun phrase with the main subject first, then what the content covers.",
+  'Good examples: "Acme onboarding flow revamp", "Voice control and PR workflow fixes", "Custom MCP server integrations".',
+  "Copy product, company, and feature names exactly as they are spelled in the posts. Never add spaces, change casing, or otherwise normalize them; if the posts spell a name in more than one way, use the most frequent spelling.",
+  'Never use GitHub repository slugs like "owner/repo" as a name; use the product or company name people would say out loud.',
+  "The organization name is provided for context; when the posts refer to the same company or product, prefer the organization's spelling.",
+  'When the posts are images or other visual assets, describe the artifact itself, like "SentDM Next.js app preview" or "Acme dashboard promo graphic".',
+  "Attached images are the actual visual assets in the batch; look at them and describe what they depict.",
   'Do not use generic labels like "Changelog", "Blog post", or "LinkedIn post" as the title.',
-  "Focus on the concrete subject matter: the features, fixes, announcements, or themes the posts cover.",
+  'Do not use vague filler such as "updates", "improvements", "services", or "preview" on their own; name the concrete features, fixes, announcements, or themes the posts cover.',
 ].join(" ");
 
 function buildPostExcerpt(markdown: string | null, content: string) {
@@ -62,19 +73,49 @@ export async function generateCollectionTitle(
     return null;
   }
 
+  const organization = await db.query.organizations.findFirst({
+    columns: { name: true },
+    where: eq(organizations.id, params.organizationId),
+  });
+
   const postSummaries = collectionPosts.map((post, index) => {
     const label = post.contentType.replaceAll("_", " ");
-    const excerpt = buildPostExcerpt(post.markdown, post.content);
+    const excerpt =
+      post.contentType === IMAGE_CONTENT_TYPE
+        ? ""
+        : buildPostExcerpt(post.markdown, post.content);
     return [`Post ${index + 1} (${label}): ${post.title}`, excerpt]
       .filter(Boolean)
       .join("\n");
   });
 
+  const imageParts = collectionPosts
+    .filter(
+      (post) =>
+        post.contentType === IMAGE_CONTENT_TYPE &&
+        post.content.startsWith("http")
+    )
+    .slice(0, COLLECTION_TITLE_MAX_IMAGES)
+    .map(
+      (post): ImagePart => ({ type: "image", image: new URL(post.content) })
+    );
+
+  const promptText = [
+    organization ? `Organization: ${organization.name}` : null,
+    ...postSummaries,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  const userContent: Array<TextPart | ImagePart> = [
+    { type: "text", text: promptText },
+    ...imageParts,
+  ];
+
   const { object } = await generateObject({
     model: gateway(COLLECTION_TITLE_MODEL_ID),
     schema: collectionTitleResultSchema,
     system: SYSTEM_PROMPT,
-    prompt: postSummaries.join("\n\n"),
+    messages: [{ role: "user", content: userContent }],
     providerOptions: withGatewayAutomaticCaching(undefined, {
       modelId: COLLECTION_TITLE_MODEL_ID,
     }),
@@ -116,6 +157,7 @@ export async function maybeGenerateCollectionTitle(
   try {
     const collection = await db.query.postCollections.findFirst({
       columns: {
+        name: true,
         nameSource: true,
         expectedPostCount: true,
         completedPostCount: true,
@@ -126,7 +168,11 @@ export async function maybeGenerateCollectionTitle(
       ),
     });
 
-    if (!collection || collection.nameSource === "user") {
+    if (
+      !collection ||
+      collection.nameSource === "user" ||
+      !isLegacyPostCollectionName(collection.name)
+    ) {
       return;
     }
 

--- a/packages/ai/src/schemas/collection-title.ts
+++ b/packages/ai/src/schemas/collection-title.ts
@@ -1,0 +1,15 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+export const COLLECTION_TITLE_MAX_LENGTH = 70;
+
+export const collectionTitleResultSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(3)
+    .max(COLLECTION_TITLE_MAX_LENGTH)
+    .describe(
+      "A short, specific display title summarizing what this batch of content covers. Plain text, no dates, no surrounding quotes."
+    ),
+});

--- a/packages/ai/src/tools/image.ts
+++ b/packages/ai/src/tools/image.ts
@@ -7,6 +7,7 @@ import { calculateAiCreditCostCents } from "@notra/ai/billing/ai-credit-cost";
 import { autumn } from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { IMAGE_GEN_MODEL_ID } from "@notra/ai/constants/repo-image";
+import { maybeGenerateCollectionTitle } from "@notra/ai/jobs/collection-title";
 import {
   imageRevisionToolInputSchema,
   imageToolInputSchema,
@@ -424,6 +425,11 @@ async function saveGeneratedImagePost(params: {
     contentType: "image",
     status: "draft",
     sourceMetadata: params.sourceMetadata,
+  });
+
+  await maybeGenerateCollectionTitle({
+    collectionId: collection.id,
+    organizationId: params.organizationId,
   });
 
   return postId;

--- a/packages/ai/src/tools/post.ts
+++ b/packages/ai/src/tools/post.ts
@@ -1,3 +1,4 @@
+import { maybeGenerateCollectionTitle } from "@notra/ai/jobs/collection-title";
 import { contentTypeSchema } from "@notra/ai/schemas/content";
 import {
   POST_SLUG_MAX_LENGTH,
@@ -132,6 +133,10 @@ export function createCreatePostTool(
               )
             );
         });
+        await maybeGenerateCollectionTitle({
+          collectionId,
+          organizationId: config.organizationId,
+        });
         result.posts ??= [];
         result.posts.push({
           postId: id,
@@ -212,6 +217,10 @@ export function createCreatePostTool(
               eq(postCollections.organizationId, config.organizationId)
             )
           );
+      });
+      await maybeGenerateCollectionTitle({
+        collectionId,
+        organizationId: config.organizationId,
       });
       result.posts ??= [];
       result.posts.push({

--- a/packages/ai/src/types/collection-title.ts
+++ b/packages/ai/src/types/collection-title.ts
@@ -1,0 +1,13 @@
+export type CollectionTitleNameSource = "generated" | "backfill";
+
+export interface GenerateCollectionTitleParams {
+  collectionId: string;
+  organizationId: string;
+  nameSource?: CollectionTitleNameSource;
+  dryRun?: boolean;
+}
+
+export interface MaybeGenerateCollectionTitleParams {
+  collectionId: string;
+  organizationId: string;
+}

--- a/packages/db/src/utils/post-collections.ts
+++ b/packages/db/src/utils/post-collections.ts
@@ -1,3 +1,6 @@
+const LEGACY_POST_COLLECTION_NAME_REGEX =
+  / - (?:January|February|March|April|May|June|July|August|September|October|November|December) \d{1,2}(?:st|nd|rd|th) \d{4}$/;
+
 const CONTENT_TYPE_LABELS: Record<string, string> = {
   blog_post: "Blog post",
   changelog: "Changelog",
@@ -41,6 +44,10 @@ export function formatPostCollectionDate(date: Date) {
   const year = date.getFullYear();
 
   return `${month} ${day}${ordinalSuffix(day)} ${year}`;
+}
+
+export function isLegacyPostCollectionName(name: string) {
+  return LEGACY_POST_COLLECTION_NAME_REGEX.test(name);
 }
 
 export function buildPostCollectionName(


### PR DESCRIPTION
### Description
Collection names on the Content page were all the deterministic `<content type> - <date>` format (e.g. "Changelog - July 8th 2026"), which reads generic now that projects mix multiple content types. This PR adds an AI titling job (`openai/gpt-5.5` via the Vercel AI Gateway) that names a collection from its posts' titles and content once generation completes, hooked into the create-post tool, the image tool, the schedule image handler, and the chat save route (via `after()`). User-renamed collections are never touched. Also adds `isLegacyPostCollectionName` to detect the old deterministic format and a `bun run backfill:collection-titles` script (`--dry-run`, `--limit`, `--org`) that retitles legacy-named collections and marks them `nameSource: "backfill"`.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates clear, human-readable collection titles from their posts and backfills legacy date-based names, with better title quality and a more ergonomic backfill script. User-renamed collections are never changed.

- **New Features**
  - Improved `@notra/ai/jobs/collection-title`: adds org context, uses up to 4 images and 400‑char excerpts, and enforces a 70‑char limit; runs on `openai/gpt-5.5` via the Vercel AI Gateway.
  - Auto-runs after post/image creation, scheduled image jobs, and chat posts (`after()`), only when the collection is complete and its current name matches the legacy `<type> - <date>` format; never on user-named collections.

- **Migration**
  - New script: `bun run backfill:collection-titles` to rename legacy-named collections; supports `--dry-run`, `--limit`, `--org`, and `--redo-backfilled`. Backfilled titles are marked `nameSource: "backfill"`. Recommended: run `--dry-run` first.

<sup>Written for commit c6b4d77da7149d408771d3620e9a95c01b6ad481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

