### PR TITLE
feat(billing): cancel autumn/stripe subscription when organizations are deleted

### DIFF
--- a/apps/dashboard/src/lib/billing/delete-autumn-customer.ts
+++ b/apps/dashboard/src/lib/billing/delete-autumn-customer.ts
@@ -1,0 +1,14 @@
+import { autumn } from "@notra/ai/billing/autumn";
+
+export async function deleteAutumnCustomer(
+  organizationId: string
+): Promise<void> {
+  if (!autumn) {
+    return;
+  }
+
+  await autumn.customers.delete({
+    customerId: organizationId,
+    deleteInStripe: true,
+  });
+}

--- a/apps/dashboard/src/lib/orpc/routers/user.ts
+++ b/apps/dashboard/src/lib/orpc/routers/user.ts
@@ -1,6 +1,7 @@
 import { db } from "@notra/db/drizzle";
 import { members, organizations } from "@notra/db/schema";
 import { and, count, eq, ne } from "drizzle-orm";
+import { deleteAutumnCustomer } from "@/lib/billing/delete-autumn-customer";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import {
   deleteOrganizationChatFiles,
@@ -193,6 +194,12 @@ export const userRouter = {
                 error
               );
             }),
+            deleteAutumnCustomer(input.organizationId).catch((error) => {
+              console.error(
+                `[Delete Org] Failed to cancel Autumn subscription for ${input.organizationId}:`,
+                error
+              );
+            }),
           ]);
         }
 
@@ -289,6 +296,12 @@ export const userRouter = {
           deleteOrganizationChatFiles(orgId).catch((error) => {
             console.error(
               `[Delete Org] Failed to cleanup chat files for ${orgId}:`,
+              error
+            );
+          }),
+          deleteAutumnCustomer(orgId).catch((error) => {
+            console.error(
+              `[Delete Org] Failed to cancel Autumn subscription for ${orgId}:`,
               error
             );
           }),


### PR DESCRIPTION
Deletes the Autumn customer (with delete_in_stripe) whenever an organization is deleted, including orgs deleted during account deletion, so Stripe subscriptions are cancelled instead of continuing to bill.

https://claude.ai/code/session_013i51bZotefC7fiGJ5rB5hX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel Autumn/Stripe subscriptions when organizations are deleted to prevent continued billing. Applies to direct org deletions and orgs removed during account deletion.

- **Bug Fixes**
  - Added `deleteAutumnCustomer()` using `@notra/ai/billing/autumn` with `deleteInStripe: true`.
  - Hooked into org deletion and account deletion flows in `user.ts`; no-op if `autumn` is unset and errors are logged without blocking deletion.

<sup>Written for commit 04c87d56c0f4c940d0cc148daaa53a75c6ce6724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

