### PR TITLE
fix(integrations): make GitHub org installs work and stop mid-flow errors

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -17,6 +17,7 @@ import { IntegrationCard } from "@/components/integrations/integration-card";
 import { LegacyAddIntegrationDialog } from "@/components/integrations/legacy/add-integration-dialog";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { GITHUB_CALLBACK_ERROR_MESSAGES } from "@/constants/github";
 import {
   hasAttemptedGitHubReauthorization,
   markGitHubReauthorizationAttempted,
@@ -32,6 +33,26 @@ import {
 
 interface PageClientProps {
   organizationSlug: string;
+}
+
+function useGitHubCallbackErrorToast(errorCode: string | null) {
+  const handledErrorRef = useRef(false);
+
+  useEffect(() => {
+    if (!errorCode || handledErrorRef.current) {
+      return;
+    }
+
+    handledErrorRef.current = true;
+    const nextUrl = new URL(window.location.href);
+    nextUrl.searchParams.delete("githubError");
+    window.history.replaceState(null, "", nextUrl);
+
+    toast.error(
+      GITHUB_CALLBACK_ERROR_MESSAGES[errorCode] ??
+        GITHUB_CALLBACK_ERROR_MESSAGES.github_callback_failed
+    );
+  }, [errorCode]);
 }
 
 function useResumeGitHubInstall(params: {
@@ -180,6 +201,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     reauthorizationState: searchParams.get("githubReauthorizeState"),
     shouldResume: searchParams.get("githubAccountConnected") === "true",
   });
+  useGitHubCallbackErrorToast(searchParams.get("githubError"));
 
   const githubAppQuery = useQuery(
     dashboardOrpc.github.app.get.queryOptions({
@@ -281,13 +303,11 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
   const handleOpenConnect = () => setConnectOpen(true);
 
-  const handleConnect = startInstall;
-
-  const handleAddAccount = startInstall;
+  const handleOpenRepositories = () => setReposOpen(true);
 
   useHotkey(
     "C",
-    () => (isConnected ? handleAddAccount() : handleOpenConnect()),
+    () => (isConnected ? handleOpenRepositories() : handleOpenConnect()),
     {
       enabled: !!organizationId,
     }
@@ -335,10 +355,10 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           </div>
           <Button
             className="gap-1.5"
-            onClick={isConnected ? handleAddAccount : handleOpenConnect}
+            onClick={isConnected ? handleOpenRepositories : handleOpenConnect}
           >
             <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
-            {isConnected ? "Add GitHub account" : "Connect GitHub"}
+            {isConnected ? "Add repositories" : "Connect GitHub"}
             <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
           </Button>
         </div>
@@ -368,7 +388,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
       <ConnectGitHubDialog
         isConnecting={false}
-        onConnect={handleConnect}
+        onConnect={startInstall}
         onOpenChange={setConnectOpen}
         open={connectOpen}
       />
@@ -377,7 +397,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         initialSelected={selectedRepositoryIds}
         isLoading={githubAppQuery.isLoading && !data}
         isSaving={saveRepositoriesMutation.isPending}
-        onAddAccount={handleAddAccount}
+        onAddAccount={startInstall}
         onOpenChange={setReposOpen}
         onSave={handleSaveRepositories}
         open={reposOpen}

--- a/apps/dashboard/src/app/api/integrations/github/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/github/callback/route.ts
@@ -10,11 +10,22 @@ import { ORPCError } from "@orpc/server";
 import { type NextRequest, NextResponse } from "next/server";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { getServerSession } from "@/lib/auth/session";
+import { getLastVisitedOrganization } from "@/utils/cookies";
 
 interface GitHubAppInstallState {
   organizationId: string;
   userId: string;
   callbackPath: string;
+}
+
+const ORGANIZATION_SLUG_PATTERN = /^[a-z0-9-]+$/i;
+
+function getFallbackCallbackPath(request: NextRequest) {
+  const slug = getLastVisitedOrganization(request.cookies);
+  if (!slug || !ORGANIZATION_SLUG_PATTERN.test(slug)) {
+    return null;
+  }
+  return `/${slug}/integrations/github`;
 }
 
 function buildErrorRedirect(params: {
@@ -64,13 +75,17 @@ export async function GET(request: NextRequest) {
     const error = searchParams.get("error");
 
     const installState = await readInstallState(state);
-    callbackPath = installState?.callbackPath ?? null;
+    callbackPath =
+      installState?.callbackPath ?? getFallbackCallbackPath(request);
 
     if (error) {
       return buildErrorRedirect({
         baseUrl,
         callbackPath,
-        code: error === "access_denied" ? "install_cancelled" : error,
+        code:
+          error === "access_denied"
+            ? "install_cancelled"
+            : "github_callback_failed",
       });
     }
 

--- a/apps/dashboard/src/app/api/integrations/github/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/github/callback/route.ts
@@ -11,6 +11,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { getServerSession } from "@/lib/auth/session";
 import { getLastVisitedOrganization } from "@/utils/cookies";
+import { ratelimit } from "@/utils/ratelimit";
 
 interface GitHubAppInstallState {
   organizationId: string;
@@ -114,6 +115,17 @@ export async function GET(request: NextRequest) {
       });
     }
 
+    const { success: withinLimit } = await ratelimit.githubAppCallback.limit(
+      session.userId
+    );
+    if (!withinLimit) {
+      return buildErrorRedirect({
+        baseUrl,
+        callbackPath,
+        code: "too_many_requests",
+      });
+    }
+
     try {
       await assertOrganizationAccess({
         headers: request.headers,
@@ -167,7 +179,10 @@ export async function GET(request: NextRequest) {
         code: "github_installation_forbidden",
       });
     }
-    console.error("Error in GitHub App callback:", error);
+    console.error(
+      "Error in GitHub App callback:",
+      error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+    );
     return buildErrorRedirect({
       baseUrl,
       callbackPath,

--- a/apps/dashboard/src/app/api/integrations/github/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/github/callback/route.ts
@@ -17,6 +17,39 @@ interface GitHubAppInstallState {
   callbackPath: string;
 }
 
+function buildErrorRedirect(params: {
+  baseUrl: string;
+  callbackPath: string | null;
+  code: string;
+}) {
+  if (params.callbackPath) {
+    return NextResponse.redirect(
+      buildCallbackUrl(params.baseUrl, params.callbackPath, {
+        githubError: params.code,
+      })
+    );
+  }
+
+  return NextResponse.redirect(
+    `${params.baseUrl}/?error=${encodeURIComponent(params.code)}`
+  );
+}
+
+async function readInstallState(state: string | null) {
+  if (!(state && redis)) {
+    return null;
+  }
+
+  const raw = await redis.get<string>(`github_app_install:${state}`);
+  if (!raw) {
+    return null;
+  }
+
+  const installState: GitHubAppInstallState =
+    typeof raw === "string" ? JSON.parse(raw) : raw;
+  return installState;
+}
+
 export async function GET(request: NextRequest) {
   const baseUrl =
     process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
@@ -30,28 +63,40 @@ export async function GET(request: NextRequest) {
     state = searchParams.get("state");
     const error = searchParams.get("error");
 
+    const installState = await readInstallState(state);
+    callbackPath = installState?.callbackPath ?? null;
+
     if (error) {
-      return NextResponse.redirect(
-        `${baseUrl}/?error=${encodeURIComponent(error)}`
-      );
+      return buildErrorRedirect({
+        baseUrl,
+        callbackPath,
+        code: error === "access_denied" ? "install_cancelled" : error,
+      });
     }
 
     if (!(installationId && state && redis)) {
-      return NextResponse.redirect(`${baseUrl}/?error=invalid_callback`);
+      return buildErrorRedirect({
+        baseUrl,
+        callbackPath,
+        code: "invalid_callback",
+      });
     }
 
-    const raw = await redis.get<string>(`github_app_install:${state}`);
-    if (!raw) {
-      return NextResponse.redirect(`${baseUrl}/?error=expired_state`);
+    if (!installState) {
+      return buildErrorRedirect({
+        baseUrl,
+        callbackPath,
+        code: "expired_state",
+      });
     }
-
-    const installState: GitHubAppInstallState =
-      typeof raw === "string" ? JSON.parse(raw) : raw;
-    callbackPath = installState.callbackPath;
 
     const { session } = await getServerSession({ headers: request.headers });
     if (!session?.userId || session.userId !== installState.userId) {
-      return NextResponse.redirect(`${baseUrl}/?error=session_mismatch`);
+      return buildErrorRedirect({
+        baseUrl,
+        callbackPath,
+        code: "session_mismatch",
+      });
     }
 
     try {
@@ -59,11 +104,15 @@ export async function GET(request: NextRequest) {
         headers: request.headers,
         organizationId: installState.organizationId,
       });
-    } catch (error) {
-      if (error instanceof ORPCError) {
-        return NextResponse.redirect(`${baseUrl}/?error=forbidden`);
+    } catch (accessError) {
+      if (accessError instanceof ORPCError) {
+        return buildErrorRedirect({
+          baseUrl,
+          callbackPath,
+          code: "forbidden",
+        });
       }
-      throw error;
+      throw accessError;
     }
 
     await upsertGitHubAppInstallation({
@@ -71,8 +120,6 @@ export async function GET(request: NextRequest) {
       userId: installState.userId,
       installationId,
     });
-
-    await redis.del(`github_app_install:${state}`);
 
     return NextResponse.redirect(
       buildCallbackUrl(baseUrl, installState.callbackPath, {
@@ -92,16 +139,24 @@ export async function GET(request: NextRequest) {
           })
         );
       }
-      return NextResponse.redirect(
-        `${baseUrl}/?error=github_reauthorization_required`
-      );
+      return buildErrorRedirect({
+        baseUrl,
+        callbackPath,
+        code: "github_reauthorization_required",
+      });
     }
     if (error instanceof GitHubInstallationAccessDeniedError) {
-      return NextResponse.redirect(
-        `${baseUrl}/?error=github_installation_forbidden`
-      );
+      return buildErrorRedirect({
+        baseUrl,
+        callbackPath,
+        code: "github_installation_forbidden",
+      });
     }
     console.error("Error in GitHub App callback:", error);
-    return NextResponse.redirect(`${baseUrl}/?error=github_callback_failed`);
+    return buildErrorRedirect({
+      baseUrl,
+      callbackPath,
+      code: "github_callback_failed",
+    });
   }
 }

--- a/apps/dashboard/src/constants/github.ts
+++ b/apps/dashboard/src/constants/github.ts
@@ -4,7 +4,29 @@ export const GITHUB_URL_PATTERNS = [
   /^([^/]+)\/([^/]+)$/,
 ] as const;
 
-export const GITHUB_INSTALL_STATE_TTL_SECONDS = 600;
+export const GITHUB_INSTALL_STATE_TTL_SECONDS = 1800;
+
+export const GITHUB_OAUTH_SCOPES = [
+  "read:user",
+  "user:email",
+  "read:org",
+] as const;
+
+export const GITHUB_CALLBACK_ERROR_MESSAGES: Record<string, string> = {
+  install_cancelled: "The GitHub installation was cancelled.",
+  invalid_callback:
+    "The GitHub callback was missing required parameters. Please try again.",
+  expired_state:
+    "The GitHub installation link expired. Please try connecting again.",
+  session_mismatch:
+    "The installation finished under a different login session. Please try again.",
+  forbidden: "You do not have access to this organization.",
+  github_installation_forbidden:
+    "You need to be an admin of the GitHub account that owns this installation.",
+  github_reauthorization_required:
+    "GitHub needs to be reconnected to authorize organization access.",
+  github_callback_failed: "Connecting GitHub failed. Please try again.",
+};
 
 export const GITHUB_APP_PERMISSIONS = [
   "Read repository metadata, branches, and releases",

--- a/apps/dashboard/src/constants/github.ts
+++ b/apps/dashboard/src/constants/github.ts
@@ -26,6 +26,8 @@ export const GITHUB_CALLBACK_ERROR_MESSAGES: Record<string, string> = {
   github_reauthorization_required:
     "GitHub needs to be reconnected to authorize organization access.",
   github_callback_failed: "Connecting GitHub failed. Please try again.",
+  too_many_requests:
+    "Too many GitHub connection attempts. Please wait a moment and try again.",
 };
 
 export const GITHUB_APP_PERMISSIONS = [

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -25,6 +25,7 @@ import { count, eq } from "drizzle-orm";
 import { isValid as isNotDisposableEmail } from "mailchecker";
 import { cookies } from "next/headers";
 import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
+import { GITHUB_OAUTH_SCOPES } from "@/constants/github";
 import {
   OAUTH_ACCEPTED_SCOPES,
   OAUTH_ACCESS_TOKEN_TTL_SECONDS,
@@ -102,6 +103,7 @@ function buildSocialProviders() {
     providers.github = {
       clientId: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      scope: [...GITHUB_OAUTH_SCOPES],
     };
   }
 

--- a/apps/dashboard/src/utils/ratelimit.ts
+++ b/apps/dashboard/src/utils/ratelimit.ts
@@ -41,6 +41,12 @@ export const ratelimit = {
     prefix: "ratelimit:github-app-repositories",
     limiter: Ratelimit.slidingWindow(60, "1m"),
   }),
+  githubAppCallback: new Ratelimit({
+    redis,
+    analytics: true,
+    prefix: "ratelimit:github-app-callback",
+    limiter: Ratelimit.slidingWindow(10, "1m"),
+  }),
   granolaConnection: new Ratelimit({
     redis,
     analytics: true,

--- a/packages/ai/src/integrations/github.ts
+++ b/packages/ai/src/integrations/github.ts
@@ -193,7 +193,11 @@ async function getInstallationOrgMembership(params: {
     installationToken = await createGitHubAppInstallationToken(
       params.installationId
     );
-  } catch {
+  } catch (error) {
+    console.error(
+      "Failed to create GitHub App installation token for org membership check:",
+      error instanceof Error ? error.message : String(error)
+    );
     return { verified: false };
   }
 
@@ -217,6 +221,12 @@ async function getInstallationOrgMembership(params: {
   } catch (error) {
     if (getErrorStatus(error) === 404) {
       return { verified: true, isAdmin: false };
+    }
+    if (getErrorStatus(error) !== 403) {
+      console.error(
+        "GitHub org membership check via installation token failed:",
+        error instanceof Error ? error.message : String(error)
+      );
     }
     return { verified: false };
   }

--- a/packages/ai/src/integrations/github.ts
+++ b/packages/ai/src/integrations/github.ts
@@ -23,6 +23,7 @@ import type {
   ConfigureOutputParams,
   CreateGitHubIntegrationParams,
   ErrorWithStatus,
+  GitHubOrgMembershipCheck,
   ValidateRepositoryBranchExistsParams,
   WebhookConfig,
 } from "../types/integrations";
@@ -182,8 +183,42 @@ async function getGitHubAppInstallation(installationId: string) {
   return Effect.runPromise(decodeGitHubAppInstallationResponse(data));
 }
 
+async function getInstallationOrgMembership(params: {
+  installationId: string;
+  org: string;
+  username: string;
+}): Promise<GitHubOrgMembershipCheck> {
+  try {
+    const installationToken = await createGitHubAppInstallationToken(
+      params.installationId
+    );
+    const octokit = createOctokit(installationToken);
+    const { data: membership } = await octokit.request(
+      "GET /orgs/{org}/memberships/{username}",
+      {
+        org: params.org,
+        username: params.username,
+        headers: {
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      }
+    );
+
+    return {
+      verified: true,
+      isAdmin: membership.state === "active" && membership.role === "admin",
+    };
+  } catch (error) {
+    if (getErrorStatus(error) === 404) {
+      return { verified: true, isAdmin: false };
+    }
+    return { verified: false };
+  }
+}
+
 async function assertGitHubInstallationAdmin(params: {
   userId: string;
+  installationId: string;
   installationAccount: {
     id: number;
     login: string;
@@ -207,19 +242,19 @@ async function assertGitHubInstallationAdmin(params: {
   }
 
   const octokit = createOctokit(githubAccount.accessToken);
-  const githubUser = await octokit
+  const userResponse = await octokit
     .request("GET /user", {
       headers: {
         "X-GitHub-Api-Version": "2022-11-28",
       },
     })
-    .then(({ data }) => data)
     .catch((error: unknown) => {
       if (getErrorStatus(error) === 401) {
         throw new GitHubReauthorizationRequiredError();
       }
       throw error;
     });
+  const githubUser = userResponse.data;
 
   if (String(githubUser.id) !== githubAccount.accountId) {
     throw new GitHubInstallationAccessDeniedError();
@@ -232,7 +267,23 @@ async function assertGitHubInstallationAdmin(params: {
     return;
   }
 
-  if (!hasGitHubScope(githubAccount.scope, "read:org")) {
+  const installationMembership = await getInstallationOrgMembership({
+    installationId: params.installationId,
+    org: params.installationAccount.login,
+    username: githubUser.login,
+  });
+
+  if (installationMembership.verified) {
+    if (!installationMembership.isAdmin) {
+      throw new GitHubInstallationAccessDeniedError();
+    }
+    return;
+  }
+
+  const tokenScopes =
+    userResponse.headers["x-oauth-scopes"] ?? githubAccount.scope;
+
+  if (!hasGitHubScope(tokenScopes, "read:org")) {
     throw new GitHubReauthorizationRequiredError();
   }
 
@@ -570,6 +621,7 @@ export async function upsertGitHubAppInstallation(params: {
 
   await assertGitHubInstallationAdmin({
     userId: params.userId,
+    installationId: params.installationId,
     installationAccount: installation.account,
   });
 

--- a/packages/ai/src/integrations/github.ts
+++ b/packages/ai/src/integrations/github.ts
@@ -188,11 +188,17 @@ async function getInstallationOrgMembership(params: {
   org: string;
   username: string;
 }): Promise<GitHubOrgMembershipCheck> {
+  let installationToken: string;
   try {
-    const installationToken = await createGitHubAppInstallationToken(
+    installationToken = await createGitHubAppInstallationToken(
       params.installationId
     );
-    const octokit = createOctokit(installationToken);
+  } catch {
+    return { verified: false };
+  }
+
+  const octokit = createOctokit(installationToken);
+  try {
     const { data: membership } = await octokit.request(
       "GET /orgs/{org}/memberships/{username}",
       {

--- a/packages/ai/src/types/integrations.ts
+++ b/packages/ai/src/types/integrations.ts
@@ -2,6 +2,10 @@ export interface ErrorWithStatus {
   status?: number;
 }
 
+export type GitHubOrgMembershipCheck =
+  | { verified: true; isAdmin: boolean }
+  | { verified: false };
+
 export interface ValidateRepositoryBranchExistsParams {
   owner: string;
   repo: string;


### PR DESCRIPTION
## Problem

Connecting a GitHub **organization** consistently failed mid-flow while personal accounts worked. Root cause (verified against production data):

- Org installs require the user's OAuth token to carry `read:org` (`assertGitHubInstallationAdmin`), but the token's actual grant is only `read:user, user:email` (confirmed via GitHub's `x-oauth-scopes` header). The reauthorize round-trip (`linkSocial({ scopes: ["read:org"] })`) never got the scope granted, so org installs bounced into `GitHubReauthorizationRequiredError` forever.
- Separately, the Notra AI GitHub App has no organization permissions, so the app's own installation token could not be used to check membership either.
- On top of that, every callback failure redirected to `/?error=...` where nothing displays it, the Redis install state expired after 10 minutes and was deleted on first use (refresh or a slow install screen produced `expired_state`), and clicking Connect while already connected instantly redirected to GitHub.

## Changes

**Org admin verification (packages/ai)**
- Org installs are now verified with the GitHub App's **installation token** via `GET /orgs/{org}/memberships/{username}` (requires the app permission Organization -> Members: Read-only; see rollout note below). No user OAuth scope needed.
- If the installation token cannot check membership (permission not yet approved on an existing install), it falls back to the previous user-token path, now reading scopes from GitHub's `x-oauth-scopes` response header (ground truth) instead of the possibly stale DB column.

**OAuth scope (dashboard auth config)**
- The GitHub provider now requests `read:user user:email read:org` at the provider level, so linking and relinking actually grants `read:org` and the fallback path can succeed.

**Connect UX (integrations page)**
- When an installation already exists, the header button opens the repositories dialog (label "Add repositories") instead of redirecting to GitHub. Connecting another account stays available in the dialog's account dropdown.

**Error handling (callback route + page)**
- Callback failures now redirect back to the integrations page with a `githubError` code and show a specific toast (cancelled, expired link, session mismatch, admin required, and so on). The root `/?error=...` redirect only remains when the state is unknown.
- Install state TTL raised from 10 to 30 minutes and the state is no longer deleted on first use, so refreshing the callback or lingering on GitHub's install screen no longer produces `expired_state`; replays stay session-checked and idempotent.

## Rollout note

In the GitHub App settings (usenotra settings -> Notra AI -> Permissions), set **Organization permissions -> Members: Read-only** and save. Existing org installations will be prompted to approve the change; until they do, the OAuth fallback path covers them.

https://claude.ai/code/session_011GwDaMXb7hcebEtfwdi8Kj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub organization installs by verifying admin status with the app installation token and hardening the callback to always return to the integrations page with clear toasts and an idempotent, longer-lived state. Adds callback rate limiting and updates the integrations UI to open the repositories dialog when already connected.

- **Bug Fixes**
  - Verify org admin via app installation token: calls GET /orgs/{org}/memberships/{username}; no user OAuth scope required.
  - Fallback uses the user token and reads x-oauth-scopes; provider now requests `read:user user:email read:org` so relinking actually grants `read:org`.
  - Callback redirects back to the integrations page with `githubError` and specific toasts; uses the last visited org as a fallback, separates token failures from membership errors, rate limits to 10/min with a “too many requests” toast, and reduces noisy Octokit logs.
  - Install state TTL increased to 30 minutes and is no longer deleted on first use, so refreshes and slow installs don’t fail.
  - If already connected, the header button opens the repositories dialog (“Add repositories”); hotkey “C” matches this behavior.

- **Migration**
  - In the GitHub App, enable Organization permissions -> Members: Read-only.
  - Existing org installs must approve this new permission; until then, the OAuth fallback path covers them.

<sup>Written for commit a418cca74c2a5f8f47e487e4f2e90f0e9f96b8c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

1 issue found.

<sub>Written for commit [`a418cca`](https://github.com/usenotra/notra/commit/a418cca74c2a5f8f47e487e4f2e90f0e9f96b8c1). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->