### PR TITLE
fix(console): respect selected MCP auth when scanning

### DIFF
--- a/apps/console/src/components/integrations/integration-form.tsx
+++ b/apps/console/src/components/integrations/integration-form.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/lib/integrations/constants";
 import {
   applyPhraseDraftChange,
+  authChoiceToAuthType,
   buildInitialPhraseDrafts,
   rgbaToHex,
 } from "@/lib/integrations/form";
@@ -579,6 +580,7 @@ interface IntegrationQueryData {
 }
 
 function IntegrationToolsCard({
+  authChoice,
   isSaving,
   manualTools,
   onAddTool,
@@ -594,6 +596,7 @@ function IntegrationToolsCard({
   setPhraseDrafts,
   tools,
 }: {
+  authChoice: AuthChoice;
   isSaving: boolean;
   manualTools: McpIntegrationTool[];
   onAddTool: (serverToolName: string) => void;
@@ -615,7 +618,8 @@ function IntegrationToolsCard({
   );
   const autoScanTriggeredRef = useRef(false);
   const oauthParamsHandledRef = useRef(false);
-  const isOAuth = server.authType === "oauth";
+  const isOAuth = authChoice === "oauth";
+  const authTypeChanged = authChoiceToAuthType(authChoice) !== server.authType;
 
   const beginOAuthMutation = useMutation({
     mutationFn: () =>
@@ -739,6 +743,10 @@ function IntegrationToolsCard({
   }, [server.authType, server.lastToolSyncAt, indexedTools.length, startScan]);
 
   const handleScan = () => {
+    if (authTypeChanged) {
+      toast.info("Save the authentication change before scanning tools.");
+      return;
+    }
     if (isOAuth) {
       const oauthPopup = openMcpOAuthPopup();
       beginOAuthMutation.mutate(undefined, {
@@ -985,6 +993,7 @@ export function IntegrationForm({
 
         {server ? (
           <IntegrationToolsCard
+            authChoice={form.authChoice}
             isSaving={form.isSaving}
             manualTools={form.manualTools}
             onAddTool={form.addManualTool}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make MCP tool scans respect the authentication method selected in the Console integration form. Scans now use the chosen auth and prompt you to save if the auth type was changed.

- **Bug Fixes**
  - Use form `authChoice` to decide OAuth flow instead of `server.authType`.
  - Block scans when auth type changed but not saved, with a toast prompting to save first.

<sup>Written for commit 7062f5b5623aeaaf1792ec4cb95c92efa4a66e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`7062f5b`](https://github.com/usenotra/notra/commit/7062f5b5623aeaaf1792ec4cb95c92efa4a66e0c). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->