### PR TITLE
fix(auth): harden OAuth client registration

### DIFF
--- a/apps/dashboard/knip.json
+++ b/apps/dashboard/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": ["src/**/*.test.ts"],
   "ignoreIssues": {
     "src/app/(dashboard)/**/constants/**/*.ts": ["exports"],
     "src/components/**/*.tsx": ["types"],

--- a/apps/dashboard/src/app/api/auth/[...all]/route.ts
+++ b/apps/dashboard/src/app/api/auth/[...all]/route.ts
@@ -1,5 +1,6 @@
 import { toNextJsHandler } from "better-auth/next-js";
 import { auth } from "@/lib/auth/server";
+import { isOAuthDynamicClientRegistrationPath } from "@/utils/oauth-client-registration";
 import { proxyOAuthRequest } from "@/utils/oauth-proxy";
 
 const authHandler = toNextJsHandler(auth);
@@ -7,7 +8,7 @@ const authHandler = toNextJsHandler(auth);
 export const GET = authHandler.GET;
 
 export function POST(request: Request) {
-  if (new URL(request.url).pathname === "/api/auth/oauth2/register") {
+  if (isOAuthDynamicClientRegistrationPath(new URL(request.url).pathname)) {
     return proxyOAuthRequest(request, "/oauth2/register");
   }
 

--- a/apps/dashboard/src/app/api/auth/[...all]/route.ts
+++ b/apps/dashboard/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,15 @@
 import { toNextJsHandler } from "better-auth/next-js";
 import { auth } from "@/lib/auth/server";
+import { proxyOAuthRequest } from "@/utils/oauth-proxy";
 
-export const { GET, POST } = toNextJsHandler(auth);
+const authHandler = toNextJsHandler(auth);
+
+export const GET = authHandler.GET;
+
+export function POST(request: Request) {
+  if (new URL(request.url).pathname === "/api/auth/oauth2/register") {
+    return proxyOAuthRequest(request, "/oauth2/register");
+  }
+
+  return authHandler.POST(request);
+}

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -47,6 +47,23 @@ export const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = [
   ...OAUTH_DEFAULT_SCOPES,
 ] as const;
 
+export const OAUTH_DYNAMIC_CLIENT_METADATA_FIELDS = [
+  "redirect_uris",
+  "scope",
+  "client_name",
+  "client_uri",
+  "logo_uri",
+  "contacts",
+  "tos_uri",
+  "policy_uri",
+  "software_id",
+  "software_version",
+  "software_statement",
+  "token_endpoint_auth_method",
+  "grant_types",
+  "response_types",
+] as const;
+
 export const OAUTH_GRANT_QUERY_PARAM = "grant";
 
 export const OAUTH_SCOPE_LEVEL = {

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -58,8 +58,6 @@ export const OAUTH_DYNAMIC_CLIENT_METADATA_FIELDS = [
   "policy_uri",
   "software_id",
   "software_version",
-  "software_statement",
-  "token_endpoint_auth_method",
   "grant_types",
   "response_types",
 ] as const;

--- a/apps/dashboard/src/constants/oauth.ts
+++ b/apps/dashboard/src/constants/oauth.ts
@@ -1,6 +1,6 @@
 export const OAUTH_AUTH_CODE_TTL_MS = 5 * 60 * 1000;
 export const OAUTH_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
-export const OAUTH_REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+export const OAUTH_REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 export const OAUTH_OFFLINE_ACCESS_SCOPE = "offline_access";
 
@@ -44,21 +44,7 @@ export const OAUTH_DEFAULT_SCOPES = [
 ] as const;
 
 export const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = [
-  "offline_access",
-  "posts.read",
-  "posts.write",
-  "brand-identities.read",
-  "brand-identities.write",
-  "integrations.read",
-  "integrations.write",
-  "schedules.read",
-  "schedules.write",
-  "event-triggers.read",
-  "event-triggers.write",
-  "chats.read",
-  "chats.write",
-  "skills.read",
-  "skills.write",
+  ...OAUTH_DEFAULT_SCOPES,
 ] as const;
 
 export const OAUTH_GRANT_QUERY_PARAM = "grant";

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -327,7 +327,7 @@ export const auth = betterAuth({
       refreshTokenExpiresIn: OAUTH_REFRESH_TOKEN_TTL_MS / 1000,
       allowPublicClientPrelogin: true,
       allowDynamicClientRegistration: true,
-      allowUnauthenticatedClientRegistration: true,
+      allowUnauthenticatedClientRegistration: false,
       clientRegistrationDefaultScopes: [
         ...OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
       ],

--- a/apps/dashboard/src/utils/oauth-client-registration.test.ts
+++ b/apps/dashboard/src/utils/oauth-client-registration.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { hasOnlyLoopbackRedirectUris } from "./oauth-client-registration";
+
+describe("hasOnlyLoopbackRedirectUris", () => {
+  test("allows HTTP loopback callbacks", () => {
+    assert.equal(
+      hasOnlyLoopbackRedirectUris({
+        redirect_uris: [
+          "http://127.0.0.1:4545/callback",
+          "http://[::1]:4545/callback",
+          "http://localhost:4545/callback",
+        ],
+      }),
+      true
+    );
+  });
+
+  test("rejects remote callbacks", () => {
+    assert.equal(
+      hasOnlyLoopbackRedirectUris({
+        redirect_uris: ["https://attacker.example/callback"],
+      }),
+      false
+    );
+  });
+
+  test("rejects credentials and malformed metadata", () => {
+    assert.equal(
+      hasOnlyLoopbackRedirectUris({
+        redirect_uris: ["http://user@localhost:4545/callback"],
+      }),
+      false
+    );
+    assert.equal(hasOnlyLoopbackRedirectUris({ redirect_uris: [] }), false);
+    assert.equal(hasOnlyLoopbackRedirectUris({}), false);
+  });
+});

--- a/apps/dashboard/src/utils/oauth-client-registration.test.ts
+++ b/apps/dashboard/src/utils/oauth-client-registration.test.ts
@@ -18,6 +18,14 @@ describe("hasOnlyLoopbackRedirectUris", () => {
       true
     );
     assert.equal(
+      isOAuthDynamicClientRegistrationPath("/api/auth/oauth2/register%2F"),
+      true
+    );
+    assert.equal(
+      isOAuthDynamicClientRegistrationPath("/api/auth//oauth2/register"),
+      true
+    );
+    assert.equal(
       isOAuthDynamicClientRegistrationPath("/api/auth/oauth2/token/"),
       false
     );
@@ -77,7 +85,9 @@ describe("hasOnlyLoopbackRedirectUris", () => {
         post_logout_redirect_uris: ["https://attacker.example/logout"],
         reference_id: "another-organization",
         skip_consent: true,
+        software_statement: "signed-client-metadata",
         subject_type: "pairwise",
+        token_endpoint_auth_method: "client_secret_basic",
         type: "web",
       }),
       {

--- a/apps/dashboard/src/utils/oauth-client-registration.test.ts
+++ b/apps/dashboard/src/utils/oauth-client-registration.test.ts
@@ -1,8 +1,28 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { hasOnlyLoopbackRedirectUris } from "./oauth-client-registration";
+import {
+  getDynamicClientRegistrationScope,
+  hasOnlyLoopbackRedirectUris,
+  isOAuthDynamicClientRegistrationPath,
+  pickDynamicClientMetadata,
+} from "./oauth-client-registration";
 
 describe("hasOnlyLoopbackRedirectUris", () => {
+  test("matches registration paths with trailing slashes", () => {
+    assert.equal(
+      isOAuthDynamicClientRegistrationPath("/api/auth/oauth2/register/"),
+      true
+    );
+    assert.equal(
+      isOAuthDynamicClientRegistrationPath("/api/auth/oauth2/register//"),
+      true
+    );
+    assert.equal(
+      isOAuthDynamicClientRegistrationPath("/api/auth/oauth2/token/"),
+      false
+    );
+  });
+
   test("allows HTTP loopback callbacks", () => {
     assert.equal(
       hasOnlyLoopbackRedirectUris({
@@ -23,6 +43,12 @@ describe("hasOnlyLoopbackRedirectUris", () => {
       }),
       false
     );
+    assert.equal(
+      hasOnlyLoopbackRedirectUris({
+        redirect_uris: ["http://evil.com/callback"],
+      }),
+      false
+    );
   });
 
   test("rejects credentials and malformed metadata", () => {
@@ -32,7 +58,46 @@ describe("hasOnlyLoopbackRedirectUris", () => {
       }),
       false
     );
+    assert.equal(
+      hasOnlyLoopbackRedirectUris({
+        redirect_uris: ["http://user:pass@localhost:4545/callback"],
+      }),
+      false
+    );
     assert.equal(hasOnlyLoopbackRedirectUris({ redirect_uris: [] }), false);
     assert.equal(hasOnlyLoopbackRedirectUris({}), false);
+  });
+
+  test("only forwards supported dynamic client metadata", () => {
+    assert.deepEqual(
+      pickDynamicClientMetadata({
+        redirect_uris: ["http://localhost:4545/callback"],
+        client_name: "Notra CLI",
+        disabled: false,
+        post_logout_redirect_uris: ["https://attacker.example/logout"],
+        reference_id: "another-organization",
+        skip_consent: true,
+        subject_type: "pairwise",
+        type: "web",
+      }),
+      {
+        redirect_uris: ["http://localhost:4545/callback"],
+        client_name: "Notra CLI",
+      }
+    );
+  });
+
+  test("only accepts configured registration scopes", () => {
+    assert.equal(
+      getDynamicClientRegistrationScope({
+        scope: "posts.read offline_access posts.read",
+      }),
+      "posts.read offline_access"
+    );
+    assert.equal(
+      getDynamicClientRegistrationScope({ scope: "posts.read admin" }),
+      null
+    );
+    assert.equal(getDynamicClientRegistrationScope({ scope: "" }), null);
   });
 });

--- a/apps/dashboard/src/utils/oauth-client-registration.ts
+++ b/apps/dashboard/src/utils/oauth-client-registration.ts
@@ -1,0 +1,29 @@
+const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost"]);
+
+export function hasOnlyLoopbackRedirectUris(payload: object): boolean {
+  if (!("redirect_uris" in payload) || !Array.isArray(payload.redirect_uris)) {
+    return false;
+  }
+
+  if (payload.redirect_uris.length === 0) {
+    return false;
+  }
+
+  return payload.redirect_uris.every((redirectUri) => {
+    if (typeof redirectUri !== "string") {
+      return false;
+    }
+
+    try {
+      const url = new URL(redirectUri);
+      return (
+        url.protocol === "http:" &&
+        LOOPBACK_HOSTNAMES.has(url.hostname) &&
+        url.username === "" &&
+        url.password === ""
+      );
+    } catch {
+      return false;
+    }
+  });
+}

--- a/apps/dashboard/src/utils/oauth-client-registration.ts
+++ b/apps/dashboard/src/utils/oauth-client-registration.ts
@@ -1,4 +1,19 @@
+import {
+  OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
+  OAUTH_DYNAMIC_CLIENT_METADATA_FIELDS,
+  OAUTH_SUPPORTED_SCOPE_SET,
+} from "@/constants/oauth";
+
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost"]);
+const TRAILING_SLASHES_PATTERN = /\/+$/;
+const WHITESPACE_PATTERN = /\s+/;
+
+export function isOAuthDynamicClientRegistrationPath(pathname: string) {
+  return (
+    pathname.replace(TRAILING_SLASHES_PATTERN, "") ===
+    "/api/auth/oauth2/register"
+  );
+}
 
 export function hasOnlyLoopbackRedirectUris(payload: object): boolean {
   if (!("redirect_uris" in payload) || !Array.isArray(payload.redirect_uris)) {
@@ -26,4 +41,38 @@ export function hasOnlyLoopbackRedirectUris(payload: object): boolean {
       return false;
     }
   });
+}
+
+export function pickDynamicClientMetadata(payload: object) {
+  const metadata: Record<string, unknown> = {};
+
+  for (const field of OAUTH_DYNAMIC_CLIENT_METADATA_FIELDS) {
+    if (field in payload) {
+      metadata[field] = payload[field as keyof typeof payload];
+    }
+  }
+
+  return metadata;
+}
+
+export function getDynamicClientRegistrationScope(
+  payload: object
+): string | null {
+  if (!("scope" in payload)) {
+    return OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES.join(" ");
+  }
+
+  if (typeof payload.scope !== "string") {
+    return null;
+  }
+
+  const scopes = [...new Set(payload.scope.trim().split(WHITESPACE_PATTERN))];
+  if (
+    scopes.length === 0 ||
+    scopes.some((scope) => !scope || !OAUTH_SUPPORTED_SCOPE_SET.has(scope))
+  ) {
+    return null;
+  }
+
+  return scopes.join(" ");
 }

--- a/apps/dashboard/src/utils/oauth-client-registration.ts
+++ b/apps/dashboard/src/utils/oauth-client-registration.ts
@@ -5,13 +5,22 @@ import {
 } from "@/constants/oauth";
 
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost"]);
+const REPEATED_SLASHES_PATTERN = /\/{2,}/g;
 const TRAILING_SLASHES_PATTERN = /\/+$/;
 const WHITESPACE_PATTERN = /\s+/;
 
 export function isOAuthDynamicClientRegistrationPath(pathname: string) {
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(pathname);
+  } catch {
+    return false;
+  }
+
   return (
-    pathname.replace(TRAILING_SLASHES_PATTERN, "") ===
-    "/api/auth/oauth2/register"
+    decodedPathname
+      .replace(REPEATED_SLASHES_PATTERN, "/")
+      .replace(TRAILING_SLASHES_PATTERN, "") === "/api/auth/oauth2/register"
   );
 }
 

--- a/apps/dashboard/src/utils/oauth-proxy.ts
+++ b/apps/dashboard/src/utils/oauth-proxy.ts
@@ -1,6 +1,9 @@
-import { OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES } from "@/constants/oauth";
 import { auth } from "@/lib/auth/server";
-import { hasOnlyLoopbackRedirectUris } from "@/utils/oauth-client-registration";
+import {
+  getDynamicClientRegistrationScope,
+  hasOnlyLoopbackRedirectUris,
+  pickDynamicClientMetadata,
+} from "@/utils/oauth-client-registration";
 
 const AUTH_ROUTE_PREFIX = "/api/auth";
 const INTERNAL_AUTH_ORIGIN = "http://notra.internal";
@@ -55,13 +58,15 @@ function secureRegistrationBody(body: ArrayBuffer) {
       return null;
     }
 
+    const scope = getDynamicClientRegistrationScope(payload);
+    if (!scope) {
+      return null;
+    }
+
     return new TextEncoder().encode(
       JSON.stringify({
-        ...payload,
-        scope:
-          "scope" in payload && typeof payload.scope === "string"
-            ? payload.scope
-            : OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES.join(" "),
+        ...pickDynamicClientMetadata(payload),
+        scope,
       })
     ).buffer;
   } catch {
@@ -92,9 +97,9 @@ export async function proxyOAuthRequest(request: Request, pathname: string) {
   if (rawBody && pathname === REGISTER_PATH && !body) {
     return Response.json(
       {
-        error: "invalid_redirect_uri",
+        error: "invalid_client_metadata",
         error_description:
-          "Dynamic clients must use an HTTP loopback redirect URI",
+          "Dynamic clients must use HTTP loopback redirect URIs and supported scopes",
       },
       { status: 400 }
     );

--- a/apps/dashboard/src/utils/oauth-proxy.ts
+++ b/apps/dashboard/src/utils/oauth-proxy.ts
@@ -111,7 +111,7 @@ export async function proxyOAuthRequest(request: Request, pathname: string) {
 
   const headers = new Headers(response.headers);
 
-  if (pathname === TOKEN_PATH) {
+  if (pathname === TOKEN_PATH || pathname === REGISTER_PATH) {
     headers.set("Cache-Control", "no-store");
     headers.set("Pragma", "no-cache");
   }

--- a/apps/dashboard/src/utils/oauth-proxy.ts
+++ b/apps/dashboard/src/utils/oauth-proxy.ts
@@ -1,8 +1,6 @@
-import {
-  OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
-  OAUTH_OFFLINE_ACCESS_SCOPE,
-} from "@/constants/oauth";
+import { OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES } from "@/constants/oauth";
 import { auth } from "@/lib/auth/server";
+import { hasOnlyLoopbackRedirectUris } from "@/utils/oauth-client-registration";
 
 const AUTH_ROUTE_PREFIX = "/api/auth";
 const INTERNAL_AUTH_ORIGIN = "http://notra.internal";
@@ -45,42 +43,29 @@ export function buildOAuthForwardedHeaders(
   return headers;
 }
 
-const REGISTRATION_SCOPE_SEPARATOR = " ";
-const REGISTRATION_SCOPE_SPLIT_REGEX = /\s+/;
-
-function ensureOfflineAccessScope(scope: string) {
-  const scopes = scope.split(REGISTRATION_SCOPE_SPLIT_REGEX).filter(Boolean);
-
-  if (!scopes.includes(OAUTH_OFFLINE_ACCESS_SCOPE)) {
-    scopes.push(OAUTH_OFFLINE_ACCESS_SCOPE);
-  }
-
-  return scopes.join(REGISTRATION_SCOPE_SEPARATOR);
-}
-
-function withDefaultRegistrationScopes(body: ArrayBuffer) {
+function secureRegistrationBody(body: ArrayBuffer) {
   try {
     const payload = JSON.parse(new TextDecoder().decode(body));
 
     if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-      return body;
+      return null;
     }
 
-    const requestedScope =
-      "scope" in payload && typeof payload.scope === "string"
-        ? payload.scope
-        : OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES.join(
-            REGISTRATION_SCOPE_SEPARATOR
-          );
+    if (!hasOnlyLoopbackRedirectUris(payload)) {
+      return null;
+    }
 
     return new TextEncoder().encode(
       JSON.stringify({
         ...payload,
-        scope: ensureOfflineAccessScope(requestedScope),
+        scope:
+          "scope" in payload && typeof payload.scope === "string"
+            ? payload.scope
+            : OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES.join(" "),
       })
     ).buffer;
   } catch {
-    return body;
+    return null;
   }
 }
 
@@ -101,8 +86,19 @@ export async function proxyOAuthRequest(request: Request, pathname: string) {
       : await request.arrayBuffer();
   const body =
     rawBody && pathname === REGISTER_PATH
-      ? withDefaultRegistrationScopes(rawBody)
+      ? secureRegistrationBody(rawBody)
       : rawBody;
+
+  if (rawBody && pathname === REGISTER_PATH && !body) {
+    return Response.json(
+      {
+        error: "invalid_redirect_uri",
+        error_description:
+          "Dynamic clients must use an HTTP loopback redirect URI",
+      },
+      { status: 400 }
+    );
+  }
 
   const response = await auth.handler(
     new Request(targetUrl, {

--- a/apps/dashboard/src/utils/oauth-proxy.ts
+++ b/apps/dashboard/src/utils/oauth-proxy.ts
@@ -67,6 +67,7 @@ function secureRegistrationBody(body: ArrayBuffer) {
       JSON.stringify({
         ...pickDynamicClientMetadata(payload),
         scope,
+        token_endpoint_auth_method: "none",
       })
     ).buffer;
   } catch {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened OAuth dynamic client registration and proxied the raw registration route. Clients must use HTTP loopback redirect URIs; registration now requires auth; only safe metadata is forwarded; scopes are validated/defaulted; refresh token TTL is 30 days.

- **Bug Fixes**
  - Enforce loopback-only redirect URIs (no credentials) and forward only allowed metadata; force `token_endpoint_auth_method: "none"`; invalid requests return 400 `invalid_client_metadata`; token and registration responses are `no-store`.
  - Validate registration scopes (dedupe; must be in `OAUTH_SUPPORTED_SCOPE_SET`); default to `OAUTH_DEFAULT_SCOPES` when absent.
  - Normalize dynamic registration route matching (handles repeated/trailing slashes and encoded paths) and proxy it via the OAuth handler.
  - Disable unauthenticated client registration.
  - Reduce `OAUTH_REFRESH_TOKEN_TTL_MS` from 90d to 30d.
  - Tests/CI: add unit tests for path matching, URI checks, metadata picking, and scope validation; include dashboard tests in `knip` entry.

<sup>Written for commit 9de816e8d85574d7cbb7de933e67024545ec5ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`9de816e`](https://github.com/usenotra/notra/commit/9de816e8d85574d7cbb7de933e67024545ec5ee9). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->