### PR TITLE
fix(chat): validate stream ownership

### DIFF
--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/[chatId]/stream/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/[chatId]/stream/route.ts
@@ -1,5 +1,6 @@
 import {
   getActiveChatStream,
+  getChatSession,
   getChatStreamChannelName,
 } from "@notra/ai/chat/history";
 import { realtime } from "@notra/ai/realtime";
@@ -22,6 +23,11 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 
   if (!auth.success) {
     return auth.response;
+  }
+
+  const session = await getChatSession(organizationId, chatId);
+  if (!session) {
+    return Response.json({ error: "Chat not found" }, { status: 404 });
   }
 
   const activeStreamId = await getActiveChatStream(organizationId, chatId);


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the chat stream endpoint only serves existing sessions within the organization. Returns 404 when the `chatId` is invalid or not owned by the org.

- **Bug Fixes**
  - Added `getChatSession(organizationId, chatId)` check before streaming.
  - Respond with 404 if the session is missing, preventing unauthorized stream access.

<sup>Written for commit 69a0ff23acad051323d68eef8ca12b803a75c3a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

1 issue found.

<sub>Written for commit `69a0ff2`. New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->