### PR TITLE
fix(web): add horizontal padding around the CTA banner

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -169,7 +169,7 @@ export default function LandingPage() {
         <section className="content-defer" id="faq">
           <FaqSection />
         </section>
-        <section className="pt-27.5 pb-27.5 content-defer" id="cta">
+        <section className="px-6 pt-27.5 pb-27.5 content-defer lg:px-20" id="cta">
           <CtaBanner />
         </section>
       </main>

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -169,7 +169,10 @@ export default function LandingPage() {
         <section className="content-defer" id="faq">
           <FaqSection />
         </section>
-        <section className="px-6 pt-27.5 pb-27.5 content-defer lg:px-20" id="cta">
+        <section
+          className="px-6 pt-27.5 pb-27.5 content-defer lg:px-20"
+          id="cta"
+        >
           <CtaBanner />
         </section>
       </main>

--- a/apps/web/src/app/(site)/pricing/page.tsx
+++ b/apps/web/src/app/(site)/pricing/page.tsx
@@ -120,7 +120,7 @@ export default function PricingPage() {
 
         <PricingComparisonTable />
 
-        <div className="pt-8 pb-24">
+        <div className="px-6 pt-8 pb-24 lg:px-20">
           <CtaBanner />
         </div>
       </div>


### PR DESCRIPTION
The CTA banner sections on the landing page and pricing page had no horizontal padding, so below the banner's 87rem max width it touched the viewport edges. Adds the same px-6 lg:px-20 wrapper padding the features pages already use.

https://claude.ai/code/session_013tm3itnTNNxM6qcha5pjti

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add horizontal padding around the CTA banner on the landing and pricing pages to prevent it from touching the viewport edges on narrower screens. Applies px-6 lg:px-20 to match the features pages, and formats the CTA section markup.

<sup>Written for commit e9e7052eae9be108d2424366f52d715b4e94f424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`e9e7052`](https://github.com/usenotra/notra/commit/e9e7052eae9be108d2424366f52d715b4e94f424). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->