### PR TITLE
feat(integrations): support multiple GitHub App installations per organization

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -192,6 +192,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     () => searchParams.get("githubConnected") === "true"
   );
   const [legacyOpen, setLegacyOpen] = useState(false);
+  const [selectedDialogAccountId, setSelectedDialogAccountId] = useState<
+    string | null
+  >(null);
   useResumeGitHubInstall({
     callbackPath: pathname,
     organizationId,
@@ -224,7 +227,8 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         integration.connectionMethod === "personal-access-token"
     ) ?? [];
   const data = githubAppQuery.data;
-  const isConnected = Boolean(data?.account);
+  const accounts = data?.accounts ?? [];
+  const isConnected = accounts.length > 0;
   const isLoading =
     isLoadingOrganizations ||
     (!!organizationId && githubAppQuery.isLoading && !data);
@@ -233,6 +237,16 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
     (!!organizationId && legacyQuery.isLoading && !legacyQuery.data);
   const selectedRepositoryIds = data?.selectedRepositoryIds ?? [];
   const repositories = data?.repositories ? [...data.repositories] : [];
+  const dialogAccountId = selectedDialogAccountId ?? accounts[0]?.id;
+  const dialogAccount = accounts.find(
+    (account) => account.id === dialogAccountId
+  );
+  const dialogRepositories = dialogAccount
+    ? repositories.filter(
+        (repository) =>
+          repository.owner.toLowerCase() === dialogAccount.login.toLowerCase()
+      )
+    : repositories;
 
   useEffect(() => {
     if (searchParams.get("githubConnected") !== "true" || !organization?.id) {
@@ -272,8 +286,11 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   });
 
   const disconnectMutation = useMutation({
-    mutationFn: async () => {
-      return dashboardOrpc.github.app.disconnect.call({ organizationId });
+    mutationFn: async (accountId: string) => {
+      return dashboardOrpc.github.app.disconnect.call({
+        organizationId,
+        accountId,
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -303,7 +320,10 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
   const handleOpenConnect = () => setConnectOpen(true);
 
-  const handleOpenRepositories = () => setReposOpen(true);
+  const handleOpenRepositories = (accountId?: string) => {
+    setSelectedDialogAccountId(accountId ?? null);
+    setReposOpen(true);
+  };
 
   useHotkey(
     "C",
@@ -312,10 +332,6 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
       enabled: !!organizationId,
     }
   );
-
-  const handleDisconnect = () => {
-    disconnectMutation.mutate();
-  };
 
   const handleSaveRepositories = (repositoryIds: string[]) => {
     saveRepositoriesMutation.mutate(repositoryIds);
@@ -330,15 +346,23 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
   if (isLoading) {
     githubAppContent = <GitHubIntegrationSkeleton />;
-  } else if (isConnected && data?.account) {
+  } else if (isConnected) {
     githubAppContent = (
-      <GitHubAccountCard
-        account={data.account}
-        onAddRepositories={() => setReposOpen(true)}
-        onDisconnect={handleDisconnect}
-        repositories={repositories}
-        selectedRepositoryIds={selectedRepositoryIds}
-      />
+      <div className="grid gap-4">
+        {accounts.map((account) => (
+          <GitHubAccountCard
+            account={account}
+            key={account.id}
+            onAddRepositories={() => handleOpenRepositories(account.id)}
+            onDisconnect={() => disconnectMutation.mutate(account.id)}
+            repositories={repositories.filter(
+              (repository) =>
+                repository.owner.toLowerCase() === account.login.toLowerCase()
+            )}
+            selectedRepositoryIds={selectedRepositoryIds}
+          />
+        ))}
+      </div>
     );
   }
 
@@ -355,7 +379,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           </div>
           <Button
             className="gap-1.5"
-            onClick={isConnected ? handleOpenRepositories : handleOpenConnect}
+            onClick={
+              isConnected ? () => handleOpenRepositories() : handleOpenConnect
+            }
           >
             <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
             {isConnected ? "Add repositories" : "Connect GitHub"}
@@ -393,16 +419,17 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         open={connectOpen}
       />
       <SelectRepositoriesDialog
-        accounts={data?.account ? [data.account] : []}
+        accounts={accounts}
         initialSelected={selectedRepositoryIds}
         isLoading={githubAppQuery.isLoading && !data}
         isSaving={saveRepositoriesMutation.isPending}
         onAddAccount={startInstall}
         onOpenChange={setReposOpen}
         onSave={handleSaveRepositories}
+        onSelectAccount={setSelectedDialogAccountId}
         open={reposOpen}
-        repositories={repositories}
-        selectedAccountId={data?.account?.id}
+        repositories={dialogRepositories}
+        selectedAccountId={dialogAccountId}
       />
       <LegacyAddIntegrationDialog
         onOpenChange={setLegacyOpen}

--- a/apps/dashboard/src/components/integrations/github/github-integration-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/github/github-integration-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { toast } from "sonner";
 import { startGitHubInstall } from "@/lib/integrations/github/install";
 import { dashboardOrpc } from "@/lib/orpc/query";
@@ -15,6 +16,9 @@ export function GitHubIntegrationDialog({
   onOpenChange,
 }: GitHubIntegrationDialogProps) {
   const queryClient = useQueryClient();
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(
+    null
+  );
 
   const githubAppQuery = useQuery(
     dashboardOrpc.github.app.get.queryOptions({
@@ -25,9 +29,20 @@ export function GitHubIntegrationDialog({
   );
 
   const data = githubAppQuery.data;
-  const isConnected = Boolean(data?.account);
+  const accounts = data?.accounts ?? [];
+  const isConnected = accounts.length > 0;
   const repositories = data?.repositories ? [...data.repositories] : [];
   const selectedRepositoryIds = data?.selectedRepositoryIds ?? [];
+  const dialogAccountId = selectedAccountId ?? accounts[0]?.id;
+  const dialogAccount = accounts.find(
+    (account) => account.id === dialogAccountId
+  );
+  const dialogRepositories = dialogAccount
+    ? repositories.filter(
+        (repository) =>
+          repository.owner.toLowerCase() === dialogAccount.login.toLowerCase()
+      )
+    : repositories;
 
   const invalidateGithubApp = () =>
     queryClient.invalidateQueries({
@@ -65,10 +80,10 @@ export function GitHubIntegrationDialog({
     }
   };
 
-  if (isConnected && data?.account) {
+  if (isConnected) {
     return (
       <SelectRepositoriesDialog
-        accounts={[data.account]}
+        accounts={accounts}
         initialSelected={selectedRepositoryIds}
         isLoading={githubAppQuery.isLoading}
         isSaving={saveRepositoriesMutation.isPending}
@@ -77,9 +92,10 @@ export function GitHubIntegrationDialog({
         onSave={(repositoryIds) =>
           saveRepositoriesMutation.mutate(repositoryIds)
         }
+        onSelectAccount={setSelectedAccountId}
         open={open}
-        repositories={repositories}
-        selectedAccountId={data.account.id}
+        repositories={dialogRepositories}
+        selectedAccountId={dialogAccountId}
       />
     );
   }

--- a/apps/dashboard/src/lib/orpc/routers/github.ts
+++ b/apps/dashboard/src/lib/orpc/routers/github.ts
@@ -223,7 +223,7 @@ export const githubRouter = {
           Effect.tryPromise({
             try: async () => {
               const [repositories, selectedRepositoryIds] = await Promise.all([
-                listGitHubAppRepositories(input.organizationId),
+                listGitHubAppRepositories(input.organizationId, installations),
                 getSelectedGitHubAppRepositoryIds(
                   input.organizationId,
                   installations.map((installation) => installation.id)
@@ -287,8 +287,13 @@ export const githubRouter = {
         const installations = await listGitHubAppInstallationsByOrganization(
           input.organizationId
         );
+        const hasMatchingInstallation = input.accountId
+          ? installations.some(
+              (installation) => installation.accountId === input.accountId
+            )
+          : installations.length > 0;
 
-        if (installations.length === 0) {
+        if (!hasMatchingInstallation) {
           throw notFound("GitHub App installation not found");
         }
 

--- a/apps/dashboard/src/lib/orpc/routers/github.ts
+++ b/apps/dashboard/src/lib/orpc/routers/github.ts
@@ -1,10 +1,10 @@
 import {
   deleteGitHubAppInstallationForOrganization,
   GitHubAppNotConfiguredError,
-  getGitHubAppInstallationByOrganization,
   getGitHubAppInstallUrl,
   getSelectedGitHubAppRepositoryIds,
   isGitHubAccountConnectionRequired,
+  listGitHubAppInstallationsByOrganization,
   listGitHubAppRepositories,
   setSelectedGitHubAppRepositories,
 } from "@notra/ai/integrations/github";
@@ -38,6 +38,10 @@ const organizationIdInputSchema = z.object({
 
 const saveGitHubAppRepositoriesInputSchema = organizationIdInputSchema.extend({
   repositoryIds: z.array(z.string().min(1)).default([]),
+});
+
+const disconnectGitHubAppInputSchema = organizationIdInputSchema.extend({
+  accountId: z.string().min(1).optional(),
 });
 
 const prepareInstallUrlInputSchema = organizationIdInputSchema.extend({
@@ -193,13 +197,13 @@ export const githubRouter = {
           organizationId: input.organizationId,
         });
 
-        const installation = await getGitHubAppInstallationByOrganization(
+        const installations = await listGitHubAppInstallationsByOrganization(
           input.organizationId
         );
 
-        if (!installation) {
+        if (installations.length === 0) {
           return {
-            account: null,
+            accounts: [],
             repositories: [],
             selectedRepositoryIds: [],
           };
@@ -222,18 +226,18 @@ export const githubRouter = {
                 listGitHubAppRepositories(input.organizationId),
                 getSelectedGitHubAppRepositoryIds(
                   input.organizationId,
-                  installation.id
+                  installations.map((installation) => installation.id)
                 ),
               ]);
 
               return {
-                account: {
+                accounts: installations.map((installation) => ({
                   id: installation.accountId,
                   login: installation.accountLogin,
                   name: installation.accountName,
                   avatarUrl: installation.accountAvatarUrl,
                   type: toGitHubAccountType(installation.accountType),
-                },
+                })),
                 repositories,
                 selectedRepositoryIds,
               };
@@ -273,22 +277,25 @@ export const githubRouter = {
         );
       }),
     disconnect: authorizedProcedure
-      .input(organizationIdInputSchema)
+      .input(disconnectGitHubAppInputSchema)
       .handler(async ({ context, input }) => {
         await assertOrganizationAccess({
           headers: context.headers,
           organizationId: input.organizationId,
         });
 
-        const installation = await getGitHubAppInstallationByOrganization(
+        const installations = await listGitHubAppInstallationsByOrganization(
           input.organizationId
         );
 
-        if (!installation) {
+        if (installations.length === 0) {
           throw notFound("GitHub App installation not found");
         }
 
-        await deleteGitHubAppInstallationForOrganization(input.organizationId);
+        await deleteGitHubAppInstallationForOrganization(
+          input.organizationId,
+          input.accountId
+        );
 
         return { success: true };
       }),

--- a/packages/ai/src/integrations/github.ts
+++ b/packages/ai/src/integrations/github.ts
@@ -693,15 +693,22 @@ export async function getGitHubAppInstallationByOrganization(
   });
 }
 
-export async function listGitHubAppRepositories(organizationId: string) {
-  const installation =
-    await getGitHubAppInstallationByOrganization(organizationId);
+export async function listGitHubAppInstallationsByOrganization(
+  organizationId: string
+) {
+  return db.query.githubAppInstallations.findMany({
+    where: and(
+      eq(githubAppInstallations.organizationId, organizationId),
+      eq(githubAppInstallations.enabled, true)
+    ),
+  });
+}
 
-  if (!installation) {
-    return [];
-  }
-
-  const cacheKey = `github_app_repositories:${organizationId}:${installation.installationId}`;
+async function listRepositoriesForInstallation(installation: {
+  organizationId: string;
+  installationId: string;
+}) {
+  const cacheKey = `github_app_repositories:${installation.organizationId}:${installation.installationId}`;
   if (redis) {
     const cached = await redis.get(cacheKey);
     const decodedCached = await Effect.runPromise(
@@ -763,14 +770,45 @@ export async function listGitHubAppRepositories(organizationId: string) {
   return mappedRepositories;
 }
 
+export async function listGitHubAppRepositories(organizationId: string) {
+  const installations =
+    await listGitHubAppInstallationsByOrganization(organizationId);
+
+  if (installations.length === 0) {
+    return [];
+  }
+
+  const repositoryLists = await Promise.all(
+    installations.map((installation) =>
+      listRepositoriesForInstallation(installation)
+    )
+  );
+
+  const repositoriesById = new Map<string, GitHubAppRepository>();
+  for (const repositories of repositoryLists) {
+    for (const repository of repositories) {
+      repositoriesById.set(repository.id, repository);
+    }
+  }
+
+  return [...repositoriesById.values()];
+}
+
 export async function getSelectedGitHubAppRepositoryIds(
   organizationId: string,
-  githubAppInstallationId: string
+  githubAppInstallationIds: string[]
 ) {
+  if (githubAppInstallationIds.length === 0) {
+    return [];
+  }
+
   const selected = await db.query.githubIntegrations.findMany({
     where: and(
       eq(githubIntegrations.organizationId, organizationId),
-      eq(githubIntegrations.githubAppInstallationId, githubAppInstallationId),
+      inArray(
+        githubIntegrations.githubAppInstallationId,
+        githubAppInstallationIds
+      ),
       eq(githubIntegrations.enabled, true)
     ),
     columns: {
@@ -788,16 +826,30 @@ export async function setSelectedGitHubAppRepositories(params: {
   userId: string;
   repositoryIds: string[];
 }) {
-  const installation = await getGitHubAppInstallationByOrganization(
+  const installations = await listGitHubAppInstallationsByOrganization(
     params.organizationId
   );
 
-  if (!installation) {
+  if (installations.length === 0) {
     throw new Error("GitHub App installation not found");
   }
 
-  const repositories = await listGitHubAppRepositories(params.organizationId);
-  const repositoryById = new Map(repositories.map((repo) => [repo.id, repo]));
+  const repositoryLists = await Promise.all(
+    installations.map(async (installation) => ({
+      installation,
+      repositories: await listRepositoriesForInstallation(installation),
+    }))
+  );
+
+  const repositoryById = new Map<string, GitHubAppRepository>();
+  const installationRecordIdByRepositoryId = new Map<string, string>();
+  for (const { installation, repositories } of repositoryLists) {
+    for (const repository of repositories) {
+      repositoryById.set(repository.id, repository);
+      installationRecordIdByRepositoryId.set(repository.id, installation.id);
+    }
+  }
+
   const selectedRepositories = params.repositoryIds.map((repositoryId) => {
     const repository = repositoryById.get(repositoryId);
     if (!repository) {
@@ -811,7 +863,10 @@ export async function setSelectedGitHubAppRepositories(params: {
   const existing = await db.query.githubIntegrations.findMany({
     where: and(
       eq(githubIntegrations.organizationId, params.organizationId),
-      eq(githubIntegrations.githubAppInstallationId, installation.id)
+      inArray(
+        githubIntegrations.githubAppInstallationId,
+        installations.map((installation) => installation.id)
+      )
     ),
     columns: {
       id: true,
@@ -882,6 +937,15 @@ export async function setSelectedGitHubAppRepositories(params: {
     }
 
     const webhookSecret = generateWebhookSecret();
+    const owningInstallationRecordId = installationRecordIdByRepositoryId.get(
+      repository.id
+    );
+    if (!owningInstallationRecordId) {
+      throw new Error(
+        "Selected repository is not available to this installation"
+      );
+    }
+
     const [created] = await db
       .insert(githubIntegrations)
       .values({
@@ -890,7 +954,7 @@ export async function setSelectedGitHubAppRepositories(params: {
         createdByUserId: params.userId,
         displayName: repository.fullName,
         encryptedToken: null,
-        githubAppInstallationId: installation.id,
+        githubAppInstallationId: owningInstallationRecordId,
         githubRepositoryId: repository.id,
         githubRepositoryPrivate: repository.private,
         owner: repository.owner,
@@ -907,8 +971,14 @@ export async function setSelectedGitHubAppRepositories(params: {
     }
   }
 
-  await redis?.del(
-    `github_app_repositories:${params.organizationId}:${installation.installationId}`
+  await Promise.all(
+    installations.map((installation) =>
+      Promise.resolve(
+        redis?.del(
+          `github_app_repositories:${params.organizationId}:${installation.installationId}`
+        )
+      )
+    )
   );
 
   return {
@@ -917,14 +987,22 @@ export async function setSelectedGitHubAppRepositories(params: {
 }
 
 export async function deleteGitHubAppInstallationForOrganization(
-  organizationId: string
+  organizationId: string,
+  accountId?: string
 ) {
-  const installation =
-    await getGitHubAppInstallationByOrganization(organizationId);
+  const installations =
+    await listGitHubAppInstallationsByOrganization(organizationId);
+  const targets = accountId
+    ? installations.filter(
+        (installation) => installation.accountId === accountId
+      )
+    : installations;
 
-  if (!installation) {
+  if (targets.length === 0) {
     return;
   }
+
+  const targetRecordIds = targets.map((installation) => installation.id);
 
   await db
     .update(githubIntegrations)
@@ -935,17 +1013,23 @@ export async function deleteGitHubAppInstallationForOrganization(
     .where(
       and(
         eq(githubIntegrations.organizationId, organizationId),
-        eq(githubIntegrations.githubAppInstallationId, installation.id)
+        inArray(githubIntegrations.githubAppInstallationId, targetRecordIds)
       )
     );
 
   await db
     .update(githubAppInstallations)
     .set({ enabled: false })
-    .where(eq(githubAppInstallations.id, installation.id));
+    .where(inArray(githubAppInstallations.id, targetRecordIds));
 
-  await redis?.del(
-    `github_app_repositories:${organizationId}:${installation.installationId}`
+  await Promise.all(
+    targets.map((installation) =>
+      Promise.resolve(
+        redis?.del(
+          `github_app_repositories:${organizationId}:${installation.installationId}`
+        )
+      )
+    )
   );
 }
 

--- a/packages/ai/src/integrations/github.ts
+++ b/packages/ai/src/integrations/github.ts
@@ -770,9 +770,15 @@ async function listRepositoriesForInstallation(installation: {
   return mappedRepositories;
 }
 
-export async function listGitHubAppRepositories(organizationId: string) {
+export async function listGitHubAppRepositories(
+  organizationId: string,
+  preloadedInstallations?: Awaited<
+    ReturnType<typeof listGitHubAppInstallationsByOrganization>
+  >
+) {
   const installations =
-    await listGitHubAppInstallationsByOrganization(organizationId);
+    preloadedInstallations ??
+    (await listGitHubAppInstallationsByOrganization(organizationId));
 
   if (installations.length === 0) {
     return [];


### PR DESCRIPTION
Follow-up to #583.

## Problem

Connecting a second GitHub account (for example a personal account plus one or more GitHub organizations) silently hid all but one of them. The backend stored every installation but `github.app.get` used a `findFirst`, returned a single `account`, and `disconnect` wiped installations by organization - so the dashboard only ever showed one connected account and you had to disconnect it to see another.

## Changes

**Server (packages/ai)**
- New `listGitHubAppInstallationsByOrganization`; repository listing now aggregates across all enabled installations (still cached per installation) and dedupes by repository id.
- `getSelectedGitHubAppRepositoryIds` accepts the full set of installation record ids.
- `setSelectedGitHubAppRepositories` maps each selected repository to its owning installation, so saving a selection spanning several accounts writes the right `githubAppInstallationId` per row and no longer wipes other accounts' selections.
- `deleteGitHubAppInstallationForOrganization` takes an optional `accountId` to disconnect a single installation (integrations disabled and repo cache cleared per installation).

**Router**
- `github.app.get` returns `accounts` (one entry per installation) plus the aggregated repositories and selection.
- `github.app.disconnect` accepts an optional `accountId` for per-account disconnect.

**UI**
- The integrations page renders one account card per installation, each with its own repositories, Add repositories, and Disconnect.
- The repositories dialog lists every connected account in the dropdown; switching accounts filters the visible repositories by owner while the underlying selection keeps the other accounts' repositories intact, so saving never drops them.
- The shared GitHub integration dialog gets the same multi-account treatment.

https://claude.ai/code/session_011GwDaMXb7hcebEtfwdi8Kj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full support for multiple GitHub App installations per organization. Users can now view, select repos from, and disconnect accounts individually without affecting others.

- **New Features**
  - Aggregate and dedupe repository lists across all enabled installations with per-installation caching.
  - Persist selections per owning installation; saving across accounts no longer wipes other selections.
  - Per-account disconnect with validation; pass an optional `accountId` to disable a single installation and clear its cache. Invalid `accountId` returns not found.
  - Router updates: `github.app.get` returns `accounts` plus aggregated repositories and selection; `github.app.disconnect` accepts `accountId`.
  - UI: one account card per installation; repositories dialog includes an account switcher and preserves cross-account selection; the shared GitHub dialog has the same multi-account behavior.

- **Migration**
  - Consumers of `github.app.get` must read `accounts` (array) instead of `account`.
  - `github.app.disconnect` now accepts an optional `accountId` to disconnect a single account; omitting it disconnects all installations for the org.

<sup>Written for commit 995d18f1453a174b91a7873851d6d80418cf62c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`995d18f`](https://github.com/usenotra/notra/commit/995d18f1453a174b91a7873851d6d80418cf62c6). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->