### PR TITLE
fix(web): polish the pricing billing toggle

### DIFF
--- a/apps/web/src/components/landing/pricing-section.tsx
+++ b/apps/web/src/components/landing/pricing-section.tsx
@@ -6,7 +6,7 @@ import { CtaButton } from "@notra/ui/components/shared/cta-button";
 import { cn } from "@notra/ui/lib/utils";
 import {
   AnimatePresence,
-  domAnimation,
+  domMax,
   LazyMotion,
   m,
   useReducedMotion,
@@ -58,6 +58,10 @@ function PricingBillingToggle({
               <m.span
                 className="cta-gradient-primary absolute inset-0 rounded-full"
                 layoutId="pricing-billing-thumb"
+                style={{
+                  boxShadow:
+                    "0 0.0625rem 0.125rem #28282814, 0 0 0 0.0625rem #1E1E1E40",
+                }}
                 transition={
                   shouldReduceMotion
                     ? { duration: 0 }
@@ -259,7 +263,7 @@ export function LandingPricingSection({
   );
 
   return (
-    <LazyMotion features={domAnimation}>
+    <LazyMotion features={domMax}>
       <section
         className="flex w-full flex-col items-center gap-13.5 px-6 py-24"
         id="pricing"


### PR DESCRIPTION
## Summary
- Remove the purple halo outline around the active Monthly/Yearly pill. It came from the shared `cta-gradient-primary` utility's `#8b5cf640 0 0 0 0.5rem` box shadow; the toggle thumb now overrides it with just the subtle depth shadow and 1px ring, leaving the CTA buttons untouched.
- Make the pill actually slide between Monthly and Yearly. The thumb already had a `layoutId` spring, but the section loaded `LazyMotion` with `domAnimation`, which does not include layout projection, so the thumb snapped instead of animating. Switched to `domMax`.

## Test plan
- Verified /pricing renders on the local dev server and lint is clean.
- Reduced-motion behavior unchanged (duration 0 branch preserved).

https://claude.ai/code/session_01Xb7UfoyL6mCtYGiT3sSpYC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the pricing billing toggle on /pricing to remove the purple halo and add a smooth slide between Monthly and Yearly.

- **UI Improvements**
  - Override the `cta-gradient-primary` box-shadow on the toggle thumb to drop the halo while keeping a subtle shadow and 1px ring.
  - Switch `LazyMotion` features to `domMax` so the `layoutId` thumb animates smoothly; reduced-motion behavior remains unchanged.

<sup>Written for commit 28416d432512b5939505137f83d7d86341e525f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`28416d4`](https://github.com/usenotra/notra/commit/28416d432512b5939505137f83d7d86341e525f2). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->