### PR TITLE
fix(web): keep the landing navbar inset on mid-size viewports

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -368,11 +368,11 @@ export function Navbar({ variant }: NavbarProps = {}) {
   const isLandingTop = isLanding && !chrome;
   const mutedNavClass =
     "text-[#1E1E1EA6] hover:text-[#1E1E1E] dark:text-neutral-400 dark:hover:text-white";
-  let positionClass = "sticky top-4";
+  let positionClass = "w-full sticky top-4";
   if (isLanding) {
-    positionClass = "fixed inset-x-0";
+    positionClass = "fixed inset-x-4 sm:inset-x-6";
   } else if (isStatic) {
-    positionClass = "";
+    positionClass = "w-full";
   }
   const shellAnimate = isLanding
     ? {
@@ -381,13 +381,15 @@ export function Navbar({ variant }: NavbarProps = {}) {
       }
     : { maxWidth: chrome ? "64rem" : "80rem" };
   const rowHeightClass = isLandingTop ? "h-11 lg:h-[2.4375rem]" : "h-16";
-  const innerPaddingClass = isLandingTop ? "px-11 lg:px-0" : "px-4 sm:px-6";
+  const innerPaddingClass = isLandingTop
+    ? "px-7 sm:px-5 lg:px-0"
+    : "px-4 sm:px-6";
 
   return (
     <LazyMotion features={domAnimation} strict>
       <m.div
         animate={shellAnimate}
-        className={`z-50 mx-auto w-full ${positionClass}`}
+        className={`z-50 mx-auto ${positionClass}`}
         initial={false}
         transition={shellTransition}
       >

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -382,7 +382,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
     : { maxWidth: chrome ? "64rem" : "80rem" };
   const rowHeightClass = isLandingTop ? "h-11 lg:h-[2.4375rem]" : "h-16";
   const innerPaddingClass = isLandingTop
-    ? "px-7 sm:px-5 lg:px-0"
+    ? "px-7 sm:px-5 lg:px-6 min-[87rem]:px-0"
     : "px-4 sm:px-6";
 
   return (


### PR DESCRIPTION
## Summary
The landing navbar shell was `fixed inset-x-0 w-full` with only an animated `maxWidth` (1295px at top, 1024px scrolled). On any viewport narrower than that max width the shell had zero side inset:
- ~1024-1300px (e.g. a 14" MacBook or 1150/1060px): the top-state logo sat flush against the screen edge and "Sign Up" was clipped, since the inner padding is `lg:px-0`.
- below 1024px scrolled: the floating island ran edge to edge.

Fix: the landing shell now uses `inset-x-4 sm:inset-x-6` (dropping `w-full` so the insets apply), and the top-state inner padding is rebalanced (`px-11` -> `px-7 sm:px-5`) so the total edge spacing on small screens is unchanged. On wide screens the max width still caps the shell well inside the insets, so nothing moves there. At `lg`+ the navbar content now sits 1.5rem from the viewport edge, matching the hero section's own `px-6` inset.

## Test plan
- Lint clean, homepage renders on the local dev server.
- Spacing math: old top-state edge inset below lg was 2.75rem (px-11); new is 1rem + px-7 = 2.75rem (and 1.5rem + px-5 = 2.75rem from sm). Scrolled island gains a 1-1.5rem inset on sub-1024px viewports.

https://claude.ai/code/session_01Xb7UfoyL6mCtYGiT3sSpYC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the landing navbar inset on mid-size viewports so content doesn’t hit the screen edge or clip. Adds horizontal insets to the fixed shell and adjusts padding to keep spacing consistent across breakpoints.

- **Bug Fixes**
  - Set the landing shell to fixed `inset-x-4 sm:inset-x-6` (dropping `w-full`) to add 1–1.5rem side gutters around ~1024–1300px.
  - Rebalanced top-state inner padding (`px-11` → `px-7 sm:px-5 lg:px-6 min-[87rem]:px-0`) to keep small-screen spacing, keep a 1.5rem inset at `lg`, and drop to 0 only on very wide screens once the capped shell provides the gap.
  - Prevents the scrolled island from running edge-to-edge below 1024px and stops logo/“Sign Up” from hitting the edge.

<sup>Written for commit fefce5ef8b68915e4116a76384ff55f818374c38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`fefce5e`](https://github.com/usenotra/notra/commit/fefce5ef8b68915e4116a76384ff55f818374c38). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->