### PR TITLE
fix(web): smooth and speed up mobile navbar scroll transition

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -75,7 +75,7 @@ const SHELL_TRANSITION = {
   duration: 0.32,
   ease: EASE,
 };
-const SCROLL_THRESHOLD = 64;
+const SCROLL_THRESHOLD = 16;
 const ISLAND_CHROME =
   "bg-white shadow-[0_0.125rem_1.25rem_#1E1E1E14,0_0.0625rem_0.125rem_#28282814] ring-1 ring-[#1E1E1E14] dark:bg-neutral-950 dark:shadow-black/50 dark:ring-white/10";
 const SWAP_TRANSITION = {
@@ -401,11 +401,13 @@ export function Navbar({ variant }: NavbarProps = {}) {
           initial={false}
           transition={shellTransition}
         >
-          <div className={innerPaddingClass}>
+          <div
+            className={`transition-[padding] duration-300 ease-out ${innerPaddingClass}`}
+          >
             {/* biome-ignore lint/a11y/noStaticElementInteractions: onMouseLeave is a pointer-only convenience to dismiss the hover menu; the menu is fully operable via click, focus, and Escape */}
             {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: see above */}
             <div
-              className={`relative flex items-center justify-between gap-4 ${rowHeightClass}`}
+              className={`relative flex items-center justify-between gap-4 transition-[height] duration-300 ease-out ${rowHeightClass}`}
               onMouseLeave={scheduleClose}
             >
               <DropdownMenu

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -75,7 +75,9 @@ const SHELL_TRANSITION = {
   duration: 0.32,
   ease: EASE,
 };
-const SCROLL_THRESHOLD = 16;
+const SCROLL_THRESHOLD = 64;
+const MOBILE_SCROLL_THRESHOLD = 16;
+const MOBILE_MEDIA_QUERY = "(max-width: 63.9375rem)";
 const ISLAND_CHROME =
   "bg-white shadow-[0_0.125rem_1.25rem_#1E1E1E14,0_0.0625rem_0.125rem_#28282814] ring-1 ring-[#1E1E1E14] dark:bg-neutral-950 dark:shadow-black/50 dark:ring-white/10";
 const SWAP_TRANSITION = {
@@ -257,13 +259,21 @@ export function Navbar({ variant }: NavbarProps = {}) {
   const [scrolled, setScrolled] = useState(false);
   const [logoMenuOpen, setLogoMenuOpen] = useState(false);
 
+  const getScrollThreshold = useCallback(
+    () =>
+      window.matchMedia(MOBILE_MEDIA_QUERY).matches
+        ? MOBILE_SCROLL_THRESHOLD
+        : SCROLL_THRESHOLD,
+    []
+  );
+
   useMotionValueEvent(scrollY, "change", (latest) => {
-    setScrolled(latest > SCROLL_THRESHOLD);
+    setScrolled(latest > getScrollThreshold());
   });
 
   useEffect(() => {
-    setScrolled(window.scrollY > SCROLL_THRESHOLD);
-  }, []);
+    setScrolled(window.scrollY > getScrollThreshold());
+  }, [getScrollThreshold]);
 
   const cancelClose = useCallback(() => {
     if (closeTimerRef.current) {
@@ -402,12 +412,12 @@ export function Navbar({ variant }: NavbarProps = {}) {
           transition={shellTransition}
         >
           <div
-            className={`transition-[padding] duration-300 ease-out ${innerPaddingClass}`}
+            className={`max-lg:transition-[padding] max-lg:duration-300 max-lg:ease-out ${innerPaddingClass}`}
           >
             {/* biome-ignore lint/a11y/noStaticElementInteractions: onMouseLeave is a pointer-only convenience to dismiss the hover menu; the menu is fully operable via click, focus, and Escape */}
             {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: see above */}
             <div
-              className={`relative flex items-center justify-between gap-4 transition-[height] duration-300 ease-out ${rowHeightClass}`}
+              className={`relative flex items-center justify-between gap-4 max-lg:transition-[height] max-lg:duration-300 max-lg:ease-out ${rowHeightClass}`}
               onMouseLeave={scheduleClose}
             >
               <DropdownMenu


### PR DESCRIPTION
## Summary
The marketing navbar's switch from the stationary top state to the floating background version felt janky and late on mobile.

- On mobile (below `lg`), lower the scroll threshold from 64px to 16px so the switch triggers almost immediately; desktop keeps the 64px threshold
- On mobile, animate the row height (`h-11` → `h-16`) and inner padding with 300ms ease-out transitions so they move in sync with the background, radius, and position instead of snapping instantly

Desktop behavior is unchanged.

https://claude.ai/code/session_01KGeisbDzQUaPdpgVVHYNAJ

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`49c4769`](https://github.com/usenotra/notra/commit/49c476904cd5fba7402a8a2bca73360c622a0cce). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->