### PR TITLE
feat(auth): reuse carousel progress indicators

### DIFF
--- a/apps/dashboard/src/components/auth/testimonial-carousel.tsx
+++ b/apps/dashboard/src/components/auth/testimonial-carousel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CarouselProgress } from "@notra/ui/components/ui/carousel-progress";
 import { useReducedMotion } from "motion/react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -10,23 +11,44 @@ import {
 
 export function TestimonialCarousel() {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [progress, setProgress] = useState(0);
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const shouldReduceMotion = useReducedMotion();
   const testimonial = AUTH_TESTIMONIALS[activeIndex];
   const isPaused = isHovered || isFocused;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeIndex intentionally restarts testimonial progress.
   useEffect(() => {
-    if (shouldReduceMotion || isPaused) {
+    if (shouldReduceMotion) {
       return;
     }
 
-    const timeout = setTimeout(() => {
-      setActiveIndex((activeIndex + 1) % AUTH_TESTIMONIALS.length);
-    }, AUTH_TESTIMONIAL_INTERVAL_MS);
+    if (isPaused) {
+      return;
+    }
 
-    return () => clearTimeout(timeout);
-  }, [shouldReduceMotion, isPaused, activeIndex]);
+    const startedAt = performance.now();
+
+    const interval = window.setInterval(() => {
+      const elapsed = performance.now() - startedAt;
+      const nextProgress = Math.min(
+        (elapsed / AUTH_TESTIMONIAL_INTERVAL_MS) * 100,
+        100
+      );
+
+      if (nextProgress >= 100) {
+        setProgress(0);
+        setActiveIndex(
+          (currentIndex) => (currentIndex + 1) % AUTH_TESTIMONIALS.length
+        );
+      } else {
+        setProgress(nextProgress);
+      }
+    }, 50);
+
+    return () => window.clearInterval(interval);
+  }, [activeIndex, shouldReduceMotion, isPaused]);
 
   if (!testimonial) {
     return null;
@@ -36,10 +58,16 @@ export function TestimonialCarousel() {
     // biome-ignore lint/a11y/noNoninteractiveElementInteractions: hover and focus only pause the carousel timer, this is not an interactive control
     // biome-ignore lint/a11y/noStaticElementInteractions: hover and focus only pause the carousel timer, this is not an interactive control
     <div
-      onBlur={() => setIsFocused(false)}
+      onBlur={() => {
+        setIsFocused(false);
+        setProgress(0);
+      }}
       onFocus={() => setIsFocused(true)}
       onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        setProgress(0);
+      }}
     >
       <section
         aria-label="Customer testimonials"
@@ -75,26 +103,18 @@ export function TestimonialCarousel() {
             </figcaption>
           </figure>
         </div>
-        <div className="flex items-center justify-center">
-          {AUTH_TESTIMONIALS.map((item, index) => (
-            <button
-              aria-current={index === activeIndex}
-              aria-label={`Show testimonial from ${item.name}`}
-              className="group flex size-6 cursor-pointer items-center justify-center"
-              key={item.name}
-              onClick={() => setActiveIndex(index)}
-              type="button"
-            >
-              <span
-                className={`h-1.5 rounded-full transition-all duration-300 motion-reduce:transition-none ${
-                  index === activeIndex
-                    ? "w-5 bg-white"
-                    : "w-1.5 bg-white/40 group-hover:bg-white/60"
-                }`}
-              />
-            </button>
-          ))}
-        </div>
+        <CarouselProgress
+          activeIndex={activeIndex}
+          labels={AUTH_TESTIMONIALS.map(
+            (item) => `Show testimonial from ${item.name}`
+          )}
+          onSelect={(index) => {
+            setActiveIndex(index);
+            setProgress(0);
+          }}
+          progress={shouldReduceMotion ? 100 : progress}
+          variant="inverted"
+        />
       </section>
     </div>
   );

--- a/apps/web/src/app/(site)/features/marketing/assets/page.tsx
+++ b/apps/web/src/app/(site)/features/marketing/assets/page.tsx
@@ -121,7 +121,7 @@ export default function MarketingAssetsPage() {
       </MarketingHeroWash>
 
       <div className="flex w-full flex-col items-center overflow-hidden">
-        <section className="w-full px-6 pt-12 md:px-12 md:pt-16 lg:px-16">
+        <section className="w-full px-6 pt-12 pb-8 md:px-12 md:pt-16 md:pb-10 lg:px-16">
           <div className="mx-auto w-full max-w-4xl">
             <HeroVideoCarousel videos={ASSET_HERO.videos} />
           </div>

--- a/apps/web/src/components/marketing-assets/hero-video-carousel.tsx
+++ b/apps/web/src/components/marketing-assets/hero-video-carousel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CarouselProgress } from "@notra/ui/components/ui/carousel-progress";
 import { cn } from "@notra/ui/lib/utils";
 import { useEffect, useState } from "react";
 import type { AssetHeroVideo } from "@/lib/marketing-assets/types/hero";
