### PR TITLE
fix(web): allow cdn.usenotra.com integration branding images

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -122,7 +122,7 @@ const nextConfig: NextConfig = {
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' databuddy.cc *.databuddy.cc",
             "style-src 'self' 'unsafe-inline'",
             "font-src 'self'",
-            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com media.marblecms.com *.r2.dev",
+            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com media.marblecms.com *.r2.dev cdn.usenotra.com",
             "connect-src 'self' databuddy.cc *.databuddy.cc *.inth.app *.c15t.com *.c15t.dev",
             "frame-src 'none'",
             "frame-ancestors 'none'",
@@ -157,6 +157,10 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "**.r2.dev",
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.usenotra.com",
       },
     ],
   },


### PR DESCRIPTION
Production integration branding uploads are served from `cdn.usenotra.com` (custom domain in front of R2), but only `*.r2.dev` was allowed. Logos and banners for listings stored there were CSP-blocked on `/integrations` (confirmed live via captured CSP violations). Adds the host to the CSP `img-src` directive and `next/image` remotePatterns.

https://claude.ai/code/session_01CWmpGY1gzXqm9sTUddek6j

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows integration branding images from cdn.usenotra.com to load on /integrations. Adds the domain to the CSP img-src directive and `next/image` remotePatterns to prevent blocked logos and banners.

<sup>Written for commit 81da90f7baa93dc378c1a387b80aa58907c99cfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

2 issues found.

<sub>Written for commit [`81da90f`](https://github.com/usenotra/notra/commit/81da90f7baa93dc378c1a387b80aa58907c99cfd). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->