### PR TITLE
fix(onboarding): remove Eve workspace status text

### DIFF
--- a/apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-onboarding.tsx
@@ -181,12 +181,6 @@ export function SidebarOnboarding() {
                     </MotionDiv>
                   </OnboardingChecklistHeader>
                   <OnboardingChecklistContent title="Complete these steps to get the most out of Notra.">
-                    {agentRunning && (
-                      <div className="flex items-center gap-2 pb-1 text-muted-foreground text-xs">
-                        <BrailleLoader className="text-xs" />
-                        <span>Eve is setting up your workspace…</span>
-                      </div>
-                    )}
                     <MotionDiv
                       layoutId="onboarding-progress"
                       transition={MORPH_TRANSITION}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Eve is setting up your workspace…" status row and `BrailleLoader` from the onboarding sidebar to reduce noise and avoid misleading state. Onboarding progress remains unchanged.

<sup>Written for commit df3edbdcb7303af4d7b51ebd29f66c76c2ddfbc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

