### PR TITLE
fix(console): restrict reviews to admins

### DIFF
--- a/apps/console/src/app/(console)/[slug]/layout.tsx
+++ b/apps/console/src/app/(console)/[slug]/layout.tsx
@@ -5,6 +5,7 @@ import {
 import { cookies } from "next/headers";
 import { ConsoleShell } from "@/components/layout/console-shell";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
+import { hasAdminRole } from "@/lib/auth/role";
 
 export default async function OrganizationLayout({
   children,
@@ -29,7 +30,7 @@ export default async function OrganizationLayout({
         logo: organization.logo,
       }}
       initialSidebarOpen={initialSidebarOpen}
-      isAdmin={user.role === "admin"}
+      isAdmin={hasAdminRole(user.role)}
       user={{
         name: user.name,
         email: user.email,

--- a/apps/console/src/app/(console)/[slug]/review/page.tsx
+++ b/apps/console/src/app/(console)/[slug]/review/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ReviewQueueClient } from "@/components/review/review-queue-client";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
+import { hasAdminRole } from "@/lib/auth/role";
 
 export const metadata: Metadata = {
   title: "Review Queue · Notra Console",
@@ -15,7 +16,7 @@ export default async function ReviewQueuePage({
   const { slug } = await params;
   const { user } = await validateOrganizationAccess(slug);
 
-  if (user.role !== "admin") {
+  if (!hasAdminRole(user.role)) {
     notFound();
   }
 

--- a/apps/console/src/lib/auth/admin.ts
+++ b/apps/console/src/lib/auth/admin.ts
@@ -1,10 +1,11 @@
 import { ORPCError } from "@orpc/server";
 import { assertAuthenticated } from "@/lib/auth/organization";
+import { hasAdminRole } from "@/lib/auth/role";
 
 export async function assertAdmin({ headers }: { headers: Headers }) {
   const { user } = await assertAuthenticated({ headers });
 
-  if (user.role !== "admin") {
+  if (!hasAdminRole(user.role)) {
     throw new ORPCError("FORBIDDEN", {
       message: "You do not have access to integration reviews",
     });

--- a/apps/console/src/lib/auth/role.test.ts
+++ b/apps/console/src/lib/auth/role.test.ts
@@ -6,9 +6,12 @@ describe("hasAdminRole", () => {
   test("accepts the platform admin role", () => {
     assert.equal(hasAdminRole("admin"), true);
     assert.equal(hasAdminRole("user,admin"), true);
+    assert.equal(hasAdminRole(" admin "), true);
+    assert.equal(hasAdminRole("user, admin "), true);
   });
 
   test("rejects non-admin and missing roles", () => {
+    assert.equal(hasAdminRole(""), false);
     assert.equal(hasAdminRole("user"), false);
     assert.equal(hasAdminRole("owner"), false);
     assert.equal(hasAdminRole("member"), false);

--- a/apps/console/src/lib/auth/role.test.ts
+++ b/apps/console/src/lib/auth/role.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { hasAdminRole } from "./role";
+
+describe("hasAdminRole", () => {
+  test("accepts the platform admin role", () => {
+    assert.equal(hasAdminRole("admin"), true);
+    assert.equal(hasAdminRole("user,admin"), true);
+  });
+
+  test("rejects non-admin and missing roles", () => {
+    assert.equal(hasAdminRole("user"), false);
+    assert.equal(hasAdminRole("owner"), false);
+    assert.equal(hasAdminRole("member"), false);
+    assert.equal(hasAdminRole(null), false);
+    assert.equal(hasAdminRole(undefined), false);
+  });
+});

--- a/apps/console/src/lib/auth/role.ts
+++ b/apps/console/src/lib/auth/role.ts
@@ -1,0 +1,8 @@
+export function hasAdminRole(role: string | null | undefined): boolean {
+  return (
+    role
+      ?.split(",")
+      .map((value) => value.trim())
+      .includes("admin") ?? false
+  );
+}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the review queue and related API actions to admins only using a single, consistent role check. Non-admins see a 404 in the console; API requests return FORBIDDEN.

- **Bug Fixes**
  - Added `hasAdminRole` with tests to detect the `admin` role in comma-separated roles, trimming whitespace and handling empty/null values.
  - Updated console layout, review page, and `assertAdmin` to use `hasAdminRole` for consistent access control.

<sup>Written for commit a25f932f2d621d01f34dc91692816db35e7e99d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`06fcf41`](https://github.com/usenotra/notra/commit/06fcf4106c387bb77bc26e72803965991aa1fafd). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->