### PR TITLE
fix(slack): skip free email invitations

### DIFF
--- a/apps/dashboard/src/lib/onboarding-agent.ts
+++ b/apps/dashboard/src/lib/onboarding-agent.ts
@@ -15,6 +15,7 @@ import { getVercelOidcToken } from "@vercel/oidc";
 import { and, eq, isNull, lt, or } from "drizzle-orm";
 import { Effect } from "effect";
 import { Client } from "eve/client";
+import { isFreeEmail } from "free-email-domains-list";
 import {
   AGENT_RUN_HARD_LIMIT_MS,
   EVE_CREATE_SESSION_ROUTE_PATH,
@@ -177,7 +178,7 @@ export async function sendOnboardingSlackInvite({
   email,
   organizationName,
 }: OnboardingSlackInviteInput): Promise<OnboardingSlackInviteResult> {
-  if (!hasSlackConnectConfigured()) {
+  if (!hasSlackConnectConfigured() || isFreeEmail(email.trim().toLowerCase())) {
     return { invited: false };
   }
 

--- a/packages/agents/onboarding/README.md
+++ b/packages/agents/onboarding/README.md
@@ -109,7 +109,7 @@ The 401 is the point: route auth fails closed. Only three callers get in — the
 4. Checks the website actually responds (HEAD/GET with a 5s timeout).
 5. Triggers the Upstash workflow with `{ organizationId, domain, email, organizationName }`.
 
-When the workflow starts, it creates a Slack Connect channel `ext-<company-name>-notra`, adds the configured founder, and invites the signup email with permission to post and invite. This is skipped unless both Slack variables are set. If an invite fails, the failure is caught and does not fail the workflow.
+When the workflow starts, it creates a Slack Connect channel `ext-<company-name>-notra`, adds the configured founder, and invites the signup email with permission to post and invite only when it is not from a free provider. The email and website domains do not need to match. Slack setup is skipped unless both Slack variables are set. If an invite fails, the failure is caught and does not fail the workflow.
 
 ## Local development
 


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Slack Connect invites during onboarding when the signup email is from a free provider (e.g., Gmail) to avoid unwanted invites and reduce abuse. Uses `free-email-domains-list` to detect free emails and updates the onboarding README to document the behavior and note that email and website domains don’t need to match.

<sup>Written for commit 72f4ca0569803bb904b9195335b55d738a1f3641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit `72f4ca0`. New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->