### PR TITLE
fix(dashboard): remove Eve researching placeholder from onboarding suggestions

### DIFF
--- a/apps/dashboard/src/components/automation/onboarding-suggestions.tsx
+++ b/apps/dashboard/src/components/automation/onboarding-suggestions.tsx
@@ -32,20 +32,8 @@ export function OnboardingSuggestions({
     (suggestion) => suggestion.type === type
   );
 
-  if (matching.length === 0 && !agentRunning) {
-    return null;
-  }
-
   if (matching.length === 0) {
-    return (
-      <div className="flex items-center gap-2.5 rounded-lg border border-border/60 border-dashed px-4 py-3">
-        <BrailleLoader className="text-sm" />
-        <p className="text-muted-foreground text-sm">
-          Eve is researching your company — automation suggestions will appear
-          here.
-        </p>
-      </div>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Eve is researching your company” placeholder from onboarding suggestions. When no suggestions match, the component now renders nothing to avoid confusing loading states and reduce visual clutter.

<sup>Written for commit 1303b7a582dec8cae069d104b14dec762482f446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

