### PR TITLE
feat(dev): add portless URLs for all apps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,11 @@ bun run db:migrate
 bun dev
 ```
 
+On first run, approve Portless's local certificate prompt. The apps are then
+available at `https://app.notra.localhost`, `https://notra.localhost`,
+`https://api.notra.localhost`, and `https://docs.notra.localhost`. Portless
+prefixes these hostnames automatically in linked Git worktrees.
+
 Run a single app when needed:
 
 ```bash
@@ -107,6 +112,9 @@ bun dev --filter=api
 bun dev --filter=web
 bun dev --filter=docs
 ```
+
+The React Email preview is available at `https://email.notra.localhost` when
+running all development tasks, or on its own with `bun run email:dev`.
 
 ## QStash Local Workflows
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,28 @@ bun install
 bun run dev
 ```
 
+Development servers run through [Portless](https://portless.sh/), which assigns
+free internal ports and exposes stable HTTPS URLs:
+
+| Service | Local URL |
+| --- | --- |
+| Dashboard | `https://app.notra.localhost` |
+| Website | `https://notra.localhost` |
+| API | `https://api.notra.localhost` |
+| Docs | `https://docs.notra.localhost` |
+| Email preview | `https://email.notra.localhost` |
+
+The first run asks to trust Portless's local certificate authority. Linked Git
+worktrees automatically receive a hostname prefix, so their servers do not
+collide with the main checkout.
+
 To run only the dashboard app:
 
 ```bash
 bun run dev --filter=dashboard
 ```
+
+Set `PORTLESS=0` to bypass the proxy and use the apps' fallback ports.
 
 To build the dashboard app:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,11 +2,16 @@
   "name": "api",
   "type": "module",
   "scripts": {
-    "dev": "NODE_ENV=development bun --watch src/index.ts",
+    "dev": "portless",
+    "dev:app": "NODE_ENV=development bun --watch src/index.ts",
     "build": "tsup",
     "start": "node dist/index.mjs",
     "check-types": "bunx tsc --noEmit",
     "knip": "knip"
+  },
+  "portless": {
+    "name": "api.notra",
+    "script": "dev:app"
   },
   "dependencies": {
     "@contextcompany/otel": "^1.0.16",
@@ -36,6 +41,7 @@
     "@types/sanitize-html": "^2.16.0",
     "@notra/typescript-config": "workspace:*",
     "knip": "^6.12.1",
+    "portless": "^0.15.1",
     "typescript": "^5"
   }
 }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "portless",
+    "dev:app": "next dev --port ${PORT:-3000}",
     "build": "next build",
     "start": "next start",
     "check-types": "tsc --noEmit",
@@ -14,6 +15,10 @@
     "db:studio": "drizzle-kit studio",
     "backfill:system-skills": "bun run scripts/backfill-system-skills.ts",
     "backfill:collection-titles": "bun run scripts/backfill-collection-titles.ts"
