### PR TITLE
feat: add integrations marketplace pages

### DIFF
--- a/apps/console/src/app/api/store/integrations/[id]/route.ts
+++ b/apps/console/src/app/api/store/integrations/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { STORE_CACHE_CONTROL_HEADER } from "@/constants/store";
+import { getPublicStoreIntegration } from "@/lib/store/public-integrations";
+import { storeIntegrationIdParamSchema } from "@/schemas/store";
+
+export const revalidate = 300;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const parsed = storeIntegrationIdParamSchema.safeParse(await params);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid integration ID" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const integration = await getPublicStoreIntegration(parsed.data.id);
+    if (!integration) {
+      return NextResponse.json(
+        { error: "Integration not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(
+      { integration },
+      { headers: { "Cache-Control": STORE_CACHE_CONTROL_HEADER } }
+    );
+  } catch (error) {
+    console.error("[Store] Failed to load integration", error);
+    return NextResponse.json(
+      { error: "Could not load integration" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/console/src/app/api/store/integrations/route.ts
+++ b/apps/console/src/app/api/store/integrations/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { STORE_CACHE_CONTROL_HEADER } from "@/constants/store";
+import { listPublicStoreIntegrations } from "@/lib/store/public-integrations";
+
+export const revalidate = 300;
+
+export async function GET() {
+  try {
+    const integrations = await listPublicStoreIntegrations();
+    return NextResponse.json(
+      { integrations },
+      { headers: { "Cache-Control": STORE_CACHE_CONTROL_HEADER } }
+    );
+  } catch (error) {
+    console.error("[Store] Failed to list integrations", error);
+    return NextResponse.json(
+      { error: "Could not load integrations" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/console/src/components/integrations/integration-form.tsx
+++ b/apps/console/src/components/integrations/integration-form.tsx
@@ -134,21 +134,25 @@ function IntegrationFormHeader({
 function IntegrationDetailsCard({
   author,
   description,
+  handleNameChange,
+  handleSlugChange,
+  integrationSlug,
   isSaving,
   name,
   setAuthor,
   setDescription,
-  setName,
   setWebsiteUrl,
   websiteUrl,
 }: {
   author: string;
   description: string;
+  handleNameChange: (value: string) => void;
+  handleSlugChange: (value: string) => void;
+  integrationSlug: string;
   isSaving: boolean;
   name: string;
   setAuthor: Dispatch<SetStateAction<string>>;
   setDescription: Dispatch<SetStateAction<string>>;
-  setName: Dispatch<SetStateAction<string>>;
   setWebsiteUrl: Dispatch<SetStateAction<string>>;
   websiteUrl: string;
 }) {
@@ -165,7 +169,7 @@ function IntegrationDetailsCard({
             <Input
               disabled={isSaving}
               id="integration-name"
-              onChange={(event) => setName(event.target.value)}
+              onChange={(event) => handleNameChange(event.target.value)}
               placeholder="Neon"
               required
               value={name}
@@ -181,6 +185,21 @@ function IntegrationDetailsCard({
               value={author}
             />
           </div>
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="integration-slug">Slug</Label>
+          <Input
+            disabled={isSaving}
+            id="integration-slug"
+            onChange={(event) => handleSlugChange(event.target.value)}
+            placeholder="neon"
+            required
+            value={integrationSlug}
+          />
+          <p className="text-muted-foreground text-xs">
+            Used in the public store URL. Lowercase letters, numbers, and
+            hyphens.
+          </p>
         </div>
         <div className="grid gap-2">
           <Label htmlFor="integration-website">
@@ -952,11 +971,13 @@ export function IntegrationForm({
         <IntegrationDetailsCard
           author={form.author}
           description={form.description}
+          handleNameChange={form.handleNameChange}
+          handleSlugChange={form.handleSlugChange}
+          integrationSlug={form.integrationSlug}
           isSaving={form.isSaving}
           name={form.name}
           setAuthor={form.setAuthor}
           setDescription={form.setDescription}
-          setName={form.setName}
           setWebsiteUrl={form.setWebsiteUrl}
           websiteUrl={form.websiteUrl}
         />

--- a/apps/console/src/constants/store.ts
+++ b/apps/console/src/constants/store.ts
@@ -1,0 +1,5 @@
+export const STORE_TOOL_PREVIEW_LIMIT = 8;
+
+export const STORE_CACHE_REVALIDATE_SECONDS = 300;
+
+export const STORE_CACHE_CONTROL_HEADER = `public, s-maxage=${STORE_CACHE_REVALIDATE_SECONDS}, stale-while-revalidate=${STORE_CACHE_REVALIDATE_SECONDS}`;

--- a/apps/console/src/lib/integrations/use-integration-form.ts
+++ b/apps/console/src/lib/integrations/use-integration-form.ts
@@ -1,10 +1,11 @@
 "use client";
 
 import { openMcpOAuthPopup } from "@notra/utils/oauth-popup";
+import { slugify } from "@notra/utils/slugify";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import type { ZodError } from "zod";
 import {
@@ -51,6 +52,8 @@ export function useIntegrationForm({
   const isEdit = Boolean(server);
 
   const [name, setName] = useState(server?.name ?? "");
+  const [integrationSlug, setIntegrationSlug] = useState(server?.slug ?? "");
+  const slugEditedRef = useRef(Boolean(server?.slug));
   const [author, setAuthor] = useState(server?.author ?? "");
   const [description, setDescription] = useState(server?.description ?? "");
   const [url, setUrl] = useState(server?.url ?? "");
@@ -89,11 +92,24 @@ export function useIntegrationForm({
 
   const backHref = `/${slug}/integrations`;
 
+  function handleNameChange(value: string) {
+    setName(value);
+    if (!slugEditedRef.current) {
+      setIntegrationSlug(slugify(value));
+    }
+  }
+
+  function handleSlugChange(value: string) {
+    slugEditedRef.current = true;
+    setIntegrationSlug(value);
+  }
+
   function getSharedFields() {
     return {
       organizationId,
       ownershipConsent,
       name,
+      slug: integrationSlug.trim(),
       author: author.trim() || null,
       description: description.trim() || null,
       url,
@@ -557,9 +573,12 @@ export function useIntegrationForm({
     brandColor,
     canSubmitForReview,
     description,
+    handleNameChange,
     handleSaveDraft,
+    handleSlugChange,
     handleSubmit,
     headerRows,
+    integrationSlug,
     isBusy,
     isSaving,
     logoDarkUrl,

--- a/apps/console/src/lib/orpc/routers/integrations.ts
+++ b/apps/console/src/lib/orpc/routers/integrations.ts
@@ -64,6 +64,27 @@ function isUniqueConstraintError(error: unknown): boolean {
   return "cause" in error && isUniqueConstraintError(error.cause);
 }
 
+function getConstraintName(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  if ("constraint" in error && typeof error.constraint === "string") {
+    return error.constraint;
+  }
+  if ("cause" in error) {
+    return getConstraintName(error.cause);
+  }
+  return null;
+}
+
+function throwUniqueConstraintConflict(error: unknown): never {
+  const constraint = getConstraintName(error);
+  if (constraint?.includes("slug")) {
+    throw conflict("This slug is already taken");
+  }
+  throw conflict("An MCP server with this name already exists");
+}
+
 export const integrationsRouter = {
   list: baseProcedure
     .input(organizationIdInputSchema)
@@ -186,6 +207,7 @@ export const integrationsRouter = {
             },
             {
               name: input.name,
+              slug: input.slug,
               url: input.url,
               description: input.description ?? null,
               author: input.author ?? null,
@@ -223,7 +245,7 @@ export const integrationsRouter = {
           return serializeMcpServerIntegration(refreshed ?? updated);
         } catch (error) {
           if (isUniqueConstraintError(error)) {
-            throw conflict("An MCP server with this name already exists");
+            throwUniqueConstraintConflict(error);
           }
           if (error instanceof PublicUrlValidationError) {
             throw badRequest(error.message);
@@ -468,6 +490,7 @@ export const integrationsRouter = {
             organizationId: input.organizationId,
             userId: access.user.id,
             name: input.name,
+            slug: input.slug,
             url: input.url,
             description: input.description ?? null,
             author: input.author ?? null,
@@ -482,7 +505,7 @@ export const integrationsRouter = {
           return serializeMcpServerIntegration(integration);
         } catch (error) {
           if (isUniqueConstraintError(error)) {
-            throw conflict("An MCP server with this name already exists");
+            throwUniqueConstraintConflict(error);
           }
           if (error instanceof PublicUrlValidationError) {
             throw badRequest(error.message);

--- a/apps/console/src/lib/store/public-integrations.ts
+++ b/apps/console/src/lib/store/public-integrations.ts
@@ -1,0 +1,96 @@
+import {
+  getLiveMcpStoreIntegrationById,
+  getLiveMcpStoreIntegrationBySlug,
+  listLiveMcpStoreIntegrations,
+  listMcpIntegrationToolsByIntegrationIds,
+} from "@notra/ai/integrations/mcp-store";
+import { STORE_TOOL_PREVIEW_LIMIT } from "@/constants/store";
+import type {
+  IndexedStoreTool,
+  PublicStoreIntegration,
+  PublicStoreTool,
+} from "@/types/store";
+
+function toPublicTool(tool: IndexedStoreTool): PublicStoreTool {
+  return {
+    name: tool.serverToolName,
+    title: tool.title ?? null,
+    description: tool.description ?? null,
+  };
+}
+
+function groupToolsByIntegration(tools: IndexedStoreTool[]) {
+  const grouped = new Map<string, PublicStoreTool[]>();
+  for (const tool of tools) {
+    const existing = grouped.get(tool.serverIntegrationId);
+    if (existing) {
+      existing.push(toPublicTool(tool));
+    } else {
+      grouped.set(tool.serverIntegrationId, [toPublicTool(tool)]);
+    }
+  }
+  return grouped;
+}
+
+export async function listPublicStoreIntegrations(): Promise<
+  PublicStoreIntegration[]
+> {
+  const integrations = await listLiveMcpStoreIntegrations();
+  const integrationIds = integrations.map((integration) => integration.id);
+  const tools = await listMcpIntegrationToolsByIntegrationIds(integrationIds);
+  const toolsByIntegration = groupToolsByIntegration(tools);
+
+  return integrations.map((integration) => ({
+    id: integration.id,
+    name: integration.name,
+    description: integration.description ?? null,
+    author: integration.author ?? null,
+    websiteUrl: integration.websiteUrl ?? null,
+    brandColor: integration.brandColor ?? null,
+    logoLightUrl: integration.logoLightUrl ?? null,
+    logoDarkUrl: integration.logoDarkUrl ?? null,
+    bannerUrl: integration.bannerUrl ?? null,
+    slug: integration.slug ?? null,
+    authType: integration.authType,
+    indexedToolCount: integration.indexedToolCount,
+    tools: (toolsByIntegration.get(integration.id) ?? []).slice(
+      0,
+      STORE_TOOL_PREVIEW_LIMIT
+    ),
+  }));
+}
+
+const INTEGRATION_ID_PREFIX_REGEX = /^mcp_/;
+
+export async function getPublicStoreIntegration(
+  slugOrId: string
+): Promise<PublicStoreIntegration | null> {
+  const bySlug = await getLiveMcpStoreIntegrationBySlug(slugOrId);
+  const integration =
+    bySlug ??
+    (INTEGRATION_ID_PREFIX_REGEX.test(slugOrId)
+      ? await getLiveMcpStoreIntegrationById(slugOrId)
+      : null);
+
+  if (!integration) {
+    return null;
+  }
+
+  const tools = await listMcpIntegrationToolsByIntegrationIds([integration.id]);
+
+  return {
+    id: integration.id,
+    name: integration.name,
+    description: integration.description ?? null,
+    author: integration.author ?? null,
+    websiteUrl: integration.websiteUrl ?? null,
+    brandColor: integration.brandColor ?? null,
+    logoLightUrl: integration.logoLightUrl ?? null,
+    logoDarkUrl: integration.logoDarkUrl ?? null,
+    bannerUrl: integration.bannerUrl ?? null,
+    slug: integration.slug ?? null,
+    authType: integration.authType,
+    indexedToolCount: integration.indexedToolCount,
+    tools: tools.map(toPublicTool),
+  };
+}

--- a/apps/console/src/lib/store/public-integrations.ts
+++ b/apps/console/src/lib/store/public-integrations.ts
@@ -9,6 +9,7 @@ import type {
   IndexedStoreTool,
   PublicStoreIntegration,
   PublicStoreTool,
+  StoreListingRow,
 } from "@/types/store";
 
 function toPublicTool(tool: IndexedStoreTool): PublicStoreTool {
@@ -16,6 +17,27 @@ function toPublicTool(tool: IndexedStoreTool): PublicStoreTool {
     name: tool.serverToolName,
     title: tool.title ?? null,
     description: tool.description ?? null,
+  };
+}
+
+function toPublicIntegration(
+  integration: StoreListingRow,
+  tools: PublicStoreTool[]
+): PublicStoreIntegration {
+  return {
+    id: integration.id,
+    name: integration.name,
+    description: integration.description ?? null,
+    author: integration.author ?? null,
+    websiteUrl: integration.websiteUrl ?? null,
+    brandColor: integration.brandColor ?? null,
+    logoLightUrl: integration.logoLightUrl ?? null,
+    logoDarkUrl: integration.logoDarkUrl ?? null,
+    bannerUrl: integration.bannerUrl ?? null,
+    slug: integration.slug ?? null,
+    authType: integration.authType,
+    indexedToolCount: integration.indexedToolCount,
+    tools,
   };
 }
 
@@ -40,24 +62,15 @@ export async function listPublicStoreIntegrations(): Promise<
   const tools = await listMcpIntegrationToolsByIntegrationIds(integrationIds);
   const toolsByIntegration = groupToolsByIntegration(tools);
 
-  return integrations.map((integration) => ({
-    id: integration.id,
-    name: integration.name,
-    description: integration.description ?? null,
-    author: integration.author ?? null,
-    websiteUrl: integration.websiteUrl ?? null,
-    brandColor: integration.brandColor ?? null,
-    logoLightUrl: integration.logoLightUrl ?? null,
-    logoDarkUrl: integration.logoDarkUrl ?? null,
-    bannerUrl: integration.bannerUrl ?? null,
-    slug: integration.slug ?? null,
-    authType: integration.authType,
-    indexedToolCount: integration.indexedToolCount,
-    tools: (toolsByIntegration.get(integration.id) ?? []).slice(
-      0,
-      STORE_TOOL_PREVIEW_LIMIT
-    ),
-  }));
+  return integrations.map((integration) =>
+    toPublicIntegration(
+      integration,
+      (toolsByIntegration.get(integration.id) ?? []).slice(
+        0,
+        STORE_TOOL_PREVIEW_LIMIT
+      )
+    )
+  );
 }
 
 const INTEGRATION_ID_PREFIX_REGEX = /^mcp_/;
@@ -65,12 +78,9 @@ const INTEGRATION_ID_PREFIX_REGEX = /^mcp_/;
 export async function getPublicStoreIntegration(
   slugOrId: string
 ): Promise<PublicStoreIntegration | null> {
-  const bySlug = await getLiveMcpStoreIntegrationBySlug(slugOrId);
-  const integration =
-    bySlug ??
-    (INTEGRATION_ID_PREFIX_REGEX.test(slugOrId)
-      ? await getLiveMcpStoreIntegrationById(slugOrId)
-      : null);
+  const integration = INTEGRATION_ID_PREFIX_REGEX.test(slugOrId)
+    ? await getLiveMcpStoreIntegrationById(slugOrId)
+    : await getLiveMcpStoreIntegrationBySlug(slugOrId);
 
   if (!integration) {
     return null;
@@ -78,19 +88,5 @@ export async function getPublicStoreIntegration(
 
   const tools = await listMcpIntegrationToolsByIntegrationIds([integration.id]);
 
-  return {
-    id: integration.id,
-    name: integration.name,
-    description: integration.description ?? null,
-    author: integration.author ?? null,
-    websiteUrl: integration.websiteUrl ?? null,
-    brandColor: integration.brandColor ?? null,
-    logoLightUrl: integration.logoLightUrl ?? null,
-    logoDarkUrl: integration.logoDarkUrl ?? null,
-    bannerUrl: integration.bannerUrl ?? null,
-    slug: integration.slug ?? null,
-    authType: integration.authType,
-    indexedToolCount: integration.indexedToolCount,
-    tools: tools.map(toPublicTool),
-  };
+  return toPublicIntegration(integration, tools.map(toPublicTool));
 }

--- a/apps/console/src/schemas/integrations.ts
+++ b/apps/console/src/schemas/integrations.ts
@@ -86,6 +86,15 @@ const createMcpServerRequestFieldsSchema = z.object({
   }),
   organizationId: z.string().min(1, "Organization ID is required"),
   name: z.string().trim().min(1, "Name is required").max(120),
+  slug: z
+    .string()
+    .trim()
+    .min(1, "Slug is required")
+    .max(120, "Slug is too long")
+    .regex(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      "Use lowercase letters, numbers, and hyphens"
+    ),
   url: mcpUrlSchema,
   description: z
     .string()

--- a/apps/console/src/schemas/store.ts
+++ b/apps/console/src/schemas/store.ts
@@ -2,5 +2,5 @@
 import * as z from "zod";
 
 export const storeIntegrationIdParamSchema = z.object({
-  id: z.string().trim().min(1, "Integration ID is required").max(128),
+  id: z.string().trim().min(1, "Integration ID is required").max(120),
 });

--- a/apps/console/src/schemas/store.ts
+++ b/apps/console/src/schemas/store.ts
@@ -1,0 +1,6 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+export const storeIntegrationIdParamSchema = z.object({
+  id: z.string().trim().min(1, "Integration ID is required").max(128),
+});

--- a/apps/console/src/types/integrations.ts
+++ b/apps/console/src/types/integrations.ts
@@ -50,6 +50,7 @@ export interface McpServer {
   logoLightUrl: string | null;
   logoDarkUrl: string | null;
   bannerUrl: string | null;
+  slug: string | null;
   storeStatus: StoreStatus;
   reviewNote: string | null;
   submittedAt: string | null;

--- a/apps/console/src/types/store.ts
+++ b/apps/console/src/types/store.ts
@@ -1,0 +1,32 @@
+export interface IndexedStoreTool {
+  serverIntegrationId: string;
+  serverToolName: string;
+  title: string | null;
+  description: string | null;
+}
+
+export interface PublicStoreTool {
+  name: string;
+  title: string | null;
+  description: string | null;
+}
+
+export interface PublicStoreIntegration {
+  id: string;
+  name: string;
+  description: string | null;
+  author: string | null;
+  websiteUrl: string | null;
+  brandColor: string | null;
+  logoLightUrl: string | null;
+  logoDarkUrl: string | null;
+  bannerUrl: string | null;
+  slug: string | null;
+  authType: string;
+  indexedToolCount: number;
+  tools: PublicStoreTool[];
+}
+
+export interface PublicStoreIntegrationListResponse {
+  integrations: PublicStoreIntegration[];
+}

--- a/apps/console/src/types/store.ts
+++ b/apps/console/src/types/store.ts
@@ -11,7 +11,7 @@ export interface PublicStoreTool {
   description: string | null;
 }
 
-export interface PublicStoreIntegration {
+export interface StoreListingRow {
   id: string;
   name: string;
   description: string | null;
@@ -24,6 +24,9 @@ export interface PublicStoreIntegration {
   slug: string | null;
   authType: string;
   indexedToolCount: number;
+}
+
+export interface PublicStoreIntegration extends StoreListingRow {
   tools: PublicStoreTool[];
 }
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -122,7 +122,7 @@ const nextConfig: NextConfig = {
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' databuddy.cc *.databuddy.cc",
             "style-src 'self' 'unsafe-inline'",
             "font-src 'self'",
-            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com media.marblecms.com",
+            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com media.marblecms.com *.r2.dev",
             "connect-src 'self' databuddy.cc *.databuddy.cc *.inth.app *.c15t.com *.c15t.dev",
             "frame-src 'none'",
             "frame-ancestors 'none'",
@@ -153,6 +153,10 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "media.marblecms.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.r2.dev",
       },
     ],
   },

--- a/apps/web/src/app/(site)/integrations/@modal/(.)[id]/page.tsx
+++ b/apps/web/src/app/(site)/integrations/@modal/(.)[id]/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from "next/navigation";
+import { IntegrationModal } from "@/components/integrations/integration-modal";
+import { fetchIntegration } from "@/lib/integrations/fetch";
+import type { IntegrationDetailPageProps } from "@/types/integrations";
+
+export default async function InterceptedIntegrationModal({
+  params,
+}: IntegrationDetailPageProps) {
+  const { id } = await params;
+  const integration = await fetchIntegration(id);
+
+  if (!integration) {
+    notFound();
+  }
+
+  return <IntegrationModal integration={integration} />;
+}

--- a/apps/web/src/app/(site)/integrations/@modal/[...catchAll]/page.tsx
+++ b/apps/web/src/app/(site)/integrations/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function IntegrationsModalCatchAll() {
+  return null;
+}

--- a/apps/web/src/app/(site)/integrations/@modal/default.tsx
+++ b/apps/web/src/app/(site)/integrations/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function IntegrationsModalDefault() {
+  return null;
+}

--- a/apps/web/src/app/(site)/integrations/[id]/page.tsx
+++ b/apps/web/src/app/(site)/integrations/[id]/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { IntegrationDetailView } from "@/components/integrations/integration-detail-view";
+import { fetchIntegration } from "@/lib/integrations/fetch";
+import type { IntegrationDetailPageProps } from "@/types/integrations";
+import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
+import { PAGE_SOCIAL_IMAGES, TWITTER_HANDLE } from "@/utils/metadata";
+import { SITE_URL } from "@/utils/urls";
+
+export async function generateMetadata({
+  params,
+}: IntegrationDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const integration = await fetchIntegration(id);
+
+  if (!integration) {
+    return { title: "Integration not found" };
+  }
+
+  const title = `${integration.name} integration for Notra`;
+  const description =
+    integration.description ??
+    `Connect ${integration.name} to your Notra workspace in one click.`;
+  const url = `${SITE_URL}/integrations/${integration.slug ?? integration.id}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+      siteName: "Notra",
+      images: [PAGE_SOCIAL_IMAGES.integrations],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [PAGE_SOCIAL_IMAGES.integrations.url],
+      site: TWITTER_HANDLE,
+      creator: TWITTER_HANDLE,
+    },
+  };
+}
+
+export default async function IntegrationDetailPage({
+  params,
+}: IntegrationDetailPageProps) {
+  const { id } = await params;
+  const integration = await fetchIntegration(id);
+
+  if (!integration) {
+    notFound();
+  }
+
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Integrations", url: `${SITE_URL}/integrations` },
+    {
+      name: integration.name,
+      url: `${SITE_URL}/integrations/${integration.slug ?? integration.id}`,
+    },
+  ]);
+
+  return (
+    <div className="flex w-full flex-col items-center antialiased [font-synthesis:none]">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
+      <IntegrationDetailView integration={integration} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(site)/integrations/default.tsx
+++ b/apps/web/src/app/(site)/integrations/default.tsx
@@ -1,0 +1,5 @@
+import IntegrationsPage from "./page";
+
+export default function IntegrationsDefault() {
+  return <IntegrationsPage />;
+}

--- a/apps/web/src/app/(site)/integrations/layout.tsx
+++ b/apps/web/src/app/(site)/integrations/layout.tsx
@@ -1,0 +1,13 @@
+import type { IntegrationsLayoutProps } from "@/types/integrations";
+
+export default function IntegrationsLayout({
+  children,
+  modal,
+}: IntegrationsLayoutProps) {
+  return (
+    <>
+      {children}
+      {modal}
+    </>
+  );
+}

--- a/apps/web/src/app/(site)/integrations/page.tsx
+++ b/apps/web/src/app/(site)/integrations/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { ConsoleCallout } from "@/components/integrations/console-callout";
 import { IntegrationsMarketplace } from "@/components/integrations/integrations-marketplace";
+import { IntegrationsMarketplaceFallback } from "@/components/integrations/integrations-marketplace-fallback";
 import { fetchIntegrations } from "@/lib/integrations/fetch";
 import { buildCategoryFilters } from "@/lib/integrations/helpers";
 import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
@@ -51,7 +52,14 @@ export default async function IntegrationsPage() {
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
         type="application/ld+json"
       />
-      <Suspense fallback={null}>
+      <Suspense
+        fallback={
+          <IntegrationsMarketplaceFallback
+            categories={categories}
+            integrations={integrations}
+          />
+        }
+      >
         <IntegrationsMarketplace
           categories={categories}
           integrations={integrations}

--- a/apps/web/src/app/(site)/integrations/page.tsx
+++ b/apps/web/src/app/(site)/integrations/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { ConsoleCallout } from "@/components/integrations/console-callout";
+import { IntegrationsMarketplace } from "@/components/integrations/integrations-marketplace";
+import { fetchIntegrations } from "@/lib/integrations/fetch";
+import { buildCategoryFilters } from "@/lib/integrations/helpers";
+import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
+import { PAGE_SOCIAL_IMAGES, TWITTER_HANDLE } from "@/utils/metadata";
+import { SITE_URL } from "@/utils/urls";
+
+const title = "Notra Integrations Marketplace";
+const description =
+  "Browse integrations built by the community and reviewed by us. Connect any of them to your Notra workspace in one click.";
+const url = `${SITE_URL}/integrations`;
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: url },
+  openGraph: {
+    title,
+    description,
+    url,
+    type: "website",
+    siteName: "Notra",
+    images: [PAGE_SOCIAL_IMAGES.integrations],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: [PAGE_SOCIAL_IMAGES.integrations.url],
+    site: TWITTER_HANDLE,
+    creator: TWITTER_HANDLE,
+  },
+};
+
+const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+  { name: "Home", url: SITE_URL },
+  { name: "Integrations", url },
+]);
+
+export default async function IntegrationsPage() {
+  const integrations = await fetchIntegrations();
+  const categories = buildCategoryFilters(integrations);
+
+  return (
+    <div className="flex w-full flex-col items-center pb-8 antialiased [font-synthesis:none]">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
+      <Suspense fallback={null}>
+        <IntegrationsMarketplace
+          categories={categories}
+          integrations={integrations}
+        />
+      </Suspense>
+      <ConsoleCallout />
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Databuddy, FlagsProvider } from "@databuddy/sdk/react";
 import type { Metadata, Viewport } from "next";
 import { Instrument_Serif, Inter } from "next/font/google";
 import localFont from "next/font/local";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Toaster } from "sonner";
 import { ConsentManager } from "../components/consent-manager";
 import { ThemeProvider } from "../components/theme-provider";
@@ -136,7 +137,9 @@ export default function RootLayout({
                 trackHashChanges={true}
               />
             )}
-            <ConsentManager>{children}</ConsentManager>
+            <ConsentManager>
+              <NuqsAdapter>{children}</NuqsAdapter>
+            </ConsentManager>
           </FlagsProvider>
           <Toaster position="bottom-right" />
         </ThemeProvider>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -106,6 +106,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
+      url: `${SITE_URL}/integrations`,
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
+    },
+    {
       url: `${SITE_URL}/brand`,
       lastModified: STATIC_PAGE_LAST_MODIFIED,
     },

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,7 @@
 import type { MetadataRoute } from "next";
 import { changelog } from "@/../.source/server";
+import { fetchIntegrations } from "@/lib/integrations/fetch";
+import { getIntegrationHref } from "@/lib/integrations/helpers";
 import {
   filterPostsByAuthorSlug,
   getAuthorHref,
@@ -37,6 +39,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const notraBlogEntries = notraBlogPosts.map((post) => ({
     url: `${SITE_URL}/blog/${post.slug}`,
     lastModified: new Date(post.updatedAt),
+  }));
+
+  const integrationEntries = (await fetchIntegrations()).map((integration) => ({
+    url: `${SITE_URL}${getIntegrationHref(integration)}`,
+    lastModified: STATIC_PAGE_LAST_MODIFIED,
   }));
 
   const notraAuthorEntries = (await listNotraAuthors()).map((author) => {
@@ -162,6 +169,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified:
         latestShowcaseByCompany.get(company.slug) ?? STATIC_PAGE_LAST_MODIFIED,
     })),
+    ...integrationEntries,
     ...showcaseEntries,
     ...notraChangelogEntries,
     ...notraBlogEntries,

--- a/apps/web/src/components/integrations/console-callout.tsx
+++ b/apps/web/src/components/integrations/console-callout.tsx
@@ -1,0 +1,52 @@
+import { CtaButton } from "@notra/ui/components/shared/cta-button";
+import Link from "next/link";
+import { HeroDither } from "@/components/landing/hero-dither";
+import {
+  INTEGRATIONS_CONSOLE_URL,
+  INTEGRATIONS_DOCS_URL,
+} from "@/constants/integrations";
+import { ConsoleFormMock } from "./console-form-mock";
+
+const CTA_BUTTON_CLASSNAME =
+  "h-auto rounded-[2.5625rem] px-6 py-3 font-display font-medium text-[1.125rem] leading-[1.14] tracking-[-0.015em]";
+
+export function ConsoleCallout() {
+  return (
+    <section className="w-[min(100%-3rem,80rem)] pt-14 antialiased [font-synthesis:none]">
+      <div className="relative isolate flex w-full flex-col items-center gap-12 overflow-clip rounded-3xl bg-[#EFEAFA] px-8 py-16 lg:flex-row lg:justify-between lg:gap-16 lg:px-20 lg:py-20 dark:bg-[#2a2140]">
+        <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
+          <HeroDither className="-top-15 -left-27.5 absolute h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />
+        </div>
+        <div className="relative flex w-full max-w-[31.25rem] flex-col items-start gap-5">
+          <h2 className="font-medium font-sans text-[#1E1E1E] text-[2.25rem] leading-[1.13] tracking-[-0.02em] sm:text-[2.875rem] dark:text-white">
+            List your integration in the marketplace.
+          </h2>
+          <p className="font-medium font-sans text-[#1E1E1EBF] text-[1.0625rem] leading-[1.44] tracking-[-0.005em] sm:text-[1.125rem] dark:text-white/70">
+            Manage everything from the Notra Console: name, description, logo,
+            banner and brand color. Submit for review and go live for every
+            workspace.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-3">
+            <CtaButton
+              className={CTA_BUTTON_CLASSNAME}
+              nativeButton={false}
+              render={<Link href={INTEGRATIONS_CONSOLE_URL} />}
+              variant="primary"
+            >
+              Open the Console
+            </CtaButton>
+            <CtaButton
+              className={CTA_BUTTON_CLASSNAME}
+              nativeButton={false}
+              render={<Link href={INTEGRATIONS_DOCS_URL} />}
+              variant="light"
+            >
+              Read the docs
+            </CtaButton>
+          </div>
+        </div>
+        <ConsoleFormMock />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/integrations/console-form-mock.tsx
+++ b/apps/web/src/components/integrations/console-form-mock.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { Linear } from "@notra/ui/components/ui/svgs/linear";
+import { useState } from "react";
+
+const BANNER_GRADIENT =
+  "bg-[linear-gradient(120deg,#5e6ad2_0%,#7c86dd_55%,#9aa4e8_100%)]";
+const PURPLE_GRADIENT = "cta-gradient-primary-flat";
+const INPUT_RING =
+  "[box-shadow:#E4E4E4_0_0_0_0.0625rem] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]";
+
+export function ConsoleFormMock() {
+  const [closed, setClosed] = useState(false);
+
+  return (
+    <div className="relative hidden w-[35rem] shrink-0 lg:block">
+      <div className="relative flex flex-col overflow-clip rounded-2xl bg-white [box-shadow:#E7E3F2_0_0_0_0.0625rem,#2828281F_0_1.5rem_3rem_-0.75rem] dark:bg-[#161320] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem]">
+        <div className="flex items-center gap-3 bg-[#FAFAFA] px-4 py-3 [box-shadow:#F0F0F0_0_-0.0625rem_0_inset] dark:bg-white/[0.03] dark:[box-shadow:#FFFFFF12_0_-0.0625rem_0_inset]">
+          <div className="flex shrink-0 items-center gap-1.5">
+            <button
+              aria-hidden={closed}
+              aria-label="Close tab"
+              className={`size-2.5 rounded-full bg-[#FF5F57] outline-none [box-shadow:#00000014_0_0_0_0.0625rem_inset] ${closed ? "" : "cursor-pointer transition-[filter] hover:brightness-95 focus-visible:ring-2 focus-visible:ring-primary"}`}
+              disabled={closed}
+              onClick={() => setClosed(true)}
+              type="button"
+            />
+            <span
+              aria-hidden="true"
+              className="size-2.5 rounded-full bg-[#FEBC2E] [box-shadow:#00000014_0_0_0_0.0625rem_inset]"
+            />
+            <span
+              aria-hidden="true"
+              className="size-2.5 rounded-full bg-[#28C840] [box-shadow:#00000014_0_0_0_0.0625rem_inset]"
+            />
+          </div>
+          <div
+            aria-hidden="true"
+            className="flex grow items-center justify-center rounded-lg bg-white px-3 py-1.25 [box-shadow:#ECECEC_0_0_0_0.0625rem] dark:bg-white/[0.06] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]"
+          >
+            <span className="font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] dark:text-white/50">
+              console.usenotra.com/integrations
+            </span>
+          </div>
+        </div>
+        <div className="relative">
+          <div
+            aria-hidden="true"
+            className={`transition-opacity duration-300 ${closed ? "pointer-events-none opacity-0" : "opacity-100"}`}
+            inert={closed}
+          >
+            <div className="flex flex-col gap-4 p-5">
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] dark:text-white/50">
+                    Banner
+                  </span>
+                  <span className="font-sans text-[#1E1E1E66] text-[0.6875rem] leading-[1.27] dark:text-white/40">
+                    3:1 · PNG or SVG · max 4 MB
+                  </span>
+                </div>
+                <div
+                  className={`relative flex h-[8.125rem] items-center justify-center overflow-clip rounded-xl ${BANNER_GRADIENT}`}
+                >
+                  <Linear className="size-10" />
+                  <span className="absolute right-2.5 bottom-2.5 flex items-center rounded-full bg-white/90 px-3 py-1.25">
+                    <span className="font-medium font-sans text-[#1E1E1E] text-[0.75rem] leading-[1.25]">
+                      Replace
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div className="flex gap-3">
+                <MockField label="Name" value="Linear" />
+                <MockField label="Author" value="Linear Orbit, Inc." />
+              </div>
+              <MockField
+                label="Description"
+                value="Shipped issues and project updates turn into progress posts your audience actually reads."
+              />
+              <div className="flex justify-end gap-8">
+                <div className="flex shrink-0 flex-col gap-1.5">
+                  <span className="font-medium font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] dark:text-white/50">
+                    Brand color
+                  </span>
+                  <div className="flex items-center gap-2.5">
+                    <div
+                      className={`flex items-center gap-2 rounded-[0.625rem] px-3 py-2.25 ${INPUT_RING}`}
+                    >
+                      <span className="size-4 shrink-0 rounded-[0.3125rem] bg-[#5E6AD2]" />
+                      <span className="font-mono text-[#1E1E1E] text-[0.75rem] leading-[1.33] dark:text-white">
+                        #5E6AD2
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <span className="size-5 shrink-0 rounded-[0.4375rem] bg-[#5E6AD2] [box-shadow:#FFFFFF_0_0_0_0.0625rem_inset,#7C3AED_0_0_0_0.125rem]" />
+                      <span className="size-5 shrink-0 rounded-[0.4375rem] bg-[#8B93E8]" />
+                      <span className="size-5 shrink-0 rounded-[0.4375rem] bg-[#3C478F]" />
+                      <span className="size-5 shrink-0 rounded-[0.4375rem] bg-[#1E1E1E] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]" />
+                    </div>
+                  </div>
+                </div>
+                <div className="flex w-[11.25rem] shrink-0 flex-col gap-1.5">
+                  <span className="font-medium font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] dark:text-white/50">
+                    Logo
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="flex size-[2.375rem] items-center justify-center rounded-[0.625rem] bg-[#EEF0FB] [box-shadow:#E4E4E4_0_0_0_0.0625rem] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+                      <Linear className="size-5" />
+                    </span>
+                    <span className="flex size-[2.375rem] items-center justify-center rounded-[0.625rem] bg-[#1E1E1E]">
+                      <Linear className="size-5" />
+                    </span>
+                    <span className="flex size-[2.375rem] items-center justify-center rounded-[0.625rem] border border-[#D4D4D4] border-dashed dark:border-white/20">
+                      <span className="font-sans text-[#1E1E1E66] text-[1rem] leading-none dark:text-white/40">
+                        +
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center justify-end gap-2 bg-[#FAFAFA] px-5 py-3.5 [box-shadow:#F0F0F0_0_0.0625rem_0_inset] dark:bg-white/[0.03] dark:[box-shadow:#FFFFFF12_0_0.0625rem_0_inset]">
+              <span className="flex items-center rounded-full bg-white px-4 py-2 font-medium font-sans text-[#1E1E1E] text-[0.8125rem] leading-[1.23] [box-shadow:#ECECEC_0_0_0_0.0625rem] dark:bg-white/[0.06] dark:text-white dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+                Save draft
+              </span>
+              <span
+                className={`flex items-center rounded-full px-4 py-2 font-sans font-semibold text-[0.8125rem] text-white leading-[1.23] ${PURPLE_GRADIENT}`}
+              >
+                Submit for review
+              </span>
+            </div>
+          </div>
+          <div
+            className={`absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white px-6 transition-opacity duration-300 dark:bg-[#161320] ${closed ? "opacity-100" : "pointer-events-none opacity-0"}`}
+            inert={!closed}
+          >
+            <span
+              aria-hidden="true"
+              className="font-display font-medium text-[#1E1E1E] text-[3.5rem] leading-[1] tracking-[-0.02em] dark:text-white"
+            >
+              404
+            </span>
+            <span className="font-sans text-[#1E1E1EA6] text-[0.9375rem] leading-[1.4] dark:text-white/60">
+              This integration went missing.
+            </span>
+            <button
+              className="mt-2 flex cursor-pointer items-center rounded-full bg-white px-3.5 py-1.5 font-medium font-sans text-[#1E1E1E] text-[0.8125rem] leading-[1.23] outline-none transition-colors [box-shadow:#ECECEC_0_0_0_0.0625rem] hover:bg-[#FAFAFA] focus-visible:ring-2 focus-visible:ring-primary dark:bg-white/[0.06] dark:text-white dark:hover:bg-white/[0.1] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]"
+              onClick={() => setClosed(false)}
+              type="button"
+            >
+              Reopen tab
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        aria-hidden="true"
+        className={`absolute bottom-[-2rem] left-[-2.5rem] flex w-[16.875rem] flex-col overflow-clip rounded-2xl bg-white transition-opacity duration-300 [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282826_0_1rem_2rem_-0.5rem] dark:bg-[#161320] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem] ${closed ? "pointer-events-none opacity-0" : "opacity-100"}`}
+        inert={closed}
+      >
+        <div
+          className={`flex h-[4.75rem] items-center justify-center ${BANNER_GRADIENT}`}
+        >
+          <Linear className="size-7" />
+        </div>
+        <div className="flex flex-col gap-2 px-4 pt-3.5 pb-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-px">
+              <span className="font-sans font-semibold text-[#1E1E1E] text-[0.9375rem] leading-[1.27] tracking-[-0.01em] dark:text-white">
+                Linear
+              </span>
+              <span className="font-sans text-[#1E1E1EA6] text-[0.75rem] leading-[1.25] dark:text-white/60">
+                by Linear Orbit, Inc.
+              </span>
+            </div>
+            <span
+              className={`flex items-center rounded-full px-3 py-1.25 font-sans font-semibold text-[0.75rem] text-white leading-[1.25] ${PURPLE_GRADIENT}`}
+            >
+              Connect
+            </span>
+          </div>
+          <span className="font-sans text-[#1E1E1EBF] text-[0.75rem] leading-[1.4] dark:text-white/70">
+            Shipped issues and project updates turn into progress posts.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MockField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex grow flex-col gap-1.5">
+      <span className="font-medium font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] dark:text-white/50">
+        {label}
+      </span>
+      <div className="flex rounded-[0.625rem] px-3 py-2.25 [box-shadow:#E4E4E4_0_0_0_0.0625rem] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+        <span className="font-sans text-[#1E1E1E] text-[0.8125rem] leading-[1.46] dark:text-white/80">
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/featured-integration-card.tsx
+++ b/apps/web/src/components/integrations/featured-integration-card.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import {
+  buildAuthorCategoryLine,
+  buildFeaturedMeta,
+  getIntegrationHref,
+} from "@/lib/integrations/helpers";
+import type { FeaturedIntegrationCardProps } from "@/types/integrations";
+import { IntegrationBanner } from "./integration-banner";
+import { IntegrationConnectButton } from "./integration-connect-button";
+import { IntegrationLogo } from "./integration-logo";
+
+const CARD_RING =
+  "[box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.1875rem] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem]";
+
+export function FeaturedIntegrationCard({
+  integration,
+}: FeaturedIntegrationCardProps) {
+  return (
+    <div
+      className={`relative flex flex-col overflow-clip rounded-3xl bg-white dark:bg-white/[0.02] ${CARD_RING}`}
+    >
+      <Link
+        aria-label={`View ${integration.name} details`}
+        className="absolute inset-0 z-0 cursor-pointer rounded-3xl outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        href={getIntegrationHref(integration)}
+      />
+      <div className="pointer-events-none relative z-10 flex flex-col">
+        <IntegrationBanner
+          className="h-[11.875rem] w-full shrink-0"
+          integration={integration}
+        />
+        <div className="flex flex-col gap-3.5 px-7 pt-6 pb-7">
+          <div className="flex items-center justify-start gap-3.5">
+            <span className="flex size-11 shrink-0 items-center justify-center overflow-clip rounded-xl bg-white [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.125rem] dark:bg-white/[0.06] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+              <IntegrationLogo fill integration={integration} size={44} />
+            </span>
+            <div className="flex grow flex-col gap-0.5">
+              <span className="font-sans font-semibold text-[#1E1E1E] text-[1.375rem] leading-[1.18] tracking-[-0.015em] dark:text-white">
+                {integration.name}
+              </span>
+              <span className="font-sans text-[#1E1E1EA6] text-[0.875rem] leading-[1.29] tracking-[-0.01em] dark:text-white/60">
+                {buildAuthorCategoryLine(integration)}
+              </span>
+            </div>
+            <IntegrationConnectButton className="pointer-events-auto px-5.5 py-2.5 text-[0.875rem] leading-[1.29]" />
+          </div>
+          {integration.description ? (
+            <span className="line-clamp-2 font-sans text-[#1E1E1EBF] text-[0.9375rem] leading-[1.47] tracking-[-0.005em] dark:text-white/70">
+              {integration.description}
+            </span>
+          ) : null}
+          <span className="font-medium font-sans text-[#1E1E1E80] text-[0.8125rem] leading-[1.38] tracking-[-0.005em] dark:text-white/50">
+            {buildFeaturedMeta(integration)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/integration-author-meta.tsx
+++ b/apps/web/src/components/integrations/integration-author-meta.tsx
@@ -19,7 +19,7 @@ export function IntegrationAuthorMeta({
         <a
           className="underline-offset-2 transition-colors hover:text-[#1E1E1E] hover:underline dark:hover:text-white"
           href={websiteUrl}
-          rel="noopener"
+          rel="noopener noreferrer"
           target="_blank"
         >
           {author}

--- a/apps/web/src/components/integrations/integration-author-meta.tsx
+++ b/apps/web/src/components/integrations/integration-author-meta.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@notra/ui/lib/utils";
+import type { IntegrationAuthorMetaProps } from "@/types/integrations";
+
+export function IntegrationAuthorMeta({
+  integration,
+  tail,
+  className,
+}: IntegrationAuthorMetaProps) {
+  const { author, websiteUrl } = integration;
+
+  if (!author) {
+    return <span className={cn("truncate", className)}>{tail}</span>;
+  }
+
+  return (
+    <span className={cn("truncate", className)}>
+      by{" "}
+      {websiteUrl ? (
+        <a
+          className="underline-offset-2 transition-colors hover:text-[#1E1E1E] hover:underline dark:hover:text-white"
+          href={websiteUrl}
+          rel="noopener"
+          target="_blank"
+        >
+          {author}
+        </a>
+      ) : (
+        author
+      )}
+      {tail ? ` · ${tail}` : ""}
+    </span>
+  );
+}

--- a/apps/web/src/components/integrations/integration-banner.tsx
+++ b/apps/web/src/components/integrations/integration-banner.tsx
@@ -6,6 +6,7 @@ import { IntegrationLogo } from "./integration-logo";
 export function IntegrationBanner({
   integration,
   className,
+  priority = false,
 }: IntegrationBannerProps) {
   if (integration.bannerUrl) {
     return (
@@ -14,6 +15,7 @@ export function IntegrationBanner({
           alt={`${integration.name} banner`}
           className="object-cover"
           fill
+          priority={priority}
           sizes="(max-width: 48rem) 100vw, 40rem"
           src={integration.bannerUrl}
           unoptimized

--- a/apps/web/src/components/integrations/integration-banner.tsx
+++ b/apps/web/src/components/integrations/integration-banner.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@notra/ui/lib/utils";
+import Image from "next/image";
+import type { IntegrationBannerProps } from "@/types/integrations";
+import { IntegrationLogo } from "./integration-logo";
+
+export function IntegrationBanner({
+  integration,
+  className,
+}: IntegrationBannerProps) {
+  if (integration.bannerUrl) {
+    return (
+      <div className={cn("relative overflow-hidden", className)}>
+        <Image
+          alt={`${integration.name} banner`}
+          className="object-cover"
+          fill
+          sizes="(max-width: 48rem) 100vw, 40rem"
+          src={integration.bannerUrl}
+          unoptimized
+        />
+      </div>
+    );
+  }
+
+  const brandColor = integration.brandColor ?? "#7C3AED";
+
+  return (
+    <div
+      className={cn(
+        "relative flex items-center justify-center overflow-hidden bg-[#EEF0FB] dark:bg-white/[0.04]",
+        className
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className="absolute inset-0"
+        style={{
+          background: `linear-gradient(120deg, ${brandColor}26 0%, ${brandColor}0d 100%)`,
+        }}
+      />
+      <IntegrationLogo
+        className="relative flex items-center justify-center"
+        integration={integration}
+        size={64}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/integration-card.tsx
+++ b/apps/web/src/components/integrations/integration-card.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import {
+  buildAuthorCategoryLine,
+  buildCardMeta,
+  getIntegrationHref,
+} from "@/lib/integrations/helpers";
+import type { IntegrationCardProps } from "@/types/integrations";
+import { IntegrationConnectButton } from "./integration-connect-button";
+import { IntegrationLogo } from "./integration-logo";
+
+const CARD_RING =
+  "[box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.125rem] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem]";
+
+export function IntegrationCard({ integration }: IntegrationCardProps) {
+  const brandColor = integration.brandColor ?? "#7C3AED";
+
+  return (
+    <div
+      className={`relative flex flex-col gap-3 rounded-[1.25rem] bg-white p-5 dark:bg-white/[0.02] ${CARD_RING}`}
+    >
+      <Link
+        aria-label={`View ${integration.name} details`}
+        className="absolute inset-0 z-0 cursor-pointer rounded-[1.25rem] outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        href={getIntegrationHref(integration)}
+      />
+      <div className="pointer-events-none relative z-10 flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <span
+            className="flex size-11 shrink-0 items-center justify-center overflow-clip rounded-xl"
+            style={{ backgroundColor: `${brandColor}14` }}
+          >
+            <IntegrationLogo fill integration={integration} size={44} />
+          </span>
+          <IntegrationConnectButton className="pointer-events-auto px-3.5 py-1.5 text-[0.8125rem] leading-[1.23]" />
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <span className="font-sans font-semibold text-[#1E1E1E] text-[1.0625rem] leading-[1.29] tracking-[-0.01em] dark:text-white">
+            {integration.name}
+          </span>
+          <span className="font-sans text-[#1E1E1EA6] text-[0.8125rem] leading-[1.31] tracking-[-0.005em] dark:text-white/60">
+            {buildAuthorCategoryLine(integration)}
+          </span>
+        </div>
+        {integration.description ? (
+          <span className="line-clamp-2 font-sans text-[#1E1E1EBF] text-[0.8125rem] leading-[1.46] tracking-[-0.005em] dark:text-white/70">
+            {integration.description}
+          </span>
+        ) : null}
+        <span className="font-medium font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] dark:text-white/50">
+          {buildCardMeta(integration)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/integration-connect-button.tsx
+++ b/apps/web/src/components/integrations/integration-connect-button.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@notra/ui/lib/utils";
+import { INTEGRATIONS_CONNECT_URL } from "@/constants/integrations";
+
+const PRIMARY_CLASSNAME = "cta-gradient-primary-flat text-white";
+
+export function IntegrationConnectButton({
+  className,
+  label = "Connect",
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <a
+      className={cn(
+        "inline-flex shrink-0 cursor-pointer items-center justify-center rounded-full font-sans font-semibold outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        PRIMARY_CLASSNAME,
+        className
+      )}
+      href={INTEGRATIONS_CONNECT_URL}
+      rel="noopener"
+    >
+      {label}
+    </a>
+  );
+}

--- a/apps/web/src/components/integrations/integration-connect-button.tsx
+++ b/apps/web/src/components/integrations/integration-connect-button.tsx
@@ -18,7 +18,6 @@ export function IntegrationConnectButton({
         className
       )}
       href={INTEGRATIONS_CONNECT_URL}
-      rel="noopener"
     >
       {label}
     </a>

--- a/apps/web/src/components/integrations/integration-detail-view.tsx
+++ b/apps/web/src/components/integrations/integration-detail-view.tsx
@@ -34,6 +34,7 @@ export function IntegrationDetailView({
         <IntegrationBanner
           className="h-[15rem] w-full rounded-[1.25rem] sm:h-[21.25rem]"
           integration={integration}
+          priority
         />
 
         <div className="flex flex-col gap-7">

--- a/apps/web/src/components/integrations/integration-detail-view.tsx
+++ b/apps/web/src/components/integrations/integration-detail-view.tsx
@@ -1,0 +1,100 @@
+import {
+  ArrowLeft01Icon,
+  ArrowUpRight01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import {
+  buildDetailMetaTail,
+  buildDetailStats,
+} from "@/lib/integrations/helpers";
+import type { IntegrationDetailViewProps } from "@/types/integrations";
+import { IntegrationAuthorMeta } from "./integration-author-meta";
+import { IntegrationBanner } from "./integration-banner";
+import { IntegrationConnectButton } from "./integration-connect-button";
+import { IntegrationLogo } from "./integration-logo";
+import { IntegrationToolsGrid } from "./integration-tools-grid";
+
+export function IntegrationDetailView({
+  integration,
+}: IntegrationDetailViewProps) {
+  const stats = buildDetailStats(integration);
+
+  return (
+    <div className="flex w-full flex-col items-center pb-14">
+      <div className="flex w-[min(100%-3rem,64rem)] flex-col gap-8 pt-24 lg:pt-28">
+        <Link
+          className="inline-flex w-max cursor-pointer items-center gap-1.5 whitespace-nowrap font-medium font-sans text-[#1E1E1E80] text-[0.875rem] leading-[1.29] transition-colors hover:text-[#1E1E1E] dark:text-white/50 dark:hover:text-white"
+          href="/integrations"
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} size={16} />
+          <span>All integrations</span>
+        </Link>
+
+        <IntegrationBanner
+          className="h-[15rem] w-full rounded-[1.25rem] sm:h-[21.25rem]"
+          integration={integration}
+        />
+
+        <div className="flex flex-col gap-7">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-3.5">
+            <span className="flex size-15 shrink-0 items-center justify-center overflow-clip rounded-2xl bg-white [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.1875rem] dark:bg-white/[0.06] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+              <IntegrationLogo fill integration={integration} size={60} />
+            </span>
+            <div className="flex min-w-0 grow flex-col gap-1">
+              <h1 className="font-sans font-semibold text-[#1E1E1E] text-[2.375rem] leading-[1.16] tracking-[-0.02em] dark:text-white">
+                {integration.name}
+              </h1>
+              <IntegrationAuthorMeta
+                className="font-sans text-[#1E1E1EA6] text-[0.9375rem] leading-[1.33] tracking-[-0.01em] dark:text-white/60"
+                integration={integration}
+                tail={buildDetailMetaTail(integration)}
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              {integration.websiteUrl ? (
+                <a
+                  className="flex cursor-pointer items-center gap-1.5 rounded-full bg-white px-5.5 py-2.75 font-medium font-sans text-[#1E1E1E] text-[0.875rem] leading-[1.29] transition-colors [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.125rem] hover:bg-[#FAFAFA] dark:bg-white/[0.08] dark:text-white dark:hover:bg-white/[0.12] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]"
+                  href={integration.websiteUrl}
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Website
+                  <HugeiconsIcon icon={ArrowUpRight01Icon} size={14} />
+                </a>
+              ) : null}
+              <IntegrationConnectButton className="px-6.5 py-2.75 text-[0.875rem] leading-[1.29]" />
+            </div>
+          </div>
+
+          {integration.description ? (
+            <p className="font-sans text-[#1E1E1EBF] text-[1rem] leading-[1.56] tracking-[-0.005em] dark:text-white/70">
+              {integration.description}
+            </p>
+          ) : null}
+
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:gap-6">
+            {stats.map((stat) => (
+              <div
+                className="flex flex-col gap-0.5 rounded-2xl px-5.5 py-4.5 [box-shadow:#ECECEC_0_0_0_0.0625rem] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem]"
+                key={stat.label}
+              >
+                <span className="font-medium font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] tracking-[0.04em] dark:text-white/50">
+                  {stat.label}
+                </span>
+                <span className="font-sans font-semibold text-[#1E1E1E] text-[1.125rem] leading-[1.33] tracking-[-0.01em] dark:text-white">
+                  {stat.value}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <IntegrationToolsGrid
+            tools={integration.tools}
+            totalCount={integration.indexedToolCount}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/integration-logo.tsx
+++ b/apps/web/src/components/integrations/integration-logo.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@notra/ui/lib/utils";
+import Image from "next/image";
+import type { IntegrationLogoProps } from "@/types/integrations";
+
+export function IntegrationLogo({
+  integration,
+  size,
+  className,
+  fill = false,
+}: IntegrationLogoProps) {
+  const light = integration.logoLightUrl ?? integration.logoDarkUrl;
+  const dark = integration.logoDarkUrl ?? integration.logoLightUrl;
+  const alt = `${integration.name} logo`;
+  const fit = fill ? "object-cover" : "object-contain";
+  const boxClass = fill ? "h-full w-full" : "";
+  const boxStyle = fill
+    ? undefined
+    : { width: `${size / 16}rem`, height: `${size / 16}rem` };
+
+  if (!(light && dark)) {
+    return (
+      <span
+        className={cn("flex items-center justify-center", boxClass, className)}
+        style={{ ...boxStyle, color: integration.brandColor ?? "#7C3AED" }}
+      >
+        <span className="font-sans font-semibold text-[0.9em]">
+          {integration.name.charAt(0).toUpperCase()}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={cn(boxClass, className)} style={boxStyle}>
+      <Image
+        alt={alt}
+        className={`block h-full w-full ${fit} dark:hidden`}
+        height={size}
+        src={light}
+        unoptimized
+        width={size}
+      />
+      <Image
+        alt={alt}
+        className={`hidden h-full w-full ${fit} dark:block`}
+        height={size}
+        src={dark}
+        unoptimized
+        width={size}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/integrations/integration-logo.tsx
+++ b/apps/web/src/components/integrations/integration-logo.tsx
@@ -30,6 +30,21 @@ export function IntegrationLogo({
     );
   }
 
+  if (light === dark) {
+    return (
+      <span className={cn(boxClass, className)} style={boxStyle}>
+        <Image
+          alt={alt}
+          className={`block h-full w-full ${fit}`}
+          height={size}
+          src={light}
+          unoptimized
+          width={size}
+        />
+      </span>
+    );
+  }
+
   return (
     <span className={cn(boxClass, className)} style={boxStyle}>
       <Image

--- a/apps/web/src/components/integrations/integration-modal.tsx
+++ b/apps/web/src/components/integrations/integration-modal.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogTitle,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { useRouter } from "next/navigation";
+import { QUICK_VIEW_VISIBLE_TOOLS } from "@/constants/integrations";
+import {
+  buildQuickViewMetaTail,
+  getToolDescription,
+} from "@/lib/integrations/helpers";
+import type { IntegrationModalProps } from "@/types/integrations";
+import { IntegrationAuthorMeta } from "./integration-author-meta";
+import { IntegrationBanner } from "./integration-banner";
+import { IntegrationConnectButton } from "./integration-connect-button";
+import { IntegrationLogo } from "./integration-logo";
+
+export function IntegrationModal({ integration }: IntegrationModalProps) {
+  const router = useRouter();
+
+  return (
+    <ResponsiveDialog
+      onOpenChange={(open) => {
+        if (!open) {
+          router.back();
+        }
+      }}
+      open
+    >
+      <ResponsiveDialogContent
+        className="max-h-[min(85vh,48rem)] gap-0 overflow-hidden rounded-3xl p-0 sm:max-w-[40rem]"
+        showCloseButton={false}
+      >
+        <ModalBody integration={integration} />
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}
+
+function ModalBody({ integration }: IntegrationModalProps) {
+  const visibleTools = integration.tools.slice(0, QUICK_VIEW_VISIBLE_TOOLS);
+  const remaining = integration.indexedToolCount - visibleTools.length;
+
+  return (
+    <div className="relative flex max-h-[min(85vh,48rem)] w-full min-w-0 flex-col">
+      <IntegrationBanner
+        className="h-[10.625rem] w-full shrink-0"
+        integration={integration}
+      />
+      <ResponsiveDialogClose className="absolute top-4 right-4 z-10 flex size-8 cursor-pointer items-center justify-center rounded-full bg-white text-[#1E1E1E] transition-colors [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.125rem] hover:bg-[#FAFAFA] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:bg-[#1c1c1f] dark:text-white dark:hover:bg-white/[0.1] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+        <HugeiconsIcon icon={Cancel01Icon} size={15} strokeWidth={2} />
+        <span className="sr-only">Close</span>
+      </ResponsiveDialogClose>
+      <div className="flex w-full min-w-0 shrink-0 items-center gap-3.5 px-7 pt-6">
+        <span className="flex size-12 shrink-0 items-center justify-center overflow-clip rounded-[0.875rem] bg-white [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.125rem] dark:bg-white/[0.06] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+          <IntegrationLogo fill integration={integration} size={48} />
+        </span>
+        <div className="flex min-w-0 grow flex-col gap-0.5">
+          <ResponsiveDialogTitle className="truncate font-sans font-semibold text-[#1E1E1E] text-[1.5rem] leading-[1.25] tracking-[-0.015em] dark:text-white">
+            {integration.name}
+          </ResponsiveDialogTitle>
+          <IntegrationAuthorMeta
+            className="font-sans text-[#1E1E1EA6] text-[0.875rem] leading-[1.29] tracking-[-0.01em] dark:text-white/60"
+            integration={integration}
+            tail={buildQuickViewMetaTail(integration)}
+          />
+        </div>
+        <IntegrationConnectButton className="px-6 py-2.5 text-[0.875rem] leading-[1.29]" />
+      </div>
+      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-y-auto pb-6">
+        {integration.description ? (
+          <ResponsiveDialogDescription className="px-7 pt-3.5 text-left font-sans text-[#1E1E1EBF] text-[0.875rem] leading-[1.5] tracking-[-0.005em] dark:text-white/70">
+            {integration.description}
+          </ResponsiveDialogDescription>
+        ) : null}
+        {visibleTools.length > 0 ? (
+          <div className="flex w-full min-w-0 flex-col px-7 pt-5">
+            <span className="mb-2 font-medium font-sans text-[#1E1E1E80] text-[0.75rem] leading-[1.33] tracking-[0.04em] dark:text-white/50">
+              TOOLS · {integration.indexedToolCount}
+            </span>
+            {visibleTools.map((tool) => (
+              <div
+                className="flex h-[2.375rem] w-full min-w-0 items-center gap-4 [box-shadow:#F0F0F0_0_-0.0625rem_0_inset] dark:[box-shadow:#FFFFFF12_0_-0.0625rem_0_inset]"
+                key={tool.name}
+              >
+                <span className="max-w-[45%] shrink-0 truncate font-medium font-mono text-[#1E1E1E] text-[0.8125rem] leading-[1.38] dark:text-white">
+                  {tool.name}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-right font-sans text-[#1E1E1EA6] text-[0.8125rem] leading-[1.38] dark:text-white/60">
+                  {getToolDescription(tool)}
+                </span>
+              </div>
+            ))}
+            {remaining > 0 ? (
+              <span className="pt-1.5 font-medium font-sans text-[#1E1E1E80] text-[0.8125rem] leading-[1.38] dark:text-white/50">
+                + {remaining} more {remaining === 1 ? "tool" : "tools"}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex w-full min-w-0 shrink-0 items-center bg-[#FAFAFA] px-7 py-4 [box-shadow:#F0F0F0_0_0.0625rem_0_inset] dark:bg-white/[0.03] dark:[box-shadow:#FFFFFF12_0_0.0625rem_0_inset]">
+        <span className="min-w-0 truncate font-sans text-[#1E1E1E80] text-[0.8125rem] leading-[1.31] dark:text-white/50">
+          Reviewed by Notra · Verified publisher
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/integration-tools-grid.tsx
+++ b/apps/web/src/components/integrations/integration-tools-grid.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { DETAIL_VISIBLE_TOOLS } from "@/constants/integrations";
+import { getToolDescription } from "@/lib/integrations/helpers";
+import type {
+  IntegrationTool,
+  IntegrationToolsGridProps,
+} from "@/types/integrations";
+
+const TOOL_CARD =
+  "flex flex-col gap-1 rounded-2xl px-5.5 py-4.5 [box-shadow:#ECECEC_0_0_0_0.0625rem] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem]";
+
+function ToolCard({ tool }: { tool: IntegrationTool }) {
+  const description = getToolDescription(tool);
+
+  return (
+    <div className={TOOL_CARD}>
+      <span className="truncate font-medium font-mono text-[#1E1E1E] text-[0.875rem] leading-[1.36] dark:text-white">
+        {tool.name}
+      </span>
+      {description ? (
+        <span className="line-clamp-2 font-sans text-[#1E1E1EA6] text-[0.8125rem] leading-[1.46] dark:text-white/60">
+          {description}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function IntegrationToolsGrid({
+  tools,
+  totalCount,
+}: IntegrationToolsGridProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (tools.length === 0) {
+    return null;
+  }
+
+  const visibleTools = expanded ? tools : tools.slice(0, DETAIL_VISIBLE_TOOLS);
+  const remaining = totalCount - visibleTools.length;
+
+  return (
+    <section className="flex flex-col gap-5">
+      <h2 className="font-medium font-sans text-[#1E1E1E] text-[1.75rem] leading-[1.21] tracking-[-0.02em] dark:text-white">
+        Tools
+      </h2>
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        {visibleTools.map((tool) => (
+          <ToolCard key={tool.name} tool={tool} />
+        ))}
+        {!expanded && remaining > 0 ? (
+          <button
+            className="flex cursor-pointer items-center justify-center rounded-2xl px-5.5 py-4.5 outline-none transition-colors [box-shadow:#ECECEC_0_0_0_0.0625rem] hover:bg-[#FAFAFA] focus-visible:ring-2 focus-visible:ring-primary dark:hover:bg-white/[0.04] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem]"
+            onClick={() => setExpanded(true)}
+            type="button"
+          >
+            <span className="font-medium font-sans text-[#1E1E1E80] text-[0.875rem] leading-[1.36] dark:text-white/50">
+              + {remaining} more {remaining === 1 ? "tool" : "tools"}
+            </span>
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/integrations/integrations-marketplace-fallback.tsx
+++ b/apps/web/src/components/integrations/integrations-marketplace-fallback.tsx
@@ -1,0 +1,23 @@
+import { ALL_CATEGORY_ID } from "@/constants/integrations";
+import { getFeaturedIntegrations } from "@/lib/integrations/helpers";
+import type { IntegrationsMarketplaceProps } from "@/types/integrations";
+import { IntegrationsView } from "./integrations-view";
+
+export function IntegrationsMarketplaceFallback({
+  integrations,
+  categories,
+}: IntegrationsMarketplaceProps) {
+  const featured = getFeaturedIntegrations(integrations);
+
+  return (
+    <IntegrationsView
+      activeCategory={ALL_CATEGORY_ID}
+      categories={categories}
+      featured={featured}
+      filtered={integrations}
+      integrations={integrations}
+      query=""
+      showFeatured={featured.length > 0}
+    />
+  );
+}

--- a/apps/web/src/components/integrations/integrations-marketplace.tsx
+++ b/apps/web/src/components/integrations/integrations-marketplace.tsx
@@ -1,24 +1,13 @@
 "use client";
 
-import { Search01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { parseAsString, useQueryState } from "nuqs";
-
-import { HeroDither } from "@/components/landing/hero-dither";
 import { ALL_CATEGORY_ID } from "@/constants/integrations";
 import {
   filterIntegrations,
   getFeaturedIntegrations,
 } from "@/lib/integrations/helpers";
 import type { IntegrationsMarketplaceProps } from "@/types/integrations";
-import { FeaturedIntegrationCard } from "./featured-integration-card";
-import { IntegrationCard } from "./integration-card";
-
-const PILL_BASE =
-  "flex shrink-0 cursor-pointer items-center rounded-full px-4 py-1.75 font-medium font-sans text-[0.875rem] leading-[1.29] tracking-[-0.01em] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary";
-const PILL_ACTIVE = "bg-[#1E1E1E] text-white dark:bg-white dark:text-[#1E1E1E]";
-const PILL_INACTIVE =
-  "bg-white text-[#1E1E1EA6] [box-shadow:#ECECEC_0_0_0_0.0625rem] hover:text-[#1E1E1E] dark:bg-white/[0.04] dark:text-white/60 dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem] dark:hover:text-white";
+import { IntegrationsView } from "./integrations-view";
 
 export function IntegrationsMarketplace({
   integrations,
@@ -43,130 +32,20 @@ export function IntegrationsMarketplace({
   const showFeatured = !isBrowsing && featured.length > 0;
 
   return (
-    <div className="flex w-full flex-col items-center">
-      <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
-        <div className="relative isolate overflow-clip rounded-3xl bg-[#EFEAFA] dark:bg-[#2a2140]">
-          <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
-            <HeroDither className="-top-1.25 -left-10.75 absolute h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />
-          </div>
-          <div className="relative flex w-full flex-col items-center gap-6 px-6 pt-20 pb-16 lg:pt-24">
-            <h1 className="max-w-[47rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.12] tracking-[-0.015em] sm:text-[3.25rem] lg:text-[4rem] dark:text-white">
-              Every tool you ship with,{" "}
-              <span className="text-primary">plugged</span> into Notra.
-            </h1>
-            <p className="max-w-[36rem] text-center font-medium font-sans text-[#1E1E1EBF] text-[1.0625rem] leading-[1.42] tracking-[-0.005em] sm:text-[1.1875rem] dark:text-white/70">
-              Browse integrations built by the community and reviewed by us.
-              Connect any of them to your workspace in one click.
-            </p>
-            <div className="mt-2 flex w-full max-w-[35rem] items-center justify-between gap-2.5 rounded-full bg-white py-2.5 pr-2.5 pl-5 [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.1875rem] dark:bg-white/[0.06] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
-              <div className="flex grow items-center gap-2.5">
-                <HugeiconsIcon
-                  className="shrink-0 text-[#1E1E1E80] dark:text-white/50"
-                  icon={Search01Icon}
-                  size={18}
-                />
-                <input
-                  aria-label="Search integrations"
-                  className="w-full bg-transparent font-sans text-[#1E1E1E] text-[1rem] leading-[1.25] tracking-[-0.01em] outline-none placeholder:text-[#1E1E1E66] dark:text-white dark:placeholder:text-white/40"
-                  onChange={(event) => {
-                    setQuery(event.target.value);
-                  }}
-                  placeholder="Search integrations…"
-                  type="search"
-                  value={query}
-                />
-              </div>
-              <a
-                className="cta-gradient-primary-flat flex shrink-0 cursor-pointer items-center justify-center rounded-full px-4.5 py-2 font-sans font-semibold text-[0.875rem] text-white leading-[1.29]"
-                href="#all-integrations"
-              >
-                Browse all
-              </a>
-            </div>
-            <div className="flex w-full max-w-[45rem] items-center gap-2.5 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-              {categories.map((category) => {
-                const isActive = category.id === activeCategory;
-                return (
-                  <button
-                    className={`${PILL_BASE} ${isActive ? PILL_ACTIVE : PILL_INACTIVE}`}
-                    key={category.id}
-                    onClick={() => {
-                      setActiveCategory(category.id);
-                    }}
-                    type="button"
-                  >
-                    {category.label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <div className="flex w-[min(100%-3rem,80rem)] flex-col gap-14 pt-14">
-        {showFeatured ? (
-          <section className="flex flex-col gap-7">
-            <div className="flex items-end justify-between gap-4">
-              <div className="flex flex-col gap-2">
-                <span className="font-medium font-sans text-[#1E1E1E80] text-[1.125rem] leading-[1.22] tracking-[-0.02em] dark:text-white/50">
-                  Featured this month
-                </span>
-                <h2 className="font-medium font-sans text-[#1E1E1E] text-[2.125rem] leading-[1.18] tracking-[-0.02em] dark:text-white">
-                  Editor's picks
-                </h2>
-              </div>
-              <a
-                className="shrink-0 cursor-pointer font-medium font-sans text-[1rem] text-primary leading-[1.25]"
-                href="#all-integrations"
-              >
-                View all {integrations.length} →
-              </a>
-            </div>
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-              {featured.map((integration) => (
-                <FeaturedIntegrationCard
-                  integration={integration}
-                  key={integration.id}
-                />
-              ))}
-            </div>
-          </section>
-        ) : null}
-
-        <section
-          className="flex scroll-mt-24 flex-col gap-7"
-          id="all-integrations"
-        >
-          <div className="flex items-end justify-between gap-4">
-            <div className="flex flex-col gap-2">
-              <span className="font-medium font-sans text-[#1E1E1E80] text-[1.125rem] leading-[1.22] tracking-[-0.02em] dark:text-white/50">
-                Reviewed and live
-              </span>
-              <h2 className="font-medium font-sans text-[#1E1E1E] text-[2.125rem] leading-[1.18] tracking-[-0.02em] dark:text-white">
-                All integrations
-              </h2>
-            </div>
-            <span className="shrink-0 font-sans text-[#1E1E1E80] text-[0.875rem] leading-[1.29] dark:text-white/50">
-              Sorted A–Z
-            </span>
-          </div>
-          {filtered.length > 0 ? (
-            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {filtered.map((integration) => (
-                <IntegrationCard
-                  integration={integration}
-                  key={integration.id}
-                />
-              ))}
-            </div>
-          ) : (
-            <p className="py-14 text-center font-sans text-[#1E1E1E80] text-[0.9375rem] dark:text-white/50">
-              No integrations match your search yet.
-            </p>
-          )}
-        </section>
-      </div>
-    </div>
+    <IntegrationsView
+      activeCategory={activeCategory}
+      categories={categories}
+      featured={featured}
+      filtered={filtered}
+      integrations={integrations}
+      onCategoryChange={(id) => {
+        setActiveCategory(id);
+      }}
+      onQueryChange={(value) => {
+        setQuery(value);
+      }}
+      query={query}
+      showFeatured={showFeatured}
+    />
   );
 }

--- a/apps/web/src/components/integrations/integrations-marketplace.tsx
+++ b/apps/web/src/components/integrations/integrations-marketplace.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Search01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { parseAsString, useQueryState } from "nuqs";
+import { useMemo } from "react";
+import { HeroDither } from "@/components/landing/hero-dither";
+import { ALL_CATEGORY_ID } from "@/constants/integrations";
+import {
+  filterIntegrations,
+  getFeaturedIntegrations,
+} from "@/lib/integrations/helpers";
+import type { IntegrationsMarketplaceProps } from "@/types/integrations";
+import { FeaturedIntegrationCard } from "./featured-integration-card";
+import { IntegrationCard } from "./integration-card";
+
+const PILL_BASE =
+  "flex shrink-0 cursor-pointer items-center rounded-full px-4 py-1.75 font-medium font-sans text-[0.875rem] leading-[1.29] tracking-[-0.01em] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary";
+const PILL_ACTIVE = "bg-[#1E1E1E] text-white dark:bg-white dark:text-[#1E1E1E]";
+const PILL_INACTIVE =
+  "bg-white text-[#1E1E1EA6] [box-shadow:#ECECEC_0_0_0_0.0625rem] hover:text-[#1E1E1E] dark:bg-white/[0.04] dark:text-white/60 dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem] dark:hover:text-white";
+
+export function IntegrationsMarketplace({
+  integrations,
+  categories,
+}: IntegrationsMarketplaceProps) {
+  const [query, setQuery] = useQueryState(
+    "q",
+    parseAsString.withDefault("").withOptions({ clearOnDefault: true })
+  );
+  const [activeCategory, setActiveCategory] = useQueryState(
+    "category",
+    parseAsString
+      .withDefault(ALL_CATEGORY_ID)
+      .withOptions({ clearOnDefault: true })
+  );
+
+  const featured = useMemo(
+    () => getFeaturedIntegrations(integrations),
+    [integrations]
+  );
+  const filtered = useMemo(
+    () => filterIntegrations(integrations, query, activeCategory),
+    [integrations, query, activeCategory]
+  );
+
+  const isBrowsing =
+    query.trim().length > 0 || activeCategory !== ALL_CATEGORY_ID;
+  const showFeatured = !isBrowsing && featured.length > 0;
+
+  return (
+    <div className="flex w-full flex-col items-center">
+      <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
+        <div className="relative isolate overflow-clip rounded-3xl bg-[#EFEAFA] dark:bg-[#2a2140]">
+          <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
+            <HeroDither className="-top-1.25 -left-10.75 absolute h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />
+          </div>
+          <div className="relative flex w-full flex-col items-center gap-6 px-6 pt-20 pb-16 lg:pt-24">
+            <h1 className="max-w-[47rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.12] tracking-[-0.015em] sm:text-[3.25rem] lg:text-[4rem] dark:text-white">
+              Every tool you ship with,{" "}
+              <span className="text-primary">plugged</span> into Notra.
+            </h1>
+            <p className="max-w-[36rem] text-center font-medium font-sans text-[#1E1E1EBF] text-[1.0625rem] leading-[1.42] tracking-[-0.005em] sm:text-[1.1875rem] dark:text-white/70">
+              Browse integrations built by the community and reviewed by us.
+              Connect any of them to your workspace in one click.
+            </p>
+            <div className="mt-2 flex w-full max-w-[35rem] items-center justify-between gap-2.5 rounded-full bg-white py-2.5 pr-2.5 pl-5 [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.1875rem] dark:bg-white/[0.06] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+              <div className="flex grow items-center gap-2.5">
+                <HugeiconsIcon
+                  className="shrink-0 text-[#1E1E1E80] dark:text-white/50"
+                  icon={Search01Icon}
+                  size={18}
+                />
+                <input
+                  aria-label="Search integrations"
+                  className="w-full bg-transparent font-sans text-[#1E1E1E] text-[1rem] leading-[1.25] tracking-[-0.01em] outline-none placeholder:text-[#1E1E1E66] dark:text-white dark:placeholder:text-white/40"
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                  }}
+                  placeholder="Search integrations…"
+                  type="search"
+                  value={query}
+                />
+              </div>
+              <a
+                className="cta-gradient-primary-flat flex shrink-0 cursor-pointer items-center justify-center rounded-full px-4.5 py-2 font-sans font-semibold text-[0.875rem] text-white leading-[1.29]"
+                href="#all-integrations"
+              >
+                Browse all
+              </a>
+            </div>
+            <div className="flex w-full max-w-[45rem] items-center gap-2.5 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              {categories.map((category) => {
+                const isActive = category.id === activeCategory;
+                return (
+                  <button
+                    className={`${PILL_BASE} ${isActive ? PILL_ACTIVE : PILL_INACTIVE}`}
+                    key={category.id}
+                    onClick={() => {
+                      setActiveCategory(category.id);
+                    }}
+                    type="button"
+                  >
+                    {category.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="flex w-[min(100%-3rem,80rem)] flex-col gap-14 pt-14">
+        {showFeatured ? (
+          <section className="flex flex-col gap-7">
+            <div className="flex items-end justify-between gap-4">
+              <div className="flex flex-col gap-2">
+                <span className="font-medium font-sans text-[#1E1E1E80] text-[1.125rem] leading-[1.22] tracking-[-0.02em] dark:text-white/50">
+                  Featured this month
+                </span>
+                <h2 className="font-medium font-sans text-[#1E1E1E] text-[2.125rem] leading-[1.18] tracking-[-0.02em] dark:text-white">
+                  Editor's picks
+                </h2>
+              </div>
+              <a
+                className="shrink-0 cursor-pointer font-medium font-sans text-[1rem] text-primary leading-[1.25]"
+                href="#all-integrations"
+              >
+                View all {integrations.length} →
+              </a>
+            </div>
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              {featured.map((integration) => (
+                <FeaturedIntegrationCard
+                  integration={integration}
+                  key={integration.id}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section
+          className="flex scroll-mt-24 flex-col gap-7"
+          id="all-integrations"
+        >
+          <div className="flex items-end justify-between gap-4">
+            <div className="flex flex-col gap-2">
+              <span className="font-medium font-sans text-[#1E1E1E80] text-[1.125rem] leading-[1.22] tracking-[-0.02em] dark:text-white/50">
+                Reviewed and live
+              </span>
+              <h2 className="font-medium font-sans text-[#1E1E1E] text-[2.125rem] leading-[1.18] tracking-[-0.02em] dark:text-white">
+                All integrations
+              </h2>
+            </div>
+            <span className="shrink-0 font-sans text-[#1E1E1E80] text-[0.875rem] leading-[1.29] dark:text-white/50">
+              Sorted A–Z
+            </span>
+          </div>
+          {filtered.length > 0 ? (
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {filtered.map((integration) => (
+                <IntegrationCard
+                  integration={integration}
+                  key={integration.id}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="py-14 text-center font-sans text-[#1E1E1E80] text-[0.9375rem] dark:text-white/50">
+              No integrations match your search yet.
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/integrations-marketplace.tsx
+++ b/apps/web/src/components/integrations/integrations-marketplace.tsx
@@ -3,7 +3,7 @@
 import { Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { parseAsString, useQueryState } from "nuqs";
-import { useMemo } from "react";
+
 import { HeroDither } from "@/components/landing/hero-dither";
 import { ALL_CATEGORY_ID } from "@/constants/integrations";
 import {
@@ -35,14 +35,8 @@ export function IntegrationsMarketplace({
       .withOptions({ clearOnDefault: true })
   );
 
-  const featured = useMemo(
-    () => getFeaturedIntegrations(integrations),
-    [integrations]
-  );
-  const filtered = useMemo(
-    () => filterIntegrations(integrations, query, activeCategory),
-    [integrations, query, activeCategory]
-  );
+  const featured = getFeaturedIntegrations(integrations);
+  const filtered = filterIntegrations(integrations, query, activeCategory);
 
   const isBrowsing =
     query.trim().length > 0 || activeCategory !== ALL_CATEGORY_ID;

--- a/apps/web/src/components/integrations/integrations-view.tsx
+++ b/apps/web/src/components/integrations/integrations-view.tsx
@@ -1,0 +1,157 @@
+import { Search01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { HeroDither } from "@/components/landing/hero-dither";
+import type { IntegrationsViewProps } from "@/types/integrations";
+import { FeaturedIntegrationCard } from "./featured-integration-card";
+import { IntegrationCard } from "./integration-card";
+
+const PILL_BASE =
+  "flex shrink-0 cursor-pointer items-center rounded-full px-4 py-1.75 font-medium font-sans text-[0.875rem] leading-[1.29] tracking-[-0.01em] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary";
+const PILL_ACTIVE = "bg-[#1E1E1E] text-white dark:bg-white dark:text-[#1E1E1E]";
+const PILL_INACTIVE =
+  "bg-white text-[#1E1E1EA6] [box-shadow:#ECECEC_0_0_0_0.0625rem] hover:text-[#1E1E1E] dark:bg-white/[0.04] dark:text-white/60 dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem] dark:hover:text-white";
+
+export function IntegrationsView({
+  integrations,
+  categories,
+  query,
+  activeCategory,
+  filtered,
+  featured,
+  showFeatured,
+  onQueryChange,
+  onCategoryChange,
+}: IntegrationsViewProps) {
+  return (
+    <div className="flex w-full flex-col items-center">
+      <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
+        <div className="relative isolate overflow-clip rounded-3xl bg-[#EFEAFA] dark:bg-[#2a2140]">
+          <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
+            <HeroDither className="-top-1.25 -left-10.75 absolute h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />
+          </div>
+          <div className="relative flex w-full flex-col items-center gap-6 px-6 pt-20 pb-16 lg:pt-24">
+            <h1 className="max-w-[47rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.12] tracking-[-0.015em] sm:text-[3.25rem] lg:text-[4rem] dark:text-white">
+              Every tool you ship with,{" "}
+              <span className="text-primary">plugged</span> into Notra.
+            </h1>
+            <p className="max-w-[36rem] text-center font-medium font-sans text-[#1E1E1EBF] text-[1.0625rem] leading-[1.42] tracking-[-0.005em] sm:text-[1.1875rem] dark:text-white/70">
+              Browse integrations built by the community and reviewed by us.
+              Connect any of them to your workspace in one click.
+            </p>
+            <div className="mt-2 flex w-full max-w-[35rem] items-center justify-between gap-2.5 rounded-full bg-white py-2.5 pr-2.5 pl-5 [box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.1875rem] dark:bg-white/[0.06] dark:[box-shadow:#FFFFFF1F_0_0_0_0.0625rem]">
+              <div className="flex grow items-center gap-2.5">
+                <HugeiconsIcon
+                  className="shrink-0 text-[#1E1E1E80] dark:text-white/50"
+                  icon={Search01Icon}
+                  size={18}
+                />
+                <input
+                  aria-label="Search integrations"
+                  className="w-full bg-transparent font-sans text-[#1E1E1E] text-[1rem] leading-[1.25] tracking-[-0.01em] outline-none placeholder:text-[#1E1E1E66] dark:text-white dark:placeholder:text-white/40"
+                  onChange={
+                    onQueryChange
+                      ? (event) => onQueryChange(event.target.value)
+                      : undefined
+                  }
+                  placeholder="Search integrations…"
+                  readOnly={!onQueryChange}
+                  type="search"
+                  value={query}
+                />
+              </div>
+              <a
+                className="cta-gradient-primary-flat flex shrink-0 cursor-pointer items-center justify-center rounded-full px-4.5 py-2 font-sans font-semibold text-[0.875rem] text-white leading-[1.29]"
+                href="#all-integrations"
+              >
+                Browse all
+              </a>
+            </div>
+            <div className="flex w-full max-w-[45rem] items-center gap-2.5 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              {categories.map((category) => {
+                const isActive = category.id === activeCategory;
+                return (
+                  <button
+                    className={`${PILL_BASE} ${isActive ? PILL_ACTIVE : PILL_INACTIVE}`}
+                    key={category.id}
+                    onClick={
+                      onCategoryChange
+                        ? () => onCategoryChange(category.id)
+                        : undefined
+                    }
+                    type="button"
+                  >
+                    {category.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="flex w-[min(100%-3rem,80rem)] flex-col gap-14 pt-14">
+        {showFeatured ? (
+          <section className="flex flex-col gap-7">
+            <div className="flex items-end justify-between gap-4">
+              <div className="flex flex-col gap-2">
+                <span className="font-medium font-sans text-[#1E1E1E80] text-[1.125rem] leading-[1.22] tracking-[-0.02em] dark:text-white/50">
+                  Featured this month
+                </span>
+                <h2 className="font-medium font-sans text-[#1E1E1E] text-[2.125rem] leading-[1.18] tracking-[-0.02em] dark:text-white">
+                  Editor's picks
+                </h2>
+              </div>
+              <a
+                className="shrink-0 cursor-pointer font-medium font-sans text-[1rem] text-primary leading-[1.25]"
+                href="#all-integrations"
+              >
+                View all {integrations.length} →
+              </a>
+            </div>
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              {featured.map((integration) => (
+                <FeaturedIntegrationCard
+                  integration={integration}
+                  key={integration.id}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section
+          className="flex scroll-mt-24 flex-col gap-7"
+          id="all-integrations"
+        >
+          <div className="flex items-end justify-between gap-4">
+            <div className="flex flex-col gap-2">
+              <span className="font-medium font-sans text-[#1E1E1E80] text-[1.125rem] leading-[1.22] tracking-[-0.02em] dark:text-white/50">
+                Reviewed and live
+              </span>
+              <h2 className="font-medium font-sans text-[#1E1E1E] text-[2.125rem] leading-[1.18] tracking-[-0.02em] dark:text-white">
+                All integrations
+              </h2>
+            </div>
+            <span className="shrink-0 font-sans text-[#1E1E1E80] text-[0.875rem] leading-[1.29] dark:text-white/50">
+              Sorted A–Z
+            </span>
+          </div>
+          {filtered.length > 0 ? (
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {filtered.map((integration) => (
+                <IntegrationCard
+                  integration={integration}
+                  key={integration.id}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="py-14 text-center font-sans text-[#1E1E1E80] text-[0.9375rem] dark:text-white/50">
+              No integrations match your search yet.
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/constants/integrations.ts
+++ b/apps/web/src/constants/integrations.ts
@@ -1,0 +1,42 @@
+import type { Integration } from "@/types/integrations";
+import { APP_URL, DOCS_URL } from "@/utils/urls";
+
+export const INTEGRATIONS_CONSOLE_URL = "https://console.usenotra.com";
+
+export const INTEGRATIONS_DOCS_URL = DOCS_URL;
+
+export const INTEGRATIONS_CONNECT_URL = `${APP_URL}/login`;
+
+export const FEATURED_INTEGRATIONS_LIMIT = 2;
+
+export const QUICK_VIEW_VISIBLE_TOOLS = 5;
+
+export const DETAIL_VISIBLE_TOOLS = 5;
+
+export const ALL_CATEGORY_ID = "all";
+
+const R2_ASSET_PREFIX = "https://pub-006cb776ab3047f59b502d72fca0f223.r2.dev";
+
+const FALLBACK_INTEGRATION_ID = "brew-store-listing";
+
+export const INTEGRATION_CATEGORY_MAP: Record<string, string> = {
+  Brew: "Productivity",
+};
+
+export const FALLBACK_INTEGRATIONS: Integration[] = [
+  {
+    id: FALLBACK_INTEGRATION_ID,
+    name: "Brew",
+    description: "Manage brew stuff",
+    author: "Brew, Inc.",
+    websiteUrl: "https://brew.new",
+    brandColor: "#FF772D",
+    logoLightUrl: `${R2_ASSET_PREFIX}/organization/Z2zWjF9rtxltZopse25PQlGLyjIMspkP/integration-branding/logo-light-5cf3f874-1c50-4cd7-8683-168309190b1f.svg`,
+    logoDarkUrl: `${R2_ASSET_PREFIX}/organization/Z2zWjF9rtxltZopse25PQlGLyjIMspkP/integration-branding/logo-dark-6f8c0ac4-8a8b-499d-9114-b0ddcf876728.svg`,
+    bannerUrl: `${R2_ASSET_PREFIX}/organization/Z2zWjF9rtxltZopse25PQlGLyjIMspkP/integration-branding/banner-8e004074-d488-49f8-827d-9a1492faaaad.png`,
+    slug: "brew",
+    authType: "oauth",
+    indexedToolCount: 67,
+    tools: [],
+  },
+];

--- a/apps/web/src/constants/landing/footer.ts
+++ b/apps/web/src/constants/landing/footer.ts
@@ -49,6 +49,7 @@ export const FOOTER_LINK_COLUMNS: readonly FooterLinkColumn[] = [
       {
         title: "Integrations",
         links: [
+          { label: "Marketplace", href: "/integrations" },
           {
             label: "Framer",
             href: "https://www.framer.com/marketplace/plugins/notra/",

--- a/apps/web/src/lib/integrations/fetch.ts
+++ b/apps/web/src/lib/integrations/fetch.ts
@@ -1,0 +1,71 @@
+import { FALLBACK_INTEGRATIONS } from "@/constants/integrations";
+import {
+  integrationDetailResponseSchema,
+  integrationListResponseSchema,
+} from "@/schemas/integrations";
+import type { Integration } from "@/types/integrations";
+
+const CONSOLE_URL =
+  process.env.NOTRA_CONSOLE_URL ?? "https://console.usenotra.com";
+
+const FETCH_REVALIDATE_SECONDS = 300;
+const FETCH_TIMEOUT_MS = 15_000;
+
+export async function fetchIntegrations(): Promise<Integration[]> {
+  try {
+    const response = await fetch(`${CONSOLE_URL}/api/store/integrations`, {
+      next: { revalidate: FETCH_REVALIDATE_SECONDS },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return FALLBACK_INTEGRATIONS;
+    }
+    const parsed = integrationListResponseSchema.safeParse(
+      await response.json()
+    );
+    if (!parsed.success || parsed.data.integrations.length === 0) {
+      return FALLBACK_INTEGRATIONS;
+    }
+    return parsed.data.integrations;
+  } catch {
+    return FALLBACK_INTEGRATIONS;
+  }
+}
+
+function findFallbackIntegration(slugOrId: string): Integration | null {
+  const normalized = slugOrId.toLowerCase();
+  return (
+    FALLBACK_INTEGRATIONS.find(
+      (integration) =>
+        integration.id === slugOrId ||
+        integration.slug === normalized ||
+        integration.name.toLowerCase() === normalized
+    ) ?? null
+  );
+}
+
+export async function fetchIntegration(
+  integrationId: string
+): Promise<Integration | null> {
+  try {
+    const response = await fetch(
+      `${CONSOLE_URL}/api/store/integrations/${encodeURIComponent(integrationId)}`,
+      {
+        next: { revalidate: FETCH_REVALIDATE_SECONDS },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      }
+    );
+    if (!response.ok) {
+      return findFallbackIntegration(integrationId);
+    }
+    const parsed = integrationDetailResponseSchema.safeParse(
+      await response.json()
+    );
+    if (!parsed.success) {
+      return findFallbackIntegration(integrationId);
+    }
+    return parsed.data.integration;
+  } catch {
+    return findFallbackIntegration(integrationId);
+  }
+}

--- a/apps/web/src/lib/integrations/helpers.ts
+++ b/apps/web/src/lib/integrations/helpers.ts
@@ -26,7 +26,11 @@ export function getToolDescription(tool: {
   description: string | null;
   title: string | null;
 }): string {
-  return collapseWhitespace(tool.description ?? tool.title ?? "");
+  const description = collapseWhitespace(tool.description ?? "");
+  if (description) {
+    return description;
+  }
+  return collapseWhitespace(tool.title ?? "");
 }
 
 function formatAuthType(authType: string): string {

--- a/apps/web/src/lib/integrations/helpers.ts
+++ b/apps/web/src/lib/integrations/helpers.ts
@@ -1,0 +1,143 @@
+import {
+  ALL_CATEGORY_ID,
+  FEATURED_INTEGRATIONS_LIMIT,
+  INTEGRATION_CATEGORY_MAP,
+} from "@/constants/integrations";
+import type {
+  Integration,
+  IntegrationCategoryFilter,
+} from "@/types/integrations";
+
+const WHITESPACE_REGEX = /\s+/g;
+
+function getIntegrationCategory(name: string): string | null {
+  return INTEGRATION_CATEGORY_MAP[name] ?? null;
+}
+
+export function getIntegrationHref(integration: Integration): string {
+  return `/integrations/${integration.slug ?? integration.id}`;
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(WHITESPACE_REGEX, " ").trim();
+}
+
+export function getToolDescription(tool: {
+  description: string | null;
+  title: string | null;
+}): string {
+  return collapseWhitespace(tool.description ?? tool.title ?? "");
+}
+
+function formatAuthType(authType: string): string {
+  if (authType === "oauth") {
+    return "OAuth";
+  }
+  if (authType === "headers") {
+    return "API key";
+  }
+  if (authType === "none") {
+    return "None";
+  }
+  return authType;
+}
+
+function formatToolCount(count: number): string {
+  return `${count} ${count === 1 ? "tool" : "tools"}`;
+}
+
+export function buildAuthorCategoryLine(integration: Integration): string {
+  const category = getIntegrationCategory(integration.name);
+  const parts = [integration.author ? `by ${integration.author}` : null];
+  if (category) {
+    parts.push(category);
+  }
+  return parts.filter(Boolean).join(" · ");
+}
+
+export function buildCardMeta(integration: Integration): string {
+  return [
+    formatToolCount(integration.indexedToolCount),
+    formatAuthType(integration.authType),
+  ].join(" · ");
+}
+
+export function buildFeaturedMeta(integration: Integration): string {
+  return [
+    formatToolCount(integration.indexedToolCount),
+    formatAuthType(integration.authType),
+    "Verified",
+  ].join(" · ");
+}
+
+export function buildQuickViewMetaTail(integration: Integration): string {
+  return [
+    getIntegrationCategory(integration.name),
+    formatToolCount(integration.indexedToolCount),
+    formatAuthType(integration.authType),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function buildCategoryFilters(
+  integrations: Integration[]
+): IntegrationCategoryFilter[] {
+  const categories: IntegrationCategoryFilter[] = [
+    { id: ALL_CATEGORY_ID, label: "All" },
+  ];
+  const seen = new Set<string>();
+  for (const integration of integrations) {
+    const category = getIntegrationCategory(integration.name);
+    if (category && !seen.has(category)) {
+      seen.add(category);
+      categories.push({ id: category, label: category });
+    }
+  }
+  return categories;
+}
+
+export function getFeaturedIntegrations(
+  integrations: Integration[]
+): Integration[] {
+  return integrations
+    .filter((integration) => Boolean(integration.bannerUrl))
+    .slice(0, FEATURED_INTEGRATIONS_LIMIT);
+}
+
+export function buildDetailMetaTail(integration: Integration): string {
+  return [getIntegrationCategory(integration.name), "Verified publisher"]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function buildDetailStats(
+  integration: Integration
+): { label: string; value: string }[] {
+  return [
+    { label: "TOOLS", value: `${integration.indexedToolCount} available` },
+    { label: "AUTHENTICATION", value: formatAuthType(integration.authType) },
+  ];
+}
+
+export function filterIntegrations(
+  integrations: Integration[],
+  query: string,
+  categoryId: string
+): Integration[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  return integrations.filter((integration) => {
+    if (
+      categoryId !== ALL_CATEGORY_ID &&
+      getIntegrationCategory(integration.name) !== categoryId
+    ) {
+      return false;
+    }
+    if (normalizedQuery.length === 0) {
+      return true;
+    }
+    return [integration.name, integration.author, integration.description]
+      .filter(Boolean)
+      .some((value) => value?.toLowerCase().includes(normalizedQuery));
+  });
+}

--- a/apps/web/src/schemas/integrations.ts
+++ b/apps/web/src/schemas/integrations.ts
@@ -1,6 +1,21 @@
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 
+function toSafeHttpUrl(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      return value;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 const integrationToolSchema = z.object({
   name: z.string(),
   title: z
@@ -27,7 +42,7 @@ const integrationSchema = z.object({
   websiteUrl: z
     .string()
     .nullish()
-    .transform((value) => value ?? null),
+    .transform((value) => toSafeHttpUrl(value)),
   brandColor: z
     .string()
     .nullish()

--- a/apps/web/src/schemas/integrations.ts
+++ b/apps/web/src/schemas/integrations.ts
@@ -1,0 +1,62 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+const integrationToolSchema = z.object({
+  name: z.string(),
+  title: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  description: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+});
+
+const integrationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  author: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  websiteUrl: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  brandColor: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  logoLightUrl: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  logoDarkUrl: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  bannerUrl: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  slug: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
+  authType: z.string(),
+  indexedToolCount: z.number(),
+  tools: z.array(integrationToolSchema).default([]),
+});
+
+export const integrationListResponseSchema = z.object({
+  integrations: z.array(integrationSchema),
+});
+
+export const integrationDetailResponseSchema = z.object({
+  integration: integrationSchema,
+});

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -357,6 +357,36 @@
   scrollbar-gutter: stable;
 }
 
+@utility cta-gradient-primary-flat {
+  --cta-gradient-from: oklab(69.9% 0.067 -0.16);
+  --cta-gradient-to: oklab(52.6% 0.113 -0.27);
+  background-image: linear-gradient(
+    180deg,
+    var(--cta-gradient-from) 0%,
+    var(--cta-gradient-to) 100%
+  );
+  background-image: linear-gradient(
+    180deg in oklab,
+    var(--cta-gradient-from) 0%,
+    var(--cta-gradient-to) 100%
+  );
+  box-shadow:
+    #28282814 0 0.0625rem 0.125rem,
+    #1e1e1e40 0 0 0 0.0625rem;
+  transition:
+    --cta-gradient-from 200ms ease-out,
+    --cta-gradient-to 200ms ease-out;
+
+  &:hover {
+    --cta-gradient-to: oklab(33.9% 0.073 -0.174);
+  }
+
+  &:active {
+    --cta-gradient-from: oklab(52.6% 0.113 -0.27);
+    --cta-gradient-to: oklab(24.8% 0.053 -0.127);
+  }
+}
+
 @keyframes orbitSpin {
   from {
     transform: translate(-50%, -50%) rotate(0deg);

--- a/apps/web/src/types/integrations.ts
+++ b/apps/web/src/types/integrations.ts
@@ -32,6 +32,18 @@ export interface IntegrationsMarketplaceProps {
   categories: IntegrationCategoryFilter[];
 }
 
+export interface IntegrationsViewProps {
+  integrations: Integration[];
+  categories: IntegrationCategoryFilter[];
+  query: string;
+  activeCategory: string;
+  filtered: Integration[];
+  featured: Integration[];
+  showFeatured: boolean;
+  onQueryChange?: (value: string) => void;
+  onCategoryChange?: (id: string) => void;
+}
+
 export interface IntegrationCardProps {
   integration: Integration;
 }
@@ -52,7 +64,7 @@ export interface IntegrationsLayoutProps {
 export interface IntegrationBannerProps {
   integration: Integration;
   className?: string;
-  label?: string;
+  priority?: boolean;
 }
 
 export interface IntegrationAuthorMetaProps {

--- a/apps/web/src/types/integrations.ts
+++ b/apps/web/src/types/integrations.ts
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+
+export interface IntegrationTool {
+  name: string;
+  title: string | null;
+  description: string | null;
+}
+
+export interface Integration {
+  id: string;
+  name: string;
+  description: string | null;
+  author: string | null;
+  websiteUrl: string | null;
+  brandColor: string | null;
+  logoLightUrl: string | null;
+  logoDarkUrl: string | null;
+  bannerUrl: string | null;
+  slug: string | null;
+  authType: string;
+  indexedToolCount: number;
+  tools: IntegrationTool[];
+}
+
+export interface IntegrationCategoryFilter {
+  id: string;
+  label: string;
+}
+
+export interface IntegrationsMarketplaceProps {
+  integrations: Integration[];
+  categories: IntegrationCategoryFilter[];
+}
+
+export interface IntegrationCardProps {
+  integration: Integration;
+}
+
+export interface FeaturedIntegrationCardProps {
+  integration: Integration;
+}
+
+export interface IntegrationModalProps {
+  integration: Integration;
+}
+
+export interface IntegrationsLayoutProps {
+  children: ReactNode;
+  modal: ReactNode;
+}
+
+export interface IntegrationBannerProps {
+  integration: Integration;
+  className?: string;
+  label?: string;
+}
+
+export interface IntegrationAuthorMetaProps {
+  integration: Integration;
+  tail: string;
+  className?: string;
+}
+
+export interface IntegrationLogoProps {
+  integration: Integration;
+  size: number;
+  className?: string;
+  fill?: boolean;
+}
+
+export interface IntegrationToolsGridProps {
+  tools: IntegrationTool[];
+  totalCount: number;
+}
+
+export interface IntegrationDetailViewProps {
+  integration: Integration;
+}
+
+export interface IntegrationDetailPageProps {
+  params: Promise<{ id: string }>;
+}

--- a/apps/web/src/utils/metadata.ts
+++ b/apps/web/src/utils/metadata.ts
@@ -58,6 +58,12 @@ export const PAGE_SOCIAL_IMAGES = {
     height: SOCIAL_IMAGE_HEIGHT,
     alt: "Notra OSS program social preview image",
   },
+  integrations: {
+    url: DEFAULT_SOCIAL_IMAGE.url,
+    width: SOCIAL_IMAGE_WIDTH,
+    height: SOCIAL_IMAGE_HEIGHT,
+    alt: "Notra integrations marketplace social preview image",
+  },
 } as const;
 
 export const TWITTER_HANDLE = "@usenotra";

--- a/apps/web/src/utils/navigation.ts
+++ b/apps/web/src/utils/navigation.ts
@@ -5,41 +5,42 @@ import {
   FavouriteIcon,
   Megaphone01Icon,
   PaintBoardIcon,
+  PuzzleIcon,
   QuillWrite01Icon,
   SparklesIcon,
   UserGroupIcon,
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
 
-export type MarketingNavCard = {
+export interface MarketingNavCard {
   href: string;
   label: string;
   description: string;
   icon: IconSvgElement;
   external?: boolean;
-};
+}
 
-export type MarketingNavRailItem = {
+export interface MarketingNavRailItem {
   href: string;
   label: string;
   icon: IconSvgElement;
   external?: boolean;
-};
+}
 
-export type MarketingNavGroup = {
+export interface MarketingNavGroup {
   type: "group";
   label: string;
   cardsHeading: string;
   cards: readonly MarketingNavCard[];
   railHeading: string;
   rail: readonly MarketingNavRailItem[];
-};
+}
 
-type MarketingNavLink = {
+interface MarketingNavLink {
   type: "link";
   href: string;
   label: string;
-};
+}
 
 export type MarketingNavEntry = MarketingNavGroup | MarketingNavLink;
 
@@ -60,6 +61,12 @@ export const MARKETING_NAV: readonly MarketingNavEntry[] = [
         label: "Marketing Assets",
         description: "Generate assets from shipped work",
         icon: PaintBoardIcon,
+      },
+      {
+        href: "/integrations",
+        label: "Integrations",
+        description: "Connect the tools you ship with",
+        icon: PuzzleIcon,
       },
     ],
     railHeading: "Developers",

--- a/packages/ai/src/integrations/mcp-store.ts
+++ b/packages/ai/src/integrations/mcp-store.ts
@@ -344,32 +344,6 @@ function isManualToolMeta(meta: unknown) {
   );
 }
 
-export async function listLiveMcpStoreIntegrations() {
-  return await db.query.mcpServerIntegrations.findMany({
-    where: and(
-      eq(mcpServerIntegrations.resourceType, "store_listing"),
-      eq(mcpServerIntegrations.storeStatus, "live"),
-      eq(mcpServerIntegrations.enabled, true)
-    ),
-    orderBy: asc(mcpServerIntegrations.name),
-    columns: {
-      id: true,
-      name: true,
-      url: true,
-      description: true,
-      author: true,
-      websiteUrl: true,
-      brandColor: true,
-      logoLightUrl: true,
-      logoDarkUrl: true,
-      bannerUrl: true,
-      slug: true,
-      authType: true,
-      indexedToolCount: true,
-    },
-  });
-}
-
 const LIVE_STORE_LISTING_DETAIL_COLUMNS = {
   id: true,
   name: true,
@@ -385,6 +359,18 @@ const LIVE_STORE_LISTING_DETAIL_COLUMNS = {
   authType: true,
   indexedToolCount: true,
 } as const;
+
+export async function listLiveMcpStoreIntegrations() {
+  return await db.query.mcpServerIntegrations.findMany({
+    where: and(
+      eq(mcpServerIntegrations.resourceType, "store_listing"),
+      eq(mcpServerIntegrations.storeStatus, "live"),
+      eq(mcpServerIntegrations.enabled, true)
+    ),
+    orderBy: asc(mcpServerIntegrations.name),
+    columns: LIVE_STORE_LISTING_DETAIL_COLUMNS,
+  });
+}
 
 export async function getLiveMcpStoreIntegrationById(integrationId: string) {
   const integration = await db.query.mcpServerIntegrations.findFirst({

--- a/packages/ai/src/integrations/mcp-store.ts
+++ b/packages/ai/src/integrations/mcp-store.ts
@@ -362,11 +362,29 @@ export async function listLiveMcpStoreIntegrations() {
       brandColor: true,
       logoLightUrl: true,
       logoDarkUrl: true,
+      bannerUrl: true,
+      slug: true,
       authType: true,
       indexedToolCount: true,
     },
   });
 }
+
+const LIVE_STORE_LISTING_DETAIL_COLUMNS = {
+  id: true,
+  name: true,
+  url: true,
+  description: true,
+  author: true,
+  websiteUrl: true,
+  brandColor: true,
+  logoLightUrl: true,
+  logoDarkUrl: true,
+  bannerUrl: true,
+  slug: true,
+  authType: true,
+  indexedToolCount: true,
+} as const;
 
 export async function getLiveMcpStoreIntegrationById(integrationId: string) {
   const integration = await db.query.mcpServerIntegrations.findFirst({
@@ -376,20 +394,21 @@ export async function getLiveMcpStoreIntegrationById(integrationId: string) {
       eq(mcpServerIntegrations.storeStatus, "live"),
       eq(mcpServerIntegrations.enabled, true)
     ),
-    columns: {
-      id: true,
-      name: true,
-      url: true,
-      description: true,
-      author: true,
-      websiteUrl: true,
-      brandColor: true,
-      logoLightUrl: true,
-      logoDarkUrl: true,
-      bannerUrl: true,
-      authType: true,
-      indexedToolCount: true,
-    },
+    columns: LIVE_STORE_LISTING_DETAIL_COLUMNS,
+  });
+
+  return integration ?? null;
+}
+
+export async function getLiveMcpStoreIntegrationBySlug(slug: string) {
+  const integration = await db.query.mcpServerIntegrations.findFirst({
+    where: and(
+      eq(mcpServerIntegrations.slug, slug),
+      eq(mcpServerIntegrations.resourceType, "store_listing"),
+      eq(mcpServerIntegrations.storeStatus, "live"),
+      eq(mcpServerIntegrations.enabled, true)
+    ),
+    columns: LIVE_STORE_LISTING_DETAIL_COLUMNS,
   });
 
   return integration ?? null;

--- a/packages/ai/src/integrations/mcp.ts
+++ b/packages/ai/src/integrations/mcp.ts
@@ -82,6 +82,7 @@ export function serializeMcpServerIntegration(
     logoLightUrl: integration.logoLightUrl ?? null,
     logoDarkUrl: integration.logoDarkUrl ?? null,
     bannerUrl: integration.bannerUrl ?? null,
+    slug: integration.slug ?? null,
     storeSourceIntegrationId: integration.storeSourceIntegrationId ?? null,
     storeStatus: getMcpStoreStatus(integration.storeStatus),
     reviewNote: integration.reviewNote ?? null,
@@ -145,6 +146,7 @@ async function createMcpServerIntegration(
       logoLightUrl: params.logoLightUrl ?? null,
       logoDarkUrl: params.logoDarkUrl ?? null,
       bannerUrl: params.bannerUrl ?? null,
+      slug: resourceType === "store_listing" ? (params.slug ?? null) : null,
       storeSourceIntegrationId:
         resourceType === "connection"
           ? (params.storeSourceIntegrationId ?? null)
@@ -335,6 +337,7 @@ async function updateMcpServerIntegration(
         ...(updates.bannerUrl !== undefined
           ? { bannerUrl: updates.bannerUrl }
           : {}),
+        ...(updates.slug !== undefined ? { slug: updates.slug } : {}),
         ...(updates.headers !== undefined
           ? { encryptedHeaders: encryptMcpHeaders(updates.headers) }
           : {}),

--- a/packages/ai/src/types/integrations.ts
+++ b/packages/ai/src/types/integrations.ts
@@ -96,6 +96,7 @@ export interface McpServerIntegrationSerializationInput {
   logoLightUrl?: string | null;
   logoDarkUrl?: string | null;
   bannerUrl?: string | null;
+  slug?: string | null;
   storeSourceIntegrationId?: string | null;
   storeStatus?: string;
   reviewNote?: string | null;
@@ -134,6 +135,7 @@ export interface CreateMcpServerIntegrationParams {
   logoLightUrl?: string | null;
   logoDarkUrl?: string | null;
   bannerUrl?: string | null;
+  slug?: string | null;
   storeSourceIntegrationId?: string | null;
   headers?: McpHeaderMap;
 }
@@ -159,6 +161,7 @@ export interface UpdateMcpServerIntegrationParams {
   logoLightUrl?: string | null;
   logoDarkUrl?: string | null;
   bannerUrl?: string | null;
+  slug?: string | null;
   headers?: McpHeaderMap;
   enabled?: boolean;
 }

--- a/packages/db/migrations/0053_numerous_morlun.sql
+++ b/packages/db/migrations/0053_numerous_morlun.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "mcp_server_integrations" ADD COLUMN "slug" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "mcpServerIntegrations_storeListing_slug_uidx" ON "mcp_server_integrations" USING btree ("slug") WHERE "mcp_server_integrations"."resource_type" = 'store_listing';

--- a/packages/db/migrations/0054_backfill_store_listing_slugs.sql
+++ b/packages/db/migrations/0054_backfill_store_listing_slugs.sql
@@ -1,2 +1,19 @@
 -- Custom SQL migration file, put your code below! --
-UPDATE mcp_server_integrations SET slug = lower(name) WHERE slug IS NULL AND resource_type = 'store_listing';
+WITH candidates AS (
+	SELECT
+		id,
+		btrim(regexp_replace(lower(name), '[^a-z0-9]+', '-', 'g'), '-') AS base,
+		row_number() OVER (
+			PARTITION BY btrim(regexp_replace(lower(name), '[^a-z0-9]+', '-', 'g'), '-')
+			ORDER BY created_at, id
+		) AS occurrence
+	FROM mcp_server_integrations
+	WHERE slug IS NULL AND resource_type = 'store_listing'
+)
+UPDATE mcp_server_integrations AS target
+SET slug = CASE
+	WHEN candidates.occurrence = 1 THEN candidates.base
+	ELSE candidates.base || '-' || candidates.occurrence
+END
+FROM candidates
+WHERE target.id = candidates.id AND candidates.base <> '';

--- a/packages/db/migrations/0054_backfill_store_listing_slugs.sql
+++ b/packages/db/migrations/0054_backfill_store_listing_slugs.sql
@@ -1,0 +1,2 @@
+-- Custom SQL migration file, put your code below! --
+UPDATE mcp_server_integrations SET slug = lower(name) WHERE slug IS NULL AND resource_type = 'store_listing';

--- a/packages/db/migrations/meta/0053_snapshot.json
+++ b/packages/db/migrations/meta/0053_snapshot.json
@@ -1,0 +1,6755 @@
+{
+  "id": "6d9b44c9-15d1-42d9-8038-0b992491afc2",
+  "prevId": "db13297b-045a-4ff8-875c-c2c8d121a980",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_assets": {
+      "name": "brand_guideline_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "brand_guideline_asset_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "brand_guideline_asset_variant",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineAssets_guidelineId_idx": {
+          "name": "brandGuidelineAssets_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineAssets_guideline_kind_idx": {
+          "name": "brandGuidelineAssets_guideline_kind_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineAssets_guideline_kind_variant_uidx": {
+          "name": "brandGuidelineAssets_guideline_kind_variant_uidx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_assets_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_assets_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_assets",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_colors": {
+      "name": "brand_guideline_colors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "brand_guideline_color_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "light_value": {
+          "name": "light_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dark_value": {
+          "name": "dark_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineColors_guidelineId_idx": {
+          "name": "brandGuidelineColors_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineColors_guideline_role_idx": {
+          "name": "brandGuidelineColors_guideline_role_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_colors_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_colors_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_colors",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_fonts": {
+      "name": "brand_guideline_fonts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "brand_guideline_font_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_height": {
+          "name": "line_height",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineFonts_guidelineId_idx": {
+          "name": "brandGuidelineFonts_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineFonts_guideline_role_idx": {
+          "name": "brandGuidelineFonts_guideline_role_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_fonts_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_fonts_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_fonts",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_screenshots": {
+      "name": "brand_guideline_screenshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "brand_guideline_screenshot_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_page": {
+          "name": "full_page",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineScreenshots_guidelineId_idx": {
+          "name": "brandGuidelineScreenshots_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineScreenshots_guideline_kind_uidx": {
+          "name": "brandGuidelineScreenshots_guideline_kind_uidx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_screenshots_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_screenshots_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_screenshots",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_tokens": {
+      "name": "brand_guideline_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "brand_guideline_token_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineTokens_guidelineId_idx": {
+          "name": "brandGuidelineTokens_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineTokens_guideline_type_idx": {
+          "name": "brandGuidelineTokens_guideline_type_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_tokens_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_tokens_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_tokens",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guidelines": {
+      "name": "brand_guidelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "brand_guideline_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "context_dev_meta": {
+          "name": "context_dev_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generation_error": {
+          "name": "last_generation_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelines_brandSettingsId_uidx": {
+          "name": "brandGuidelines_brandSettingsId_uidx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelines_status_idx": {
+          "name": "brandGuidelines_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guidelines_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_guidelines_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_guidelines",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_references": {
+      "name": "brand_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot_key": {
+          "name": "source_snapshot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_captured_at": {
+          "name": "source_captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_document_id": {
+          "name": "supermemory_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_memory_id": {
+          "name": "supermemory_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_synced_at": {
+          "name": "supermemory_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_last_sync_error": {
+          "name": "supermemory_last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to": {
+          "name": "applicable_to",
+          "type": "applicable_platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['all']::applicable_platform[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandReferences_brandSettingsId_idx": {
+          "name": "brandReferences_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandReferences_brandSettingsId_sourceUrl_idx": {
+          "name": "brandReferences_brandSettingsId_sourceUrl_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_references_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_references_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_references",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_settings": {
+      "name": "brand_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_description": {
+          "name": "company_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone_profile": {
+          "name": "tone_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_tone": {
+          "name": "custom_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'English'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSettings_org_name_uidx": {
+          "name": "brandSettings_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_org_default_uidx": {
+          "name": "brandSettings_org_default_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brand_settings\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_organizationId_idx": {
+          "name": "brandSettings_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_settings_organization_id_organizations_id_fk": {
+          "name": "brand_settings_organization_id_organizations_id_fk",
+          "tableFrom": "brand_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "brandSettings_toneProfile_check": {
+          "name": "brandSettings_toneProfile_check",
+          "value": "\"brand_settings\".\"tone_profile\" IS NULL OR \"brand_settings\".\"tone_profile\" IN ('Conversational', 'Professional', 'Casual', 'Formal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemap_pages": {
+      "name": "brand_sitemap_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sitemap_id": {
+          "name": "sitemap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "brand_sitemap_page_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_ratio": {
+          "name": "text_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_links": {
+          "name": "internal_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_links": {
+          "name": "external_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawled_at": {
+          "name": "crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemapPages_sitemapId_idx": {
+          "name": "brandSitemapPages_sitemapId_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemapPages_sitemap_category_idx": {
+          "name": "brandSitemapPages_sitemap_category_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemapPages_sitemap_url_uidx": {
+          "name": "brandSitemapPages_sitemap_url_uidx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk": {
+          "name": "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk",
+          "tableFrom": "brand_sitemap_pages",
+          "tableTo": "brand_sitemaps",
+          "columnsFrom": [
+            "sitemap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemaps": {
+      "name": "brand_sitemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "brand_sitemap_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indexed_pages": {
+          "name": "indexed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_pages": {
+          "name": "failed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context_dev_meta": {
+          "name": "context_dev_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_started_at": {
+          "name": "last_crawl_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawled_at": {
+          "name": "last_crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_error": {
+          "name": "last_crawl_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemaps_brandSettingsId_idx": {
+          "name": "brandSitemaps_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemaps_brandSettings_url_uidx": {
+          "name": "brandSitemaps_brandSettings_url_uidx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemaps_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_sitemaps_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_sitemaps",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_attachments": {
+      "name": "chat_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatAttachments_organizationId_createdAt_idx": {
+          "name": "chatAttachments_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatAttachments_userId_idx": {
+          "name": "chatAttachments_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_attachments_organization_id_organizations_id_fk": {
+          "name": "chat_attachments_organization_id_organizations_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_attachments_user_id_users_id_fk": {
+          "name": "chat_attachments_user_id_users_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_attachments_key_unique": {
+          "name": "chat_attachments_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_source": {
+          "name": "external_channel_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_id": {
+          "name": "external_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatSessions_organizationId_idx": {
+          "name": "chatSessions_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_organizationId_deletedAt_idx": {
+          "name": "chatSessions_organizationId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_org_externalChannel_uidx": {
+          "name": "chatSessions_org_externalChannel_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_sessions\".\"external_channel_source\" IN ('discord', 'slack') AND \"chat_sessions\".\"external_channel_id\" IS NOT NULL AND \"chat_sessions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_sessions_organization_id_organizations_id_fk": {
+          "name": "chat_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_social_accounts": {
+      "name": "connected_social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectedSocialAccounts_organizationId_idx": {
+          "name": "connectedSocialAccounts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connectedSocialAccounts_org_provider_account_uidx": {
+          "name": "connectedSocialAccounts_org_provider_account_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connected_social_accounts_organization_id_organizations_id_fk": {
+          "name": "connected_social_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "connected_social_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_trigger_lookback_windows": {
+      "name": "content_trigger_lookback_windows",
+      "schema": "",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "lookback_window",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk": {
+          "name": "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk",
+          "tableFrom": "content_trigger_lookback_windows",
+          "tableTo": "content_triggers",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_triggers": {
+      "name": "content_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Schedule'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_config": {
+          "name": "output_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_hash": {
+          "name": "dedupe_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_publish": {
+          "name": "auto_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentTriggers_organizationId_idx": {
+          "name": "contentTriggers_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contentTriggers_organization_dedupe_uidx": {
+          "name": "contentTriggers_organization_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_triggers_organization_id_organizations_id_fk": {
+          "name": "content_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "content_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_avatar_url": {
+          "name": "account_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubAppInstallations_organizationId_idx": {
+          "name": "githubAppInstallations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubAppInstallations_createdByUserId_idx": {
+          "name": "githubAppInstallations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubAppInstallations_organization_installation_uidx": {
+          "name": "githubAppInstallations_organization_installation_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_users_id_fk": {
+          "name": "github_app_installations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_app_installation_id": {
+          "name": "github_app_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_private": {
+          "name": "github_repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_enabled": {
+          "name": "repository_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubIntegrations_organizationId_idx": {
+          "name": "githubIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_createdByUserId_idx": {
+          "name": "githubIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_organization_owner_repo_uidx": {
+          "name": "githubIntegrations_organization_owner_repo_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_organization_id_organizations_id_fk": {
+          "name": "github_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_created_by_user_id_users_id_fk": {
+          "name": "github_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_github_app_installation_id_github_app_installations_id_fk": {
+          "name": "github_integrations_github_app_installation_id_github_app_installations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "github_app_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.granola_integrations": {
+      "name": "granola_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "granolaIntegrations_organizationId_idx": {
+          "name": "granolaIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "granolaIntegrations_createdByUserId_idx": {
+          "name": "granolaIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "granola_integrations_organization_id_organizations_id_fk": {
+          "name": "granola_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "granola_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "granola_integrations_created_by_user_id_users_id_fk": {
+          "name": "granola_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "granola_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitations_organizationId_idx": {
+          "name": "invitations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_integrations": {
+      "name": "linear_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_id": {
+          "name": "linear_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_name": {
+          "name": "linear_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linearIntegrations_organizationId_idx": {
+          "name": "linearIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_createdByUserId_idx": {
+          "name": "linearIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_no_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_no_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"linear_integrations\".\"linear_team_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_integrations_organization_id_organizations_id_fk": {
+          "name": "linear_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_integrations_created_by_user_id_users_id_fk": {
+          "name": "linear_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_credentials": {
+      "name": "mcp_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_tokens": {
+          "name": "encrypted_tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_client_information": {
+          "name": "encrypted_client_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_authorization_server_information": {
+          "name": "encrypted_authorization_server_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_refresh_at": {
+          "name": "access_token_refresh_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_lease_id": {
+          "name": "refresh_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_lease_expires_at": {
+          "name": "refresh_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpOAuthCredentials_organizationId_idx": {
+          "name": "mcpOAuthCredentials_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthCredentials_connectedByUserId_idx": {
+          "name": "mcpOAuthCredentials_connectedByUserId_idx",
+          "columns": [
+            {
+              "expression": "connected_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_credentials_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_oauth_credentials_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_credentials_organization_id_organizations_id_fk": {
+          "name": "mcp_oauth_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_credentials_connected_by_user_id_users_id_fk": {
+          "name": "mcp_oauth_credentials_connected_by_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpOAuthCredentials_org_server_fk": {
+          "name": "mcpOAuthCredentials_org_server_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcpOAuthCredentials_status_check": {
+          "name": "mcpOAuthCredentials_status_check",
+          "value": "\"mcp_oauth_credentials\".\"status\" IN ('connected', 'refreshing', 'reauth_required')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_pending_authorizations": {
+      "name": "mcp_oauth_pending_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_source_integration_id": {
+          "name": "store_source_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callback_path": {
+          "name": "callback_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_state": {
+          "name": "encrypted_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_code_verifier": {
+          "name": "encrypted_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_client_information": {
+          "name": "encrypted_client_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_authorization_server_information": {
+          "name": "encrypted_authorization_server_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpOAuthPendingAuthorizations_organizationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_userId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_serverIntegrationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_serverIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_expiresAt_idx": {
+          "name": "mcpOAuthPendingAuthorizations_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_pending_authorizations_organization_id_organizations_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_pending_authorizations_user_id_users_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_pending_authorizations_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpOAuthPendingAuthorizations_org_server_fk": {
+          "name": "mcpOAuthPendingAuthorizations_org_server_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_fk": {
+          "name": "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "store_source_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_pending_authorizations_state_hash_unique": {
+          "name": "mcp_oauth_pending_authorizations_state_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_integrations": {
+      "name": "mcp_server_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection'"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_light_url": {
+          "name": "logo_light_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_dark_url": {
+          "name": "logo_dark_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_source_integration_id": {
+          "name": "store_source_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_status": {
+          "name": "store_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_tool_sync_at": {
+          "name": "last_tool_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_sync_status": {
+          "name": "tool_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "tool_sync_error": {
+          "name": "tool_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_tool_count": {
+          "name": "indexed_tool_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpServerIntegrations_resourceType_idx": {
+          "name": "mcpServerIntegrations_resourceType_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_storeStatus_idx": {
+          "name": "mcpServerIntegrations_storeStatus_idx",
+          "columns": [
+            {
+              "expression": "store_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_organizationId_idx": {
+          "name": "mcpServerIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_createdByUserId_idx": {
+          "name": "mcpServerIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_storeSourceIntegrationId_idx": {
+          "name": "mcpServerIntegrations_storeSourceIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_id_uidx": {
+          "name": "mcpServerIntegrations_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_resourceType_name_uidx": {
+          "name": "mcpServerIntegrations_org_resourceType_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_storeSource_uidx": {
+          "name": "mcpServerIntegrations_org_storeSource_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mcp_server_integrations\".\"store_source_integration_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_storeListing_slug_uidx": {
+          "name": "mcpServerIntegrations_storeListing_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mcp_server_integrations\".\"resource_type\" = 'store_listing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_integrations_organization_id_organizations_id_fk": {
+          "name": "mcp_server_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_integrations_created_by_user_id_users_id_fk": {
+          "name": "mcp_server_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpServerIntegrations_storeSourceIntegrationId_fk": {
+          "name": "mcpServerIntegrations_storeSourceIntegrationId_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "store_source_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcpServerIntegrations_authType_check": {
+          "name": "mcpServerIntegrations_authType_check",
+          "value": "\"mcp_server_integrations\".\"auth_type\" IN ('none', 'headers', 'oauth')"
+        },
+        "mcpServerIntegrations_storeStatus_check": {
+          "name": "mcpServerIntegrations_storeStatus_check",
+          "value": "\"mcp_server_integrations\".\"store_status\" IN ('draft', 'pending_review', 'live', 'rejected')"
+        },
+        "mcpServerIntegrations_resourceType_check": {
+          "name": "mcpServerIntegrations_resourceType_check",
+          "value": "\"mcp_server_integrations\".\"resource_type\" IN ('connection', 'store_listing')"
+        },
+        "mcpServerIntegrations_resourceState_check": {
+          "name": "mcpServerIntegrations_resourceState_check",
+          "value": "(\n        (\"mcp_server_integrations\".\"resource_type\" = 'store_listing' AND \"mcp_server_integrations\".\"store_source_integration_id\" IS NULL)\n        OR\n        (\"mcp_server_integrations\".\"resource_type\" = 'connection' AND \"mcp_server_integrations\".\"store_status\" = 'draft' AND \"mcp_server_integrations\".\"review_note\" IS NULL AND \"mcp_server_integrations\".\"submitted_at\" IS NULL AND \"mcp_server_integrations\".\"reviewed_at\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_session_tool_activations": {
+      "name": "mcp_session_tool_activations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_tool_index_id": {
+          "name": "mcp_tool_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_query": {
+          "name": "source_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcpSessionToolActivations_session_tool_uidx": {
+          "name": "mcpSessionToolActivations_session_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mcp_tool_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpSessionToolActivations_session_idx": {
+          "name": "mcpSessionToolActivations_session_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpSessionToolActivations_expiresAt_idx": {
+          "name": "mcpSessionToolActivations_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_session_tool_activations_organization_id_organizations_id_fk": {
+          "name": "mcp_session_tool_activations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk": {
+          "name": "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "mcp_tool_index",
+          "columnsFrom": [
+            "mcp_tool_index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpSessionToolActivations_org_tool_fk": {
+          "name": "mcpSessionToolActivations_org_tool_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "mcp_tool_index",
+          "columnsFrom": [
+            "organization_id",
+            "mcp_tool_index_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tool_index": {
+      "name": "mcp_tool_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_tool_name": {
+          "name": "server_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_phrase_present": {
+          "name": "action_phrase_present",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_phrase_past": {
+          "name": "action_phrase_past",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_indexed_at": {
+          "name": "last_indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpToolIndex_server_tool_uidx": {
+          "name": "mcpToolIndex_server_tool_uidx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_org_id_uidx": {
+          "name": "mcpToolIndex_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_org_runtime_tool_uidx": {
+          "name": "mcpToolIndex_org_runtime_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_organizationId_status_idx": {
+          "name": "mcpToolIndex_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_serverIntegrationId_status_idx": {
+          "name": "mcpToolIndex_serverIntegrationId_status_idx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_searchText_gin_idx": {
+          "name": "mcpToolIndex_searchText_gin_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"search_text\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_index_organization_id_organizations_id_fk": {
+          "name": "mcp_tool_index_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpToolIndex_org_server_fk": {
+          "name": "mcpToolIndex_org_server_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_organizationId_idx": {
+          "name": "members_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_userId_idx": {
+          "name": "members_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessTokens_clientId_idx": {
+          "name": "oauthAccessTokens_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessTokens_sessionId_idx": {
+          "name": "oauthAccessTokens_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessTokens_userId_idx": {
+          "name": "oauthAccessTokens_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessTokens_refreshId_idx": {
+          "name": "oauthAccessTokens_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_access_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClients_userId_idx": {
+          "name": "oauthClients_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauthConsents_clientId_idx": {
+          "name": "oauthConsents_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsents_userId_idx": {
+          "name": "oauthConsents_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshTokens_clientId_idx": {
+          "name": "oauthRefreshTokens_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshTokens_sessionId_idx": {
+          "name": "oauthRefreshTokens_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshTokens_userId_idx": {
+          "name": "oauthRefreshTokens_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_unique": {
+          "name": "oauth_refresh_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_suggestions": {
+      "name": "onboarding_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "onboarding_suggestion_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboardingSuggestions_org_type_idx": {
+          "name": "onboardingSuggestions_org_type_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_suggestions_organization_id_organizations_id_fk": {
+          "name": "onboarding_suggestions_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_suggestions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_notification_settings": {
+      "name": "organization_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_content_creation": {
+          "name": "scheduled_content_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_content_failed": {
+          "name": "scheduled_content_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scheduled_content_skipped": {
+          "name": "scheduled_content_skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orgNotificationSettings_organizationId_uidx": {
+          "name": "orgNotificationSettings_organizationId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_settings_organization_id_organizations_id_fk": {
+          "name": "organization_notification_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heard_about_notra_source": {
+          "name": "heard_about_notra_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heard_about_notra_other": {
+          "name": "heard_about_notra_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_dismissed": {
+          "name": "onboarding_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_agent_ran": {
+          "name": "onboarding_agent_ran",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_agent_started_at": {
+          "name": "onboarding_agent_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organizations_slug_uidx": {
+          "name": "organizations_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_collections": {
+      "name": "post_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "post_collection_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_source": {
+          "name": "name_source",
+          "type": "post_collection_name_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generated'"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_post_count": {
+          "name": "expected_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_post_count": {
+          "name": "completed_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_collections_org_created_at_idx": {
+          "name": "post_collections_org_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_collections_source_idx": {
+          "name": "post_collections_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_collections_chat_source_uidx": {
+          "name": "post_collections_chat_source_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"post_collections\".\"source\" = 'chat' AND \"post_collections\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_collections_organization_id_organizations_id_fk": {
+          "name": "post_collections_organization_id_organizations_id_fk",
+          "tableFrom": "post_collections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_org_slug_uidx": {
+          "name": "posts_org_slug_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_org_createdAt_id_idx": {
+          "name": "posts_org_createdAt_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_collection_id_idx": {
+          "name": "posts_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_organization_id_organizations_id_fk": {
+          "name": "posts_organization_id_organizations_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_collection_id_post_collections_id_fk": {
+          "name": "posts_collection_id_post_collections_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "post_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_outputs": {
+      "name": "repository_outputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositoryOutputs_repositoryId_idx": {
+          "name": "repositoryOutputs_repositoryId_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositoryOutputs_repository_outputType_uidx": {
+          "name": "repositoryOutputs_repository_outputType_uidx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "output_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_outputs_repository_id_github_integrations_id_fk": {
+          "name": "repository_outputs_repository_id_github_integrations_id_fk",
+          "tableFrom": "repository_outputs",
+          "tableTo": "github_integrations",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skills_organizationId_idx": {
+          "name": "skills_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skills_org_name_uidx": {
+          "name": "skills_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_organization_id_organizations_id_fk": {
+          "name": "skills_organization_id_organizations_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_personal_data": {
+          "name": "hide_personal_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_agent_stats": {
+          "name": "show_agent_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.applicable_platform": {
+      "name": "applicable_platform",
+      "schema": "public",
+      "values": [
+        "all",
+        "twitter",
+        "linkedin",
+        "blog"
+      ]
+    },
+    "public.brand_guideline_asset_kind": {
+      "name": "brand_guideline_asset_kind",
+      "schema": "public",
+      "values": [
+        "logo",
+        "wordmark"
+      ]
+    },
+    "public.brand_guideline_asset_variant": {
+      "name": "brand_guideline_asset_variant",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark"
+      ]
+    },
+    "public.brand_guideline_color_role": {
+      "name": "brand_guideline_color_role",
+      "schema": "public",
+      "values": [
+        "primary",
+        "secondary",
+        "accent",
+        "background",
+        "foreground",
+        "neutral",
+        "custom"
+      ]
+    },
+    "public.brand_guideline_font_role": {
+      "name": "brand_guideline_font_role",
+      "schema": "public",
+      "values": [
+        "heading",
+        "body",
+        "button",
+        "unknown"
+      ]
+    },
+    "public.brand_guideline_screenshot_kind": {
+      "name": "brand_guideline_screenshot_kind",
+      "schema": "public",
+      "values": [
+        "desktop_hero",
+        "desktop_full_page",
+        "mobile_hero"
+      ]
+    },
+    "public.brand_guideline_status": {
+      "name": "brand_guideline_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "generating",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.brand_guideline_token_type": {
+      "name": "brand_guideline_token_type",
+      "schema": "public",
+      "values": [
+        "spacing",
+        "radius",
+        "shadow",
+        "component",
+        "unknown"
+      ]
+    },
+    "public.brand_sitemap_page_category": {
+      "name": "brand_sitemap_page_category",
+      "schema": "public",
+      "values": [
+        "crawled",
+        "redirect",
+        "queued",
+        "failed"
+      ]
+    },
+    "public.brand_sitemap_status": {
+      "name": "brand_sitemap_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "crawling",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.lookback_window": {
+      "name": "lookback_window",
+      "schema": "public",
+      "values": [
+        "current_day",
+        "yesterday",
+        "last_7_days",
+        "last_14_days",
+        "last_30_days"
+      ]
+    },
+    "public.onboarding_suggestion_type": {
+      "name": "onboarding_suggestion_type",
+      "schema": "public",
+      "values": [
+        "schedule_automation",
+        "event_automation"
+      ]
+    },
+    "public.post_collection_name_source": {
+      "name": "post_collection_name_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user",
+        "backfill"
+      ]
+    },
+    "public.post_collection_source": {
+      "name": "post_collection_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "chat",
+        "schedule",
+        "automation",
+        "api",
+        "backfill"
+      ]
+    },
+    "public.post_status": {
+      "name": "post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.reference_type": {
+      "name": "reference_type",
+      "schema": "public",
+      "values": [
+        "twitter_post",
+        "linkedin_post",
+        "blog_post",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0054_snapshot.json
+++ b/packages/db/migrations/meta/0054_snapshot.json
@@ -1,0 +1,6755 @@
+{
+  "id": "477ebd76-da0c-4c98-81fe-7858ff10051e",
+  "prevId": "6d9b44c9-15d1-42d9-8038-0b992491afc2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_assets": {
+      "name": "brand_guideline_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "brand_guideline_asset_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "brand_guideline_asset_variant",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineAssets_guidelineId_idx": {
+          "name": "brandGuidelineAssets_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandGuidelineAssets_guideline_kind_idx": {
+          "name": "brandGuidelineAssets_guideline_kind_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandGuidelineAssets_guideline_kind_variant_uidx": {
+          "name": "brandGuidelineAssets_guideline_kind_variant_uidx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_assets_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_assets_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_assets",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "tableTo": "brand_guidelines",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_colors": {
+      "name": "brand_guideline_colors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "brand_guideline_color_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "light_value": {
+          "name": "light_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dark_value": {
+          "name": "dark_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineColors_guidelineId_idx": {
+          "name": "brandGuidelineColors_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandGuidelineColors_guideline_role_idx": {
+          "name": "brandGuidelineColors_guideline_role_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_colors_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_colors_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_colors",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "tableTo": "brand_guidelines",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_fonts": {
+      "name": "brand_guideline_fonts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "brand_guideline_font_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_height": {
+          "name": "line_height",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineFonts_guidelineId_idx": {
+          "name": "brandGuidelineFonts_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandGuidelineFonts_guideline_role_idx": {
+          "name": "brandGuidelineFonts_guideline_role_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_fonts_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_fonts_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_fonts",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "tableTo": "brand_guidelines",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_screenshots": {
+      "name": "brand_guideline_screenshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "brand_guideline_screenshot_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_page": {
+          "name": "full_page",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineScreenshots_guidelineId_idx": {
+          "name": "brandGuidelineScreenshots_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandGuidelineScreenshots_guideline_kind_uidx": {
+          "name": "brandGuidelineScreenshots_guideline_kind_uidx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_screenshots_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_screenshots_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_screenshots",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "tableTo": "brand_guidelines",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_tokens": {
+      "name": "brand_guideline_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "brand_guideline_token_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineTokens_guidelineId_idx": {
+          "name": "brandGuidelineTokens_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandGuidelineTokens_guideline_type_idx": {
+          "name": "brandGuidelineTokens_guideline_type_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_tokens_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_tokens_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_tokens",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "tableTo": "brand_guidelines",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guidelines": {
+      "name": "brand_guidelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "brand_guideline_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "context_dev_meta": {
+          "name": "context_dev_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generation_error": {
+          "name": "last_generation_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelines_brandSettingsId_uidx": {
+          "name": "brandGuidelines_brandSettingsId_uidx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandGuidelines_status_idx": {
+          "name": "brandGuidelines_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_guidelines_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_guidelines_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_guidelines",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "tableTo": "brand_settings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_references": {
+      "name": "brand_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot_key": {
+          "name": "source_snapshot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_captured_at": {
+          "name": "source_captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_document_id": {
+          "name": "supermemory_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_memory_id": {
+          "name": "supermemory_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_synced_at": {
+          "name": "supermemory_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_last_sync_error": {
+          "name": "supermemory_last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to": {
+          "name": "applicable_to",
+          "type": "applicable_platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['all']::applicable_platform[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandReferences_brandSettingsId_idx": {
+          "name": "brandReferences_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandReferences_brandSettingsId_sourceUrl_idx": {
+          "name": "brandReferences_brandSettingsId_sourceUrl_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_references_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_references_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_references",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "tableTo": "brand_settings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_settings": {
+      "name": "brand_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_description": {
+          "name": "company_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone_profile": {
+          "name": "tone_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_tone": {
+          "name": "custom_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'English'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSettings_org_name_uidx": {
+          "name": "brandSettings_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandSettings_org_default_uidx": {
+          "name": "brandSettings_org_default_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"brand_settings\".\"is_default\" = true",
+          "concurrently": false
+        },
+        "brandSettings_organizationId_idx": {
+          "name": "brandSettings_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_settings_organization_id_organizations_id_fk": {
+          "name": "brand_settings_organization_id_organizations_id_fk",
+          "tableFrom": "brand_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "brandSettings_toneProfile_check": {
+          "name": "brandSettings_toneProfile_check",
+          "value": "\"brand_settings\".\"tone_profile\" IS NULL OR \"brand_settings\".\"tone_profile\" IN ('Conversational', 'Professional', 'Casual', 'Formal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemap_pages": {
+      "name": "brand_sitemap_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sitemap_id": {
+          "name": "sitemap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "brand_sitemap_page_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_ratio": {
+          "name": "text_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_links": {
+          "name": "internal_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_links": {
+          "name": "external_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawled_at": {
+          "name": "crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemapPages_sitemapId_idx": {
+          "name": "brandSitemapPages_sitemapId_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandSitemapPages_sitemap_category_idx": {
+          "name": "brandSitemapPages_sitemap_category_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandSitemapPages_sitemap_url_uidx": {
+          "name": "brandSitemapPages_sitemap_url_uidx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk": {
+          "name": "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk",
+          "tableFrom": "brand_sitemap_pages",
+          "columnsFrom": [
+            "sitemap_id"
+          ],
+          "tableTo": "brand_sitemaps",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemaps": {
+      "name": "brand_sitemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "brand_sitemap_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indexed_pages": {
+          "name": "indexed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_pages": {
+          "name": "failed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context_dev_meta": {
+          "name": "context_dev_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_started_at": {
+          "name": "last_crawl_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawled_at": {
+          "name": "last_crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_error": {
+          "name": "last_crawl_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemaps_brandSettingsId_idx": {
+          "name": "brandSitemaps_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brandSitemaps_brandSettings_url_uidx": {
+          "name": "brandSitemaps_brandSettings_url_uidx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemaps_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_sitemaps_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_sitemaps",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "tableTo": "brand_settings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_attachments": {
+      "name": "chat_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatAttachments_organizationId_createdAt_idx": {
+          "name": "chatAttachments_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "chatAttachments_userId_idx": {
+          "name": "chatAttachments_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chat_attachments_organization_id_organizations_id_fk": {
+          "name": "chat_attachments_organization_id_organizations_id_fk",
+          "tableFrom": "chat_attachments",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "chat_attachments_user_id_users_id_fk": {
+          "name": "chat_attachments_user_id_users_id_fk",
+          "tableFrom": "chat_attachments",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_attachments_key_unique": {
+          "name": "chat_attachments_key_unique",
+          "columns": [
+            "key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_source": {
+          "name": "external_channel_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_id": {
+          "name": "external_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatSessions_organizationId_idx": {
+          "name": "chatSessions_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "chatSessions_organizationId_deletedAt_idx": {
+          "name": "chatSessions_organizationId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "chatSessions_org_externalChannel_uidx": {
+          "name": "chatSessions_org_externalChannel_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"chat_sessions\".\"external_channel_source\" IN ('discord', 'slack') AND \"chat_sessions\".\"external_channel_id\" IS NOT NULL AND \"chat_sessions\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chat_sessions_organization_id_organizations_id_fk": {
+          "name": "chat_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "chat_sessions",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_social_accounts": {
+      "name": "connected_social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectedSocialAccounts_organizationId_idx": {
+          "name": "connectedSocialAccounts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "connectedSocialAccounts_org_provider_account_uidx": {
+          "name": "connectedSocialAccounts_org_provider_account_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "connected_social_accounts_organization_id_organizations_id_fk": {
+          "name": "connected_social_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "connected_social_accounts",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_trigger_lookback_windows": {
+      "name": "content_trigger_lookback_windows",
+      "schema": "",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "lookback_window",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk": {
+          "name": "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk",
+          "tableFrom": "content_trigger_lookback_windows",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "tableTo": "content_triggers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_triggers": {
+      "name": "content_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Schedule'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_config": {
+          "name": "output_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_hash": {
+          "name": "dedupe_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_publish": {
+          "name": "auto_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentTriggers_organizationId_idx": {
+          "name": "contentTriggers_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "contentTriggers_organization_dedupe_uidx": {
+          "name": "contentTriggers_organization_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "content_triggers_organization_id_organizations_id_fk": {
+          "name": "content_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "content_triggers",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_avatar_url": {
+          "name": "account_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubAppInstallations_organizationId_idx": {
+          "name": "githubAppInstallations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "githubAppInstallations_createdByUserId_idx": {
+          "name": "githubAppInstallations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "githubAppInstallations_organization_installation_uidx": {
+          "name": "githubAppInstallations_organization_installation_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_app_installations_created_by_user_id_users_id_fk": {
+          "name": "github_app_installations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_app_installations",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_app_installation_id": {
+          "name": "github_app_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_private": {
+          "name": "github_repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_enabled": {
+          "name": "repository_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubIntegrations_organizationId_idx": {
+          "name": "githubIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "githubIntegrations_createdByUserId_idx": {
+          "name": "githubIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "githubIntegrations_organization_owner_repo_uidx": {
+          "name": "githubIntegrations_organization_owner_repo_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_organization_id_organizations_id_fk": {
+          "name": "github_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "github_integrations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_integrations_created_by_user_id_users_id_fk": {
+          "name": "github_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_integrations",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_integrations_github_app_installation_id_github_app_installations_id_fk": {
+          "name": "github_integrations_github_app_installation_id_github_app_installations_id_fk",
+          "tableFrom": "github_integrations",
+          "columnsFrom": [
+            "github_app_installation_id"
+          ],
+          "tableTo": "github_app_installations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.granola_integrations": {
+      "name": "granola_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "granolaIntegrations_organizationId_idx": {
+          "name": "granolaIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "granolaIntegrations_createdByUserId_idx": {
+          "name": "granolaIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "granola_integrations_organization_id_organizations_id_fk": {
+          "name": "granola_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "granola_integrations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "granola_integrations_created_by_user_id_users_id_fk": {
+          "name": "granola_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "granola_integrations",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitations_organizationId_idx": {
+          "name": "invitations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_integrations": {
+      "name": "linear_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_id": {
+          "name": "linear_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_name": {
+          "name": "linear_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linearIntegrations_organizationId_idx": {
+          "name": "linearIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "linearIntegrations_createdByUserId_idx": {
+          "name": "linearIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "linearIntegrations_org_linearOrg_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "linearIntegrations_org_linearOrg_no_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_no_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"linear_integrations\".\"linear_team_id\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "linear_integrations_organization_id_organizations_id_fk": {
+          "name": "linear_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "linear_integrations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "linear_integrations_created_by_user_id_users_id_fk": {
+          "name": "linear_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "linear_integrations",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_credentials": {
+      "name": "mcp_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_tokens": {
+          "name": "encrypted_tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_client_information": {
+          "name": "encrypted_client_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_authorization_server_information": {
+          "name": "encrypted_authorization_server_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_refresh_at": {
+          "name": "access_token_refresh_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_lease_id": {
+          "name": "refresh_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_lease_expires_at": {
+          "name": "refresh_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpOAuthCredentials_organizationId_idx": {
+          "name": "mcpOAuthCredentials_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpOAuthCredentials_connectedByUserId_idx": {
+          "name": "mcpOAuthCredentials_connectedByUserId_idx",
+          "columns": [
+            {
+              "expression": "connected_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_credentials_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_oauth_credentials_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_oauth_credentials_organization_id_organizations_id_fk": {
+          "name": "mcp_oauth_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_oauth_credentials_connected_by_user_id_users_id_fk": {
+          "name": "mcp_oauth_credentials_connected_by_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "columnsFrom": [
+            "connected_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcpOAuthCredentials_org_server_fk": {
+          "name": "mcpOAuthCredentials_org_server_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcpOAuthCredentials_status_check": {
+          "name": "mcpOAuthCredentials_status_check",
+          "value": "\"mcp_oauth_credentials\".\"status\" IN ('connected', 'refreshing', 'reauth_required')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_pending_authorizations": {
+      "name": "mcp_oauth_pending_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_source_integration_id": {
+          "name": "store_source_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callback_path": {
+          "name": "callback_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_state": {
+          "name": "encrypted_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_code_verifier": {
+          "name": "encrypted_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_client_information": {
+          "name": "encrypted_client_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_authorization_server_information": {
+          "name": "encrypted_authorization_server_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpOAuthPendingAuthorizations_organizationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpOAuthPendingAuthorizations_userId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpOAuthPendingAuthorizations_serverIntegrationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_serverIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpOAuthPendingAuthorizations_expiresAt_idx": {
+          "name": "mcpOAuthPendingAuthorizations_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_pending_authorizations_organization_id_organizations_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_oauth_pending_authorizations_user_id_users_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_oauth_pending_authorizations_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcpOAuthPendingAuthorizations_org_server_fk": {
+          "name": "mcpOAuthPendingAuthorizations_org_server_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_fk": {
+          "name": "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "columnsFrom": [
+            "store_source_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_pending_authorizations_state_hash_unique": {
+          "name": "mcp_oauth_pending_authorizations_state_hash_unique",
+          "columns": [
+            "state_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_integrations": {
+      "name": "mcp_server_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection'"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_light_url": {
+          "name": "logo_light_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_dark_url": {
+          "name": "logo_dark_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_source_integration_id": {
+          "name": "store_source_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_status": {
+          "name": "store_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_tool_sync_at": {
+          "name": "last_tool_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_sync_status": {
+          "name": "tool_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "tool_sync_error": {
+          "name": "tool_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_tool_count": {
+          "name": "indexed_tool_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpServerIntegrations_resourceType_idx": {
+          "name": "mcpServerIntegrations_resourceType_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_storeStatus_idx": {
+          "name": "mcpServerIntegrations_storeStatus_idx",
+          "columns": [
+            {
+              "expression": "store_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_organizationId_idx": {
+          "name": "mcpServerIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_createdByUserId_idx": {
+          "name": "mcpServerIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_storeSourceIntegrationId_idx": {
+          "name": "mcpServerIntegrations_storeSourceIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_org_id_uidx": {
+          "name": "mcpServerIntegrations_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_org_resourceType_name_uidx": {
+          "name": "mcpServerIntegrations_org_resourceType_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_org_storeSource_uidx": {
+          "name": "mcpServerIntegrations_org_storeSource_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"mcp_server_integrations\".\"store_source_integration_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "mcpServerIntegrations_storeListing_slug_uidx": {
+          "name": "mcpServerIntegrations_storeListing_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"mcp_server_integrations\".\"resource_type\" = 'store_listing'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_integrations_organization_id_organizations_id_fk": {
+          "name": "mcp_server_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_server_integrations_created_by_user_id_users_id_fk": {
+          "name": "mcp_server_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcpServerIntegrations_storeSourceIntegrationId_fk": {
+          "name": "mcpServerIntegrations_storeSourceIntegrationId_fk",
+          "tableFrom": "mcp_server_integrations",
+          "columnsFrom": [
+            "store_source_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcpServerIntegrations_authType_check": {
+          "name": "mcpServerIntegrations_authType_check",
+          "value": "\"mcp_server_integrations\".\"auth_type\" IN ('none', 'headers', 'oauth')"
+        },
+        "mcpServerIntegrations_storeStatus_check": {
+          "name": "mcpServerIntegrations_storeStatus_check",
+          "value": "\"mcp_server_integrations\".\"store_status\" IN ('draft', 'pending_review', 'live', 'rejected')"
+        },
+        "mcpServerIntegrations_resourceType_check": {
+          "name": "mcpServerIntegrations_resourceType_check",
+          "value": "\"mcp_server_integrations\".\"resource_type\" IN ('connection', 'store_listing')"
+        },
+        "mcpServerIntegrations_resourceState_check": {
+          "name": "mcpServerIntegrations_resourceState_check",
+          "value": "(\n        (\"mcp_server_integrations\".\"resource_type\" = 'store_listing' AND \"mcp_server_integrations\".\"store_source_integration_id\" IS NULL)\n        OR\n        (\"mcp_server_integrations\".\"resource_type\" = 'connection' AND \"mcp_server_integrations\".\"store_status\" = 'draft' AND \"mcp_server_integrations\".\"review_note\" IS NULL AND \"mcp_server_integrations\".\"submitted_at\" IS NULL AND \"mcp_server_integrations\".\"reviewed_at\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_session_tool_activations": {
+      "name": "mcp_session_tool_activations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_tool_index_id": {
+          "name": "mcp_tool_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_query": {
+          "name": "source_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcpSessionToolActivations_session_tool_uidx": {
+          "name": "mcpSessionToolActivations_session_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mcp_tool_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpSessionToolActivations_session_idx": {
+          "name": "mcpSessionToolActivations_session_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpSessionToolActivations_expiresAt_idx": {
+          "name": "mcpSessionToolActivations_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_session_tool_activations_organization_id_organizations_id_fk": {
+          "name": "mcp_session_tool_activations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk": {
+          "name": "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "columnsFrom": [
+            "mcp_tool_index_id"
+          ],
+          "tableTo": "mcp_tool_index",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcpSessionToolActivations_org_tool_fk": {
+          "name": "mcpSessionToolActivations_org_tool_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "columnsFrom": [
+            "organization_id",
+            "mcp_tool_index_id"
+          ],
+          "tableTo": "mcp_tool_index",
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tool_index": {
+      "name": "mcp_tool_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_tool_name": {
+          "name": "server_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_phrase_present": {
+          "name": "action_phrase_present",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_phrase_past": {
+          "name": "action_phrase_past",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_indexed_at": {
+          "name": "last_indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpToolIndex_server_tool_uidx": {
+          "name": "mcpToolIndex_server_tool_uidx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpToolIndex_org_id_uidx": {
+          "name": "mcpToolIndex_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpToolIndex_org_runtime_tool_uidx": {
+          "name": "mcpToolIndex_org_runtime_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpToolIndex_organizationId_status_idx": {
+          "name": "mcpToolIndex_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpToolIndex_serverIntegrationId_status_idx": {
+          "name": "mcpToolIndex_serverIntegrationId_status_idx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcpToolIndex_searchText_gin_idx": {
+          "name": "mcpToolIndex_searchText_gin_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"search_text\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_index_organization_id_organizations_id_fk": {
+          "name": "mcp_tool_index_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcpToolIndex_org_server_fk": {
+          "name": "mcpToolIndex_org_server_fk",
+          "tableFrom": "mcp_tool_index",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "tableTo": "mcp_server_integrations",
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_organizationId_idx": {
+          "name": "members_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "members_userId_idx": {
+          "name": "members_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessTokens_clientId_idx": {
+          "name": "oauthAccessTokens_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauthAccessTokens_sessionId_idx": {
+          "name": "oauthAccessTokens_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauthAccessTokens_userId_idx": {
+          "name": "oauthAccessTokens_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauthAccessTokens_refreshId_idx": {
+          "name": "oauthAccessTokens_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "oauth_clients",
+          "columnsTo": [
+            "client_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_access_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_access_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "tableTo": "oauth_refresh_tokens",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClients_userId_idx": {
+          "name": "oauthClients_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauthConsents_clientId_idx": {
+          "name": "oauthConsents_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauthConsents_userId_idx": {
+          "name": "oauthConsents_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "oauth_clients",
+          "columnsTo": [
+            "client_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshTokens_clientId_idx": {
+          "name": "oauthRefreshTokens_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauthRefreshTokens_sessionId_idx": {
+          "name": "oauthRefreshTokens_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauthRefreshTokens_userId_idx": {
+          "name": "oauthRefreshTokens_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "oauth_clients",
+          "columnsTo": [
+            "client_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_refresh_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_unique": {
+          "name": "oauth_refresh_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_suggestions": {
+      "name": "onboarding_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "onboarding_suggestion_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboardingSuggestions_org_type_idx": {
+          "name": "onboardingSuggestions_org_type_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "onboarding_suggestions_organization_id_organizations_id_fk": {
+          "name": "onboarding_suggestions_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_suggestions",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_notification_settings": {
+      "name": "organization_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_content_creation": {
+          "name": "scheduled_content_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_content_failed": {
+          "name": "scheduled_content_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scheduled_content_skipped": {
+          "name": "scheduled_content_skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orgNotificationSettings_organizationId_uidx": {
+          "name": "orgNotificationSettings_organizationId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_settings_organization_id_organizations_id_fk": {
+          "name": "organization_notification_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heard_about_notra_source": {
+          "name": "heard_about_notra_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heard_about_notra_other": {
+          "name": "heard_about_notra_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_dismissed": {
+          "name": "onboarding_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_agent_ran": {
+          "name": "onboarding_agent_ran",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_agent_started_at": {
+          "name": "onboarding_agent_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organizations_slug_uidx": {
+          "name": "organizations_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_collections": {
+      "name": "post_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "post_collection_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_source": {
+          "name": "name_source",
+          "type": "post_collection_name_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generated'"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_post_count": {
+          "name": "expected_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_post_count": {
+          "name": "completed_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_collections_org_created_at_idx": {
+          "name": "post_collections_org_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "post_collections_source_idx": {
+          "name": "post_collections_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "post_collections_chat_source_uidx": {
+          "name": "post_collections_chat_source_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"post_collections\".\"source\" = 'chat' AND \"post_collections\".\"source_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "post_collections_organization_id_organizations_id_fk": {
+          "name": "post_collections_organization_id_organizations_id_fk",
+          "tableFrom": "post_collections",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_org_slug_uidx": {
+          "name": "posts_org_slug_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"posts\".\"slug\" IS NOT NULL",
+          "concurrently": false
+        },
+        "posts_org_createdAt_id_idx": {
+          "name": "posts_org_createdAt_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "posts_collection_id_idx": {
+          "name": "posts_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "posts_organization_id_organizations_id_fk": {
+          "name": "posts_organization_id_organizations_id_fk",
+          "tableFrom": "posts",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "posts_collection_id_post_collections_id_fk": {
+          "name": "posts_collection_id_post_collections_id_fk",
+          "tableFrom": "posts",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "tableTo": "post_collections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_outputs": {
+      "name": "repository_outputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositoryOutputs_repositoryId_idx": {
+          "name": "repositoryOutputs_repositoryId_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "repositoryOutputs_repository_outputType_uidx": {
+          "name": "repositoryOutputs_repository_outputType_uidx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "output_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "repository_outputs_repository_id_github_integrations_id_fk": {
+          "name": "repository_outputs_repository_id_github_integrations_id_fk",
+          "tableFrom": "repository_outputs",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "tableTo": "github_integrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skills_organizationId_idx": {
+          "name": "skills_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "skills_org_name_uidx": {
+          "name": "skills_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "skills_organization_id_organizations_id_fk": {
+          "name": "skills_organization_id_organizations_id_fk",
+          "tableFrom": "skills",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_personal_data": {
+          "name": "hide_personal_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_agent_stats": {
+          "name": "show_agent_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.applicable_platform": {
+      "name": "applicable_platform",
+      "schema": "public",
+      "values": [
+        "all",
+        "twitter",
+        "linkedin",
+        "blog"
+      ]
+    },
+    "public.brand_guideline_asset_kind": {
+      "name": "brand_guideline_asset_kind",
+      "schema": "public",
+      "values": [
+        "logo",
+        "wordmark"
+      ]
+    },
+    "public.brand_guideline_asset_variant": {
+      "name": "brand_guideline_asset_variant",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark"
+      ]
+    },
+    "public.brand_guideline_color_role": {
+      "name": "brand_guideline_color_role",
+      "schema": "public",
+      "values": [
+        "primary",
+        "secondary",
+        "accent",
+        "background",
+        "foreground",
+        "neutral",
+        "custom"
+      ]
+    },
+    "public.brand_guideline_font_role": {
+      "name": "brand_guideline_font_role",
+      "schema": "public",
+      "values": [
+        "heading",
+        "body",
+        "button",
+        "unknown"
+      ]
+    },
+    "public.brand_guideline_screenshot_kind": {
+      "name": "brand_guideline_screenshot_kind",
+      "schema": "public",
+      "values": [
+        "desktop_hero",
+        "desktop_full_page",
+        "mobile_hero"
+      ]
+    },
+    "public.brand_guideline_status": {
+      "name": "brand_guideline_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "generating",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.brand_guideline_token_type": {
+      "name": "brand_guideline_token_type",
+      "schema": "public",
+      "values": [
+        "spacing",
+        "radius",
+        "shadow",
+        "component",
+        "unknown"
+      ]
+    },
+    "public.brand_sitemap_page_category": {
+      "name": "brand_sitemap_page_category",
+      "schema": "public",
+      "values": [
+        "crawled",
+        "redirect",
+        "queued",
+        "failed"
+      ]
+    },
+    "public.brand_sitemap_status": {
+      "name": "brand_sitemap_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "crawling",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.lookback_window": {
+      "name": "lookback_window",
+      "schema": "public",
+      "values": [
+        "current_day",
+        "yesterday",
+        "last_7_days",
+        "last_14_days",
+        "last_30_days"
+      ]
+    },
+    "public.onboarding_suggestion_type": {
+      "name": "onboarding_suggestion_type",
+      "schema": "public",
+      "values": [
+        "schedule_automation",
+        "event_automation"
+      ]
+    },
+    "public.post_collection_name_source": {
+      "name": "post_collection_name_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user",
+        "backfill"
+      ]
+    },
+    "public.post_collection_source": {
+      "name": "post_collection_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "chat",
+        "schedule",
+        "automation",
+        "api",
+        "backfill"
+      ]
+    },
+    "public.post_status": {
+      "name": "post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.reference_type": {
+      "name": "reference_type",
+      "schema": "public",
+      "values": [
+        "twitter_post",
+        "linkedin_post",
+        "blog_post",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -372,6 +372,20 @@
       "when": 1784354287455,
       "tag": "0052_woozy_prowler",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1784734545122,
+      "tag": "0053_numerous_morlun",
+      "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1784734559957,
+      "tag": "0054_backfill_store_listing_slugs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -536,6 +536,7 @@ export const mcpServerIntegrations = pgTable(
     logoLightUrl: text("logo_light_url"),
     logoDarkUrl: text("logo_dark_url"),
     bannerUrl: text("banner_url"),
+    slug: text("slug"),
     storeSourceIntegrationId: text("store_source_integration_id"),
     storeStatus: text("store_status").default("draft").notNull(),
     reviewNote: text("review_note"),
@@ -599,6 +600,9 @@ export const mcpServerIntegrations = pgTable(
     uniqueIndex("mcpServerIntegrations_org_storeSource_uidx")
       .on(table.organizationId, table.storeSourceIntegrationId)
       .where(sql`${table.storeSourceIntegrationId} IS NOT NULL`),
+    uniqueIndex("mcpServerIntegrations_storeListing_slug_uidx")
+      .on(table.slug)
+      .where(sql`${table.resourceType} = 'store_listing'`),
     foreignKey({
       columns: [table.storeSourceIntegrationId],
       foreignColumns: [table.id],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,8 @@
   "exports": {
     "./url": "./src/url.ts",
     "./callback-url": "./src/callback-url.ts",
-    "./oauth-popup": "./src/oauth-popup.ts"
+    "./oauth-popup": "./src/oauth-popup.ts",
+    "./slugify": "./src/slugify.ts"
   },
   "devDependencies": {
     "@notra/typescript-config": "workspace:*",

--- a/packages/utils/src/slugify.ts
+++ b/packages/utils/src/slugify.ts
@@ -1,0 +1,10 @@
+const NON_ALPHANUMERIC_RUN_REGEX = /[^a-z0-9]+/g;
+const EDGE_HYPHENS_REGEX = /^-+|-+$/g;
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(NON_ALPHANUMERIC_RUN_REGEX, "-")
+    .replace(EDGE_HYPHENS_REGEX, "");
+}

--- a/packages/utils/src/slugify.ts
+++ b/packages/utils/src/slugify.ts
@@ -1,10 +1,9 @@
-const NON_ALPHANUMERIC_RUN_REGEX = /[^a-z0-9]+/g;
-const EDGE_HYPHENS_REGEX = /^-+|-+$/g;
+const NON_ALPHANUMERIC_RUN_REGEX = /[^a-z0-9]+/;
 
 export function slugify(value: string): string {
   return value
     .toLowerCase()
-    .trim()
-    .replace(NON_ALPHANUMERIC_RUN_REGEX, "-")
-    .replace(EDGE_HYPHENS_REGEX, "");
+    .split(NON_ALPHANUMERIC_RUN_REGEX)
+    .filter(Boolean)
+    .join("-");
 }


### PR DESCRIPTION
## Summary

Adds a public integrations marketplace to the marketing site, backed by the console's store listings.

- **web**: `/integrations` listing page from the Paper designs: hero with search and category pills (URL state via nuqs), Editor's picks featured cards, A-Z grid, quick-view modal built on parallel + intercepting routes (`@modal/(.)[id]`), `/integrations/[slug]` detail pages, and a "List your integration" CTA with an interactive console mockup (traffic-light easter egg included). Responsive, full light/dark support.
- **console**: public read-only store API (`/api/store/integrations`, `/api/store/integrations/[id]`) exposing only public listing columns plus tools; slug input on the integration form, live-derived from the name until manually edited.
- **db**: nullable `slug` column on `mcp_server_integrations` with a partial unique index for store listings, plus a backfill migration setting `slug = lower(name)` (already applied).
- **ai**: store queries expose slug and banner; new slug-based lookup.

Web fetches over HTTP with a static fallback (no direct DB dependency). Old `mcp_*` id URLs still resolve.

## Notes for reviewers

- Interception routes break in `next dev` after HMR saves due to a known Next 16/Turbopack bug (vercel/next.js#91265) - restart the dev server; production builds are unaffected.
- Set `NOTRA_CONSOLE_URL` for non-default console origins.

## Testing

- `bun run build` passes for web, console, and dashboard; biome and knip clean.
- Modal open/close verified headlessly (soft nav to `/integrations/brew`, Escape restores `/integrations`).

https://claude.ai/code/session_01CWmpGY1gzXqm9sTUddek6j

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Launches a public integrations marketplace on the marketing site, backed by live Console listings and a public read API. Adds SSR fallback, improves banner/logo rendering and link safety, and includes marketplace and detail pages in the sitemap.

- New Features
  - Web (`apps/web`)
    - `/integrations` page with search and category pills (URL state via `nuqs` + `NuqsAdapter`), Editor’s picks, A–Z grid, and quick-view modal using parallel/intercepting routes (`@modal/(.)[id]`). Server-renders the default marketplace view as the Suspense fallback, and adds sitemap entries for the marketplace and all integration detail pages.
    - `/integrations/[slug]` detail pages with SEO metadata; banner image prioritized, author links limited to `http`/`https` with `noreferrer`, single logo image when light/dark assets match, and tool descriptions falling back to title. Console CTA with form mock; image allowlist expanded to `*.r2.dev`.
  - Console (`apps/console`)
    - Public read-only Store API: `GET /api/store/integrations` and `GET /api/store/integrations/[id]` (`s-maxage=300`); resolves legacy `mcp_*` IDs before slug lookup, aligns `id` param length to slug max, and shares a consistent column projection and public payload mapper.
    - Integration form adds a slug field; auto-derives from name until edited, validated, and conflicts handled (“This slug is already taken”).
  - Data/AI
    - DB: new nullable `slug` on `mcp_server_integrations` with a partial unique index for `store_listing`; collision-safe backfill with numbered suffixes.
    - `@notra/ai` store queries expose `slug` and `banner`, with slug-based lookup; legacy `mcp_*` IDs still resolve. `@notra/utils` adds a regex-backtracking-free `slugify`.
    - Web fetch supports `NOTRA_CONSOLE_URL` and falls back to static data if the API is unavailable.
  - Cleanup
    - Dropped redundant `useMemo` calls flagged by React Doctor.

- Migration
  - Apply DB migrations `0053_numerous_morlun` and `0054_backfill_store_listing_slugs`.
  - Set `NOTRA_CONSOLE_URL` if the Console origin differs from `https://console.usenotra.com`.
  - Known dev caveat: Next 16/Turbopack may break interception routes after HMR; restart `next dev` if the modal stops working.

<sup>Written for commit 819b25fad0cc45547740d2d5fe24eb3d2917c011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

1 issue found.

<sub>Written for commit [`5e26ccc`](https://github.com/usenotra/notra/commit/5e26cccd202e7ac647f0c0b4c9b39931e1a878a8). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->