### PR TITLE
test(auth): remove OAuth review cases

### DIFF
--- a/apps/dashboard/src/utils/oauth-client-registration.test.ts
+++ b/apps/dashboard/src/utils/oauth-client-registration.test.ts
@@ -18,14 +18,6 @@ describe("hasOnlyLoopbackRedirectUris", () => {
       true
     );
     assert.equal(
-      isOAuthDynamicClientRegistrationPath("/api/auth/oauth2/register%2F"),
-      true
-    );
-    assert.equal(
-      isOAuthDynamicClientRegistrationPath("/api/auth//oauth2/register"),
-      true
-    );
-    assert.equal(
       isOAuthDynamicClientRegistrationPath("/api/auth/oauth2/token/"),
       false
     );
@@ -85,9 +77,7 @@ describe("hasOnlyLoopbackRedirectUris", () => {
         post_logout_redirect_uris: ["https://attacker.example/logout"],
         reference_id: "another-organization",
         skip_consent: true,
-        software_statement: "signed-client-metadata",
         subject_type: "pairwise",
-        token_endpoint_auth_method: "client_secret_basic",
         type: "web",
       }),
       {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed OAuth review-only test cases from `apps/dashboard/src/utils/oauth-client-registration.test.ts` to reflect current dynamic client registration behavior. This drops path edge-case assertions (encoded or double slashes) and outdated metadata fields (`software_statement`, `token_endpoint_auth_method`) to reduce noise and prevent false positives.

<sup>Written for commit 2245304f35ff321f3fc3d1ce7008298896522b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

