### PR TITLE
fix(github): contain repository selection dialog

### DIFF
--- a/apps/dashboard/src/components/integrations/github/select-repositories-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/github/select-repositories-dialog.tsx
@@ -63,40 +63,42 @@ export function SelectRepositoriesDialog({
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
       {triggerElement}
-      <ResponsiveDialogContent className="sm:max-w-[520px]">
-        <ResponsiveDialogHeader>
+      <ResponsiveDialogContent className="flex max-h-[85svh] flex-col gap-0 overflow-hidden p-0 sm:max-w-[520px] [&>*]:min-w-0">
+        <ResponsiveDialogHeader className="shrink-0 p-4 pb-0">
           <ResponsiveDialogTitle>Select repositories</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>
             Choose which repositories Notra should generate content from. Only
             repositories granted to the GitHub App appear here.
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
-        <div className="space-y-3 py-4">
-          <Field>
-            <FieldLabel>Repositories</FieldLabel>
-            <RepositoryMultiSelect
-              accounts={accounts}
-              isLoading={isLoading}
-              onAddAccount={onAddAccount}
-              onChange={setSelected}
-              onSelectAccount={onSelectAccount}
-              repositories={repositories}
-              selectedAccountId={selectedAccountId}
-              value={selected}
-            />
-          </Field>
-          {onAddAccount ? (
-            <button
-              className="inline-flex items-center gap-1 text-muted-foreground text-xs underline-offset-4 hover:text-foreground hover:underline"
-              onClick={onAddAccount}
-              type="button"
-            >
-              Missing a repository? Add access on GitHub
-              <HugeiconsIcon className="size-3" icon={ArrowUpRight01Icon} />
-            </button>
-          ) : null}
+        <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-4">
+          <div className="space-y-3 py-4">
+            <Field>
+              <FieldLabel>Repositories</FieldLabel>
+              <RepositoryMultiSelect
+                accounts={accounts}
+                isLoading={isLoading}
+                onAddAccount={onAddAccount}
+                onChange={setSelected}
+                onSelectAccount={onSelectAccount}
+                repositories={repositories}
+                selectedAccountId={selectedAccountId}
+                value={selected}
+              />
+            </Field>
+            {onAddAccount ? (
+              <button
+                className="inline-flex items-center gap-1 text-muted-foreground text-xs underline-offset-4 hover:text-foreground hover:underline"
+                onClick={onAddAccount}
+                type="button"
+              >
+                Missing a repository? Add access on GitHub
+                <HugeiconsIcon className="size-3" icon={ArrowUpRight01Icon} />
+              </button>
+            ) : null}
+          </div>
         </div>
-        <ResponsiveDialogFooter>
+        <ResponsiveDialogFooter className="mx-0 mb-0 shrink-0 rounded-b-xl border-t bg-muted/50 p-4">
           <ResponsiveDialogClose
             disabled={isSaving}
             render={<Button variant="outline" />}


### PR DESCRIPTION
### Description
Fixes the GitHub repository selection dialog overflowing its bounds when many repositories are available. The dialog now stays within the viewport, scrolls its content independently, and keeps the header and footer visible across desktop and mobile layouts.

### Screenshot/Recording (if applicable)
<img width="1298" height="1418" alt="image" src="https://github.com/user-attachments/assets/58c4d266-e0da-4617-ae7c-8a69ad24c0f0" />


<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain the GitHub repository selection dialog to the viewport and move scrolling to the content area. Prevents overflow and layout jumps on small screens.

- **Bug Fixes**
  - Limited dialog height and enabled internal scrolling for the repositories list.
  - Kept header and footer fixed within the dialog; added a subtle footer border/background for separation.
  - Prevented the modal from stretching the page on mobile.

<sup>Written for commit 2ef1ce888b83a2eb88413f5dc9454b56a760ac68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


