### PR TITLE
feat(console): require MCP branding consent

### DIFF
--- a/apps/console/src/components/integrations/integration-form.tsx
+++ b/apps/console/src/components/integrations/integration-form.tsx
@@ -867,6 +867,53 @@ function IntegrationFormActions({
   );
 }
 
+function IntegrationOwnershipConsent({
+  checked,
+  disabled,
+  error,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  disabled: boolean;
+  error: string | null;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  const errorId = "integration-ownership-consent-error";
+  const labelId = "integration-ownership-consent-label";
+
+  return (
+    <div className="grid gap-2 rounded-lg border p-4">
+      <div className="flex items-start gap-3">
+        <input
+          aria-describedby={error ? errorId : undefined}
+          aria-invalid={Boolean(error)}
+          aria-labelledby={labelId}
+          checked={checked}
+          className="mt-0.5 size-4 shrink-0 accent-primary"
+          disabled={disabled}
+          id="integration-ownership-consent"
+          onChange={(event) => onCheckedChange(event.target.checked)}
+          type="checkbox"
+        />
+        <Label
+          className="font-normal leading-relaxed"
+          htmlFor="integration-ownership-consent"
+          id={labelId}
+        >
+          I confirm that I own this MCP server or am authorized to represent it,
+          and I allow Notra to use its name, logo, and banner in the integration
+          store.
+        </Label>
+      </div>
+      {error ? (
+        <p className="ml-7 text-destructive text-xs" id={errorId} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export function IntegrationForm({
   organizationId,
   server,
@@ -971,6 +1018,13 @@ export function IntegrationForm({
             tools={mergeManualTools(form.draftTools, form.manualTools)}
           />
         )}
+
+        <IntegrationOwnershipConsent
+          checked={form.ownershipConsent}
+          disabled={form.isBusy}
+          error={form.ownershipConsentError}
+          onCheckedChange={form.setOwnershipConsent}
+        />
 
         <IntegrationFormActions
           backHref={form.backHref}

--- a/apps/console/src/lib/integrations/use-integration-form.ts
+++ b/apps/console/src/lib/integrations/use-integration-form.ts
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import type { FormEvent } from "react";
 import { useState } from "react";
 import { toast } from "sonner";
+import type { ZodError } from "zod";
 import {
   authChoiceToAuthType,
   authTypeToAuthChoice,
@@ -60,6 +61,10 @@ export function useIntegrationForm({
   );
   const [logoDarkUrl, setLogoDarkUrl] = useState(server?.logoDarkUrl ?? null);
   const [bannerUrl, setBannerUrl] = useState(server?.bannerUrl ?? null);
+  const [ownershipConsent, setOwnershipConsent] = useState(false);
+  const [ownershipConsentError, setOwnershipConsentError] = useState<
+    string | null
+  >(null);
   const [uploadingCount, setUploadingCount] = useState(0);
   const [scanning, setScanning] = useState(false);
   const [authChoice, setAuthChoice] = useState<AuthChoice>(
@@ -87,6 +92,7 @@ export function useIntegrationForm({
   function getSharedFields() {
     return {
       organizationId,
+      ownershipConsent,
       name,
       author: author.trim() || null,
       description: description.trim() || null,
@@ -104,6 +110,14 @@ export function useIntegrationForm({
       logoDarkUrl,
       bannerUrl,
     };
+  }
+
+  function getValidationMessage(error: ZodError, fallback: string) {
+    const ownershipIssue = error.issues.find(
+      (issue) => issue.path[0] === "ownershipConsent"
+    );
+    setOwnershipConsentError(ownershipIssue?.message ?? null);
+    return ownershipIssue?.message ?? error.issues[0]?.message ?? fallback;
   }
 
   function validateApiKeyInput() {
@@ -216,7 +230,7 @@ export function useIntegrationForm({
       const parsed = createMcpServerRequestSchema.safeParse(getSharedFields());
       if (!parsed.success) {
         throw new Error(
-          parsed.error.issues[0]?.message ?? "Check the integration details"
+          getValidationMessage(parsed.error, "Check the integration details")
         );
       }
 
@@ -276,7 +290,7 @@ export function useIntegrationForm({
       const parsed = createMcpServerRequestSchema.safeParse(getSharedFields());
       if (!parsed.success) {
         throw new Error(
-          parsed.error.issues[0]?.message ?? "Check the integration details"
+          getValidationMessage(parsed.error, "Check the integration details")
         );
       }
       const created = await consoleOrpc.integrations.mcp.create.call(
@@ -314,7 +328,7 @@ export function useIntegrationForm({
       });
       if (!parsed.success) {
         throw new Error(
-          parsed.error.issues[0]?.message ?? "Check the integration details"
+          getValidationMessage(parsed.error, "Check the integration details")
         );
       }
       const updated = await consoleOrpc.integrations.mcp.update.call(
@@ -359,7 +373,7 @@ export function useIntegrationForm({
       });
       if (!parsed.success) {
         throw new Error(
-          parsed.error.issues[0]?.message ?? "Check the integration details"
+          getValidationMessage(parsed.error, "Check the integration details")
         );
       }
       await consoleOrpc.integrations.mcp.update.call(parsed.data);
@@ -514,7 +528,7 @@ export function useIntegrationForm({
       const parsed = createMcpServerRequestSchema.safeParse(getSharedFields());
       if (!parsed.success) {
         toast.error(
-          parsed.error.issues[0]?.message ?? "Add a server name and URL first"
+          getValidationMessage(parsed.error, "Add a server name and URL first")
         );
         return;
       }
@@ -551,6 +565,8 @@ export function useIntegrationForm({
     logoDarkUrl,
     logoLightUrl,
     name,
+    ownershipConsent,
+    ownershipConsentError,
     phraseDrafts,
     setApiKeyStyle,
     setAuthChoice,
@@ -563,6 +579,12 @@ export function useIntegrationForm({
     setLogoDarkUrl,
     setLogoLightUrl,
     setName,
+    setOwnershipConsent: (checked: boolean) => {
+      setOwnershipConsent(checked);
+      if (checked) {
+        setOwnershipConsentError(null);
+      }
+    },
     setPhraseBaseline,
     setPhraseDrafts,
     setScanning,

--- a/apps/console/src/schemas/integrations.ts
+++ b/apps/console/src/schemas/integrations.ts
@@ -80,6 +80,10 @@ export const BRANDING_ASSET_CONTENT_TYPES: Record<string, string> = {
 
 const createMcpServerRequestFieldsSchema = z.object({
   authType: z.enum(["none", "headers", "oauth"]),
+  ownershipConsent: z.literal(true, {
+    error:
+      "Confirm that you own or represent this MCP server and allow Notra to use its branding",
+  }),
   organizationId: z.string().min(1, "Organization ID is required"),
   name: z.string().trim().min(1, "Name is required").max(120),
   url: mcpUrlSchema,


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit branding consent for MCP integrations in the console. Adds a mandatory checkbox confirming ownership and permission to use the integration’s name, logo, and banner in the store.

- **New Features**
  - Added a required “ownership and branding consent” checkbox to the MCP integration form.
  - Client-side schema now validates `ownershipConsent` and shows an inline, accessible error message.
  - Form hook manages consent state and errors; consent is required for both create and update.

- **Migration**
  - When creating or editing an MCP integration, you must check the new consent box to submit.

<sup>Written for commit cb63daab41864f41569cfffde123a49d8bd668e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`cb63daa`](https://github.com/usenotra/notra/commit/cb63daab41864f41569cfffde123a49d8bd668e2). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->