+  },
+  "portless": {
+    "name": "app.notra",
+    "script": "dev:app"
   },
   "dependencies": {
     "@ai-sdk/react": "3.0.208",
@@ -110,6 +115,7 @@
     "drizzle-kit": "^0.31.8",
     "knip": "^6.12.1",
     "postcss": "^8.5.8",
+    "portless": "^0.15.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/apps/dashboard/src/app/api/integrations/github/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/github/callback/route.ts
@@ -1,5 +1,6 @@
 import { upsertGitHubAppInstallation } from "@notra/ai/integrations/github";
 import { redis } from "@notra/ai/utils/redis";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { ORPCError } from "@orpc/server";
 import { type NextRequest, NextResponse } from "next/server";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
@@ -14,7 +15,7 @@ interface GitHubAppInstallState {
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.PORTLESS_URL ??
+    getPortlessUrl() ??
     process.env.BETTER_AUTH_URL ??
     process.env.NEXT_PUBLIC_SITE_URL ??
     "";

--- a/apps/dashboard/src/app/api/integrations/github/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/github/callback/route.ts
@@ -14,7 +14,10 @@ interface GitHubAppInstallState {
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    "";
 
   try {
     const { searchParams } = new URL(request.url);

--- a/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
@@ -7,7 +7,10 @@ import { linearAuthorizeQuerySchema } from "@/schemas/linear";
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    "";
 
   try {
     const { searchParams } = new URL(request.url);

--- a/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/authorize/route.ts
@@ -1,4 +1,5 @@
 import { redis } from "@notra/ai/utils/redis";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { ORPCError } from "@orpc/server";
 import { type NextRequest, NextResponse } from "next/server";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
@@ -7,7 +8,7 @@ import { linearAuthorizeQuerySchema } from "@/schemas/linear";
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.PORTLESS_URL ??
+    getPortlessUrl() ??
     process.env.BETTER_AUTH_URL ??
     process.env.NEXT_PUBLIC_SITE_URL ??
     "";

--- a/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
@@ -3,6 +3,7 @@ import {
   getLinearIntegrationsByOrganization,
 } from "@notra/ai/integrations/linear";
 import { redis } from "@notra/ai/utils/redis";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { ORPCError } from "@orpc/server";
 import { type NextRequest, NextResponse } from "next/server";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
@@ -17,7 +18,7 @@ import { buildCallbackUrl } from "@/utils/build-callback-url";
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.PORTLESS_URL ??
+    getPortlessUrl() ??
     process.env.BETTER_AUTH_URL ??
     process.env.NEXT_PUBLIC_SITE_URL ??
     "";

--- a/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/linear/callback/route.ts
@@ -17,7 +17,10 @@ import { buildCallbackUrl } from "@/utils/build-callback-url";
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    "";
 
   try {
     const { searchParams } = new URL(request.url);

--- a/apps/dashboard/src/app/api/social-accounts/twitter/callback/route.ts
+++ b/apps/dashboard/src/app/api/social-accounts/twitter/callback/route.ts
@@ -33,7 +33,10 @@ interface OAuthState {
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    "";
 
   try {
     const { searchParams } = new URL(request.url);

--- a/apps/dashboard/src/app/api/social-accounts/twitter/callback/route.ts
+++ b/apps/dashboard/src/app/api/social-accounts/twitter/callback/route.ts
@@ -1,5 +1,6 @@
 import { encryptToken } from "@notra/ai/crypto/token-encryption";
 import { redis } from "@notra/ai/utils/redis";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { db } from "@notra/db/drizzle";
 import { connectedSocialAccounts } from "@notra/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -33,7 +34,7 @@ interface OAuthState {
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.PORTLESS_URL ??
+    getPortlessUrl() ??
     process.env.BETTER_AUTH_URL ??
     process.env.NEXT_PUBLIC_SITE_URL ??
     "";

--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -4,6 +4,7 @@ import { FEATURES } from "@notra/ai/billing/features";
 import { getGitHubToolRepositoryContextByIntegrationId } from "@notra/ai/integrations/github";
 import { getBaseUrl } from "@notra/ai/qstash/triggers";
 import { getValidToneProfile } from "@notra/ai/schemas/tone";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { db } from "@notra/db/drizzle";
 import type { PostSourceMetadata } from "@notra/db/schema";
 import {
@@ -767,7 +768,7 @@ export const { POST } = serve<EventWorkflowPayload>(
       if (notificationData.enabled && notificationData.ownerEmails.length > 0) {
         await context.run("send-notification-emails", async () => {
           const baseUrl =
-            process.env.PORTLESS_URL ??
+            getPortlessUrl() ??
             process.env.BETTER_AUTH_URL ??
             "https://app.usenotra.com";
           const contentOverviewLink = `${baseUrl}/${notificationData.organizationSlug}/content`;

--- a/apps/dashboard/src/app/api/workflows/event/route.ts
+++ b/apps/dashboard/src/app/api/workflows/event/route.ts
@@ -767,7 +767,9 @@ export const { POST } = serve<EventWorkflowPayload>(
       if (notificationData.enabled && notificationData.ownerEmails.length > 0) {
         await context.run("send-notification-emails", async () => {
           const baseUrl =
-            process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com";
+            process.env.PORTLESS_URL ??
+            process.env.BETTER_AUTH_URL ??
+            "https://app.usenotra.com";
           const contentOverviewLink = `${baseUrl}/${notificationData.organizationSlug}/content`;
           const createdContent = createdPosts.map((createdPost) => ({
             title: createdPost.title,

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -5,6 +5,7 @@ import { getGitHubToolRepositoryContextByIntegrationId } from "@notra/ai/integra
 import { getLinearToolContextByIntegrationId } from "@notra/ai/integrations/linear";
 import { getBaseUrl, triggerScheduleNow } from "@notra/ai/qstash/triggers";
 import { getValidToneProfile } from "@notra/ai/schemas/tone";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { db } from "@notra/db/drizzle";
 import type { PostSourceMetadata } from "@notra/db/schema";
 import {
@@ -1144,7 +1145,7 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
       if (notificationData.enabled && notificationData.ownerEmails.length > 0) {
         await context.run("send-notification-emails", async () => {
           const baseUrl =
-            process.env.PORTLESS_URL ??
+            getPortlessUrl() ??
             process.env.BETTER_AUTH_URL ??
             "https://app.usenotra.com";
           const contentOverviewLink = `${baseUrl}/${notificationData.organizationSlug}/content`;

--- a/apps/dashboard/src/app/api/workflows/schedule/route.ts
+++ b/apps/dashboard/src/app/api/workflows/schedule/route.ts
@@ -1144,7 +1144,9 @@ export const { POST } = serve<ScheduleWorkflowPayload>(
       if (notificationData.enabled && notificationData.ownerEmails.length > 0) {
         await context.run("send-notification-emails", async () => {
           const baseUrl =
-            process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com";
+            process.env.PORTLESS_URL ??
+            process.env.BETTER_AUTH_URL ??
+            "https://app.usenotra.com";
           const contentOverviewLink = `${baseUrl}/${notificationData.organizationSlug}/content`;
           const createdContent = createdPosts.map((createdPost) => ({
             title: createdPost.title,

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -143,6 +143,7 @@ function getTrustedOrigins() {
       [
         "http://localhost:3000",
         "https://app.usenotra.com",
+        process.env.PORTLESS_URL,
         process.env.BETTER_AUTH_URL,
         process.env.NEXT_PUBLIC_APP_URL,
         process.env.WORKFLOW_BASE_URL,
@@ -257,7 +258,7 @@ export const auth = betterAuth({
     }),
     organization({
       sendInvitationEmail: async (data) => {
-        const inviteLink = `${process.env.BETTER_AUTH_URL}/invitation/${data.id}`;
+        const inviteLink = `${process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL}/invitation/${data.id}`;
         await sendInviteEmailAction({
           inviteeEmail: data.email,
           inviterName: data.inviter.user.name,
@@ -415,7 +416,7 @@ export const auth = betterAuth({
     storeSessionInDatabase: true,
     preserveSessionInDatabase: true,
   },
-  baseURL: process.env.BETTER_AUTH_URL,
+  baseURL: process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL,
   emailAndPassword: {
     enabled: true,
     sendResetPassword: async ({ user, url }) => {

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -2,6 +2,7 @@ import { oauthProvider } from "@better-auth/oauth-provider";
 import { autumn } from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { redis } from "@notra/ai/utils/redis";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { db } from "@notra/db/drizzle";
 import { members, organizations, sessions } from "@notra/db/schema";
 import type { CheckResponse } from "autumn-js";
@@ -143,7 +144,7 @@ function getTrustedOrigins() {
       [
         "http://localhost:3000",
         "https://app.usenotra.com",
-        process.env.PORTLESS_URL,
+        getPortlessUrl(),
         process.env.BETTER_AUTH_URL,
         process.env.NEXT_PUBLIC_APP_URL,
         process.env.WORKFLOW_BASE_URL,
@@ -258,7 +259,7 @@ export const auth = betterAuth({
     }),
     organization({
       sendInvitationEmail: async (data) => {
-        const inviteLink = `${process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL}/invitation/${data.id}`;
+        const inviteLink = `${getPortlessUrl() ?? process.env.BETTER_AUTH_URL}/invitation/${data.id}`;
         await sendInviteEmailAction({
           inviteeEmail: data.email,
           inviterName: data.inviter.user.name,
@@ -416,7 +417,7 @@ export const auth = betterAuth({
     storeSessionInDatabase: true,
     preserveSessionInDatabase: true,
   },
-  baseURL: process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL,
+  baseURL: getPortlessUrl() ?? process.env.BETTER_AUTH_URL,
   emailAndPassword: {
     enabled: true,
     sendResetPassword: async ({ user, url }) => {

--- a/apps/dashboard/src/lib/email/send.ts
+++ b/apps/dashboard/src/lib/email/send.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { AiCreditsDepletedEmail } from "@notra/email/emails/ai-credits-depleted";
 import { FeedbackEmail } from "@notra/email/emails/feedback";
 import { InviteUserEmail } from "@notra/email/emails/invite";
@@ -246,9 +247,7 @@ export async function sendScheduledContentFailedEmail(
   }: SendScheduledContentFailedEmailProps
 ) {
   const appUrl =
-    process.env.PORTLESS_URL ??
-    process.env.BETTER_AUTH_URL ??
-    EMAIL_CONFIG.getAppUrl();
+    getPortlessUrl() ?? process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
   const settingsLink = `${appUrl}/${organizationSlug}/schedules`;
 
   return sendWithRetry(
@@ -284,9 +283,7 @@ export async function sendScheduledContentSkippedEmail(
   }: SendScheduledContentSkippedEmailProps
 ) {
   const appUrl =
-    process.env.PORTLESS_URL ??
-    process.env.BETTER_AUTH_URL ??
-    EMAIL_CONFIG.getAppUrl();
+    getPortlessUrl() ?? process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
   const settingsLink = `${appUrl}/${organizationSlug}/schedules`;
 
   return sendWithRetry(
@@ -321,9 +318,7 @@ export async function sendAiCreditsDepletedEmail(
   }: SendAiCreditsDepletedEmailProps
 ) {
   const appUrl =
-    process.env.PORTLESS_URL ??
-    process.env.BETTER_AUTH_URL ??
-    EMAIL_CONFIG.getAppUrl();
+    getPortlessUrl() ?? process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
   const creditsLink = `${appUrl}/${organizationSlug}/settings/credits`;
   const idempotencyKey = createHash("sha256")
     .update(
@@ -364,9 +359,7 @@ export async function sendWorkflowPausedEmail(
   }: SendWorkflowPausedEmailProps
 ) {
   const appUrl =
-    process.env.PORTLESS_URL ??
-    process.env.BETTER_AUTH_URL ??
-    EMAIL_CONFIG.getAppUrl();
+    getPortlessUrl() ?? process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
   const settingsLink = `${appUrl}/${organizationSlug}/automation/schedules`;
   const idempotencyKey = createHash("sha256")
     .update(

--- a/apps/dashboard/src/lib/email/send.ts
+++ b/apps/dashboard/src/lib/email/send.ts
@@ -245,7 +245,7 @@ export async function sendScheduledContentFailedEmail(
     subject,
   }: SendScheduledContentFailedEmailProps
 ) {
-  const settingsLink = `${process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com"}/${organizationSlug}/schedules`;
+  const settingsLink = `${process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com"}/${organizationSlug}/schedules`;
 
   return sendWithRetry(
     resend,
@@ -279,7 +279,7 @@ export async function sendScheduledContentSkippedEmail(
     subject,
   }: SendScheduledContentSkippedEmailProps
 ) {
-  const settingsLink = `${process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com"}/${organizationSlug}/schedules`;
+  const settingsLink = `${process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com"}/${organizationSlug}/schedules`;
 
   return sendWithRetry(
     resend,
@@ -312,7 +312,10 @@ export async function sendAiCreditsDepletedEmail(
     subject,
   }: SendAiCreditsDepletedEmailProps
 ) {
-  const appUrl = process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
+  const appUrl =
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    EMAIL_CONFIG.getAppUrl();
   const creditsLink = `${appUrl}/${organizationSlug}/settings/credits`;
   const idempotencyKey = createHash("sha256")
     .update(
@@ -352,7 +355,10 @@ export async function sendWorkflowPausedEmail(
     subject,
   }: SendWorkflowPausedEmailProps
 ) {
-  const appUrl = process.env.BETTER_AUTH_URL ?? EMAIL_CONFIG.getAppUrl();
+  const appUrl =
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    EMAIL_CONFIG.getAppUrl();
   const settingsLink = `${appUrl}/${organizationSlug}/automation/schedules`;
   const idempotencyKey = createHash("sha256")
     .update(

--- a/apps/dashboard/src/lib/email/send.ts
+++ b/apps/dashboard/src/lib/email/send.ts
@@ -245,7 +245,11 @@ export async function sendScheduledContentFailedEmail(
     subject,
   }: SendScheduledContentFailedEmailProps
 ) {
-  const settingsLink = `${process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com"}/${organizationSlug}/schedules`;
+  const appUrl =
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    EMAIL_CONFIG.getAppUrl();
+  const settingsLink = `${appUrl}/${organizationSlug}/schedules`;
 
   return sendWithRetry(
     resend,
@@ -279,7 +283,11 @@ export async function sendScheduledContentSkippedEmail(
     subject,
   }: SendScheduledContentSkippedEmailProps
 ) {
-  const settingsLink = `${process.env.PORTLESS_URL ?? process.env.BETTER_AUTH_URL ?? "https://app.usenotra.com"}/${organizationSlug}/schedules`;
+  const appUrl =
+    process.env.PORTLESS_URL ??
+    process.env.BETTER_AUTH_URL ??
+    EMAIL_CONFIG.getAppUrl();
+  const settingsLink = `${appUrl}/${organizationSlug}/schedules`;
 
   return sendWithRetry(
     resend,

--- a/apps/dashboard/src/lib/orpc/client.ts
+++ b/apps/dashboard/src/lib/orpc/client.ts
@@ -1,3 +1,4 @@
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { RouterClient } from "@orpc/server";
@@ -9,7 +10,7 @@ function getBaseUrl() {
   }
 
   return (
-    process.env.PORTLESS_URL ??
+    getPortlessUrl() ??
     process.env.NEXT_PUBLIC_SITE_URL ??
     process.env.BETTER_AUTH_URL ??
     "http://localhost:3000"

--- a/apps/dashboard/src/lib/orpc/client.ts
+++ b/apps/dashboard/src/lib/orpc/client.ts
@@ -9,6 +9,7 @@ function getBaseUrl() {
   }
 
   return (
+    process.env.PORTLESS_URL ??
     process.env.NEXT_PUBLIC_SITE_URL ??
     process.env.BETTER_AUTH_URL ??
     "http://localhost:3000"

--- a/apps/dashboard/src/lib/orpc/routers/social-accounts.ts
+++ b/apps/dashboard/src/lib/orpc/routers/social-accounts.ts
@@ -1,4 +1,5 @@
 import { redis } from "@notra/ai/utils/redis";
+import { getPortlessUrl } from "@notra/ai/utils/url";
 import { db } from "@notra/db/drizzle";
 import { connectedSocialAccounts } from "@notra/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -127,7 +128,7 @@ export const socialAccountsRouter = {
         }
 
         const baseUrl =
-          process.env.PORTLESS_URL ??
+          getPortlessUrl() ??
           process.env.BETTER_AUTH_URL ??
           process.env.NEXT_PUBLIC_SITE_URL;
         if (!baseUrl) {

--- a/apps/dashboard/src/lib/orpc/routers/social-accounts.ts
+++ b/apps/dashboard/src/lib/orpc/routers/social-accounts.ts
@@ -127,7 +127,9 @@ export const socialAccountsRouter = {
         }
 
         const baseUrl =
-          process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL;
+          process.env.PORTLESS_URL ??
+          process.env.BETTER_AUTH_URL ??
+          process.env.NEXT_PUBLIC_SITE_URL;
         if (!baseUrl) {
           throw badRequest("Application base URL is not configured");
         }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,11 +2,17 @@
   "name": "docs",
   "type": "module",
   "scripts": {
-    "dev": "mint dev --port 3005 --no-open",
+    "dev": "portless",
+    "dev:app": "mint dev --port ${PORT:-3005} --no-open",
     "open": "mint dev --port 3005",
     "openapi:check": "mint openapi-check https://api.usenotra.com/openapi.json"
   },
+  "portless": {
+    "name": "docs.notra",
+    "script": "dev:app"
+  },
   "devDependencies": {
-    "mint": "^4.2.536"
+    "mint": "^4.2.536",
+    "portless": "^0.15.1"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,10 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3001",
+    "dev": "portless",
+    "dev:app": "next dev --port ${PORT:-3001}",
     "build": "next build",
     "start": "next start",
     "knip": "knip"
+  },
+  "portless": {
+    "name": "notra",
+    "script": "dev:app"
   },
   "dependencies": {
     "@bydefault/vercel": "^0.1.4",
@@ -57,6 +62,7 @@
     "@types/react-dom": "^19.2.3",
     "babel-plugin-react-compiler": "1.0.0",
     "knip": "^6.12.1",
+    "portless": "^0.15.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@notra/typescript-config": "workspace:*",
         "@types/sanitize-html": "^2.16.0",
         "knip": "^6.12.1",
+        "portless": "^0.15.1",
         "typescript": "^5",
       },
     },
@@ -148,6 +149,7 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "drizzle-kit": "^0.31.8",
         "knip": "^6.12.1",
+        "portless": "^0.15.1",
         "postcss": "^8.5.8",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -157,6 +159,7 @@
       "name": "docs",
       "devDependencies": {
         "mint": "^4.2.536",
+        "portless": "^0.15.1",
       },
     },
     "apps/web": {
@@ -211,6 +214,7 @@
         "@types/react-dom": "^19.2.3",
         "babel-plugin-react-compiler": "1.0.0",
         "knip": "^6.12.1",
+        "portless": "^0.15.1",
         "tailwindcss": "^4",
         "typescript": "^5",
       },
@@ -299,6 +303,7 @@
         "@react-email/preview-server": "5.2.8",
         "@types/node": "22.9.0",
         "@types/react": "^19.2.10",
+        "portless": "^0.15.1",
         "react-email": "5.2.8",
         "typescript": "^5.6.3",
       },
@@ -3560,6 +3565,8 @@
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "pony-cause": ["pony-cause@1.1.1", "", {}, "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g=="],
+
+    "portless": ["portless@0.15.1", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-MQTt405HrcIa3m9OSKpH6WjJDbfNP4oFMNg0VzAoUO4B19l1eFJBFcSWfQY8KYMhzZVfa+Gea2OUrlDm8+/M4A=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 

--- a/packages/ai/src/utils/url.ts
+++ b/packages/ai/src/utils/url.ts
@@ -16,6 +16,7 @@ export function getConfiguredWorkflowUrl(): string | undefined {
 
 export function getConfiguredAppUrl(): string | undefined {
   const url =
+    process.env.PORTLESS_URL ||
     process.env.NEXT_PUBLIC_APP_URL ||
     process.env.APP_URL ||
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);

--- a/packages/ai/src/utils/url.ts
+++ b/packages/ai/src/utils/url.ts
@@ -4,6 +4,14 @@ export function normalizeUrl(url: string): string {
   return url.replace(TRAILING_SLASHES_REGEX, "");
 }
 
+export function getPortlessUrl(): string | undefined {
+  if (process.env.NODE_ENV !== "development" || !process.env.PORTLESS_URL) {
+    return undefined;
+  }
+
+  return normalizeUrl(process.env.PORTLESS_URL);
+}
+
 export function getConfiguredWorkflowUrl(): string | undefined {
   const url = process.env.WORKFLOW_BASE_URL;
 
@@ -16,7 +24,7 @@ export function getConfiguredWorkflowUrl(): string | undefined {
 
 export function getConfiguredAppUrl(): string | undefined {
   const url =
-    process.env.PORTLESS_URL ||
+    getPortlessUrl() ||
     process.env.NEXT_PUBLIC_APP_URL ||
     process.env.APP_URL ||
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -25,7 +25,12 @@
     "./utils/resend": "./src/utils/resend.ts"
   },
   "scripts": {
-    "dev": "email dev --dir ./src/emails --port 3002"
+    "dev": "portless",
+    "dev:app": "email dev --dir ./src/emails --port ${PORT:-3002}"
+  },
+  "portless": {
+    "name": "email.notra",
+    "script": "dev:app"
   },
   "dependencies": {
     "@react-email/components": "1.0.8",
@@ -37,6 +42,7 @@
     "@react-email/preview-server": "5.2.8",
     "@types/node": "22.9.0",
     "@types/react": "^19.2.10",
+    "portless": "^0.15.1",
     "react-email": "5.2.8",
     "typescript": "^5.6.3"
   }

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,7 @@
     "GOOGLE_CLIENT_SECRET",
     "INTEGRATION_ENCRYPTION_KEY",
     "OPENROUTER_API_KEY",
+    "PORTLESS_URL",
     "QSTASH_URL",
     "QSTASH_CURRENT_SIGNING_KEY",
     "QSTASH_NEXT_SIGNING_KEY",
@@ -75,7 +76,7 @@
     },
     "dev": {
       "cache": false,
-      "passThroughEnv": ["PORTLESS", "PORTLESS_*"],
+      "passThroughEnv": ["PORT", "PORTLESS", "PORTLESS_*"],
       "persistent": true
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -75,6 +75,7 @@
     },
     "dev": {
       "cache": false,
+      "passThroughEnv": ["PORTLESS", "PORTLESS_*"],
       "persistent": true
     }
   }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `portless` to all apps to provide stable, HTTPS, portless local URLs in development. Updates callbacks, auth, ORPC, and emails to prefer `PORTLESS_URL` only in dev; production behavior is unchanged.

- **New Features**
  - Dev servers now run via `portless` with URLs: `https://app.notra.localhost`, `https://notra.localhost`, `https://api.notra.localhost`, `https://docs.notra.localhost`, `https://email.notra.localhost`.
  - Added `portless` config and `dev:app` scripts in `apps/api`, `apps/dashboard`, `apps/web`, `apps/docs`, and `packages/email`; `turbo.json` now passes `PORT`, `PORTLESS`, `PORTLESS_*` and includes `PORTLESS_URL`.
  - Base URL resolution uses `getPortlessUrl()` to prefer `PORTLESS_URL` only in development across dashboard integrations (GitHub, Linear, Twitter), workflow and notification emails, auth (baseURL, invite links, trusted origins), ORPC client, email links, and `packages/ai` URL utils.

- **Migration**
  - First run: approve Portless’s local certificate.
  - No config changes; run dev as usual. Portless is dev-only. Set `PORTLESS=0` to bypass the proxy and use fallback ports.

<sup>Written for commit f03e4fd5488849aa87eae1622c6fd7a9f1aaddfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

