### PR TITLE
fix(dashboard): remove Eve mention from suggestion labels

### DIFF
--- a/apps/dashboard/src/components/automation/onboarding-suggestions.tsx
+++ b/apps/dashboard/src/components/automation/onboarding-suggestions.tsx
@@ -43,7 +43,7 @@ export function OnboardingSuggestions({
           className="size-4 text-muted-foreground"
           icon={SparklesIcon}
         />
-        <h2 className="font-medium text-sm">Suggested by Eve</h2>
+        <h2 className="font-medium text-sm">Suggestions</h2>
         {agentRunning && <BrailleLoader className="text-xs" />}
       </div>
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
@@ -83,7 +83,7 @@ export function OnboardingSuggestions({
             >
               <div className="space-y-1.5">
                 <Badge className="font-normal text-xs" variant="secondary">
-                  Suggested by Eve
+                  Suggestion
                 </Badge>
                 {suggestion.description ? (
                   <p className="line-clamp-3 text-muted-foreground text-sm">


### PR DESCRIPTION
Removes the user-facing "Suggested by Eve" copy in the automation onboarding suggestions. The section header now reads "Suggestions" and the card badge reads "Suggestion". All other Eve references are internal (constants, CSS variables, route paths) and are unchanged.

https://claude.ai/code/session_01GgMKh2TcLKGNzvZ89wZgTL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed user-facing "Eve" mentions in automation onboarding suggestions to use neutral copy. The section header now reads "Suggestions" and the card badge reads "Suggestion".

<sup>Written for commit 6a4301d262afa47b1893b007ceafc13910f70a17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`6a4301d`](https://github.com/usenotra/notra/commit/6a4301d262afa47b1893b007ceafc13910f70a17). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->