### PR TITLE
feat(integrations): deeplink marketplace connect buttons into the dashboard

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/[integrationSlug]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/[integrationSlug]/page.tsx
@@ -1,15 +1,8 @@
-import {
-  getLiveMcpStoreIntegrationById,
-  getLiveMcpStoreIntegrationBySlug,
-} from "@notra/ai/integrations/mcp-store";
+import { Effect } from "effect";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
-import {
-  buildOrganizationIntegrationsPath,
-  decodeIntegrationSlugParam,
-} from "@/lib/integrations/deeplink";
-import { storeIntegrationDeeplinkSlugSchema } from "@/schemas/integrations";
+import { resolveOrganizationIntegrationConnect } from "@/lib/integrations/deeplink-resolution";
 import PageClient from "../page-client";
 
 export const metadata: Metadata = {
@@ -25,25 +18,23 @@ async function Page({
   }>;
 }) {
   const { slug, integrationSlug } = await params;
-  const parsed = storeIntegrationDeeplinkSlugSchema.safeParse(
-    decodeIntegrationSlugParam(integrationSlug)
+  const resolution = await Effect.runPromise(
+    resolveOrganizationIntegrationConnect({
+      organizationSlug: slug,
+      integrationSlugParam: integrationSlug,
+    })
   );
 
-  if (!parsed.success) {
-    redirect(buildOrganizationIntegrationsPath(slug));
-  }
-
-  const storeIntegration =
-    (await getLiveMcpStoreIntegrationBySlug(parsed.data)) ??
-    (await getLiveMcpStoreIntegrationById(parsed.data));
-
-  if (!storeIntegration) {
-    redirect(buildOrganizationIntegrationsPath(slug));
+  if (resolution.kind === "redirect") {
+    redirect(resolution.path);
   }
 
   return (
     <Suspense>
-      <PageClient connectSlug={parsed.data} organizationSlug={slug} />
+      <PageClient
+        connectSlug={resolution.connectSlug}
+        organizationSlug={slug}
+      />
     </Suspense>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/[integrationSlug]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/[integrationSlug]/page.tsx
@@ -1,0 +1,51 @@
+import {
+  getLiveMcpStoreIntegrationById,
+  getLiveMcpStoreIntegrationBySlug,
+} from "@notra/ai/integrations/mcp-store";
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import {
+  buildOrganizationIntegrationsPath,
+  decodeIntegrationSlugParam,
+} from "@/lib/integrations/deeplink";
+import { storeIntegrationDeeplinkSlugSchema } from "@/schemas/integrations";
+import PageClient from "../page-client";
+
+export const metadata: Metadata = {
+  title: "Integrations",
+};
+
+async function Page({
+  params,
+}: {
+  params: Promise<{
+    slug: string;
+    integrationSlug: string;
+  }>;
+}) {
+  const { slug, integrationSlug } = await params;
+  const parsed = storeIntegrationDeeplinkSlugSchema.safeParse(
+    decodeIntegrationSlugParam(integrationSlug)
+  );
+
+  if (!parsed.success) {
+    redirect(buildOrganizationIntegrationsPath(slug));
+  }
+
+  const storeIntegration =
+    (await getLiveMcpStoreIntegrationBySlug(parsed.data)) ??
+    (await getLiveMcpStoreIntegrationById(parsed.data));
+
+  if (!storeIntegration) {
+    redirect(buildOrganizationIntegrationsPath(slug));
+  }
+
+  return (
+    <Suspense>
+      <PageClient connectSlug={parsed.data} organizationSlug={slug} />
+    </Suspense>
+  );
+}
+
+export default Page;

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
@@ -30,7 +30,10 @@ import {
 } from "@/lib/integrations/constants";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { IntegrationType } from "@/schemas/integrations";
-import type { IntegrationConfig } from "@/types/integrations/catalog";
+import type {
+  IntegrationConfig,
+  IntegrationsPageClientProps,
+} from "@/types/integrations/catalog";
 
 interface Integration {
   id: string;
@@ -38,10 +41,6 @@ interface Integration {
   type: IntegrationType;
   enabled: boolean;
   createdAt: string;
-}
-
-interface PageClientProps {
-  organizationSlug: string;
 }
 
 const GitHubIntegrationDialog = dynamic(
@@ -163,7 +162,10 @@ const IntegrationCard = memo(function IntegrationCard({
   );
 });
 
-export default function PageClient({ organizationSlug }: PageClientProps) {
+export default function PageClient({
+  organizationSlug,
+  connectSlug,
+}: IntegrationsPageClientProps) {
   const { getOrganization } = useOrganizationsContext();
   const organization = getOrganization(organizationSlug);
   const organizationId = organization?.id;
@@ -265,7 +267,11 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           })}
         </Tabs>
 
-        <StoreIntegrationsSection organizationId={organizationId} />
+        <StoreIntegrationsSection
+          connectSlug={connectSlug}
+          organizationId={organizationId}
+          organizationSlug={organizationSlug}
+        />
       </div>
     </PageContainer>
   );

--- a/apps/dashboard/src/app/integrations/[integrationSlug]/page.tsx
+++ b/apps/dashboard/src/app/integrations/[integrationSlug]/page.tsx
@@ -1,11 +1,6 @@
+import { Effect } from "effect";
 import { notFound, redirect } from "next/navigation";
-import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
-import {
-  buildIntegrationConnectLoginUrl,
-  buildOrganizationIntegrationConnectPath,
-  decodeIntegrationSlugParam,
-} from "@/lib/integrations/deeplink";
-import { storeIntegrationDeeplinkSlugSchema } from "@/schemas/integrations";
+import { resolveIntegrationConnectDeeplink } from "@/lib/integrations/deeplink-resolution";
 
 async function Page({
   params,
@@ -15,29 +10,15 @@ async function Page({
   }>;
 }) {
   const { integrationSlug } = await params;
-  const parsed = storeIntegrationDeeplinkSlugSchema.safeParse(
-    decodeIntegrationSlugParam(integrationSlug)
+  const resolution = await Effect.runPromise(
+    resolveIntegrationConnectDeeplink(integrationSlug)
   );
 
-  if (!parsed.success) {
+  if (resolution.kind === "not-found") {
     notFound();
   }
 
-  const session = await getSession();
-
-  if (!session?.user) {
-    redirect(buildIntegrationConnectLoginUrl(parsed.data));
-  }
-
-  const organization = await getLastActiveOrganization();
-
-  if (!organization) {
-    redirect("/onboarding");
-  }
-
-  redirect(
-    buildOrganizationIntegrationConnectPath(organization.slug, parsed.data)
-  );
+  redirect(resolution.path);
 }
 
 export default Page;

--- a/apps/dashboard/src/app/integrations/[integrationSlug]/page.tsx
+++ b/apps/dashboard/src/app/integrations/[integrationSlug]/page.tsx
@@ -1,0 +1,43 @@
+import { notFound, redirect } from "next/navigation";
+import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
+import {
+  buildIntegrationConnectLoginUrl,
+  buildOrganizationIntegrationConnectPath,
+  decodeIntegrationSlugParam,
+} from "@/lib/integrations/deeplink";
+import { storeIntegrationDeeplinkSlugSchema } from "@/schemas/integrations";
+
+async function Page({
+  params,
+}: {
+  params: Promise<{
+    integrationSlug: string;
+  }>;
+}) {
+  const { integrationSlug } = await params;
+  const parsed = storeIntegrationDeeplinkSlugSchema.safeParse(
+    decodeIntegrationSlugParam(integrationSlug)
+  );
+
+  if (!parsed.success) {
+    notFound();
+  }
+
+  const session = await getSession();
+
+  if (!session?.user) {
+    redirect(buildIntegrationConnectLoginUrl(parsed.data));
+  }
+
+  const organization = await getLastActiveOrganization();
+
+  if (!organization) {
+    redirect("/onboarding");
+  }
+
+  redirect(
+    buildOrganizationIntegrationConnectPath(organization.slug, parsed.data)
+  );
+}
+
+export default Page;

--- a/apps/dashboard/src/components/integrations/connect-store-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/connect-store-integration-dialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { Button } from "@/components/button";
+import { StoreIntegrationLogo } from "@/components/integrations/store-integration-logo";
+import { getStoreIntegrationConnectHint } from "@/lib/integrations/mcp";
+import type { ConnectStoreIntegrationDialogProps } from "@/types/integrations/mcp";
+
+export function ConnectStoreIntegrationDialog({
+  connecting,
+  integration,
+  onConnect,
+  onOpenChange,
+  open,
+}: ConnectStoreIntegrationDialogProps) {
+  return (
+    <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
+      <ResponsiveDialogContent className="sm:max-w-md">
+        <ResponsiveDialogHeader>
+          <div className="flex items-center gap-3">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-lg border">
+              <StoreIntegrationLogo integration={integration} />
+            </span>
+            <div className="flex min-w-0 flex-col gap-0.5 text-left">
+              <ResponsiveDialogTitle className="truncate">
+                Connect {integration.name}
+              </ResponsiveDialogTitle>
+              {integration.author ? (
+                <span className="truncate text-muted-foreground text-xs">
+                  By {integration.author}
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <ResponsiveDialogDescription className="pt-2 text-left">
+            {integration.description ??
+              "MCP server from the integration store."}
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <p className="text-muted-foreground text-sm">
+          {getStoreIntegrationConnectHint(
+            integration.authType,
+            integration.name
+          )}
+        </p>
+        <ResponsiveDialogFooter>
+          <Button
+            disabled={connecting}
+            onClick={() => onOpenChange(false)}
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button disabled={connecting} onClick={onConnect}>
+            {connecting ? "Connecting..." : "Connect"}
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/apps/dashboard/src/components/integrations/store-integration-card.tsx
+++ b/apps/dashboard/src/components/integrations/store-integration-card.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { MoreHorizontalIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Badge } from "@notra/ui/components/ui/badge";
+import { TitleCard } from "@notra/ui/components/ui/title-card";
+import { Button } from "@/components/button";
+import { StoreIntegrationLogo } from "@/components/integrations/store-integration-logo";
+import { MCP_ACCENT_COLOR } from "@/lib/integrations/mcp";
+import type { StoreIntegrationCardProps } from "@/types/integrations/mcp";
+
+export function StoreIntegrationCard({
+  integration,
+  connectPending,
+  onConnect,
+  onManage,
+}: StoreIntegrationCardProps) {
+  return (
+    <TitleCard
+      accentColor={integration.brandColor ?? MCP_ACCENT_COLOR}
+      action={
+        integration.connected ? (
+          <div className="flex items-center gap-2">
+            <Badge className="text-xs" variant="default">
+              Connected
+            </Badge>
+            <span className="text-muted-foreground">
+              <HugeiconsIcon
+                aria-hidden="true"
+                className="size-4"
+                icon={MoreHorizontalIcon}
+              />
+              <span className="sr-only">Manage integration</span>
+            </span>
+          </div>
+        ) : (
+          <Button
+            disabled={connectPending}
+            onClick={() => onConnect(integration)}
+            size="sm"
+            variant="outline"
+          >
+            {connectPending ? "Connecting..." : "Connect"}
+          </Button>
+        )
+      }
+      className={
+        integration.connected
+          ? "h-full cursor-pointer transition-colors hover:bg-muted/80"
+          : "h-full"
+      }
+      heading={integration.name}
+      icon={<StoreIntegrationLogo integration={integration} />}
+      onClick={() => {
+        if (integration.connected) {
+          onManage(integration);
+        }
+      }}
+      onKeyDown={(event) => {
+        if (
+          integration.connected &&
+          (event.key === "Enter" || event.key === " ")
+        ) {
+          event.preventDefault();
+          onManage(integration);
+        }
+      }}
+      role={integration.connected ? "button" : undefined}
+      tabIndex={integration.connected ? 0 : undefined}
+    >
+      <p className="line-clamp-2 text-muted-foreground text-sm">
+        {integration.description ??
+          (integration.author
+            ? `By ${integration.author}`
+            : "MCP server from the integration store")}
+      </p>
+    </TitleCard>
+  );
+}

--- a/apps/dashboard/src/components/integrations/store-integration-dialogs.tsx
+++ b/apps/dashboard/src/components/integrations/store-integration-dialogs.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { AddMcpServerDialog } from "@/components/integrations/add-mcp-server-dialog";
+import { ConnectStoreIntegrationDialog } from "@/components/integrations/connect-store-integration-dialog";
+import { ManageStoreIntegrationDialog } from "@/components/integrations/manage-store-integration-dialog";
+import { toMcpFormAuthType, toMcpFormUrl } from "@/lib/integrations/mcp";
+import type { StoreIntegrationDialogsProps } from "@/types/integrations/mcp";
+
+export function StoreIntegrationDialogs({
+  organizationId,
+  confirmingIntegration,
+  confirmingPending,
+  connectingIntegration,
+  managingIntegration,
+  onConfirmConnect,
+  onConfirmingClose,
+  onConnectingClose,
+  onConnectingSuccess,
+  onManagingClose,
+}: StoreIntegrationDialogsProps) {
+  return (
+    <>
+      {confirmingIntegration ? (
+        <ConnectStoreIntegrationDialog
+          connecting={confirmingPending}
+          integration={confirmingIntegration}
+          key={confirmingIntegration.id}
+          onConnect={onConfirmConnect}
+          onOpenChange={(open) => {
+            if (!open) {
+              onConfirmingClose();
+            }
+          }}
+          open
+        />
+      ) : null}
+
+      {connectingIntegration ? (
+        <AddMcpServerDialog
+          initialValues={{
+            name: connectingIntegration.name,
+            url: toMcpFormUrl(connectingIntegration.url),
+            description: connectingIntegration.description ?? "",
+            authType: toMcpFormAuthType(connectingIntegration.authType),
+          }}
+          key={connectingIntegration.id}
+          logoDarkUrl={connectingIntegration.logoDarkUrl}
+          logoLightUrl={connectingIntegration.logoLightUrl}
+          onOpenChange={(open) => {
+            if (!open) {
+              onConnectingClose();
+            }
+          }}
+          onSuccess={onConnectingSuccess}
+          open
+          organizationId={organizationId}
+          storeIntegrationId={connectingIntegration.id}
+        />
+      ) : null}
+
+      {managingIntegration?.connection ? (
+        <ManageStoreIntegrationDialog
+          integration={{
+            ...managingIntegration,
+            connection: managingIntegration.connection,
+          }}
+          key={managingIntegration.connection.id}
+          onDisconnected={onManagingClose}
+          onOpenChange={(open) => {
+            if (!open) {
+              onManagingClose();
+            }
+          }}
+          open
+          organizationId={organizationId}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/integrations/store-integration-logo.tsx
+++ b/apps/dashboard/src/components/integrations/store-integration-logo.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Image from "next/image";
+import type { StoreIntegrationLogoProps } from "@/types/integrations/mcp";
+
+export function StoreIntegrationLogo({
+  integration,
+}: StoreIntegrationLogoProps) {
+  const lightLogo = integration.logoLightUrl ?? integration.logoDarkUrl;
+  const darkLogo = integration.logoDarkUrl ?? integration.logoLightUrl;
+
+  if (lightLogo && darkLogo) {
+    return (
+      <>
+        <Image
+          alt={`${integration.name} logo`}
+          className="size-6 rounded object-contain dark:hidden"
+          height={24}
+          src={lightLogo}
+          width={24}
+        />
+        <Image
+          alt={`${integration.name} logo`}
+          className="hidden size-6 rounded object-contain dark:block"
+          height={24}
+          src={darkLogo}
+          width={24}
+        />
+      </>
+    );
+  }
+
+  return (
+    <span className="flex size-6 items-center justify-center rounded bg-muted font-medium text-muted-foreground text-xs">
+      {integration.name.trim().slice(0, 2).toUpperCase() || "?"}
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/integrations/store-integrations-section.tsx
+++ b/apps/dashboard/src/components/integrations/store-integrations-section.tsx
@@ -1,26 +1,14 @@
 "use client";
 
-import { MoreHorizontalIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { Badge } from "@notra/ui/components/ui/badge";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
-import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { openMcpOAuthPopup } from "@notra/utils/oauth-popup";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/button";
-import { AddMcpServerDialog } from "@/components/integrations/add-mcp-server-dialog";
-import { ConnectStoreIntegrationDialog } from "@/components/integrations/connect-store-integration-dialog";
-import { ManageStoreIntegrationDialog } from "@/components/integrations/manage-store-integration-dialog";
-import { StoreIntegrationLogo } from "@/components/integrations/store-integration-logo";
+import { StoreIntegrationCard } from "@/components/integrations/store-integration-card";
+import { StoreIntegrationDialogs } from "@/components/integrations/store-integration-dialogs";
 import { buildOrganizationIntegrationsPath } from "@/lib/integrations/deeplink";
-import {
-  MCP_ACCENT_COLOR,
-  toMcpFormAuthType,
-  toMcpFormUrl,
-} from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type {
   McpStoreIntegration,
@@ -41,7 +29,9 @@ export function StoreIntegrationsSection({
   const [managingIntegrationId, setManagingIntegrationId] = useState<
     string | null
   >(null);
-  const [deeplinkDismissed, setDeeplinkDismissed] = useState(false);
+  const [dismissedConnectSlug, setDismissedConnectSlug] = useState<
+    string | null
+  >(null);
 
   const { data, isPending } = useQuery(
     dashboardOrpc.integrations.mcp.storeList.queryOptions({
@@ -64,10 +54,10 @@ export function StoreIntegrationsSection({
   };
 
   const dismissDeeplink = () => {
-    if (!connectSlug || deeplinkDismissed) {
+    if (!connectSlug || dismissedConnectSlug === connectSlug) {
       return;
     }
-    setDeeplinkDismissed(true);
+    setDismissedConnectSlug(connectSlug);
     router.replace(buildOrganizationIntegrationsPath(organizationSlug), {
       scroll: false,
     });
@@ -135,7 +125,7 @@ export function StoreIntegrationsSection({
   const integrations = data?.integrations ?? [];
 
   const deeplinkIntegration =
-    connectSlug && !deeplinkDismissed
+    connectSlug && dismissedConnectSlug !== connectSlug
       ? (integrations.find(
           (integration) =>
             integration.slug === connectSlug || integration.id === connectSlug
@@ -193,140 +183,53 @@ export function StoreIntegrationsSection({
       ) : (
         <div className="grid gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {integrations.map((integration) => (
-            <TitleCard
-              accentColor={integration.brandColor ?? MCP_ACCENT_COLOR}
-              action={
-                integration.connected ? (
-                  <div className="flex items-center gap-2">
-                    <Badge className="text-xs" variant="default">
-                      Connected
-                    </Badge>
-                    <span className="text-muted-foreground">
-                      <HugeiconsIcon
-                        aria-hidden="true"
-                        className="size-4"
-                        icon={MoreHorizontalIcon}
-                      />
-                      <span className="sr-only">Manage integration</span>
-                    </span>
-                  </div>
-                ) : (
-                  <Button
-                    disabled={isConnectPending(integration)}
-                    onClick={() => connectIntegration(integration)}
-                    size="sm"
-                    variant="outline"
-                  >
-                    {isConnectPending(integration)
-                      ? "Connecting..."
-                      : "Connect"}
-                  </Button>
-                )
-              }
-              className={
-                integration.connected
-                  ? "h-full cursor-pointer transition-colors hover:bg-muted/80"
-                  : "h-full"
-              }
-              heading={integration.name}
-              icon={<StoreIntegrationLogo integration={integration} />}
+            <StoreIntegrationCard
+              connectPending={isConnectPending(integration)}
+              integration={integration}
               key={integration.id}
-              onClick={() => {
-                if (integration.connected) {
-                  setManagingIntegrationId(integration.id);
-                }
-              }}
-              onKeyDown={(event) => {
-                if (
-                  integration.connected &&
-                  (event.key === "Enter" || event.key === " ")
-                ) {
-                  event.preventDefault();
-                  setManagingIntegrationId(integration.id);
-                }
-              }}
-              role={integration.connected ? "button" : undefined}
-              tabIndex={integration.connected ? 0 : undefined}
-            >
-              <p className="line-clamp-2 text-muted-foreground text-sm">
-                {integration.description ??
-                  (integration.author
-                    ? `By ${integration.author}`
-                    : "MCP server from the integration store")}
-              </p>
-            </TitleCard>
+              onConnect={connectIntegration}
+              onManage={(target) => setManagingIntegrationId(target.id)}
+            />
           ))}
         </div>
       )}
 
-      {activeConfirmingIntegration ? (
-        <ConnectStoreIntegrationDialog
-          connecting={isConnectPending(activeConfirmingIntegration)}
-          integration={activeConfirmingIntegration}
-          key={activeConfirmingIntegration.id}
-          onConnect={() => connectIntegration(activeConfirmingIntegration)}
-          onOpenChange={(open) => {
-            if (!open) {
-              setConfirmingIntegration(null);
-              dismissDeeplink();
-            }
-          }}
-          open
-        />
-      ) : null}
-
-      {activeConnectingIntegration ? (
-        <AddMcpServerDialog
-          initialValues={{
-            name: activeConnectingIntegration.name,
-            url: toMcpFormUrl(activeConnectingIntegration.url),
-            description: activeConnectingIntegration.description ?? "",
-            authType: toMcpFormAuthType(activeConnectingIntegration.authType),
-          }}
-          key={activeConnectingIntegration.id}
-          logoDarkUrl={activeConnectingIntegration.logoDarkUrl}
-          logoLightUrl={activeConnectingIntegration.logoLightUrl}
-          onOpenChange={(open) => {
-            if (!open) {
-              setConnectingIntegration(null);
-              dismissDeeplink();
-            }
-          }}
-          onSuccess={() => {
-            dismissDeeplink();
-            queryClient.invalidateQueries({
-              queryKey: dashboardOrpc.integrations.mcp.storeList.queryKey({
-                input: { organizationId },
-              }),
-            });
-          }}
-          open
-          organizationId={organizationId}
-          storeIntegrationId={activeConnectingIntegration.id}
-        />
-      ) : null}
-
-      {activeManagingIntegration?.connection ? (
-        <ManageStoreIntegrationDialog
-          integration={{
-            ...activeManagingIntegration,
-            connection: activeManagingIntegration.connection,
-          }}
-          key={activeManagingIntegration.connection.id}
-          onDisconnected={() => {
-            setManagingIntegrationId(null);
-            dismissDeeplink();
-          }}
-          onOpenChange={(open) => {
-            if (!open) {
-              setManagingIntegrationId(null);
-              dismissDeeplink();
-            }
-          }}
-          open
-          organizationId={organizationId}
-        />
-      ) : null}
+      <StoreIntegrationDialogs
+        confirmingIntegration={activeConfirmingIntegration}
+        confirmingPending={
+          activeConfirmingIntegration
+            ? isConnectPending(activeConfirmingIntegration)
+            : false
+        }
+        connectingIntegration={activeConnectingIntegration}
+        managingIntegration={activeManagingIntegration}
+        onConfirmConnect={() => {
+          if (activeConfirmingIntegration) {
+            connectIntegration(activeConfirmingIntegration);
+          }
+        }}
+        onConfirmingClose={() => {
+          setConfirmingIntegration(null);
+          dismissDeeplink();
+        }}
+        onConnectingClose={() => {
+          setConnectingIntegration(null);
+          dismissDeeplink();
+        }}
+        onConnectingSuccess={() => {
+          dismissDeeplink();
+          queryClient.invalidateQueries({
+            queryKey: dashboardOrpc.integrations.mcp.storeList.queryKey({
+              input: { organizationId },
+            }),
+          });
+        }}
+        onManagingClose={() => {
+          setManagingIntegrationId(null);
+          dismissDeeplink();
+        }}
+        organizationId={organizationId}
+      />
     </section>
   );
 }

--- a/apps/dashboard/src/components/integrations/store-integrations-section.tsx
+++ b/apps/dashboard/src/components/integrations/store-integrations-section.tsx
@@ -7,12 +7,15 @@ import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { openMcpOAuthPopup } from "@notra/utils/oauth-popup";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import Image from "next/image";
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { AddMcpServerDialog } from "@/components/integrations/add-mcp-server-dialog";
+import { ConnectStoreIntegrationDialog } from "@/components/integrations/connect-store-integration-dialog";
 import { ManageStoreIntegrationDialog } from "@/components/integrations/manage-store-integration-dialog";
+import { StoreIntegrationLogo } from "@/components/integrations/store-integration-logo";
+import { buildOrganizationIntegrationsPath } from "@/lib/integrations/deeplink";
 import {
   MCP_ACCENT_COLOR,
   toMcpFormAuthType,
@@ -24,51 +27,21 @@ import type {
   StoreIntegrationsSectionProps,
 } from "@/types/integrations/mcp";
 
-function StoreIntegrationLogo({
-  integration,
-}: {
-  integration: McpStoreIntegration;
-}) {
-  const lightLogo = integration.logoLightUrl ?? integration.logoDarkUrl;
-  const darkLogo = integration.logoDarkUrl ?? integration.logoLightUrl;
-
-  if (lightLogo && darkLogo) {
-    return (
-      <>
-        <Image
-          alt={`${integration.name} logo`}
-          className="size-6 rounded object-contain dark:hidden"
-          height={24}
-          src={lightLogo}
-          width={24}
-        />
-        <Image
-          alt={`${integration.name} logo`}
-          className="hidden size-6 rounded object-contain dark:block"
-          height={24}
-          src={darkLogo}
-          width={24}
-        />
-      </>
-    );
-  }
-
-  return (
-    <span className="flex size-6 items-center justify-center rounded bg-muted font-medium text-muted-foreground text-xs">
-      {integration.name.trim().slice(0, 2).toUpperCase() || "?"}
-    </span>
-  );
-}
-
 export function StoreIntegrationsSection({
   organizationId,
+  organizationSlug,
+  connectSlug,
 }: StoreIntegrationsSectionProps) {
   const queryClient = useQueryClient();
+  const router = useRouter();
   const [connectingIntegration, setConnectingIntegration] =
+    useState<McpStoreIntegration | null>(null);
+  const [confirmingIntegration, setConfirmingIntegration] =
     useState<McpStoreIntegration | null>(null);
   const [managingIntegrationId, setManagingIntegrationId] = useState<
     string | null
   >(null);
+  const connectDeeplinkHandledRef = useRef(false);
 
   const { data, isPending } = useQuery(
     dashboardOrpc.integrations.mcp.storeList.queryOptions({
@@ -90,6 +63,14 @@ export function StoreIntegrationsSection({
     });
   };
 
+  const clearConnectDeeplink = () => {
+    if (connectSlug) {
+      router.replace(buildOrganizationIntegrationsPath(organizationSlug), {
+        scroll: false,
+      });
+    }
+  };
+
   const connectPublicMutation = useMutation({
     mutationFn: async (integration: McpStoreIntegration) =>
       dashboardOrpc.integrations.mcp.create.call({
@@ -103,6 +84,8 @@ export function StoreIntegrationsSection({
       }),
     onSuccess: () => {
       invalidateIntegrations();
+      setConfirmingIntegration(null);
+      clearConnectDeeplink();
       toast.success("Integration connected");
     },
     onError: (error) => {
@@ -118,7 +101,7 @@ export function StoreIntegrationsSection({
         name: integration.name,
         url: integration.url,
         description: integration.description,
-        callbackPath: window.location.pathname,
+        callbackPath: buildOrganizationIntegrationsPath(organizationSlug),
       }),
     onError: (error) => {
       toast.error(error.message);
@@ -135,8 +118,11 @@ export function StoreIntegrationsSection({
       const oauthPopup = openMcpOAuthPopup();
       beginOAuthMutation.mutate(integration, {
         onError: () => oauthPopup.close(),
-        onSuccess: ({ authorizationUrl }) =>
-          oauthPopup.navigate(authorizationUrl),
+        onSuccess: ({ authorizationUrl }) => {
+          oauthPopup.navigate(authorizationUrl);
+          setConfirmingIntegration(null);
+          clearConnectDeeplink();
+        },
       });
       return;
     }
@@ -149,7 +135,45 @@ export function StoreIntegrationsSection({
     (integration) => integration.id === managingIntegrationId
   );
 
-  if (!isPending && integrations.length === 0) {
+  useEffect(() => {
+    if (!connectSlug || isPending || connectDeeplinkHandledRef.current) {
+      return;
+    }
+    connectDeeplinkHandledRef.current = true;
+
+    const match = integrations.find(
+      (integration) =>
+        integration.slug === connectSlug || integration.id === connectSlug
+    );
+
+    if (!match) {
+      toast.error("This integration is no longer available in the store");
+      router.replace(buildOrganizationIntegrationsPath(organizationSlug), {
+        scroll: false,
+      });
+      return;
+    }
+
+    if (match.connected) {
+      setManagingIntegrationId(match.id);
+      return;
+    }
+
+    if (match.authType === "headers") {
+      setConnectingIntegration(match);
+      return;
+    }
+
+    setConfirmingIntegration(match);
+  }, [connectSlug, isPending, integrations, organizationSlug, router]);
+
+  const isConnectPending = (integration: McpStoreIntegration) =>
+    (connectPublicMutation.isPending &&
+      connectPublicMutation.variables?.id === integration.id) ||
+    (beginOAuthMutation.isPending &&
+      beginOAuthMutation.variables?.id === integration.id);
+
+  if (!(isPending || connectSlug) && integrations.length === 0) {
     return null;
   }
 
@@ -193,21 +217,12 @@ export function StoreIntegrationsSection({
                   </div>
                 ) : (
                   <Button
-                    disabled={
-                      (connectPublicMutation.isPending &&
-                        connectPublicMutation.variables?.id ===
-                          integration.id) ||
-                      (beginOAuthMutation.isPending &&
-                        beginOAuthMutation.variables?.id === integration.id)
-                    }
+                    disabled={isConnectPending(integration)}
                     onClick={() => connectIntegration(integration)}
                     size="sm"
                     variant="outline"
                   >
-                    {(connectPublicMutation.isPending &&
-                      connectPublicMutation.variables?.id === integration.id) ||
-                    (beginOAuthMutation.isPending &&
-                      beginOAuthMutation.variables?.id === integration.id)
+                    {isConnectPending(integration)
                       ? "Connecting..."
                       : "Connect"}
                   </Button>
@@ -249,6 +264,22 @@ export function StoreIntegrationsSection({
         </div>
       )}
 
+      {confirmingIntegration ? (
+        <ConnectStoreIntegrationDialog
+          connecting={isConnectPending(confirmingIntegration)}
+          integration={confirmingIntegration}
+          key={confirmingIntegration.id}
+          onConnect={() => connectIntegration(confirmingIntegration)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setConfirmingIntegration(null);
+              clearConnectDeeplink();
+            }
+          }}
+          open
+        />
+      ) : null}
+
       {connectingIntegration ? (
         <AddMcpServerDialog
           initialValues={{
@@ -263,6 +294,7 @@ export function StoreIntegrationsSection({
           onOpenChange={(open) => {
             if (!open) {
               setConnectingIntegration(null);
+              clearConnectDeeplink();
             }
           }}
           onSuccess={() => {
@@ -285,10 +317,14 @@ export function StoreIntegrationsSection({
             connection: managingIntegration.connection,
           }}
           key={managingIntegration.connection.id}
-          onDisconnected={() => setManagingIntegrationId(null)}
+          onDisconnected={() => {
+            setManagingIntegrationId(null);
+            clearConnectDeeplink();
+          }}
           onOpenChange={(open) => {
             if (!open) {
               setManagingIntegrationId(null);
+              clearConnectDeeplink();
             }
           }}
           open

--- a/apps/dashboard/src/components/integrations/store-integrations-section.tsx
+++ b/apps/dashboard/src/components/integrations/store-integrations-section.tsx
@@ -8,7 +8,7 @@ import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { openMcpOAuthPopup } from "@notra/utils/oauth-popup";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { AddMcpServerDialog } from "@/components/integrations/add-mcp-server-dialog";
@@ -41,7 +41,7 @@ export function StoreIntegrationsSection({
   const [managingIntegrationId, setManagingIntegrationId] = useState<
     string | null
   >(null);
-  const connectDeeplinkHandledRef = useRef(false);
+  const [deeplinkDismissed, setDeeplinkDismissed] = useState(false);
 
   const { data, isPending } = useQuery(
     dashboardOrpc.integrations.mcp.storeList.queryOptions({
@@ -63,12 +63,14 @@ export function StoreIntegrationsSection({
     });
   };
 
-  const clearConnectDeeplink = () => {
-    if (connectSlug) {
-      router.replace(buildOrganizationIntegrationsPath(organizationSlug), {
-        scroll: false,
-      });
+  const dismissDeeplink = () => {
+    if (!connectSlug || deeplinkDismissed) {
+      return;
     }
+    setDeeplinkDismissed(true);
+    router.replace(buildOrganizationIntegrationsPath(organizationSlug), {
+      scroll: false,
+    });
   };
 
   const connectPublicMutation = useMutation({
@@ -83,9 +85,9 @@ export function StoreIntegrationsSection({
         headers: {},
       }),
     onSuccess: () => {
-      invalidateIntegrations();
       setConfirmingIntegration(null);
-      clearConnectDeeplink();
+      dismissDeeplink();
+      invalidateIntegrations();
       toast.success("Integration connected");
     },
     onError: (error) => {
@@ -121,7 +123,7 @@ export function StoreIntegrationsSection({
         onSuccess: ({ authorizationUrl }) => {
           oauthPopup.navigate(authorizationUrl);
           setConfirmingIntegration(null);
-          clearConnectDeeplink();
+          dismissDeeplink();
         },
       });
       return;
@@ -131,41 +133,34 @@ export function StoreIntegrationsSection({
   };
 
   const integrations = data?.integrations ?? [];
-  const managingIntegration = integrations.find(
-    (integration) => integration.id === managingIntegrationId
-  );
 
-  useEffect(() => {
-    if (!connectSlug || isPending || connectDeeplinkHandledRef.current) {
-      return;
-    }
-    connectDeeplinkHandledRef.current = true;
+  const deeplinkIntegration =
+    connectSlug && !deeplinkDismissed
+      ? (integrations.find(
+          (integration) =>
+            integration.slug === connectSlug || integration.id === connectSlug
+        ) ?? null)
+      : null;
 
-    const match = integrations.find(
-      (integration) =>
-        integration.slug === connectSlug || integration.id === connectSlug
-    );
+  const activeManagingIntegration =
+    integrations.find(
+      (integration) => integration.id === managingIntegrationId
+    ) ?? (deeplinkIntegration?.connected ? deeplinkIntegration : null);
 
-    if (!match) {
-      toast.error("This integration is no longer available in the store");
-      router.replace(buildOrganizationIntegrationsPath(organizationSlug), {
-        scroll: false,
-      });
-      return;
-    }
+  const activeConnectingIntegration =
+    connectingIntegration ??
+    (!deeplinkIntegration?.connected &&
+    deeplinkIntegration?.authType === "headers"
+      ? deeplinkIntegration
+      : null);
 
-    if (match.connected) {
-      setManagingIntegrationId(match.id);
-      return;
-    }
-
-    if (match.authType === "headers") {
-      setConnectingIntegration(match);
-      return;
-    }
-
-    setConfirmingIntegration(match);
-  }, [connectSlug, isPending, integrations, organizationSlug, router]);
+  const activeConfirmingIntegration =
+    confirmingIntegration ??
+    (deeplinkIntegration &&
+    !deeplinkIntegration.connected &&
+    deeplinkIntegration.authType !== "headers"
+      ? deeplinkIntegration
+      : null);
 
   const isConnectPending = (integration: McpStoreIntegration) =>
     (connectPublicMutation.isPending &&
@@ -173,7 +168,7 @@ export function StoreIntegrationsSection({
     (beginOAuthMutation.isPending &&
       beginOAuthMutation.variables?.id === integration.id);
 
-  if (!(isPending || connectSlug) && integrations.length === 0) {
+  if (!isPending && integrations.length === 0) {
     return null;
   }
 
@@ -264,40 +259,41 @@ export function StoreIntegrationsSection({
         </div>
       )}
 
-      {confirmingIntegration ? (
+      {activeConfirmingIntegration ? (
         <ConnectStoreIntegrationDialog
-          connecting={isConnectPending(confirmingIntegration)}
-          integration={confirmingIntegration}
-          key={confirmingIntegration.id}
-          onConnect={() => connectIntegration(confirmingIntegration)}
+          connecting={isConnectPending(activeConfirmingIntegration)}
+          integration={activeConfirmingIntegration}
+          key={activeConfirmingIntegration.id}
+          onConnect={() => connectIntegration(activeConfirmingIntegration)}
           onOpenChange={(open) => {
             if (!open) {
               setConfirmingIntegration(null);
-              clearConnectDeeplink();
+              dismissDeeplink();
             }
           }}
           open
         />
       ) : null}
 
-      {connectingIntegration ? (
+      {activeConnectingIntegration ? (
         <AddMcpServerDialog
           initialValues={{
-            name: connectingIntegration.name,
-            url: toMcpFormUrl(connectingIntegration.url),
-            description: connectingIntegration.description ?? "",
-            authType: toMcpFormAuthType(connectingIntegration.authType),
+            name: activeConnectingIntegration.name,
+            url: toMcpFormUrl(activeConnectingIntegration.url),
+            description: activeConnectingIntegration.description ?? "",
+            authType: toMcpFormAuthType(activeConnectingIntegration.authType),
           }}
-          key={connectingIntegration.id}
-          logoDarkUrl={connectingIntegration.logoDarkUrl}
-          logoLightUrl={connectingIntegration.logoLightUrl}
+          key={activeConnectingIntegration.id}
+          logoDarkUrl={activeConnectingIntegration.logoDarkUrl}
+          logoLightUrl={activeConnectingIntegration.logoLightUrl}
           onOpenChange={(open) => {
             if (!open) {
               setConnectingIntegration(null);
-              clearConnectDeeplink();
+              dismissDeeplink();
             }
           }}
           onSuccess={() => {
+            dismissDeeplink();
             queryClient.invalidateQueries({
               queryKey: dashboardOrpc.integrations.mcp.storeList.queryKey({
                 input: { organizationId },
@@ -306,25 +302,25 @@ export function StoreIntegrationsSection({
           }}
           open
           organizationId={organizationId}
-          storeIntegrationId={connectingIntegration.id}
+          storeIntegrationId={activeConnectingIntegration.id}
         />
       ) : null}
 
-      {managingIntegration?.connection ? (
+      {activeManagingIntegration?.connection ? (
         <ManageStoreIntegrationDialog
           integration={{
-            ...managingIntegration,
-            connection: managingIntegration.connection,
+            ...activeManagingIntegration,
+            connection: activeManagingIntegration.connection,
           }}
-          key={managingIntegration.connection.id}
+          key={activeManagingIntegration.connection.id}
           onDisconnected={() => {
             setManagingIntegrationId(null);
-            clearConnectDeeplink();
+            dismissDeeplink();
           }}
           onOpenChange={(open) => {
             if (!open) {
               setManagingIntegrationId(null);
-              clearConnectDeeplink();
+              dismissDeeplink();
             }
           }}
           open

--- a/apps/dashboard/src/lib/integrations/deeplink-resolution.ts
+++ b/apps/dashboard/src/lib/integrations/deeplink-resolution.ts
@@ -1,0 +1,94 @@
+import {
+  getLiveMcpStoreIntegrationById,
+  getLiveMcpStoreIntegrationBySlug,
+} from "@notra/ai/integrations/mcp-store";
+import { Effect } from "effect";
+import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
+import {
+  buildIntegrationConnectLoginUrl,
+  buildOrganizationIntegrationConnectPath,
+  buildOrganizationIntegrationsPath,
+  decodeIntegrationSlugParam,
+} from "@/lib/integrations/deeplink";
+import { storeIntegrationDeeplinkSlugSchema } from "@/schemas/integrations";
+import type {
+  IntegrationConnectResolution,
+  OrganizationIntegrationConnectParams,
+  OrganizationIntegrationConnectResolution,
+} from "@/types/integrations/deeplink";
+
+export const resolveIntegrationConnectDeeplink = Effect.fn(
+  "resolveIntegrationConnectDeeplink"
+)(function* (integrationSlugParam: string) {
+  const parsed = storeIntegrationDeeplinkSlugSchema.safeParse(
+    decodeIntegrationSlugParam(integrationSlugParam)
+  );
+
+  if (!parsed.success) {
+    return { kind: "not-found" } satisfies IntegrationConnectResolution;
+  }
+
+  const session = yield* Effect.promise(() => getSession());
+
+  if (!session?.user) {
+    return {
+      kind: "redirect",
+      path: buildIntegrationConnectLoginUrl(parsed.data),
+    } satisfies IntegrationConnectResolution;
+  }
+
+  const organization = yield* Effect.promise(() => getLastActiveOrganization());
+
+  if (!organization) {
+    return {
+      kind: "redirect",
+      path: "/onboarding",
+    } satisfies IntegrationConnectResolution;
+  }
+
+  return {
+    kind: "redirect",
+    path: buildOrganizationIntegrationConnectPath(
+      organization.slug,
+      parsed.data
+    ),
+  } satisfies IntegrationConnectResolution;
+});
+
+export const resolveOrganizationIntegrationConnect = Effect.fn(
+  "resolveOrganizationIntegrationConnect"
+)(function* ({
+  organizationSlug,
+  integrationSlugParam,
+}: OrganizationIntegrationConnectParams) {
+  const integrationsPath = buildOrganizationIntegrationsPath(organizationSlug);
+  const parsed = storeIntegrationDeeplinkSlugSchema.safeParse(
+    decodeIntegrationSlugParam(integrationSlugParam)
+  );
+
+  if (!parsed.success) {
+    return {
+      kind: "redirect",
+      path: integrationsPath,
+    } satisfies OrganizationIntegrationConnectResolution;
+  }
+
+  const listingBySlug = yield* Effect.promise(() =>
+    getLiveMcpStoreIntegrationBySlug(parsed.data)
+  );
+  const listing =
+    listingBySlug ??
+    (yield* Effect.promise(() => getLiveMcpStoreIntegrationById(parsed.data)));
+
+  if (!listing) {
+    return {
+      kind: "redirect",
+      path: integrationsPath,
+    } satisfies OrganizationIntegrationConnectResolution;
+  }
+
+  return {
+    kind: "render",
+    connectSlug: parsed.data,
+  } satisfies OrganizationIntegrationConnectResolution;
+});

--- a/apps/dashboard/src/lib/integrations/deeplink.ts
+++ b/apps/dashboard/src/lib/integrations/deeplink.ts
@@ -1,0 +1,27 @@
+export function buildIntegrationConnectLoginUrl(
+  integrationSlug: string
+): string {
+  const returnTo = `/integrations/${encodeURIComponent(integrationSlug)}`;
+  return `/login?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
+export function buildOrganizationIntegrationsPath(
+  organizationSlug: string
+): string {
+  return `/${organizationSlug}/integrations`;
+}
+
+export function buildOrganizationIntegrationConnectPath(
+  organizationSlug: string,
+  integrationSlug: string
+): string {
+  return `${buildOrganizationIntegrationsPath(organizationSlug)}/${encodeURIComponent(integrationSlug)}`;
+}
+
+export function decodeIntegrationSlugParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/apps/dashboard/src/lib/integrations/mcp.ts
+++ b/apps/dashboard/src/lib/integrations/mcp.ts
@@ -55,6 +55,16 @@ export function buildMcpHeaders(
   return headers;
 }
 
+export function getStoreIntegrationConnectHint(authType: string, name: string) {
+  if (authType === "oauth") {
+    return `You will be redirected to ${name} to authorize the connection.`;
+  }
+  if (authType === "headers") {
+    return `You will need your own ${name} credentials to finish connecting.`;
+  }
+  return `${name} connects instantly and needs no credentials.`;
+}
+
 export function toMcpFormAuthType(
   authType: string
 ): "none" | "headers" | "oauth" {

--- a/apps/dashboard/src/lib/orpc/routers/integrations.ts
+++ b/apps/dashboard/src/lib/orpc/routers/integrations.ts
@@ -1155,6 +1155,7 @@ export const integrationsRouter = {
             );
             return {
               id: integration.id,
+              slug: integration.slug,
               name: integration.name,
               url: integration.url,
               description: integration.description,

--- a/apps/dashboard/src/schemas/integrations.ts
+++ b/apps/dashboard/src/schemas/integrations.ts
@@ -31,6 +31,16 @@ export const INTEGRATION_TYPES = [
 ] as const;
 export type IntegrationType = (typeof INTEGRATION_TYPES)[number];
 
+const STORE_INTEGRATION_DEEPLINK_SLUG_MAX_LENGTH = 120;
+const STORE_INTEGRATION_DEEPLINK_SLUG_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+export const storeIntegrationDeeplinkSlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(STORE_INTEGRATION_DEEPLINK_SLUG_MAX_LENGTH)
+  .regex(STORE_INTEGRATION_DEEPLINK_SLUG_PATTERN);
+
 export const OUTPUT_CONTENT_TYPES = [
   "changelog",
   "blog_post",

--- a/apps/dashboard/src/types/integrations/catalog.ts
+++ b/apps/dashboard/src/types/integrations/catalog.ts
@@ -11,3 +11,8 @@ export interface IntegrationConfig {
   category: "input" | "output" | "extension";
   connectLabel?: string;
 }
+
+export interface IntegrationsPageClientProps {
+  organizationSlug: string;
+  connectSlug?: string;
+}

--- a/apps/dashboard/src/types/integrations/deeplink.ts
+++ b/apps/dashboard/src/types/integrations/deeplink.ts
@@ -1,0 +1,12 @@
+export type IntegrationConnectResolution =
+  | { kind: "not-found" }
+  | { kind: "redirect"; path: string };
+
+export type OrganizationIntegrationConnectResolution =
+  | { kind: "redirect"; path: string }
+  | { kind: "render"; connectSlug: string };
+
+export interface OrganizationIntegrationConnectParams {
+  organizationSlug: string;
+  integrationSlugParam: string;
+}

--- a/apps/dashboard/src/types/integrations/mcp.ts
+++ b/apps/dashboard/src/types/integrations/mcp.ts
@@ -71,6 +71,7 @@ export interface AddMcpServerDialogProps {
 
 export interface McpStoreIntegration {
   id: string;
+  slug: string | null;
   name: string;
   url: string;
   description: string | null;
@@ -91,6 +92,20 @@ export interface ConnectedMcpStoreIntegration extends McpStoreIntegration {
 
 export interface StoreIntegrationsSectionProps {
   organizationId: string;
+  organizationSlug: string;
+  connectSlug?: string;
+}
+
+export interface StoreIntegrationLogoProps {
+  integration: McpStoreIntegration;
+}
+
+export interface ConnectStoreIntegrationDialogProps {
+  connecting: boolean;
+  integration: McpStoreIntegration;
+  onConnect: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
 }
 
 export interface ManageStoreIntegrationDialogProps {

--- a/apps/dashboard/src/types/integrations/mcp.ts
+++ b/apps/dashboard/src/types/integrations/mcp.ts
@@ -100,6 +100,26 @@ export interface StoreIntegrationLogoProps {
   integration: McpStoreIntegration;
 }
 
+export interface StoreIntegrationCardProps {
+  integration: McpStoreIntegration;
+  connectPending: boolean;
+  onConnect: (integration: McpStoreIntegration) => void;
+  onManage: (integration: McpStoreIntegration) => void;
+}
+
+export interface StoreIntegrationDialogsProps {
+  organizationId: string;
+  confirmingIntegration: McpStoreIntegration | null;
+  confirmingPending: boolean;
+  connectingIntegration: McpStoreIntegration | null;
+  managingIntegration: McpStoreIntegration | null;
+  onConfirmConnect: () => void;
+  onConfirmingClose: () => void;
+  onConnectingClose: () => void;
+  onConnectingSuccess: () => void;
+  onManagingClose: () => void;
+}
+
 export interface ConnectStoreIntegrationDialogProps {
   connecting: boolean;
   integration: McpStoreIntegration;

--- a/apps/web/src/components/integrations/featured-integration-card.tsx
+++ b/apps/web/src/components/integrations/featured-integration-card.tsx
@@ -42,7 +42,10 @@ export function FeaturedIntegrationCard({
                 {buildAuthorCategoryLine(integration)}
               </span>
             </div>
-            <IntegrationConnectButton className="pointer-events-auto px-5.5 py-2.5 text-[0.875rem] leading-[1.29]" />
+            <IntegrationConnectButton
+              className="pointer-events-auto px-5.5 py-2.5 text-[0.875rem] leading-[1.29]"
+              integration={integration}
+            />
           </div>
           {integration.description ? (
             <span className="line-clamp-2 font-sans text-[#1E1E1EBF] text-[0.9375rem] leading-[1.47] tracking-[-0.005em] dark:text-white/70">

--- a/apps/web/src/components/integrations/integration-card.tsx
+++ b/apps/web/src/components/integrations/integration-card.tsx
@@ -31,7 +31,10 @@ export function IntegrationCard({ integration }: IntegrationCardProps) {
           >
             <IntegrationLogo fill integration={integration} size={44} />
           </span>
-          <IntegrationConnectButton className="pointer-events-auto px-3.5 py-1.5 text-[0.8125rem] leading-[1.23]" />
+          <IntegrationConnectButton
+            className="pointer-events-auto px-3.5 py-1.5 text-[0.8125rem] leading-[1.23]"
+            integration={integration}
+          />
         </div>
         <div className="flex flex-col gap-0.5">
           <span className="font-sans font-semibold text-[#1E1E1E] text-[1.0625rem] leading-[1.29] tracking-[-0.01em] dark:text-white">

--- a/apps/web/src/components/integrations/integration-connect-button.tsx
+++ b/apps/web/src/components/integrations/integration-connect-button.tsx
@@ -1,15 +1,14 @@
 import { cn } from "@notra/ui/lib/utils";
-import { INTEGRATIONS_CONNECT_URL } from "@/constants/integrations";
+import { getIntegrationConnectUrl } from "@/lib/integrations/helpers";
+import type { IntegrationConnectButtonProps } from "@/types/integrations";
 
 const PRIMARY_CLASSNAME = "cta-gradient-primary-flat text-white";
 
 export function IntegrationConnectButton({
+  integration,
   className,
   label = "Connect",
-}: {
-  className?: string;
-  label?: string;
-}) {
+}: IntegrationConnectButtonProps) {
   return (
     <a
       className={cn(
@@ -17,7 +16,7 @@ export function IntegrationConnectButton({
         PRIMARY_CLASSNAME,
         className
       )}
-      href={INTEGRATIONS_CONNECT_URL}
+      href={getIntegrationConnectUrl(integration)}
     >
       {label}
     </a>

--- a/apps/web/src/components/integrations/integration-detail-view.tsx
+++ b/apps/web/src/components/integrations/integration-detail-view.tsx
@@ -64,7 +64,10 @@ export function IntegrationDetailView({
                   <HugeiconsIcon icon={ArrowUpRight01Icon} size={14} />
                 </a>
               ) : null}
-              <IntegrationConnectButton className="px-6.5 py-2.75 text-[0.875rem] leading-[1.29]" />
+              <IntegrationConnectButton
+                className="px-6.5 py-2.75 text-[0.875rem] leading-[1.29]"
+                integration={integration}
+              />
             </div>
           </div>
 

--- a/apps/web/src/components/integrations/integration-modal.tsx
+++ b/apps/web/src/components/integrations/integration-modal.tsx
@@ -71,7 +71,10 @@ function ModalBody({ integration }: IntegrationModalProps) {
             tail={buildQuickViewMetaTail(integration)}
           />
         </div>
-        <IntegrationConnectButton className="px-6 py-2.5 text-[0.875rem] leading-[1.29]" />
+        <IntegrationConnectButton
+          className="px-6 py-2.5 text-[0.875rem] leading-[1.29]"
+          integration={integration}
+        />
       </div>
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-y-auto pb-6">
         {integration.description ? (

--- a/apps/web/src/constants/integrations.ts
+++ b/apps/web/src/constants/integrations.ts
@@ -1,11 +1,9 @@
 import type { Integration } from "@/types/integrations";
-import { APP_URL, DOCS_URL } from "@/utils/urls";
+import { DOCS_URL } from "@/utils/urls";
 
 export const INTEGRATIONS_CONSOLE_URL = "https://console.usenotra.com";
 
 export const INTEGRATIONS_DOCS_URL = DOCS_URL;
-
-export const INTEGRATIONS_CONNECT_URL = `${APP_URL}/login`;
 
 export const FEATURED_INTEGRATIONS_LIMIT = 2;
 

--- a/apps/web/src/lib/integrations/helpers.ts
+++ b/apps/web/src/lib/integrations/helpers.ts
@@ -6,11 +6,17 @@ import type {
   Integration,
   IntegrationCategoryFilter,
 } from "@/types/integrations";
+import { APP_URL } from "@/utils/urls";
 
 const WHITESPACE_REGEX = /\s+/g;
 
 export function getIntegrationHref(integration: Integration): string {
   return `/integrations/${integration.slug ?? integration.id}`;
+}
+
+export function getIntegrationConnectUrl(integration: Integration): string {
+  const slug = integration.slug ?? integration.id;
+  return `${APP_URL}/integrations/${encodeURIComponent(slug)}`;
 }
 
 function collapseWhitespace(value: string): string {

--- a/apps/web/src/types/integrations.ts
+++ b/apps/web/src/types/integrations.ts
@@ -50,6 +50,12 @@ export interface IntegrationCardProps {
   integration: Integration;
 }
 
+export interface IntegrationConnectButtonProps {
+  integration: Integration;
+  className?: string;
+  label?: string;
+}
+
 export interface FeaturedIntegrationCardProps {
   integration: Integration;
 }


### PR DESCRIPTION
## What

Clicking **Connect** on a marketplace integration on the web app (e.g. Brew) now deeplinks into the dashboard and opens the connect modal for that integration, instead of dropping the user on the generic login page.

## Flow

1. `apps/web`: `IntegrationConnectButton` now receives the integration and links to `app.usenotra.com/integrations/:slug` (slug with id fallback) from all four call sites: grid card, featured card, quick-view modal, detail page.
2. `apps/dashboard` org-less resolver at `/integrations/[integrationSlug]`:
   - validates the slug with a Zod schema
   - logged out: redirects to `/login?returnTo=/integrations/:slug` (the existing login -> `/callback` flow honors `returnTo`, so the deeplink survives auth)
   - logged in: resolves the last-active organization and redirects to `/:orgSlug/integrations/:slug`; users with no org go to `/onboarding`
3. Org-scoped `/[slug]/integrations/[integrationSlug]` verifies the store listing is still live (by slug, then id) server-side, then renders the integrations page with the connect flow auto-opened:
   - already connected: manage dialog
   - header auth: prefilled `AddMcpServerDialog`
   - oauth / none: new `ConnectStoreIntegrationDialog` whose Connect button triggers the existing connect logic (auto-launching the OAuth popup on load would hit popup blockers, and auto-connecting from a GET would be a side effect)
   - closing any dialog cleans the URL back to `/:orgSlug/integrations`
   - existing static routes (github, linear, mcp, ...) take precedence over the dynamic segment

## Supporting changes

- `storeList` oRPC now exposes the listing `slug` (already selected from the DB, just not returned); `McpStoreIntegration` gains `slug: string | null`
- deeplink URL builders in `lib/integrations/deeplink.ts`; OAuth `callbackPath` now uses the canonical integrations path so returning from OAuth does not re-trigger the deeplink
- `StoreIntegrationLogo` extracted for reuse by the new dialog
- removed the dead `INTEGRATIONS_CONNECT_URL` constant on the web side

## Verification

- `bun run build` passes (both apps); new routes appear in the build output
- Biome clean on all touched files; dashboard `tsc --noEmit` clean

Note: hitting an org-scoped URL like `/:orgSlug/integrations/brew` directly while logged out still loses the path (layout `requireAuth` redirects to bare `/login`); the web -> dashboard flow avoids this via the resolver. Threading `returnTo` through `requireAuth` could be a follow-up.

https://claude.ai/code/session_017iZunzJQkcJZ46DNUHaHoW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marketplace Connect buttons now deeplink into the dashboard and auto-open the right connect flow. Links survive login and route users to their last active org to reduce clicks.

- **New Features**
  - Web `IntegrationConnectButton` builds `app.usenotra.com/integrations/:slug` links from grid, featured, quick view, and detail views.
  - Resolver at `/integrations/[integrationSlug]` validates the slug, preserves `returnTo` through login, and redirects to `/:orgSlug/integrations/:slug` or `/onboarding`.
  - Org route `/:orgSlug/integrations/[integrationSlug]` validates the listing and auto-opens:
    - Manage dialog if connected
    - Prefilled `AddMcpServerDialog` for header auth
    - Confirm `ConnectStoreIntegrationDialog` for oauth/none; OAuth launches in a popup on click
    - Unknown/inactive slugs fall back to `/:orgSlug/integrations`
  - Closing any dialog cleans the URL to `/:orgSlug/integrations`.

- **Refactors**
  - Deeplink resolution runs server-side via Effect; pages only redirect/notFound/render.
  - Store section derives dialog state from query data and now tracks the dismissed deeplink by slug (supports navigating between multiple deeplinks); dismisses before invalidation to avoid flashing manage; resets URL with `replace`.
  - Split UI into `StoreIntegrationCard` and `StoreIntegrationDialogs`; extracted `StoreIntegrationLogo`; added `getStoreIntegrationConnectHint`.
  - oRPC `storeList` now returns `slug`; OAuth `callbackPath` uses the canonical org integrations path; removed `INTEGRATIONS_CONNECT_URL`; web uses `getIntegrationConnectUrl` from `APP_URL`.

<sup>Written for commit b0a06d8aad5b8e98d753b5e530b1bef1f8d551ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`3d582bf`](https://github.com/usenotra/notra/commit/3d582bfc4a5db59ce49632f481fcdf8a076cd84c). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->