### PR TITLE
fix(dashboard): run the GitHub App install in the same tab and guard OAuth retry loops

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -88,10 +88,15 @@ function useResumeGitHubInstall(params: {
       organizationId: params.organizationId,
       callbackPath: params.callbackPath,
       allowAccountConnection: false,
-    }).then((started) => {
-      if (!started) {
-        toast.error("Failed to resume GitHub installation");
+    }).then((result) => {
+      if (result.started) {
+        return;
       }
+      toast.error(
+        result.reason === "account-connection-incomplete"
+          ? "GitHub account connection didn't complete. Please try connecting again."
+          : "Failed to resume GitHub installation"
+      );
     });
   }, [
     params.callbackPath,
@@ -204,24 +209,24 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     },
   });
 
-  const openInstallTab = async () => {
+  const startInstall = async () => {
     if (!organizationId) {
       return;
     }
 
     const callbackPath = pathname || `/${organizationSlug}/integrations/github`;
-    const didStart = await startGitHubInstall({ organizationId, callbackPath });
+    const result = await startGitHubInstall({ organizationId, callbackPath });
 
-    if (!didStart) {
+    if (!result.started) {
       toast.error("Failed to start GitHub install");
     }
   };
 
   const handleOpenConnect = () => setConnectOpen(true);
 
-  const handleConnect = openInstallTab;
+  const handleConnect = startInstall;
 
-  const handleAddAccount = openInstallTab;
+  const handleAddAccount = startInstall;
 
   useHotkey(
     "C",

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -18,10 +18,8 @@ import { LegacyAddIntegrationDialog } from "@/components/integrations/legacy/add
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
-  GITHUB_INSTALL_CHANNEL,
-  GITHUB_INSTALL_MESSAGE,
-} from "@/constants/github";
-import {
+  hasAttemptedGitHubReauthorization,
+  markGitHubReauthorizationAttempted,
   reauthorizeGitHub,
   startGitHubInstall,
 } from "@/lib/integrations/github/install";
@@ -29,31 +27,6 @@ import { dashboardOrpc } from "@/lib/orpc/query";
 
 interface PageClientProps {
   organizationSlug: string;
-}
-
-interface GitHubInstallMessage {
-  type: typeof GITHUB_INSTALL_MESSAGE;
-  organizationId: string;
-}
-
-function isGitHubInstallMessage(
-  value: unknown,
-  organizationId: string
-): value is GitHubInstallMessage {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  return (
-    "type" in value &&
-    value.type === GITHUB_INSTALL_MESSAGE &&
-    "organizationId" in value &&
-    value.organizationId === organizationId
-  );
-}
-
-function getGitHubInstallStorageKey(organizationId: string) {
-  return `${GITHUB_INSTALL_CHANNEL}:${organizationId}`;
 }
 
 function useResumeGitHubInstall(params: {
@@ -85,6 +58,12 @@ function useResumeGitHubInstall(params: {
     window.history.replaceState(null, "", nextUrl);
 
     if (params.reauthorizationInstallationId && params.reauthorizationState) {
+      if (hasAttemptedGitHubReauthorization(params.reauthorizationState)) {
+        toast.error("Failed to reconnect GitHub. Please try again.");
+        return;
+      }
+      markGitHubReauthorizationAttempted(params.reauthorizationState);
+
       const callbackUrl = new URL(
         "/api/integrations/github/callback",
         window.location.origin
@@ -108,6 +87,7 @@ function useResumeGitHubInstall(params: {
     startGitHubInstall({
       organizationId: params.organizationId,
       callbackPath: params.callbackPath,
+      allowAccountConnection: false,
     }).then((started) => {
       if (!started) {
         toast.error("Failed to resume GitHub installation");
@@ -175,60 +155,15 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   });
 
   useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (
-        event.origin === window.location.origin &&
-        isGitHubInstallMessage(event.data, organization?.id ?? "")
-      ) {
-        handleGitHubInstalled();
-      }
-    };
-    const handleStorage = (event: StorageEvent) => {
-      if (event.key === getGitHubInstallStorageKey(organization?.id ?? "")) {
-        handleGitHubInstalled();
-      }
-    };
-    const channel = new BroadcastChannel(GITHUB_INSTALL_CHANNEL);
-    const handleChannelMessage = (event: MessageEvent) => {
-      if (isGitHubInstallMessage(event.data, organization?.id ?? "")) {
-        handleGitHubInstalled();
-      }
-    };
-    channel.addEventListener("message", handleChannelMessage);
-
-    window.addEventListener("message", handleMessage);
-    window.addEventListener("storage", handleStorage);
-    return () => {
-      channel.removeEventListener("message", handleChannelMessage);
-      channel.close();
-      window.removeEventListener("message", handleMessage);
-      window.removeEventListener("storage", handleStorage);
-    };
-  }, [organization?.id]);
-
-  useEffect(() => {
     if (searchParams.get("githubConnected") !== "true" || !organization?.id) {
       return;
     }
 
-    const message: GitHubInstallMessage = {
-      type: GITHUB_INSTALL_MESSAGE,
-      organizationId: organization.id,
-    };
+    const nextUrl = new URL(window.location.href);
+    nextUrl.searchParams.delete("githubConnected");
+    window.history.replaceState(null, "", nextUrl);
 
-    if (window.opener && window.opener !== window) {
-      window.opener.postMessage(message, window.location.origin);
-      window.close();
-      return;
-    }
-
-    const channel = new BroadcastChannel(GITHUB_INSTALL_CHANNEL);
-    channel.postMessage(message);
-    channel.close();
-    window.localStorage.setItem(
-      getGitHubInstallStorageKey(organization.id),
-      crypto.randomUUID()
-    );
+    handleGitHubInstalled();
   }, [searchParams, organization?.id]);
 
   const saveRepositoriesMutation = useMutation({

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -6,7 +6,7 @@ import { Kbd } from "@notra/ui/components/ui/kbd";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
@@ -115,7 +115,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [connectOpen, setConnectOpen] = useState(false);
-  const [reposOpen, setReposOpen] = useState(false);
+  const [reposOpen, setReposOpen] = useState(
+    () => searchParams.get("githubConnected") === "true"
+  );
   const [legacyOpen, setLegacyOpen] = useState(false);
   useResumeGitHubInstall({
     callbackPath: pathname,
@@ -149,16 +151,6 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   const selectedRepositoryIds = data?.selectedRepositoryIds ?? [];
   const repositories = data?.repositories ? [...data.repositories] : [];
 
-  const handleGitHubInstalled = useEffectEvent(() => {
-    queryClient.invalidateQueries({
-      queryKey: dashboardOrpc.github.app.get.queryKey({
-        input: { organizationId },
-      }),
-    });
-    setConnectOpen(false);
-    setReposOpen(true);
-  });
-
   useEffect(() => {
     if (searchParams.get("githubConnected") !== "true" || !organization?.id) {
       return;
@@ -168,8 +160,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     nextUrl.searchParams.delete("githubConnected");
     window.history.replaceState(null, "", nextUrl);
 
-    handleGitHubInstalled();
-  }, [searchParams, organization?.id]);
+    queryClient.invalidateQueries({
+      queryKey: dashboardOrpc.github.app.get.queryKey({
+        input: { organizationId: organization.id },
+      }),
+    });
+  }, [searchParams, organization?.id, queryClient]);
 
   const saveRepositoriesMutation = useMutation({
     mutationFn: async (repositoryIds: string[]) => {

--- a/apps/dashboard/src/components/integrations/github/github-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/github/github-integration-dialog.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
 import { toast } from "sonner";
-import { GITHUB_INSTALL_MESSAGE } from "@/constants/github";
 import { startGitHubInstall } from "@/lib/integrations/github/install";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { GitHubIntegrationDialogProps } from "@/types/integrations/github";
@@ -37,24 +35,6 @@ export function GitHubIntegrationDialog({
         input: { organizationId },
       }),
     });
-
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (
-        event.origin === window.location.origin &&
-        event.data === GITHUB_INSTALL_MESSAGE
-      ) {
-        queryClient.invalidateQueries({
-          queryKey: dashboardOrpc.github.app.get.queryKey({
-            input: { organizationId },
-          }),
-        });
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, [organizationId, queryClient]);
 
   const saveRepositoriesMutation = useMutation({
     mutationFn: (repositoryIds: string[]) =>

--- a/apps/dashboard/src/components/integrations/github/github-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/github/github-integration-dialog.tsx
@@ -58,9 +58,9 @@ export function GitHubIntegrationDialog({
     }
 
     const callbackPath = `/${organizationSlug}/integrations/github`;
-    const didStart = await startGitHubInstall({ organizationId, callbackPath });
+    const result = await startGitHubInstall({ organizationId, callbackPath });
 
-    if (!didStart) {
+    if (!result.started) {
       toast.error("Failed to start GitHub install");
     }
   };

--- a/apps/dashboard/src/constants/github.ts
+++ b/apps/dashboard/src/constants/github.ts
@@ -4,9 +4,6 @@ export const GITHUB_URL_PATTERNS = [
   /^([^/]+)\/([^/]+)$/,
 ] as const;
 
-export const GITHUB_INSTALL_MESSAGE = "notra:github-installed";
-export const GITHUB_INSTALL_CHANNEL = "notra:github-install";
-
 export const GITHUB_INSTALL_STATE_TTL_SECONDS = 600;
 
 export const GITHUB_APP_PERMISSIONS = [

--- a/apps/dashboard/src/lib/integrations/github/install.ts
+++ b/apps/dashboard/src/lib/integrations/github/install.ts
@@ -1,14 +1,13 @@
 "use client";
 
-import { Data, Effect } from "effect";
+import { Effect } from "effect";
 import { authClient } from "@/lib/auth/client";
 import { dashboardOrpc } from "@/lib/orpc/query";
-
-class GitHubInstallStartError extends Data.TaggedError(
-  "GitHubInstallStartError"
-)<{
-  readonly cause: unknown;
-}> {}
+import {
+  GitHubAccountConnectionIncompleteError,
+  GitHubInstallStartError,
+  type StartGitHubInstallResult,
+} from "@/types/integrations/github";
 
 function authorizeGitHub(callbackURL: string, scopes?: string[]) {
   return Effect.tryPromise({
@@ -57,7 +56,7 @@ export function startGitHubInstall(params: {
   organizationId: string;
   callbackPath: string;
   allowAccountConnection?: boolean;
-}) {
+}): Promise<StartGitHubInstallResult> {
   const allowAccountConnection = params.allowAccountConnection ?? true;
 
   return Effect.runPromise(
@@ -69,35 +68,48 @@ export function startGitHubInstall(params: {
         }),
       catch: (cause) => new GitHubInstallStartError({ cause }),
     }).pipe(
-      Effect.flatMap((preparedInstall) => {
-        if (preparedInstall.requiresAccountConnection) {
-          if (!allowAccountConnection) {
-            return Effect.fail(
-              new GitHubInstallStartError({
-                cause: new Error("GitHub account connection did not complete"),
-              })
+      Effect.flatMap(
+        (
+          preparedInstall
+        ): Effect.Effect<
+          boolean,
+          GitHubInstallStartError | GitHubAccountConnectionIncompleteError
+        > => {
+          if (preparedInstall.requiresAccountConnection) {
+            if (!allowAccountConnection) {
+              return Effect.fail(
+                new GitHubAccountConnectionIncompleteError({
+                  callbackPath: params.callbackPath,
+                })
+              );
+            }
+
+            const callbackUrl = new URL(
+              params.callbackPath,
+              window.location.origin
+            );
+            callbackUrl.searchParams.set("githubAccountConnected", "true");
+
+            return authorizeGitHub(
+              `${callbackUrl.pathname}${callbackUrl.search}`
             );
           }
 
-          const callbackUrl = new URL(
-            params.callbackPath,
-            window.location.origin
-          );
-          callbackUrl.searchParams.set("githubAccountConnected", "true");
-
-          return authorizeGitHub(
-            `${callbackUrl.pathname}${callbackUrl.search}`
-          );
+          return Effect.sync(() => {
+            window.location.assign(preparedInstall.url);
+            return true;
+          });
         }
-
-        return Effect.sync(() => {
-          window.location.assign(preparedInstall.url);
-          return true;
-        });
-      }),
+      ),
       Effect.match({
-        onFailure: () => false,
-        onSuccess: () => true,
+        onFailure: (error): StartGitHubInstallResult => ({
+          started: false,
+          reason:
+            error._tag === "GitHubAccountConnectionIncompleteError"
+              ? "account-connection-incomplete"
+              : "install-start-failed",
+        }),
+        onSuccess: (): StartGitHubInstallResult => ({ started: true }),
       })
     )
   );

--- a/apps/dashboard/src/lib/integrations/github/install.ts
+++ b/apps/dashboard/src/lib/integrations/github/install.ts
@@ -3,7 +3,6 @@
 import { Data, Effect } from "effect";
 import { authClient } from "@/lib/auth/client";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import { openGitHubInstallTab } from "./tab";
 
 class GitHubInstallStartError extends Data.TaggedError(
   "GitHubInstallStartError"
@@ -40,17 +39,46 @@ export function reauthorizeGitHub(callbackURL: string) {
   );
 }
 
+function reauthorizationAttemptKey(state: string) {
+  return `notra:github-reauthorize-attempted:${state}`;
+}
+
+export function hasAttemptedGitHubReauthorization(state: string) {
+  return (
+    window.sessionStorage.getItem(reauthorizationAttemptKey(state)) !== null
+  );
+}
+
+export function markGitHubReauthorizationAttempted(state: string) {
+  window.sessionStorage.setItem(reauthorizationAttemptKey(state), "true");
+}
+
 export function startGitHubInstall(params: {
   organizationId: string;
   callbackPath: string;
+  allowAccountConnection?: boolean;
 }) {
+  const allowAccountConnection = params.allowAccountConnection ?? true;
+
   return Effect.runPromise(
     Effect.tryPromise({
-      try: () => dashboardOrpc.github.app.prepareInstallUrl.call(params),
+      try: () =>
+        dashboardOrpc.github.app.prepareInstallUrl.call({
+          organizationId: params.organizationId,
+          callbackPath: params.callbackPath,
+        }),
       catch: (cause) => new GitHubInstallStartError({ cause }),
     }).pipe(
       Effect.flatMap((preparedInstall) => {
         if (preparedInstall.requiresAccountConnection) {
+          if (!allowAccountConnection) {
+            return Effect.fail(
+              new GitHubInstallStartError({
+                cause: new Error("GitHub account connection did not complete"),
+              })
+            );
+          }
+
           const callbackUrl = new URL(
             params.callbackPath,
             window.location.origin
@@ -63,7 +91,7 @@ export function startGitHubInstall(params: {
         }
 
         return Effect.sync(() => {
-          openGitHubInstallTab(preparedInstall.url);
+          window.location.assign(preparedInstall.url);
           return true;
         });
       }),

--- a/apps/dashboard/src/lib/integrations/github/tab.ts
+++ b/apps/dashboard/src/lib/integrations/github/tab.ts
@@ -1,7 +1,0 @@
-export function openGitHubInstallTab(url: string) {
-  const tab = window.open(url, "_blank", "noopener,noreferrer");
-
-  if (!tab) {
-    window.location.assign(url);
-  }
-}

--- a/apps/dashboard/src/types/integrations/github.ts
+++ b/apps/dashboard/src/types/integrations/github.ts
@@ -1,4 +1,17 @@
+import { Data } from "effect";
 import type React from "react";
+
+export class GitHubInstallStartError extends Data.TaggedError(
+  "GitHubInstallStartError"
+)<{
+  readonly cause: unknown;
+}> {}
+
+export class GitHubAccountConnectionIncompleteError extends Data.TaggedError(
+  "GitHubAccountConnectionIncompleteError"
+)<{
+  readonly callbackPath: string;
+}> {}
 
 export type GitHubAccountType = "User" | "Organization";
 
@@ -19,6 +32,14 @@ export interface GitHubAppRepository {
   description: string | null;
   defaultBranch: string;
 }
+
+export type GitHubInstallFailureReason =
+  | "account-connection-incomplete"
+  | "install-start-failed";
+
+export type StartGitHubInstallResult =
+  | { started: true }
+  | { started: false; reason: GitHubInstallFailureReason };
 
 export interface ConnectGitHubDialogProps {
   onConnect: () => void;


### PR DESCRIPTION
## Problem

Connecting GitHub from the dashboard had two UX issues:

1. The account-link step (`authClient.linkSocial`) replaced the current page with the GitHub OAuth URL, and after returning, the GitHub App install step opened in a **second tab** via `window.open`. Because that tab was opened with `noopener`, the `window.opener.postMessage` + `window.close()` path in it never ran, so the extra tab stayed open and the flow fell back to BroadcastChannel/localStorage signaling.
2. Retry loops: if the resumed install still reported the account as unlinked, it re-triggered `linkSocial` and redirected again with the same `githubAccountConnected=true` param. The reauthorize params (`githubReauthorizeInstallationId`/`State`) could also be replayed with the same state on every failed callback, bouncing between the page and the callback route indefinitely. `githubConnected=true` was also never removed from the URL, so a reload re-triggered the installed handler.

## Changes

- The GitHub App install URL now navigates the **current tab** (`window.location.assign`) instead of `window.open`, so the whole flow stays in one tab.
- Removed the now-dead popup signaling machinery (opener postMessage, BroadcastChannel, localStorage ping) from the integrations page and dialog, plus the unused `GITHUB_INSTALL_MESSAGE`/`GITHUB_INSTALL_CHANNEL` constants and `tab.ts` helper.
- `githubConnected=true` is stripped from the URL via `replaceState` before invalidating queries and opening the repositories dialog.
- Resuming after account linking passes `allowAccountConnection: false` to `startGitHubInstall` — if the server still reports the account as unlinked, the flow fails with a toast instead of redirecting to OAuth again.
- Reauthorization is attempted at most once per state (sessionStorage guard), so a persistently failing callback shows an error instead of looping.

https://claude.ai/code/session_011GwDaMXb7hcebEtfwdi8Kj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the GitHub install flow in the same tab, derives the repositories dialog from the callback URL, and adds guards to stop OAuth reauthorization loops. Also shows a clearer error when account linking doesn’t complete.

- **Bug Fixes**
  - Navigate to the GitHub App install in the current tab (`window.location.assign`) and remove popup/signaling code (`postMessage`, `BroadcastChannel`, `localStorage`), plus the `tab.ts` helper and `GITHUB_INSTALL_*` constants.
  - Open the repositories dialog based on the `githubConnected=true` URL param; strip it with `history.replaceState` on return and invalidate queries.
  - After account linking, resume install with `allowAccountConnection: false`; `startGitHubInstall` returns a structured result with reason `account-connection-incomplete` so we show a targeted toast instead of re-running OAuth.
  - Guard reauthorization with `sessionStorage` and reattempt at most once per state; if the callback keeps failing, show an error instead of looping.

<sup>Written for commit 10a1deda5c3cf01e509a9dd1ab0b3593de16c22c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`10a1ded`](https://github.com/usenotra/notra/commit/10a1deda5c3cf01e509a9dd1ab0b3593de16c22c). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->