### PR TITLE
fix: remove mention of mcp tool counts

### DIFF
--- a/apps/web/src/app/(site)/mcp/page.tsx
+++ b/apps/web/src/app/(site)/mcp/page.tsx
@@ -12,7 +12,7 @@ import { SITE_URL } from "@/utils/urls";
 
 const title = "Notra MCP Server";
 const description =
-  "Connect your agent to Notra over MCP. Twelve tools to draft changelogs, launch posts, and social updates from the editor it already lives in.";
+  "Connect your agent to Notra over MCP to draft changelogs, launch posts, and social updates from the editor it already lives in.";
 const url = `${SITE_URL}/mcp`;
 
 export const metadata: Metadata = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Notra MCP Server page meta description to remove the hard-coded “twelve tools” claim. Keeps messaging accurate and avoids stale info as tool counts change.

<sup>Written for commit 94b9a9b58f752e0b0bf897e788b7f077c1ba2758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`94b9a9b`](https://github.com/usenotra/notra/commit/94b9a9b58f752e0b0bf897e788b7f077c1ba2758). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->