### PR TITLE
feat(dashboard): stabilize GitHub integration loading states

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/loading.tsx
@@ -3,7 +3,10 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
-import { GitHubIntegrationSkeleton } from "./skeleton";
+import {
+  GitHubIntegrationSkeleton,
+  GitHubLegacyIntegrationsSkeleton,
+} from "./skeleton";
 
 export default function Loading() {
   return (
@@ -24,6 +27,7 @@ export default function Loading() {
           </Button>
         </div>
         <GitHubIntegrationSkeleton />
+        <GitHubLegacyIntegrationsSkeleton />
       </div>
     </PageContainer>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/loading.tsx
@@ -2,8 +2,8 @@ import { PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import { Button } from "@/components/button";
-import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/layout/container";
+import { GitHubIntegrationSkeleton } from "./skeleton";
 
 export default function Loading() {
   return (
@@ -23,10 +23,7 @@ export default function Loading() {
             <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
           </Button>
         </div>
-        <EmptyState
-          description="Loading your GitHub App installation."
-          title="Loading GitHub"
-        />
+        <GitHubIntegrationSkeleton />
       </div>
     </PageContainer>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -26,6 +26,7 @@ import {
   startGitHubInstall,
 } from "@/lib/integrations/github/install";
 import { dashboardOrpc } from "@/lib/orpc/query";
+import { GitHubIntegrationSkeleton } from "./skeleton";
 
 interface PageClientProps {
   organizationSlug: string;
@@ -123,7 +124,8 @@ function useResumeGitHubInstall(params: {
 }
 
 export default function PageClient({ organizationSlug }: PageClientProps) {
-  const { getOrganization } = useOrganizationsContext();
+  const { getOrganization, isLoading: isLoadingOrganizations } =
+    useOrganizationsContext();
   const organization = getOrganization(organizationSlug);
   const organizationId = organization?.id ?? "";
   const pathname = usePathname();
@@ -160,7 +162,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     legacyQuery.data?.integrations.filter((i) => i.type === "github") ?? [];
   const data = githubAppQuery.data;
   const isConnected = Boolean(data?.account);
-  const isLoading = !!organizationId && githubAppQuery.isLoading && !data;
+  const isLoading =
+    isLoadingOrganizations ||
+    (!!organizationId && githubAppQuery.isLoading && !data);
   const selectedRepositoryIds = data?.selectedRepositoryIds ?? [];
   const repositories = data?.repositories ? [...data.repositories] : [];
 
@@ -312,12 +316,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   );
 
   if (isLoading) {
-    githubAppContent = (
-      <EmptyState
-        description="Loading your GitHub App installation."
-        title="Loading GitHub"
-      />
-    );
+    githubAppContent = <GitHubIntegrationSkeleton />;
   } else if (isConnected && data?.account) {
     githubAppContent = (
       <GitHubAccountCard

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -26,7 +26,11 @@ import {
   startGitHubInstall,
 } from "@/lib/integrations/github/install";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import { GitHubIntegrationSkeleton } from "./skeleton";
+import type { GitHubIntegration } from "@/types/integrations";
+import {
+  GitHubIntegrationSkeleton,
+  GitHubLegacyIntegrationsSkeleton,
+} from "./skeleton";
 
 interface PageClientProps {
   organizationSlug: string;
@@ -123,6 +127,52 @@ function useResumeGitHubInstall(params: {
   ]);
 }
 
+function LegacyGitHubIntegrationsSection({
+  integrations,
+  isLoading,
+  onUpdate,
+  organizationId,
+  organizationSlug,
+}: {
+  integrations: GitHubIntegration[];
+  isLoading: boolean;
+  onUpdate: () => void;
+  organizationId: string;
+  organizationSlug: string;
+}) {
+  if (isLoading) {
+    return <GitHubLegacyIntegrationsSkeleton />;
+  }
+
+  if (integrations.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="space-y-0.5">
+        <h2 className="font-semibold text-lg">
+          Personal access token (Legacy)
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Legacy integrations connected with a personal access token.
+        </p>
+      </div>
+      <div className="grid gap-4">
+        {integrations.map((integration) => (
+          <IntegrationCard
+            integration={integration}
+            key={integration.id}
+            onUpdate={onUpdate}
+            organizationId={organizationId}
+            organizationSlug={organizationSlug}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export default function PageClient({ organizationSlug }: PageClientProps) {
   const { getOrganization, isLoading: isLoadingOrganizations } =
     useOrganizationsContext();
@@ -159,12 +209,19 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     })
   );
   const legacyIntegrations =
-    legacyQuery.data?.integrations.filter((i) => i.type === "github") ?? [];
+    legacyQuery.data?.integrations.filter(
+      (integration) =>
+        integration.type === "github" &&
+        integration.connectionMethod === "personal-access-token"
+    ) ?? [];
   const data = githubAppQuery.data;
   const isConnected = Boolean(data?.account);
   const isLoading =
     isLoadingOrganizations ||
     (!!organizationId && githubAppQuery.isLoading && !data);
+  const isLoadingLegacyIntegrations =
+    isLoadingOrganizations ||
+    (!!organizationId && legacyQuery.isLoading && !legacyQuery.data);
   const selectedRepositoryIds = data?.selectedRepositoryIds ?? [];
   const repositories = data?.repositories ? [...data.repositories] : [];
 
@@ -352,29 +409,13 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
         {githubAppContent}
 
-        {legacyIntegrations.length > 0 ? (
-          <section className="space-y-3">
-            <div className="space-y-0.5">
-              <h2 className="font-semibold text-lg">
-                Personal access token (Legacy)
-              </h2>
-              <p className="text-muted-foreground text-sm">
-                Legacy integrations connected with a personal access token.
-              </p>
-            </div>
-            <div className="grid gap-4">
-              {legacyIntegrations.map((integration) => (
-                <IntegrationCard
-                  integration={integration}
-                  key={integration.id}
-                  onUpdate={() => legacyQuery.refetch()}
-                  organizationId={organizationId}
-                  organizationSlug={organizationSlug}
-                />
-              ))}
-            </div>
-          </section>
-        ) : null}
+        <LegacyGitHubIntegrationsSection
+          integrations={legacyIntegrations}
+          isLoading={isLoadingLegacyIntegrations}
+          onUpdate={() => legacyQuery.refetch()}
+          organizationId={organizationId}
+          organizationSlug={organizationSlug}
+        />
 
         <p className="text-muted-foreground text-xs">
           Still using a personal access token?{" "}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/skeleton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/skeleton.tsx
@@ -50,3 +50,37 @@ export function GitHubIntegrationSkeleton() {
     </Card>
   );
 }
+
+export function GitHubLegacyIntegrationsSkeleton() {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-0.5">
+        <h2 className="font-semibold text-lg">
+          Personal access token (Legacy)
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Legacy integrations connected with a personal access token.
+        </p>
+      </div>
+      <Card
+        aria-busy="true"
+        aria-label="Loading personal access token integrations"
+        role="status"
+      >
+        <CardHeader>
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-48" />
+            <Skeleton className="h-4 w-36" />
+          </div>
+          <CardAction className="flex items-center gap-2">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="size-8" />
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-4 w-36" />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/skeleton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/skeleton.tsx
@@ -1,0 +1,52 @@
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+} from "@notra/ui/components/ui/card";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+
+const REPOSITORY_SKELETONS = ["first", "second", "third"];
+
+export function GitHubIntegrationSkeleton() {
+  return (
+    <Card
+      aria-busy="true"
+      aria-label="Loading GitHub integration"
+      role="status"
+    >
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-9 rounded-full" />
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+        <CardAction>
+          <Skeleton className="h-8 w-20" />
+        </CardAction>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-44" />
+          <Skeleton className="h-8 w-36" />
+        </div>
+        <div className="divide-y rounded-lg border">
+          {REPOSITORY_SKELETONS.map((repository) => (
+            <div
+              className="flex items-center gap-3 px-3 py-2.5"
+              key={repository}
+            >
+              <Skeleton className="size-4 shrink-0" />
+              <Skeleton className="h-4 w-48 max-w-2/3" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/lib/orpc/routers/integrations.ts
+++ b/apps/dashboard/src/lib/orpc/routers/integrations.ts
@@ -97,6 +97,7 @@ import type {
   GitHubRepository,
   RepositoryOutput,
 } from "@/types/integrations";
+import type { GitHubConnectionMethod } from "@/types/services/integrations";
 import { ratelimit } from "@/utils/ratelimit";
 import {
   badRequest,
@@ -228,6 +229,7 @@ function serializeListedIntegration(integration: {
   type: string;
   id: string;
   displayName: string;
+  connectionMethod?: GitHubConnectionMethod;
   enabled: boolean;
   createdAt: Date;
   repositories: Array<{
@@ -243,10 +245,16 @@ function serializeListedIntegration(integration: {
       enabled: boolean;
     }>;
   }>;
-}): GitHubIntegration & { type: IntegrationType } {
+}): GitHubIntegration & {
+  type: IntegrationType;
+  connectionMethod?: GitHubConnectionMethod;
+} {
   return {
     ...serializeIntegration(integration),
     type: integration.type as IntegrationType,
+    ...(integration.connectionMethod
+      ? { connectionMethod: integration.connectionMethod }
+      : {}),
   };
 }
 

--- a/apps/dashboard/src/lib/services/integrations.ts
+++ b/apps/dashboard/src/lib/services/integrations.ts
@@ -28,6 +28,9 @@ const integrationFetchers: Partial<
         id: integration.id,
         displayName: integration.displayName,
         type: "github" as const,
+        connectionMethod: integration.githubAppInstallationId
+          ? ("github-app" as const)
+          : ("personal-access-token" as const),
         enabled: integration.enabled,
         createdAt: integration.createdAt,
         repositories: uniqueRepositories.map((repo) => ({

--- a/apps/dashboard/src/types/services/integrations.ts
+++ b/apps/dashboard/src/types/services/integrations.ts
@@ -3,6 +3,8 @@ import type {
   OutputContentType,
 } from "@/schemas/integrations";
 
+export type GitHubConnectionMethod = "github-app" | "personal-access-token";
+
 export interface CreateGitHubIntegrationParams {
   organizationId: string;
   userId: string;
@@ -43,6 +45,7 @@ export interface IntegrationWithRepositories {
   id: string;
   displayName: string;
   type: IntegrationType;
+  connectionMethod?: GitHubConnectionMethod;
   enabled: boolean;
   createdAt: Date;
   repositories: Array<{


### PR DESCRIPTION
### Description
Adds layout-matched loading skeletons for the GitHub App and legacy personal access token sections to prevent content shifts while integration data loads. It also distinguishes GitHub App-backed repositories from PAT integrations so App repositories are not duplicated in the legacy section.

### Screenshot/Recording (if applicable)
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ebf12897-b2b8-494e-9e57-e8d78d19730f" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`95dbb0a`](https://github.com/usenotra/notra/commit/95dbb0ac122e511787b1c42a0cb4f7afaa4a9a23). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->