### PR TITLE
fix(web): update pricing billing display

### DIFF
--- a/apps/web/src/components/landing/pricing-section.tsx
+++ b/apps/web/src/components/landing/pricing-section.tsx
@@ -149,28 +149,37 @@ function PricingCard({ plan, billingPeriod }: PricingCardProps) {
 
         <div className="flex flex-1 flex-col px-6 pt-4.5">
           <div className="flex flex-col items-start gap-3.25">
-            <div className="flex items-baseline gap-4">
-              <span
-                className={cn(
-                  "font-display font-normal text-[2.625rem] leading-13 tracking-[-0.01em]",
-                  isFeatured ? "text-white" : "text-[#1E1E1E] dark:text-white"
-                )}
+            <AnimatePresence initial={false} mode="wait">
+              <m.div
+                animate={{ y: 0, opacity: 1 }}
+                className="flex items-baseline gap-2"
+                exit={{ y: "0.75rem", opacity: 0 }}
+                initial={{ y: "0.75rem", opacity: 0 }}
+                key={plan.price[billingPeriod]}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
               >
-                {plan.price}
-              </span>
-              {plan.priceSuffix ? (
                 <span
                   className={cn(
-                    "font-normal font-sans text-sm leading-[1.125rem] tracking-[-0.015em]",
-                    isFeatured
-                      ? "text-white/70"
-                      : "text-[#1E1E1EB3] dark:text-white/60"
+                    "font-display font-normal text-[2.625rem] leading-13 tracking-[-0.01em]",
+                    isFeatured ? "text-white" : "text-[#1E1E1E] dark:text-white"
                   )}
                 >
-                  {plan.priceSuffix}
+                  {plan.price[billingPeriod]}
                 </span>
-              ) : null}
-            </div>
+                {plan.priceSuffix ? (
+                  <span
+                    className={cn(
+                      "font-normal font-sans text-sm leading-[1.125rem] tracking-[-0.015em]",
+                      isFeatured
+                        ? "text-white/70"
+                        : "text-[#1E1E1EB3] dark:text-white/60"
+                    )}
+                  >
+                    {plan.priceSuffix[billingPeriod]}
+                  </span>
+                ) : null}
+              </m.div>
+            </AnimatePresence>
 
             <CtaButton
               className="w-full"

--- a/apps/web/src/constants/landing/pricing.ts
+++ b/apps/web/src/constants/landing/pricing.ts
@@ -27,8 +27,8 @@ export const PRICING_PLANS: PricingPlan[] = [
     id: "basic",
     name: "Basic",
     description: "For small teams publishing their first regular updates.",
-    price: "$20",
-    priceSuffix: "/monthly",
+    price: { monthly: "$20", yearly: "$200" },
+    priceSuffix: { monthly: "/monthly", yearly: "/yearly" },
     variant: "default",
     hasAnnualBadge: true,
     cta: {
@@ -56,8 +56,8 @@ export const PRICING_PLANS: PricingPlan[] = [
     name: "Pro",
     description:
       "For teams shipping every week who want every release covered.",
-    price: "$50",
-    priceSuffix: "/monthly",
+    price: { monthly: "$50", yearly: "$500" },
+    priceSuffix: { monthly: "/monthly", yearly: "/yearly" },
     variant: "featured",
     hasAnnualBadge: true,
     cta: {
@@ -84,7 +84,7 @@ export const PRICING_PLANS: PricingPlan[] = [
     id: "enterprise",
     name: "Enterprise",
     description: "For large teams with custom needs.",
-    price: "$Custom",
+    price: { monthly: "Custom", yearly: "Custom" },
     variant: "default",
     cta: {
       label: "Contact Us",

--- a/apps/web/src/types/landing/pricing.ts
+++ b/apps/web/src/types/landing/pricing.ts
@@ -38,8 +38,8 @@ export interface PricingPlan {
   id: string;
   name: string;
   description: string;
-  price: string;
-  priceSuffix?: string;
+  price: Record<BillingPeriod, string>;
+  priceSuffix?: Record<BillingPeriod, string>;
   variant: "default" | "featured";
   hasAnnualBadge?: boolean;
   cta: PricingCta;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pricing page billing toggle so price and suffix update correctly between monthly and yearly.

- Bug Fixes
  - Drive price and suffix from `billingPeriod`: update `PricingPlan` to use `Record<BillingPeriod, string>` and wire through the UI.
  - Update `PRICING_PLANS` with monthly/yearly values; Enterprise uses "Custom" for both.
  - Add animated price transition with `AnimatePresence` to avoid flicker when switching periods.

<sup>Written for commit 0e20f95f9308890cc5874fabda28cc35a57a4aa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

