### PR TITLE
fix(dashboard): center setup dialog buttons and rename CTA to Start Setup

### DIFF
--- a/apps/dashboard/src/components/dashboard/onboarding-agent-banner.tsx
+++ b/apps/dashboard/src/components/dashboard/onboarding-agent-banner.tsx
@@ -90,7 +90,7 @@ export function OnboardingAgentBanner({
                   className="size-4 animate-spin motion-reduce:animate-none"
                 />
               ) : null}
-              Start setup
+              Start Setup
             </ResponsiveDialogTrigger>
             <ResponsiveDialogContent>
               <ResponsiveDialogHeader>
@@ -128,11 +128,11 @@ export function OnboardingAgentBanner({
                   </li>
                 ))}
               </ul>
-              <ResponsiveDialogFooter>
+              <ResponsiveDialogFooter className="sm:justify-center">
                 <ResponsiveDialogClose render={<Button variant="outline" />}>
                   Cancel
                 </ResponsiveDialogClose>
-                <Button onClick={handleConfirm}>Start setup</Button>
+                <Button onClick={handleConfirm}>Start Setup</Button>
               </ResponsiveDialogFooter>
             </ResponsiveDialogContent>
           </ResponsiveDialog>


### PR DESCRIPTION
## Summary
- Centers the Cancel / Start Setup buttons in the workspace setup confirmation dialog footer (was right-aligned); mobile sheet layout is unchanged
- Renames the CTA label from "Start setup" to "Start Setup" on both the banner trigger and the dialog confirm button

Follow-up to #529.

https://claude.ai/code/session_01BYd1Xx8Gcbbq2TUBSzqKpL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the Cancel and Start Setup buttons in the workspace setup confirmation dialog (previously right‑aligned) and standardizes the CTA label to “Start Setup” on both the banner trigger and dialog button. Mobile sheet layout is unchanged.

<sup>Written for commit f1d5b4286fa4aaee14daa0c617081d75abf8b71b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

