### PR TITLE
fix(onboarding): run Eve build on Vercel

### DIFF
--- a/packages/agents/onboarding/package.json
+++ b/packages/agents/onboarding/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "build": "eve build",
     "dev": "dotenv -e ../../../.env -- eve dev --port 3100",
     "agent:dev": "dotenv -e ../../../.env -- eve dev",
     "agent:build": "eve build",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a `build` script to the onboarding agent package so Vercel runs `eve build` during deployments. Fixes Vercel builds failing due to the missing `build` script.

<sup>Written for commit 7465276407ba37e755d4321a8d6c2fa929eed352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

