### PR TITLE
fix(integrations): resolve React Doctor findings

### DIFF
--- a/apps/console/src/lib/integrations/use-integration-form.ts
+++ b/apps/console/src/lib/integrations/use-integration-form.ts
@@ -77,6 +77,7 @@ export function useIntegrationForm({
     Record<string, ToolPhraseDraft>
   >(() => buildInitialPhraseDrafts(tools ?? []));
   const [draftTools, setDraftTools] = useState<McpIntegrationTool[]>([]);
+  const [draftScanPending, setDraftScanPending] = useState(false);
   const [manualTools, setManualTools] = useState<McpIntegrationTool[]>(() =>
     (tools ?? []).filter(isManualTool)
   );
@@ -163,8 +164,9 @@ export function useIntegrationForm({
     });
   }
 
-  const scanDraftMutation = useMutation({
-    mutationFn: () => {
+  async function scanDraftTools() {
+    setDraftScanPending(true);
+    try {
       const parsed = testMcpServerRequestSchema.safeParse({
         organizationId,
         url,
@@ -180,9 +182,9 @@ export function useIntegrationForm({
           parsed.error.issues[0]?.message ?? "Enter a valid server URL first"
         );
       }
-      return consoleOrpc.integrations.mcp.scanDraft.call(parsed.data);
-    },
-    onSuccess: (result) => {
+      const result = await consoleOrpc.integrations.mcp.scanDraft.call(
+        parsed.data
+      );
       setDraftTools(result.tools);
       const nextBaseline = buildInitialPhraseDrafts(result.tools);
       setPhraseDrafts((current) => {
@@ -200,11 +202,14 @@ export function useIntegrationForm({
           ? "Found 1 tool"
           : `Found ${result.tools.length} tools`
       );
-    },
-    onError: (error) => {
-      toast.error(error.message);
-    },
-  });
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not scan this server"
+      );
+    } finally {
+      setDraftScanPending(false);
+    }
+  }
 
   const connectOAuthDraftMutation = useMutation({
     mutationFn: async (oauthPopup: ReturnType<typeof openMcpOAuthPopup>) => {
@@ -393,7 +398,7 @@ export function useIntegrationForm({
     isSaving ||
     uploadingCount > 0 ||
     scanning ||
-    scanDraftMutation.isPending ||
+    draftScanPending ||
     connectOAuthDraftMutation.isPending;
 
   const canSubmitForReview =
@@ -504,7 +509,7 @@ export function useIntegrationForm({
     return list?.mcpServers.find((mcpServer) => mcpServer.name === name);
   }
 
-  const scanDraft = () => {
+  const scanDraft = async () => {
     if (authChoice === "oauth") {
       const parsed = createMcpServerRequestSchema.safeParse(getSharedFields());
       if (!parsed.success) {
@@ -519,14 +524,13 @@ export function useIntegrationForm({
     if (!validateApiKeyInput()) {
       return;
     }
-    scanDraftMutation.mutate();
+    await scanDraftTools();
   };
 
   return {
     apiKeyStyle,
     addManualTool,
-    draftScanning:
-      scanDraftMutation.isPending || connectOAuthDraftMutation.isPending,
+    draftScanning: draftScanPending || connectOAuthDraftMutation.isPending,
     draftTools,
     importToolPhrases,
     manualTools,

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/mcp/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/mcp/page-client.tsx
@@ -27,6 +27,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const organizationId = organization?.id ?? "";
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [reauthorizingServerId, setReauthorizingServerId] = useState<
+    string | null
+  >(null);
   useHotkey("C", () => setDialogOpen(true), { enabled: !dialogOpen });
 
   const queryInput = { organizationId };
@@ -94,17 +97,26 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     },
   });
 
-  const reauthorizeMutation = useMutation({
-    mutationFn: async (id: string) =>
-      dashboardOrpc.integrations.mcp.reauthorizeOAuth.call({
-        organizationId,
-        serverId: id,
-        callbackPath: window.location.pathname,
-      }),
-    onError: (error) => {
-      toast.error(error.message);
-    },
-  });
+  async function reauthorize(id: string) {
+    const oauthPopup = openMcpOAuthPopup();
+    setReauthorizingServerId(id);
+    try {
+      const { authorizationUrl } =
+        await dashboardOrpc.integrations.mcp.reauthorizeOAuth.call({
+          organizationId,
+          serverId: id,
+          callbackPath: window.location.pathname,
+        });
+      setReauthorizingServerId((current) => (current === id ? null : current));
+      oauthPopup.navigate(authorizationUrl);
+    } catch (error) {
+      oauthPopup.close();
+      setReauthorizingServerId((current) => (current === id ? null : current));
+      toast.error(
+        error instanceof Error ? error.message : "Could not restart OAuth"
+      );
+    }
+  }
 
   const servers = data?.servers ?? [];
   const showLoading = Boolean(organizationId) && isLoading && !data;
@@ -152,22 +164,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 <McpServerCard
                   key={server.id}
                   onDelete={(id) => deleteMutation.mutate(id)}
-                  onReauthorize={(id) => {
-                    const oauthPopup = openMcpOAuthPopup();
-                    reauthorizeMutation.mutate(id, {
-                      onError: () => oauthPopup.close(),
-                      onSuccess: ({ authorizationUrl }) =>
-                        oauthPopup.navigate(authorizationUrl),
-                    });
-                  }}
+                  onReauthorize={reauthorize}
                   onRefreshTools={(id) => refreshMutation.mutate(id)}
                   onToggle={(id, enabled) =>
                     toggleMutation.mutate({ id, enabled })
                   }
-                  reauthorizing={
-                    reauthorizeMutation.isPending &&
-                    reauthorizeMutation.variables === server.id
-                  }
+                  reauthorizing={reauthorizingServerId === server.id}
                   refreshing={
                     refreshMutation.isPending &&
                     refreshMutation.variables === server.id

--- a/apps/dashboard/src/components/integrations/manage-store-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/manage-store-integration-dialog.tsx
@@ -58,6 +58,7 @@ export function ManageStoreIntegrationDialog({
   const connection = integration.connection;
   const queryClient = useQueryClient();
   const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
+  const [reauthorizing, setReauthorizing] = useState(false);
   const [headerRows, setHeaderRows] = useState<McpCredentialHeaderRow[]>(() => {
     const names =
       connection.headerNames && connection.headerNames.length > 0
@@ -110,15 +111,26 @@ export function ManageStoreIntegrationDialog({
     onError: (error) => toast.error(error.message),
   });
 
-  const reauthorizeMutation = useMutation({
-    mutationFn: async () =>
-      dashboardOrpc.integrations.mcp.reauthorizeOAuth.call({
-        organizationId,
-        serverId: connection.id,
-        callbackPath: window.location.pathname,
-      }),
-    onError: (error) => toast.error(error.message),
-  });
+  async function reauthorize() {
+    const oauthPopup = openMcpOAuthPopup();
+    setReauthorizing(true);
+    try {
+      const { authorizationUrl } =
+        await dashboardOrpc.integrations.mcp.reauthorizeOAuth.call({
+          organizationId,
+          serverId: connection.id,
+          callbackPath: window.location.pathname,
+        });
+      setReauthorizing(false);
+      oauthPopup.navigate(authorizationUrl);
+    } catch (error) {
+      oauthPopup.close();
+      setReauthorizing(false);
+      toast.error(
+        error instanceof Error ? error.message : "Could not restart OAuth"
+      );
+    }
+  }
 
   const disconnectMutation = useMutation({
     mutationFn: async () =>
@@ -152,15 +164,6 @@ export function ManageStoreIntegrationDialog({
       return;
     }
     updateMutation.mutate({ authType: "headers", headers });
-  };
-
-  const reauthorize = () => {
-    const oauthPopup = openMcpOAuthPopup();
-    reauthorizeMutation.mutate(undefined, {
-      onError: () => oauthPopup.close(),
-      onSuccess: ({ authorizationUrl }) =>
-        oauthPopup.navigate(authorizationUrl),
-    });
   };
 
   return (
@@ -202,7 +205,7 @@ export function ManageStoreIntegrationDialog({
             onToggle={() =>
               updateMutation.mutate({ enabled: !connection.enabled })
             }
-            reauthorizing={reauthorizeMutation.isPending}
+            reauthorizing={reauthorizing}
             refreshing={refreshMutation.isPending}
             updating={updateMutation.isPending}
           />


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes React Doctor warnings in MCP integrations by replacing improper `useMutation` usage with scoped async handlers and explicit pending state. Improves OAuth reauth and draft tool scanning reliability with accurate loading indicators and safer popup handling.

- **Bug Fixes**
  - Correct “reauthorizing” and “scanning” states to prevent flicker and wrong spinners.
  - OAuth popup now closes on error and navigates only after the authorization URL is ready.

- **Refactors**
  - Replaced `useMutation` with local async functions for draft scan and OAuth reauth; added `draftScanPending`, `reauthorizingServerId`, and `reauthorizing` state.
  - Streamlined validation and error toasts for clearer feedback.

<sup>Written for commit a3d13805e584b7133af9d77f33bf7498daf3e7f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit `a3d1380`. New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->