### PR TITLE
fix(web): scale landing type and card spacing below desktop

### DIFF
--- a/apps/web/src/components/landing/faq-section.tsx
+++ b/apps/web/src/components/landing/faq-section.tsx
@@ -55,7 +55,7 @@ function FaqRow({
       <button
         aria-controls={panelId}
         aria-expanded={open}
-        className="flex w-full cursor-pointer items-center gap-8 text-left"
+        className="flex w-full cursor-pointer items-center gap-4 text-left sm:gap-8"
         id={triggerId}
         onClick={onToggle}
         type="button"
@@ -63,7 +63,7 @@ function FaqRow({
         <span className="flex shrink-0 items-center justify-center">
           <FaqToggleIcon open={open} />
         </span>
-        <span className="grow font-medium font-sans text-[#1E1E1E] text-xl leading-[1.875rem] tracking-[-0.01em] dark:text-white">
+        <span className="grow font-medium font-sans text-[#1E1E1E] text-lg leading-7 tracking-[-0.01em] sm:text-xl sm:leading-[1.875rem] dark:text-white">
           {item.question}
         </span>
       </button>
@@ -99,10 +99,10 @@ export function FaqSection() {
     <section className="flex flex-col items-center px-6 pt-20 pb-16 antialiased sm:px-12 lg:px-20 lg:pt-35 lg:pb-24">
       <div className="flex w-full flex-col items-center gap-14 lg:gap-18">
         <div className="flex w-full max-w-[51.5625rem] flex-col items-center gap-4">
-          <h2 className="text-balance text-center font-display font-medium text-[2.25rem] text-black leading-[1.1] tracking-[-0.02em] sm:text-[2.75rem] lg:text-[3.0625rem] lg:leading-[3.5rem] dark:text-white">
+          <h2 className="text-balance text-center font-display font-medium text-[2rem] text-black leading-[1.1] tracking-[-0.02em] sm:text-[2.75rem] lg:text-[3.0625rem] lg:leading-[3.5rem] dark:text-white">
             {heading}
           </h2>
-          <p className="max-w-[31rem] text-balance text-center font-display font-medium text-[#1E1E1EBF] text-xl leading-[1.875rem] tracking-[-0.01em] dark:text-white/70">
+          <p className="max-w-[31rem] text-balance text-center font-display font-medium text-[#1E1E1EBF] text-lg leading-7 tracking-[-0.01em] sm:text-xl sm:leading-[1.875rem] dark:text-white/70">
             {subcopy}
           </p>
         </div>

--- a/apps/web/src/components/landing/features-section.tsx
+++ b/apps/web/src/components/landing/features-section.tsx
@@ -26,7 +26,7 @@ function FeaturesCard({
   return (
     <div
       className={cn(
-        "relative flex flex-col items-start overflow-clip rounded-[0.8125rem] bg-[linear-gradient(in_oklab_180deg,oklab(95.1%_0.011_-0.018_/_15%)_0%,oklab(93.7%_0.019_-0.031_/_75%)_100%)] p-8.75 [box-shadow:#0A0D1408_0rem_0.0625rem_0.125rem,#0A0D1408_0rem_0.0625rem_0.125rem,#ECECEC_0rem_0rem_0rem_0.0625rem] dark:bg-none dark:bg-white/[0.02] dark:[box-shadow:#0A0D1408_0rem_0.0625rem_0.125rem,#0A0D1408_0rem_0.0625rem_0.125rem,#FFFFFF14_0rem_0rem_0rem_0.0625rem]",
+        "relative flex flex-col items-start overflow-clip rounded-[0.8125rem] bg-[linear-gradient(in_oklab_180deg,oklab(95.1%_0.011_-0.018_/_15%)_0%,oklab(93.7%_0.019_-0.031_/_75%)_100%)] p-6 [box-shadow:#0A0D1408_0rem_0.0625rem_0.125rem,#0A0D1408_0rem_0.0625rem_0.125rem,#ECECEC_0rem_0rem_0rem_0.0625rem] sm:p-8.75 dark:bg-none dark:bg-white/[0.02] dark:[box-shadow:#0A0D1408_0rem_0.0625rem_0.125rem,#0A0D1408_0rem_0.0625rem_0.125rem,#FFFFFF14_0rem_0rem_0rem_0.0625rem]",
         className
       )}
     >
@@ -36,7 +36,7 @@ function FeaturesCard({
       />
       <div className={cn("relative shrink-0", containerClassName)}>
         <div className="absolute top-0 left-0 z-10 flex w-full flex-col items-start gap-1.5 lg:w-110.25">
-          <h3 className="font-medium font-sans text-[#0A0D14] text-[1.5625rem]/8 tracking-[-0.015em] lg:h-8 dark:text-white">
+          <h3 className="font-medium font-sans text-[#0A0D14] text-xl/7 tracking-[-0.015em] sm:text-[1.5625rem]/8 lg:h-8 dark:text-white">
             {copy.title}
           </h3>
           <p className="w-full font-medium font-sans text-[#6A6B70] text-base/6 lg:w-102 dark:text-white/60">
@@ -51,13 +51,13 @@ function FeaturesCard({
 
 export function FeaturesSection() {
   return (
-    <section className="mx-auto flex w-full max-w-360 flex-col items-center px-6 pt-20 antialiased [font-synthesis:none] lg:px-20 lg:pt-35">
+    <section className="mx-auto flex w-full max-w-360 flex-col items-center px-6 pt-20 antialiased [font-synthesis:none] sm:px-12 lg:px-20 lg:pt-35">
       <div className="flex w-full flex-col items-center gap-13.5">
         <header className="flex flex-col items-center gap-4">
-          <h2 className="text-center font-display font-medium text-[2.25rem] text-black leading-[1.15] tracking-[-0.02em] lg:text-[3.0625rem]/14 dark:text-white">
+          <h2 className="text-center font-display font-medium text-[2rem] text-black leading-[1.15] tracking-[-0.02em] sm:text-[2.25rem] lg:text-[3.0625rem]/14 dark:text-white">
             {FEATURES_HEADING}
           </h2>
-          <p className="w-full max-w-206.25 text-balance text-center font-display font-medium text-[#1E1E1EBF] text-xl/7.5 tracking-[-0.01em] dark:text-white/70">
+          <p className="w-full max-w-206.25 text-balance text-center font-display font-medium text-[#1E1E1EBF] text-lg/7 tracking-[-0.01em] sm:text-xl/7.5 dark:text-white/70">
             {FEATURES_SUBCOPY_LINE_ONE}
             <br />
             {FEATURES_SUBCOPY_LINE_TWO}

--- a/apps/web/src/components/landing/testimonials-section.tsx
+++ b/apps/web/src/components/landing/testimonials-section.tsx
@@ -22,7 +22,7 @@ function TestimonialCard({
   return (
     <article
       className={cn(
-        "relative flex w-full flex-1 flex-col overflow-clip rounded-3xl p-8 backdrop-blur-[0.375rem] sm:p-12 lg:px-16 lg:py-20",
+        "relative flex w-full flex-1 flex-col overflow-clip rounded-3xl p-6 backdrop-blur-[0.375rem] sm:p-10 lg:px-16 lg:py-20",
         "[box-shadow:#ECECEC_0_0_0_0.0625rem,#28282814_0_0.0625rem_0.125rem] dark:bg-none dark:bg-white/[0.03] dark:[box-shadow:#FFFFFF14_0_0_0_0.0625rem,#00000014_0_0.0625rem_0.125rem]",
         featured
           ? "bg-[linear-gradient(in_oklab_180deg,oklab(95.1%_0.011_-0.018_/_20%)_0%,oklab(91.7%_0.017_-0.029_/_50%)_100%)]"
@@ -36,11 +36,11 @@ function TestimonialCard({
       />
       <div
         className={cn(
-          "relative z-10 flex flex-col gap-14",
-          !featured && "min-h-[25rem] justify-between"
+          "relative z-10 flex flex-col gap-10 lg:gap-14",
+          !featured && "justify-between lg:min-h-[25rem]"
         )}
       >
-        <p className="min-w-0 self-stretch font-medium font-sans text-[#1E1E1E] text-[1.5625rem]/8 tracking-[-0.015em] dark:text-foreground">
+        <p className="min-w-0 self-stretch font-medium font-sans text-[#1E1E1E] text-xl/7 tracking-[-0.015em] sm:text-[1.375rem]/7.5 lg:text-[1.5625rem]/8 dark:text-foreground">
           {testimonial.quote}
         </p>
         <div className="flex items-center gap-4">
@@ -69,12 +69,12 @@ function TestimonialCard({
 
 export function TestimonialsSection() {
   return (
-    <section className="flex w-full flex-col items-center gap-13.5 px-6 pt-24 pb-27.5 lg:pt-70">
+    <section className="flex w-full flex-col items-center gap-10 px-6 pt-24 pb-27.5 sm:px-12 lg:gap-13.5 lg:px-20 lg:pt-70">
       <div className="flex flex-col items-center gap-4">
-        <h2 className="text-center font-display font-medium text-4xl/tight text-black tracking-[-0.02em] lg:text-[3.0625rem]/14 dark:text-foreground">
+        <h2 className="text-center font-display font-medium text-[2rem]/tight text-black tracking-[-0.02em] sm:text-4xl/tight lg:text-[3.0625rem]/14 dark:text-foreground">
           Shipping, without the <span className="text-primary">busywork</span>.
         </h2>
-        <p className="max-w-[31.875rem] text-center font-display font-medium text-[#1E1E1EBF] text-xl/7.5 tracking-[-0.01em] dark:text-muted-foreground">
+        <p className="max-w-[31.875rem] text-center font-display font-medium text-[#1E1E1EBF] text-lg/7 tracking-[-0.01em] sm:text-xl/7.5 dark:text-muted-foreground">
           {TESTIMONIALS_SUBHEADING}
         </p>
       </div>


### PR DESCRIPTION
## Summary

The landing page was designed at 1440px and several sections kept their desktop font sizes and paddings at every width, so cards and headings looked oversized on smaller screens. This scales them down responsively and fixes the testimonials gutter mismatch.

### Testimonials
- The section only had `px-6`, while the features grid above uses `sm:px-12 lg:px-20` gutters — between ~1024px and 1440px the testimonial cards rendered wider than the features grid (the off left/right padding). It now uses the same `px-6 sm:px-12 lg:px-20` scale.
- Quote text steps `text-xl → 1.375rem (sm) → 1.5625rem (lg)` instead of a fixed 25px at all widths.
- The forced `min-h-[25rem]` on the pair cards is now lg-only, and card padding steps `p-6 → sm:p-10 → lg:px-16/py-20`, so cards no longer look oversized on small screens.
- Heading/subheading get a smaller base step (`2rem` / `text-lg`).

### Features
- Card titles step `text-xl → 1.5625rem (sm)`; card padding `p-6 → sm:p-8.75`.
- Section heading gets a `2rem` base step, subheading `text-lg → sm:text-xl`.
- Added the missing `sm:px-12` gutter step so features and testimonials align at every breakpoint.

### FAQ
- Heading, subcopy, and question rows get smaller base sizes with `sm:` steps back to the design values; icon/question gap tightens to `gap-4` on mobile.

Hero, pricing, founder quote, and CTA banner already had responsive steps and are untouched. At ≥1440px everything renders exactly as before.

## Test plan
- `bun x ultracite check` clean on changed files
- `bun run build` for apps/web passes

https://claude.ai/code/session_016tudAJSKRFYC6iZppeUb64

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make landing page typography and card spacing responsive below desktop. Fixes oversized cards and headings on tablet/mobile and aligns testimonial gutters with the features grid.

- **Bug Fixes**
  - Testimonials: match gutters `px-6 sm:px-12 lg:px-20`; quote text steps; lg-only min-height; padding `p-6 sm:p-10 lg:px-16 lg:py-20`.
  - Features: card padding `p-6 sm:p-8.75`; titles `text-xl sm:text-[1.5625rem]`; section adds `sm:px-12`; smaller base heading/subcopy.
  - FAQ: smaller base heading/subcopy and row text; row gap `gap-4 sm:gap-8`.
  - No changes at ≥1440px.

<sup>Written for commit 2e79f0638fe1cd2f881d4111d5f898236df0eff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`2e79f06`](https://github.com/usenotra/notra/commit/2e79f0638fe1cd2f881d4111d5f898236df0eff2). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->