@@ -22,7 +23,6 @@ export function HeroVideoCarousel({
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const activeVideo = videos[activeIndex] ?? videos[0];
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: activeIndex intentionally restarts slide progress.
   useEffect(() => {
     const media = window.matchMedia("(prefers-reduced-motion: reduce)");
     const updatePreference = () => {
@@ -37,6 +37,7 @@ export function HeroVideoCarousel({
     };
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeIndex intentionally restarts slide progress.
   useEffect(() => {
     if (prefersReducedMotion || videos.length < 2) {
       setProgress(100);
@@ -75,37 +76,16 @@ export function HeroVideoCarousel({
       </div>
 
       {videos.length > 1 ? (
-        <div className="mt-4 flex items-center justify-center gap-2">
-          {videos.map((video, index) => {
-            const isActive = index === activeIndex;
-
-            return (
-              <button
-                aria-current={isActive ? "true" : undefined}
-                aria-label={`Go to slide ${index + 1}`}
-                className={cn(
-                  "relative h-2 cursor-pointer rounded-full transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                  isActive
-                    ? "w-12 bg-foreground/15"
-                    : "w-2 bg-foreground/20 hover:bg-foreground/40"
-                )}
-                key={video.src}
-                onClick={() => {
-                  setActiveIndex(index);
-                  setProgress(0);
-                }}
-                type="button"
-              >
-                {isActive ? (
-                  <span
-                    className="absolute inset-y-0 left-0 rounded-full bg-foreground/60"
-                    style={{ width: `${progress}%` }}
-                  />
-                ) : null}
-              </button>
-            );
-          })}
-        </div>
+        <CarouselProgress
+          activeIndex={activeIndex}
+          className="mt-4"
+          labels={videos.map((_, index) => `Go to slide ${index + 1}`)}
+          onSelect={(index) => {
+            setActiveIndex(index);
+            setProgress(0);
+          }}
+          progress={progress}
+        />
       ) : null}
     </div>
   );

--- a/packages/ui/src/components/ui/carousel-progress.tsx
+++ b/packages/ui/src/components/ui/carousel-progress.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+
+interface CarouselProgressProps {
+  activeIndex: number;
+  labels: readonly string[];
+  onSelect: (index: number) => void;
+  progress: number;
+  variant?: "default" | "inverted";
+  className?: string;
+}
+
+function CarouselProgress({
+  activeIndex,
+  labels,
+  onSelect,
+  progress,
+  variant = "default",
+  className,
+}: CarouselProgressProps) {
+  const progressWidth = Math.min(100, Math.max(0, progress));
+
+  return (
+    <div className={cn("flex items-center justify-center gap-2", className)}>
+      {labels.map((label, index) => {
+        const isActive = index === activeIndex;
+
+        return (
+          <button
+            aria-current={isActive ? "true" : undefined}
+            aria-label={label}
+            className={cn(
+              "relative h-2 cursor-pointer rounded-full transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none",
+              isActive ? "w-12" : "w-2",
+              variant === "inverted"
+                ? isActive
+                  ? "bg-white/20"
+                  : "bg-white/40 hover:bg-white/60"
+                : isActive
+                  ? "bg-foreground/15"
+                  : "bg-foreground/20 hover:bg-foreground/40"
+            )}
+            key={label}
+            onClick={() => onSelect(index)}
+            type="button"
+          >
+            {isActive ? (
+              <span
+                className={cn(
+                  "absolute inset-y-0 left-0 rounded-full",
+                  variant === "inverted" ? "bg-white" : "bg-foreground/60"
+                )}
+                style={{ width: `${progressWidth}%` }}
+              />
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export { CarouselProgress };


### PR DESCRIPTION
### Description
Reuses the marketing carousel’s timed progress indicators on the login testimonial carousel and adds more spacing below the marketing assets carousel.

### Screenshot/Recording (if applicable)
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/827a1fd2-aecc-406c-8d4e-7ed16bc3ba82" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6d9b3373-a9b1-4fd6-86b5-9b874651c669" />


<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a reusable `CarouselProgress` component and use it in auth testimonials and the marketing hero video. This unifies the indicators, improves reduced‑motion support, and removes duplicate code.

- **New Features**
  - Added `packages/ui/src/components/ui/carousel-progress.tsx` with animated progress, `default`/`inverted` variants, and accessible labels.

- **Refactors**
  - Dashboard `TestimonialCarousel`: replaced local dots with `CarouselProgress`; added interval-based progress with pause on hover/focus and reset on resume; honors reduced motion.
  - Web `HeroVideoCarousel`: replaced local indicators with `CarouselProgress`; resets progress on manual select; minor spacing tweak in `assets/page.tsx` (adds bottom padding).

<sup>Written for commit 6115dbfb63b7daac4f02dcdc202d79bb7e17bc3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/janburzinski/notra/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added animated pill-style progress indicators to testimonial and video carousels.
  - Added accessible slide labels and active-slide indicators.
  - Selecting a slide now resets its progress animation.
- **Bug Fixes**
  - Carousel advancement now pauses while hovered or focused and resumes afterward.
  - Added improved reduced-motion behavior for carousel progress.
- **Style**
  - Increased spacing below the marketing assets hero section on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`6115dbf`](https://github.com/usenotra/notra/commit/6115dbfb63b7daac4f02dcdc202d79bb7e17bc3f). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->