### PR TITLE
fix(onboarding): run Eve build on Vercel

### DIFF
--- a/packages/agents/onboarding/package.json
+++ b/packages/agents/onboarding/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "build": "eve build",
     "dev": "dotenv -e ../../../.env -- eve dev --port 3100",
     "agent:dev": "dotenv -e ../../../.env -- eve dev",
     "agent:build": "eve build",


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `build` script to `packages/agents/onboarding/package.json` that runs `eve build` so Vercel can build the onboarding agent during deploys. This fixes failing Vercel builds by using the default `npm run build` hook.

<sup>Written for commit 7465276407ba37e755d4321a8d6c2fa929eed352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

