### PR TITLE
fix(api): enforce organization chat rate limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@ NEXT_PUBLIC_C15T_BACKEND_URL=https://development-notra.inth.app
 
 # Autumn Billing
 AUTUMN_SECRET_KEY=
+ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false
 
 # Workflows
 NEXT_PUBLIC_APP_URL=

--- a/apps/api/src/routes/chats.ts
+++ b/apps/api/src/routes/chats.ts
@@ -20,8 +20,8 @@ import {
 } from "../schemas/chats";
 import { getOrganizationId } from "../utils/auth";
 import { createOpenApiApp, formatValidationError } from "../utils/openapi-app";
-import { errorResponse } from "../utils/openapi-responses";
-import { enforceRatelimit, ratelimit } from "../utils/ratelimit";
+import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
+import { enforceRatelimit, RATE_LIMITS, ratelimit } from "../utils/ratelimit";
 
 export const chatsRoutes = createOpenApiApp();
 
@@ -156,16 +156,16 @@ async function handleSend(
       requestId,
     });
 
-    const rateLimited = await enforceRatelimit(c, ratelimit.chatGeneration);
-    if (rateLimited) {
-      return rateLimited;
-    }
-
     const body = await c.req.json().catch(() => null);
     const parseResult = sendChatMessageRequestSchema.safeParse(body);
 
     if (!parseResult.success) {
       return c.json({ error: formatValidationError(parseResult.error) }, 400);
+    }
+
+    const rateLimited = await enforceRatelimit(c, ratelimit.chatGeneration);
+    if (rateLimited) {
+      return rateLimited;
     }
 
     return await runChatMessage({
@@ -219,6 +219,10 @@ const streamingChatResponses = {
   401: errorResponse("Missing or invalid API key"),
   403: errorResponse("Forbidden, or usage limit reached"),
   404: errorResponse("Chat not found"),
+  429: rateLimitResponse(
+    RATE_LIMITS.chatGeneration.requests,
+    RATE_LIMITS.chatGeneration.window
+  ),
   500: errorResponse("Failed to process chat request"),
   503: errorResponse("Authentication service unavailable"),
 };

--- a/apps/api/src/routes/chats.ts
+++ b/apps/api/src/routes/chats.ts
@@ -163,7 +163,11 @@ async function handleSend(
       return c.json({ error: formatValidationError(parseResult.error) }, 400);
     }
 
-    const rateLimited = await enforceRatelimit(c, ratelimit.chatGeneration);
+    const rateLimited = await enforceRatelimit(
+      c,
+      ratelimit.chatGeneration,
+      "organization"
+    );
     if (rateLimited) {
       return rateLimited;
     }

--- a/apps/api/src/routes/chats.ts
+++ b/apps/api/src/routes/chats.ts
@@ -21,6 +21,7 @@ import {
 import { getOrganizationId } from "../utils/auth";
 import { createOpenApiApp, formatValidationError } from "../utils/openapi-app";
 import { errorResponse } from "../utils/openapi-responses";
+import { enforceRatelimit, ratelimit } from "../utils/ratelimit";
 
 export const chatsRoutes = createOpenApiApp();
 
@@ -154,6 +155,11 @@ async function handleSend(
       organizationId,
       requestId,
     });
+
+    const rateLimited = await enforceRatelimit(c, ratelimit.chatGeneration);
+    if (rateLimited) {
+      return rateLimited;
+    }
 
     const body = await c.req.json().catch(() => null);
     const parseResult = sendChatMessageRequestSchema.safeParse(body);

--- a/apps/api/src/utils/openapi-responses.ts
+++ b/apps/api/src/utils/openapi-responses.ts
@@ -42,7 +42,7 @@ const rateLimitHeaderDescriptors = {
 
 export function rateLimitResponse(limit: number, window: string) {
   return {
-    description: `Rate limit exceeded. This endpoint allows ${limit} requests per ${window} per API key.`,
+    description: `Rate limit exceeded. This endpoint allows ${limit} requests per ${window} per organization.`,
     headers: rateLimitHeaderDescriptors,
     content: {
       "application/json": {

--- a/apps/api/src/utils/ratelimit.ts
+++ b/apps/api/src/utils/ratelimit.ts
@@ -59,10 +59,21 @@ export const ratelimit = {
   }),
 };
 
-function getRatelimitKey(c: Context): string {
-  const organizationId = c.get("auth") ? getOrganizationId(c) : null;
-  if (organizationId) {
-    return organizationId;
+type RatelimitScope = "credential" | "organization";
+
+function getRatelimitKey(c: Context, scope: RatelimitScope): string {
+  const auth = c.get("auth");
+  if (auth) {
+    if (scope === "organization") {
+      const organizationId = getOrganizationId(c);
+      if (organizationId) {
+        return organizationId;
+      }
+    }
+
+    if (auth.keyId) {
+      return auth.keyId;
+    }
   }
 
   const forwardedFor = c.req.header("x-forwarded-for");
@@ -89,8 +100,12 @@ function setRatelimitHeaders(
   return resetSeconds;
 }
 
-export async function enforceRatelimit(c: Context, limiter: Ratelimit) {
-  const result = await limiter.limit(getRatelimitKey(c));
+export async function enforceRatelimit(
+  c: Context,
+  limiter: Ratelimit,
+  scope: RatelimitScope = "credential"
+) {
+  const result = await limiter.limit(getRatelimitKey(c, scope));
   const resetSeconds = setRatelimitHeaders(c, result);
 
   if (result.success) {

--- a/apps/api/src/utils/ratelimit.ts
+++ b/apps/api/src/utils/ratelimit.ts
@@ -1,12 +1,18 @@
+import { CHAT_GENERATION_RATE_LIMIT } from "@notra/ai/constants/rate-limits";
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import type { Context } from "hono";
+import { getOrganizationId } from "./auth";
 
 const redis = Redis.fromEnv();
 
 export const RATE_LIMITS = {
   postGeneration: { requests: 10, window: "1 minute" },
   brandGeneration: { requests: 5, window: "1 minute" },
+  chatGeneration: {
+    requests: CHAT_GENERATION_RATE_LIMIT.requests,
+    window: CHAT_GENERATION_RATE_LIMIT.windowLabel,
+  },
   integrationCreate: { requests: 20, window: "1 minute" },
   postUpdate: { requests: 60, window: "1 minute" },
 } as const;
@@ -27,6 +33,15 @@ export const ratelimit = {
       "1m"
     ),
   }),
+  chatGeneration: new Ratelimit({
+    redis,
+    analytics: true,
+    prefix: "ratelimit:chat-generation",
+    limiter: Ratelimit.slidingWindow(
+      CHAT_GENERATION_RATE_LIMIT.requests,
+      CHAT_GENERATION_RATE_LIMIT.window
+    ),
+  }),
   integrationCreate: new Ratelimit({
     redis,
     analytics: true,
@@ -45,9 +60,9 @@ export const ratelimit = {
 };
 
 function getRatelimitKey(c: Context): string {
-  const auth = c.get("auth") as { keyId?: string } | undefined;
-  if (auth?.keyId) {
-    return auth.keyId;
+  const organizationId = c.get("auth") ? getOrganizationId(c) : null;
+  if (organizationId) {
+    return organizationId;
   }
 
   const forwardedFor = c.req.header("x-forwarded-for");

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -64,11 +64,6 @@ export const POST = withEvlog(async function POST(
       return auth.response;
     }
 
-    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
-    if (rateLimited) {
-      return rateLimited;
-    }
-
     let useMarkup = false;
     if (autumn) {
       let checkData: CheckResponse | null = null;
@@ -101,6 +96,11 @@ export const POST = withEvlog(async function POST(
       }
 
       useMarkup = shouldApplyMarkup(checkData?.balance ?? null);
+    } else if (process.env.NODE_ENV === "production") {
+      return NextResponse.json(
+        { error: "Billing service is unavailable", code: "BILLING_ERROR" },
+        { status: 503 }
+      );
     }
 
     const body = await request.json();
@@ -114,6 +114,11 @@ export const POST = withEvlog(async function POST(
     }
 
     const { messages } = parseResult.data;
+    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    if (rateLimited) {
+      return rateLimited;
+    }
+
     const chatId = parseResult.data.chatId ?? generateChatId();
     cleanupOrganizationId = organizationId;
     cleanupChatId = chatId;

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -36,6 +36,7 @@ import { NextResponse } from "next/server";
 import { withOrganizationAuth } from "@/lib/auth/organization";
 import { buildStandaloneChatTelemetryMetadata } from "@/lib/tcc";
 import type { RouteContext } from "@/types/api/routes";
+import { enforceChatGenerationRatelimit } from "@/utils/chat-ratelimit";
 
 export const maxDuration = 300;
 
@@ -61,6 +62,11 @@ export const POST = withEvlog(async function POST(
 
     if (!auth.success) {
       return auth.response;
+    }
+
+    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    if (rateLimited) {
+      return rateLimited;
     }
 
     let useMarkup = false;

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -64,6 +64,21 @@ export const POST = withEvlog(async function POST(
       return auth.response;
     }
 
+    const body = await request.json().catch(() => null);
+    const parseResult = standaloneChatRequestSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: parseResult.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    if (rateLimited) {
+      return rateLimited;
+    }
+
     let useMarkup = false;
     if (autumn) {
       let checkData: CheckResponse | null = null;
@@ -103,22 +118,7 @@ export const POST = withEvlog(async function POST(
       );
     }
 
-    const body = await request.json();
-    const parseResult = standaloneChatRequestSchema.safeParse(body);
-
-    if (!parseResult.success) {
-      return NextResponse.json(
-        { error: "Invalid request body", details: parseResult.error.issues },
-        { status: 400 }
-      );
-    }
-
     const { messages } = parseResult.data;
-    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
-    if (rateLimited) {
-      return rateLimited;
-    }
-
     const chatId = parseResult.data.chatId ?? generateChatId();
     cleanupOrganizationId = organizationId;
     cleanupChatId = chatId;
@@ -503,9 +503,6 @@ async function createDirectStandaloneChatResponse({
         }
         if (InvalidToolInputError.isInstance(error)) {
           return "The assistant called a tool with invalid inputs and couldn't recover. Please try sending your message again.";
-        }
-        if (error instanceof Error) {
-          return error.message;
         }
         return "An error occurred while processing your request.";
       },

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/chat/route.ts
@@ -1,5 +1,8 @@
 import { calculateAiCreditCostCents } from "@notra/ai/billing/ai-credit-cost";
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import { startChatAbortPolling } from "@notra/ai/chat/abort-polling";
@@ -74,7 +77,10 @@ export const POST = withEvlog(async function POST(
       );
     }
 
-    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    const rateLimited = await enforceChatGenerationRatelimit(
+      organizationId,
+      auth.context.user.id
+    );
     if (rateLimited) {
       return rateLimited;
     }
@@ -111,7 +117,7 @@ export const POST = withEvlog(async function POST(
       }
 
       useMarkup = shouldApplyMarkup(checkData?.balance ?? null);
-    } else if (process.env.NODE_ENV === "production") {
+    } else if (!allowUnmeteredAiInDevelopment) {
       return NextResponse.json(
         { error: "Billing service is unavailable", code: "BILLING_ERROR" },
         { status: 503 }

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
@@ -22,6 +22,7 @@ import { NextResponse } from "next/server";
 import { withOrganizationAuth } from "@/lib/auth/organization";
 import { chatRequestSchema } from "@/schemas/content";
 import type { RouteContext } from "@/types/api/routes";
+import { enforceChatGenerationRatelimit } from "@/utils/chat-ratelimit";
 
 export const maxDuration = 60;
 
@@ -46,6 +47,11 @@ export const POST = withEvlog(async function POST(
 
     if (!auth.success) {
       return auth.response;
+    }
+
+    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    if (rateLimited) {
+      return rateLimited;
     }
 
     let useMarkup = false;

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
@@ -1,5 +1,8 @@
 import { calculateAiCreditCostCents } from "@notra/ai/billing/ai-credit-cost";
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import { useLogger, withEvlog } from "@notra/ai/evlog";
@@ -59,7 +62,10 @@ export const POST = withEvlog(async function POST(
       );
     }
 
-    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    const rateLimited = await enforceChatGenerationRatelimit(
+      organizationId,
+      auth.context.user.id
+    );
     if (rateLimited) {
       return rateLimited;
     }
@@ -108,7 +114,7 @@ export const POST = withEvlog(async function POST(
 
       useMarkup = shouldApplyMarkup(checkData?.balance ?? null);
     } else {
-      if (process.env.NODE_ENV === "production") {
+      if (!allowUnmeteredAiInDevelopment) {
         return NextResponse.json(
           { error: "Billing service is unavailable", code: "BILLING_ERROR" },
           { status: 503 }

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
@@ -49,11 +49,6 @@ export const POST = withEvlog(async function POST(
       return auth.response;
     }
 
-    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
-    if (rateLimited) {
-      return rateLimited;
-    }
-
     let useMarkup = false;
     if (autumn) {
       console.log("[Autumn] Checking feature access:", {
@@ -98,6 +93,12 @@ export const POST = withEvlog(async function POST(
 
       useMarkup = shouldApplyMarkup(checkData?.balance ?? null);
     } else {
+      if (process.env.NODE_ENV === "production") {
+        return NextResponse.json(
+          { error: "Billing service is unavailable", code: "BILLING_ERROR" },
+          { status: 503 }
+        );
+      }
       console.log(
         "[Autumn] Skipping billing check - AUTUMN_SECRET_KEY not configured",
         { requestId }
@@ -112,6 +113,11 @@ export const POST = withEvlog(async function POST(
         { error: "Invalid request body", details: parseResult.error.issues },
         { status: 400 }
       );
+    }
+
+    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    if (rateLimited) {
+      return rateLimited;
     }
 
     const {

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
@@ -49,6 +49,21 @@ export const POST = withEvlog(async function POST(
       return auth.response;
     }
 
+    const body = await request.json().catch(() => null);
+    const parseResult = chatRequestSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: parseResult.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
+    if (rateLimited) {
+      return rateLimited;
+    }
+
     let useMarkup = false;
     if (autumn) {
       console.log("[Autumn] Checking feature access:", {
@@ -103,21 +118,6 @@ export const POST = withEvlog(async function POST(
         "[Autumn] Skipping billing check - AUTUMN_SECRET_KEY not configured",
         { requestId }
       );
-    }
-
-    const body = await request.json();
-    const parseResult = chatRequestSchema.safeParse(body);
-
-    if (!parseResult.success) {
-      return NextResponse.json(
-        { error: "Invalid request body", details: parseResult.error.issues },
-        { status: 400 }
-      );
-    }
-
-    const rateLimited = await enforceChatGenerationRatelimit(organizationId);
-    if (rateLimited) {
-      return rateLimited;
     }
 
     const {
@@ -236,9 +236,6 @@ export const POST = withEvlog(async function POST(
     return stream.toUIMessageStreamResponse({
       onError: (error) => {
         console.error("[Content Chat] Stream error:", { requestId, error });
-        if (error instanceof Error) {
-          return error.message;
-        }
         return "An error occurred while processing your request.";
       },
     });

--- a/apps/dashboard/src/utils/chat-ratelimit.ts
+++ b/apps/dashboard/src/utils/chat-ratelimit.ts
@@ -2,28 +2,131 @@ import {
   CHAT_GENERATION_RATE_LIMIT,
   CHAT_GENERATION_USER_RATE_LIMIT,
 } from "@notra/ai/constants/rate-limits";
-import { Ratelimit } from "@upstash/ratelimit";
+import { type Algorithm, Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { NextResponse } from "next/server";
+
+const ORGANIZATION_PREFIX = "ratelimit:chat-generation";
+const USER_PREFIX = "ratelimit:dashboard-chat-generation-user";
+const DUAL_LIMIT_PREFIX = "ratelimit:dashboard-chat-generation-dual";
+const WINDOW_MS = 60_000;
+
+const DUAL_SLIDING_WINDOW_SCRIPT = `
+local orgCurrent = KEYS[1]
+local orgPrevious = KEYS[2]
+local userCurrent = KEYS[3]
+local userPrevious = KEYS[4]
+local orgLimit = tonumber(ARGV[1])
+local userLimit = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local window = tonumber(ARGV[4])
+local consume = tonumber(ARGV[5])
+
+local function weightedUsage(currentKey, previousKey)
+  local current = tonumber(redis.call("GET", currentKey) or "0")
+  local previous = tonumber(redis.call("GET", previousKey) or "0")
+  local percentageInCurrent = (now % window) / window
+  return current + math.floor((1 - percentageInCurrent) * previous)
+end
+
+local orgUsed = weightedUsage(orgCurrent, orgPrevious)
+local userUsed = weightedUsage(userCurrent, userPrevious)
+
+if orgUsed >= orgLimit then
+  return {-1, orgLimit}
+end
+if userUsed >= userLimit then
+  return {-1, userLimit}
+end
+
+if consume == 1 then
+  local orgValue = redis.call("INCR", orgCurrent)
+  local userValue = redis.call("INCR", userCurrent)
+  if orgValue == 1 then redis.call("PEXPIRE", orgCurrent, window * 2 + 1000) end
+  if userValue == 1 then redis.call("PEXPIRE", userCurrent, window * 2 + 1000) end
+  orgUsed = orgUsed + 1
+  userUsed = userUsed + 1
+end
+
+local orgRemaining = orgLimit - orgUsed
+local userRemaining = userLimit - userUsed
+if orgRemaining <= userRemaining then
+  return {orgRemaining, orgLimit}
+end
+return {userRemaining, userLimit}
+`;
+
+interface ChatRatelimitContext {
+  redis: Redis;
+  prefix: string;
+}
+
+function getDualLimitKeys(identifier: string, now: number) {
+  const encodedIds = identifier.slice(`${DUAL_LIMIT_PREFIX}:`.length);
+  const [organizationId, userId] = JSON.parse(encodedIds) as [string, string];
+  const currentWindow = Math.floor(now / WINDOW_MS);
+
+  return [
+    `${ORGANIZATION_PREFIX}:${organizationId}:${currentWindow}`,
+    `${ORGANIZATION_PREFIX}:${organizationId}:${currentWindow - 1}`,
+    `${USER_PREFIX}:${organizationId}:${userId}:${currentWindow}`,
+    `${USER_PREFIX}:${organizationId}:${userId}:${currentWindow - 1}`,
+  ];
+}
+
+function dualChatGenerationLimiter(): Algorithm<ChatRatelimitContext> {
+  return () => ({
+    async limit(context, identifier) {
+      const now = Date.now();
+      const [remaining, limit] = await context.redis.eval<
+        [number, number, number, number, number],
+        [number, number]
+      >(DUAL_SLIDING_WINDOW_SCRIPT, getDualLimitKeys(identifier, now), [
+        CHAT_GENERATION_RATE_LIMIT.requests,
+        CHAT_GENERATION_USER_RATE_LIMIT.requests,
+        now,
+        WINDOW_MS,
+        1,
+      ]);
+
+      return {
+        success: remaining >= 0,
+        limit,
+        remaining: Math.max(0, remaining),
+        reset: (Math.floor(now / WINDOW_MS) + 1) * WINDOW_MS,
+        pending: Promise.resolve(),
+      };
+    },
+    async getRemaining(context, identifier) {
+      const now = Date.now();
+      const [remaining, limit] = await context.redis.eval<
+        [number, number, number, number, number],
+        [number, number]
+      >(DUAL_SLIDING_WINDOW_SCRIPT, getDualLimitKeys(identifier, now), [
+        CHAT_GENERATION_RATE_LIMIT.requests,
+        CHAT_GENERATION_USER_RATE_LIMIT.requests,
+        now,
+        WINDOW_MS,
+        0,
+      ]);
+
+      return {
+        limit,
+        remaining: Math.max(0, remaining),
+        reset: (Math.floor(now / WINDOW_MS) + 1) * WINDOW_MS,
+      };
+    },
+    async resetTokens(context, identifier) {
+      await context.redis.del(...getDualLimitKeys(identifier, Date.now()));
+    },
+  });
+}
 
 const chatGenerationRatelimit = new Ratelimit({
   redis: Redis.fromEnv(),
   analytics: true,
-  prefix: "ratelimit:chat-generation",
-  limiter: Ratelimit.slidingWindow(
-    CHAT_GENERATION_RATE_LIMIT.requests,
-    CHAT_GENERATION_RATE_LIMIT.window
-  ),
-});
-
-const userChatGenerationRatelimit = new Ratelimit({
-  redis: Redis.fromEnv(),
-  analytics: true,
-  prefix: "ratelimit:dashboard-chat-generation-user",
-  limiter: Ratelimit.slidingWindow(
-    CHAT_GENERATION_USER_RATE_LIMIT.requests,
-    CHAT_GENERATION_USER_RATE_LIMIT.window
-  ),
+  prefix: DUAL_LIMIT_PREFIX,
+  limiter: dualChatGenerationLimiter(),
 });
 
 function rateLimitedResponse(result: {
@@ -62,33 +165,11 @@ export async function enforceChatGenerationRatelimit(
   organizationId: string,
   userId: string
 ): Promise<NextResponse | null> {
-  const organizationAvailability =
-    await chatGenerationRatelimit.getRemaining(organizationId);
-  let organizationReservationMade = false;
-  if (organizationAvailability.remaining <= 0) {
-    const organizationResult =
-      await chatGenerationRatelimit.limit(organizationId);
-    if (!organizationResult.success) {
-      return rateLimitedResponse(organizationResult);
-    }
-    organizationReservationMade = true;
-  }
-
-  const userResult = await userChatGenerationRatelimit.limit(
-    `${organizationId}:${userId}`
+  const result = await chatGenerationRatelimit.limit(
+    JSON.stringify([organizationId, userId])
   );
-  if (!userResult.success) {
-    return rateLimitedResponse(userResult);
-  }
-
-  if (organizationReservationMade) {
-    return null;
-  }
-
-  const organizationResult =
-    await chatGenerationRatelimit.limit(organizationId);
-  if (!organizationResult.success) {
-    return rateLimitedResponse(organizationResult);
+  if (!result.success) {
+    return rateLimitedResponse(result);
   }
 
   return null;

--- a/apps/dashboard/src/utils/chat-ratelimit.ts
+++ b/apps/dashboard/src/utils/chat-ratelimit.ts
@@ -1,0 +1,49 @@
+import { CHAT_GENERATION_RATE_LIMIT } from "@notra/ai/constants/rate-limits";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { NextResponse } from "next/server";
+
+const chatGenerationRatelimit = new Ratelimit({
+  redis: Redis.fromEnv(),
+  analytics: true,
+  prefix: "ratelimit:chat-generation",
+  limiter: Ratelimit.slidingWindow(
+    CHAT_GENERATION_RATE_LIMIT.requests,
+    CHAT_GENERATION_RATE_LIMIT.window
+  ),
+});
+
+export async function enforceChatGenerationRatelimit(
+  organizationId: string
+): Promise<NextResponse | null> {
+  const result = await chatGenerationRatelimit.limit(organizationId);
+  const resetSeconds = Math.max(
+    0,
+    Math.ceil((result.reset - Date.now()) / 1000)
+  );
+
+  if (result.success) {
+    return null;
+  }
+
+  return NextResponse.json(
+    {
+      error: "Rate limit exceeded",
+      limit: result.limit,
+      remaining: Math.max(0, result.remaining),
+      reset: result.reset,
+    },
+    {
+      status: 429,
+      headers: {
+        "RateLimit-Limit": String(result.limit),
+        "RateLimit-Remaining": String(Math.max(0, result.remaining)),
+        "RateLimit-Reset": String(resetSeconds),
+        "Retry-After": String(resetSeconds),
+        "X-RateLimit-Limit": String(result.limit),
+        "X-RateLimit-Remaining": String(Math.max(0, result.remaining)),
+        "X-RateLimit-Reset": String(Math.ceil(result.reset / 1000)),
+      },
+    }
+  );
+}

--- a/apps/dashboard/src/utils/chat-ratelimit.ts
+++ b/apps/dashboard/src/utils/chat-ratelimit.ts
@@ -62,6 +62,12 @@ export async function enforceChatGenerationRatelimit(
   organizationId: string,
   userId: string
 ): Promise<NextResponse | null> {
+  const organizationAvailability =
+    await chatGenerationRatelimit.getRemaining(organizationId);
+  if (organizationAvailability.remaining <= 0) {
+    return rateLimitedResponse(organizationAvailability);
+  }
+
   const userResult = await userChatGenerationRatelimit.limit(
     `${organizationId}:${userId}`
   );

--- a/apps/dashboard/src/utils/chat-ratelimit.ts
+++ b/apps/dashboard/src/utils/chat-ratelimit.ts
@@ -64,8 +64,14 @@ export async function enforceChatGenerationRatelimit(
 ): Promise<NextResponse | null> {
   const organizationAvailability =
     await chatGenerationRatelimit.getRemaining(organizationId);
+  let organizationReservationMade = false;
   if (organizationAvailability.remaining <= 0) {
-    return rateLimitedResponse(organizationAvailability);
+    const organizationResult =
+      await chatGenerationRatelimit.limit(organizationId);
+    if (!organizationResult.success) {
+      return rateLimitedResponse(organizationResult);
+    }
+    organizationReservationMade = true;
   }
 
   const userResult = await userChatGenerationRatelimit.limit(
@@ -73,6 +79,10 @@ export async function enforceChatGenerationRatelimit(
   );
   if (!userResult.success) {
     return rateLimitedResponse(userResult);
+  }
+
+  if (organizationReservationMade) {
+    return null;
   }
 
   const organizationResult =

--- a/apps/dashboard/src/utils/chat-ratelimit.ts
+++ b/apps/dashboard/src/utils/chat-ratelimit.ts
@@ -1,4 +1,7 @@
-import { CHAT_GENERATION_RATE_LIMIT } from "@notra/ai/constants/rate-limits";
+import {
+  CHAT_GENERATION_RATE_LIMIT,
+  CHAT_GENERATION_USER_RATE_LIMIT,
+} from "@notra/ai/constants/rate-limits";
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { NextResponse } from "next/server";
@@ -13,18 +16,25 @@ const chatGenerationRatelimit = new Ratelimit({
   ),
 });
 
-export async function enforceChatGenerationRatelimit(
-  organizationId: string
-): Promise<NextResponse | null> {
-  const result = await chatGenerationRatelimit.limit(organizationId);
+const userChatGenerationRatelimit = new Ratelimit({
+  redis: Redis.fromEnv(),
+  analytics: true,
+  prefix: "ratelimit:dashboard-chat-generation-user",
+  limiter: Ratelimit.slidingWindow(
+    CHAT_GENERATION_USER_RATE_LIMIT.requests,
+    CHAT_GENERATION_USER_RATE_LIMIT.window
+  ),
+});
+
+function rateLimitedResponse(result: {
+  limit: number;
+  remaining: number;
+  reset: number;
+}) {
   const resetSeconds = Math.max(
     0,
     Math.ceil((result.reset - Date.now()) / 1000)
   );
-
-  if (result.success) {
-    return null;
-  }
 
   return NextResponse.json(
     {
@@ -46,4 +56,24 @@ export async function enforceChatGenerationRatelimit(
       },
     }
   );
+}
+
+export async function enforceChatGenerationRatelimit(
+  organizationId: string,
+  userId: string
+): Promise<NextResponse | null> {
+  const userResult = await userChatGenerationRatelimit.limit(
+    `${organizationId}:${userId}`
+  );
+  if (!userResult.success) {
+    return rateLimitedResponse(userResult);
+  }
+
+  const organizationResult =
+    await chatGenerationRatelimit.limit(organizationId);
+  if (!organizationResult.success) {
+    return rateLimitedResponse(organizationResult);
+  }
+
+  return null;
 }

--- a/apps/docs/api/rate-limits.mdx
+++ b/apps/docs/api/rate-limits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rate Limits"
-description: "Per-key rate limits on generation, integration, and update endpoints."
+description: "Per-organization rate limits on generation, integration, and update endpoints."
 authors:
   - handle: dominik
 

--- a/apps/docs/api/rate-limits.mdx
+++ b/apps/docs/api/rate-limits.mdx
@@ -24,7 +24,7 @@ docolin:
 
 The Notra API enforces rate limits on a small set of write-heavy endpoints to protect the service. Read endpoints (listing posts, fetching brand identities, etc.) are not currently rate limited.
 
-Limits are scoped per API key, with a sliding window. If your request would exceed the limit, the API returns `429 Too Many Requests` and the request is not executed.
+Limits are scoped per organization, with a sliding window. Requests made with different API keys for the same organization share the same quota. If your request would exceed the limit, the API returns `429 Too Many Requests` and the request is not executed.
 
 ## Limits
 
@@ -34,11 +34,12 @@ Limits are scoped per API key, with a sliding window. If your request would exce
 | `PATCH /v1/posts/{postId}` | 60 requests / minute |
 | `POST /v1/brand-identities/generate` | 5 requests / minute |
 | `POST /v1/integrations/github` | 20 requests / minute |
+| `POST /v1/chats` and `POST /v1/chats/{chatId}` | 30 requests / minute |
 
-All other endpoints (post list/get/delete, brand list/get/delete, integrations list/remove, schedules) have no rate limit at this time.
+All other endpoints (post list/get/delete, brand list/get/delete, chat list/get, integrations list/remove, schedules) have no rate limit at this time.
 
 <Note>
-  Limits are tracked per API key. If a request arrives without an authenticated key, the limit is applied per IP instead. Each endpoint has its own bucket, so hitting the post-generation limit does not affect post updates.
+  Limits are tracked per organization. If a request arrives without an authenticated organization, the limit is applied per IP instead. Each endpoint has its own bucket, so hitting the post-generation limit does not affect post updates.
 </Note>
 
 ## Response headers

--- a/packages/ai/src/billing/autumn.ts
+++ b/packages/ai/src/billing/autumn.ts
@@ -7,5 +7,5 @@ export const autumn = AUTUMN_SECRET_KEY
   : null;
 
 export const allowUnmeteredAiInDevelopment =
-  process.env.NODE_ENV !== "production" &&
+  process.env.NODE_ENV === "development" &&
   process.env.ALLOW_UNMETERED_AI_IN_DEVELOPMENT === "true";

--- a/packages/ai/src/billing/autumn.ts
+++ b/packages/ai/src/billing/autumn.ts
@@ -5,3 +5,7 @@ const AUTUMN_SECRET_KEY = process.env.AUTUMN_SECRET_KEY;
 export const autumn = AUTUMN_SECRET_KEY
   ? new Autumn({ secretKey: AUTUMN_SECRET_KEY })
   : null;
+
+export const allowUnmeteredAiInDevelopment =
+  process.env.NODE_ENV !== "production" &&
+  process.env.ALLOW_UNMETERED_AI_IN_DEVELOPMENT === "true";

--- a/packages/ai/src/constants/rate-limits.ts
+++ b/packages/ai/src/constants/rate-limits.ts
@@ -3,3 +3,8 @@ export const CHAT_GENERATION_RATE_LIMIT = {
   window: "1m",
   windowLabel: "1 minute",
 } as const;
+
+export const CHAT_GENERATION_USER_RATE_LIMIT = {
+  requests: 20,
+  window: "1m",
+} as const;

--- a/packages/ai/src/constants/rate-limits.ts
+++ b/packages/ai/src/constants/rate-limits.ts
@@ -1,0 +1,5 @@
+export const CHAT_GENERATION_RATE_LIMIT = {
+  requests: 30,
+  window: "1m",
+  windowLabel: "1 minute",
+} as const;

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "ui": "tui",
   "globalEnv": [
     "AI_GATEWAY_API_KEY",
+    "ALLOW_UNMETERED_AI_IN_DEVELOPMENT",
     "APP_URL",
     "AUTUMN_PROD_SECRET_KEY",
     "AUTUMN_SECRET_KEY",


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces organization-scoped chat limits (30/min) across API and dashboard, plus a per-user limit (20/min) in the dashboard, with atomic reservation to prevent race conditions. Adds consistent 429s with RateLimit headers and safer billing fallbacks.

- **Bug Fixes**
  - API: enforce org-scoped sliding window on chat routes via `@upstash/ratelimit` keyed by organization ID (fallback to API key or IP); add 429 to OpenAPI with per-organization wording and RateLimit headers.
  - Dashboard: dual limiter applies org (30/min) + user (20/min) limits with a single atomic Lua sliding window; validate body and enforce limits before billing; consistent 429s with standard and legacy headers, analytics enabled.
  - Centralize limits in `@notra/ai/constants/rate-limits`; API `RATE_LIMITS` reads from these for docs/responses.
  - Billing: return 503 when billing is unavailable unless `ALLOW_UNMETERED_AI_IN_DEVELOPMENT=true` in development (`.env.example`, `turbo.json`); stop leaking raw error messages in streamed chat errors.
  - Docs: clarify per-organization scoping and include chat endpoints.

<sup>Written for commit 2bf8074ca93626e0e3495ac68ae6593f65f21d6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

2 issues found.

<sub>Written for commit [`1dc93a8`](https://github.com/usenotra/notra/commit/1dc93a8ffb6f3a5f4cd726c57d368ac8d63993b8). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->