### PR TITLE
perf(web): defer landing shaders offscreen and trim mobile hero padding

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -37,7 +37,7 @@ const instrumentSerif = Instrument_Serif({
   variable: "--font-instrument-serif",
   weight: ["400"],
   display: "swap",
-  preload: true,
+  preload: false,
 });
 
 export const viewport: Viewport = {

--- a/apps/web/src/components/deferred-dithering.tsx
+++ b/apps/web/src/components/deferred-dithering.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+import dynamic from "next/dynamic";
+import { useDitherVisibility } from "@/lib/dithering/use-dither-visibility";
+import type { DeferredDitheringProps } from "@/types/dithering";
+
+const Dithering = dynamic(
+  () =>
+    import("@paper-design/shaders-react").then((module_) => module_.Dithering),
+  { ssr: false }
+);
+
+export function DeferredDithering({
+  className,
+  speed,
+  ...shaderProps
+}: DeferredDitheringProps) {
+  const { containerRef, shouldRender, isAnimating } = useDitherVisibility();
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("pointer-events-none", className)}
+      ref={containerRef}
+    >
+      {shouldRender && (
+        <Dithering
+          {...shaderProps}
+          className="h-full w-full"
+          speed={isAnimating ? speed : 0}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/footer-section.tsx
+++ b/apps/web/src/components/footer-section.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
-import { Dithering } from "@paper-design/shaders-react";
-import { useReducedMotion } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
+import { DeferredDithering } from "@/components/deferred-dithering";
 import {
   FOOTER_DITHERING,
   FOOTER_LEGAL_LINKS,
@@ -44,20 +43,19 @@ function FooterColumnLink({ link }: { link: FooterLink }) {
 }
 
 export default function FooterSection() {
-  const shouldReduceMotion = useReducedMotion();
   const year = new Date().getFullYear();
 
   return (
     <footer className="relative isolate overflow-hidden rounded-t-3xl bg-[linear-gradient(in_oklab_180deg,oklab(80.3%_0.045_-0.074/15%)_0%,oklab(71.8%_0.066_-0.109/50%)_100%)] pt-6 shadow-[0_0.0625rem_0.125rem_#28282814,0_0_0_0.0625rem_#ececec] dark:bg-[#141019] dark:bg-none dark:shadow-none">
       <div className="-z-10 pointer-events-none absolute inset-0 overflow-hidden">
-        <Dithering
+        <DeferredDithering
           className="absolute top-[8.8125rem] left-[-5.40625rem] h-[66.125rem] w-[calc(100%+10.8125rem)] min-w-[100.8125rem]"
           colorBack={FOOTER_DITHERING.colorBack}
           colorFront={FOOTER_DITHERING.colorFront}
           scale={FOOTER_DITHERING.scale}
           shape={FOOTER_DITHERING.shape}
           size={FOOTER_DITHERING.size}
-          speed={shouldReduceMotion ? 0 : FOOTER_DITHERING.speed}
+          speed={FOOTER_DITHERING.speed}
           type={FOOTER_DITHERING.type}
         />
       </div>

--- a/apps/web/src/components/landing/cta-banner.tsx
+++ b/apps/web/src/components/landing/cta-banner.tsx
@@ -1,9 +1,6 @@
-"use client";
-
 import { CtaButton } from "@notra/ui/components/shared/cta-button";
-import { Dithering } from "@paper-design/shaders-react";
-import { useReducedMotion } from "motion/react";
 import Link from "next/link";
+import { DeferredDithering } from "@/components/deferred-dithering";
 import { TrackedSignupLink } from "@/components/tracked-signup-link";
 import {
   CTA_BANNER_CONTACT_HREF,
@@ -15,18 +12,16 @@ import {
 } from "@/constants/landing/cta-banner";
 
 export function CtaBanner() {
-  const shouldReduceMotion = useReducedMotion();
-
   return (
     <div className="relative mx-auto flex min-h-[27.4375rem] w-full max-w-[87rem] shrink-0 items-center justify-center overflow-clip rounded-[1.5625rem] bg-[#C8B2EE40] px-6 py-16 antialiased dark:bg-[#231d3a]">
-      <Dithering
+      <DeferredDithering
         className="-top-66.25 absolute left-[-5.368rem] h-264.5 w-403.25"
         colorBack="#00000000"
         colorFront="#8B5CF62D"
         scale={0.53}
         shape="wave"
         size={2.9}
-        speed={shouldReduceMotion ? 0 : 0.7}
+        speed={0.7}
         type="4x4"
       />
       <div className="relative flex w-full max-w-[53.3125rem] flex-col items-center gap-10.5">

--- a/apps/web/src/components/landing/features-shader.tsx
+++ b/apps/web/src/components/landing/features-shader.tsx
@@ -1,22 +1,17 @@
-"use client";
-
 import { cn } from "@notra/ui/lib/utils";
-import { Dithering } from "@paper-design/shaders-react";
-import { useReducedMotion } from "motion/react";
+import { DeferredDithering } from "@/components/deferred-dithering";
 import type { FeaturesShaderProps } from "@/types/landing/features";
 
 export function FeaturesShader({ colorFront, className }: FeaturesShaderProps) {
-  const shouldReduceMotion = useReducedMotion();
-
   return (
-    <Dithering
-      className={cn("pointer-events-none absolute", className)}
+    <DeferredDithering
+      className={cn("absolute", className)}
       colorBack="#00000000"
       colorFront={colorFront}
       scale={0.74}
       shape="wave"
       size={4}
-      speed={shouldReduceMotion ? 0 : 0.5}
+      speed={0.5}
       type="4x4"
     />
   );

--- a/apps/web/src/components/landing/hero-dither.tsx
+++ b/apps/web/src/components/landing/hero-dither.tsx
@@ -1,21 +1,16 @@
-"use client";
-
-import { Dithering } from "@paper-design/shaders-react";
-import { useReducedMotion } from "motion/react";
+import { DeferredDithering } from "@/components/deferred-dithering";
 import type { HeroDitherProps } from "@/types/landing/hero";
 
 export function HeroDither({ className }: HeroDitherProps) {
-  const shouldReduceMotion = useReducedMotion();
-
   return (
-    <Dithering
+    <DeferredDithering
       className={className}
       colorBack="#00000000"
       colorFront="#8B5CF633"
       scale={0.53}
       shape="wave"
       size={2.9}
-      speed={shouldReduceMotion ? 0 : 0.53}
+      speed={0.53}
       type="4x4"
     />
   );

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -23,7 +23,7 @@ export function HeroSection() {
         </div>
 
         <div className="relative flex h-full w-full flex-col items-center">
-          <div className="flex flex-col items-center gap-10 px-6 pt-24 pb-2 lg:pt-[7.5rem]">
+          <div className="flex flex-col items-center gap-8 px-6 pt-14 pb-2 sm:gap-10 sm:pt-24 lg:pt-[7.5rem]">
             <div className="flex flex-col items-center gap-7">
               <h1 className="max-w-[56.875rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.08] tracking-[-0.015em] sm:text-[3.25rem] lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
                 {HERO_HEADLINE_SEGMENTS.map((segment) => (
@@ -60,7 +60,7 @@ export function HeroSection() {
             </div>
           </div>
 
-          <div className="mt-16.25 flex w-full flex-1 flex-col items-center overflow-clip py-3.75">
+          <div className="mt-9 flex w-full flex-1 flex-col items-center overflow-clip py-3.75 sm:mt-16.25">
             <div className="flex w-full flex-col items-center">
               <HeroCollage />
             </div>

--- a/apps/web/src/components/landing/pricing-pro-shader.tsx
+++ b/apps/web/src/components/landing/pricing-pro-shader.tsx
@@ -1,21 +1,16 @@
-"use client";
-
-import { Dithering } from "@paper-design/shaders-react";
-import { useReducedMotion } from "motion/react";
+import { DeferredDithering } from "@/components/deferred-dithering";
 
 export function PricingProShader() {
-  const shouldReduceMotion = useReducedMotion();
-
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
-      <Dithering
+      <DeferredDithering
         className="absolute bottom-0 left-[-6.375rem] h-[13.8125rem] w-[34.75rem]"
         colorBack="#00000000"
         colorFront="#C8B2EE80"
         scale={1}
         shape="wave"
         size={2.9}
-        speed={shouldReduceMotion ? 0 : 0.53}
+        speed={0.53}
         type="4x4"
       />
     </div>

--- a/apps/web/src/components/landing/testimonials-shader.tsx
+++ b/apps/web/src/components/landing/testimonials-shader.tsx
@@ -1,7 +1,4 @@
-"use client";
-
-import { Dithering } from "@paper-design/shaders-react";
-import { useReducedMotion } from "motion/react";
+import { DeferredDithering } from "@/components/deferred-dithering";
 import type { TestimonialsShaderProps } from "@/types/landing/testimonials";
 
 export function TestimonialsShader({
@@ -9,17 +6,15 @@ export function TestimonialsShader({
   colorFront,
   className,
 }: TestimonialsShaderProps) {
-  const shouldReduceMotion = useReducedMotion();
-
   return (
-    <Dithering
+    <DeferredDithering
       className={className}
       colorBack="#00000000"
       colorFront={colorFront}
       scale={0.74}
       shape="wave"
       size={size}
-      speed={shouldReduceMotion ? 0 : 0.5}
+      speed={0.5}
       type="4x4"
     />
   );

--- a/apps/web/src/lib/dithering/use-dither-visibility.ts
+++ b/apps/web/src/lib/dithering/use-dither-visibility.ts
@@ -1,7 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import type { DitherVisibilityState } from "@/types/dithering";
+import {
+  getReducedMotionServerSnapshot,
+  getReducedMotionSnapshot,
+  subscribeToReducedMotion,
+} from "@/utils/reduced-motion";
 
 const VIEWPORT_MARGIN = "200px";
 const IDLE_FALLBACK_MS = 1500;
@@ -11,7 +16,11 @@ export function useDitherVisibility(): DitherVisibilityState {
   const [isIdle, setIsIdle] = useState(false);
   const [isInView, setIsInView] = useState(false);
   const [hasEntered, setHasEntered] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot
+  );
 
   useEffect(() => {
     if (typeof window.requestIdleCallback === "function") {
@@ -42,16 +51,6 @@ export function useDitherVisibility(): DitherVisibilityState {
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setPrefersReducedMotion(query.matches);
-    const handleChange = (event: MediaQueryListEvent) => {
-      setPrefersReducedMotion(event.matches);
-    };
-    query.addEventListener("change", handleChange);
-    return () => query.removeEventListener("change", handleChange);
   }, []);
 
   return {

--- a/apps/web/src/lib/dithering/use-dither-visibility.ts
+++ b/apps/web/src/lib/dithering/use-dither-visibility.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { DitherVisibilityState } from "@/types/dithering";
+
+const VIEWPORT_MARGIN = "200px";
+const IDLE_FALLBACK_MS = 1500;
+
+export function useDitherVisibility(): DitherVisibilityState {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isIdle, setIsIdle] = useState(false);
+  const [isInView, setIsInView] = useState(false);
+  const [hasEntered, setHasEntered] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window.requestIdleCallback === "function") {
+      const idleId = window.requestIdleCallback(() => setIsIdle(true));
+      return () => window.cancelIdleCallback(idleId);
+    }
+    const timeoutId = window.setTimeout(
+      () => setIsIdle(true),
+      IDLE_FALLBACK_MS
+    );
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.some((entry) => entry.isIntersecting);
+        setIsInView(visible);
+        if (visible) {
+          setHasEntered(true);
+        }
+      },
+      { rootMargin: VIEWPORT_MARGIN }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(query.matches);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+    query.addEventListener("change", handleChange);
+    return () => query.removeEventListener("change", handleChange);
+  }, []);
+
+  return {
+    containerRef,
+    shouldRender: isIdle && hasEntered,
+    isAnimating: isInView && !prefersReducedMotion,
+  };
+}

--- a/apps/web/src/types/dithering.ts
+++ b/apps/web/src/types/dithering.ts
@@ -1,0 +1,15 @@
+import type { DitheringProps } from "@paper-design/shaders-react";
+import type { RefObject } from "react";
+
+export type DeferredDitheringProps = Pick<
+  DitheringProps,
+  "colorBack" | "colorFront" | "scale" | "shape" | "size" | "speed" | "type"
+> & {
+  className?: string;
+};
+
+export interface DitherVisibilityState {
+  containerRef: RefObject<HTMLDivElement | null>;
+  shouldRender: boolean;
+  isAnimating: boolean;
+}

--- a/apps/web/src/utils/reduced-motion.ts
+++ b/apps/web/src/utils/reduced-motion.ts
@@ -1,0 +1,15 @@
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+export function subscribeToReducedMotion(onChange: () => void) {
+  const query = window.matchMedia(REDUCED_MOTION_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+export function getReducedMotionSnapshot() {
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+export function getReducedMotionServerSnapshot() {
+  return false;
+}


### PR DESCRIPTION
## Summary

PageSpeed pass over apps/web.

- The landing page mounted 11 `Dithering` WebGL shaders (hero, 4 feature cards, 3 testimonials, pricing, CTA, footer). The paper-design shader engine runs a continuous `requestAnimationFrame` loop with no visibility handling, so all 11 rendered every frame forever, even offscreen, and the shader library shipped in the critical client bundle via the hero.
- New shared `DeferredDithering` component: loads the shader library via `next/dynamic` (`ssr: false`), mounts a shader only after browser idle and once its container is within 200px of the viewport, and sets `speed` to 0 while offscreen so the rAF loop stops. Reduced-motion handling is preserved via a `matchMedia` listener in the shared hook (previously per-component `useReducedMotion` from motion/react).
- All six shader call sites rewired (hero, features, testimonials, pricing, CTA banner, footer). MCP, changelog, and integrations pages reusing `HeroDither` benefit automatically.
- Instrument Serif no longer preloaded on every page; it is only used on the 404 page and still loads on demand.
- Mobile hero padding tightened (`pt-14`/`gap-8`/`mt-9` below `sm`), desktop spacing unchanged.

## Verification

- `bun run build` passes, `bun x ultracite check` clean on changed files.
- Local production build: hero h1 in server HTML, font preloads down to Inter + Satoshi, hydrated DOM shows only the hero canvas mounted with the rest deferred until scroll, full-page and 390px screenshots visually intact.
- Expected impact is on TBT/INP and mobile CPU; needs a PageSpeed retest of the deployed URL to confirm numbers.

https://claude.ai/code/session_01UWDEgf86UgUJ9XJGcrGF8k

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers landing-page dithering shaders and pauses them when offscreen to reduce main-thread work and move `@paper-design/shaders-react` out of the critical bundle. Also trims mobile hero spacing and stops preloading `Instrument Serif` globally.

- **New Features**
  - Added `DeferredDithering` that dynamically imports the shader with `next/dynamic` (`ssr: false`), waits for idle and near-viewport (200px), and pauses offscreen by setting `speed` to 0; replaced all landing shaders (hero, features, testimonials, pricing, CTA, footer).

- **Bug Fixes**
  - Read `prefers-reduced-motion` via `useSyncExternalStore` to avoid hydration issues; removed per-component `useReducedMotion` from `motion/react`.

<sup>Written for commit 04dcf5913a72122a69492954f8706e442e5bcdfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`706f865`](https://github.com/usenotra/notra/commit/706f865b3e21f4927c21acbc6dd5fba2c2690522). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->