### PR TITLE
fix(web): suppress react-doctor warning on navbar scroll init effect

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -272,6 +272,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
   });
 
   useEffect(() => {
+    // react-doctor-disable-next-line react-hooks-js/set-state-in-effect
     setScrolled(window.scrollY > getScrollThreshold());
   }, [getScrollThreshold]);
 


### PR DESCRIPTION
## Summary
React Doctor flagged `react-hooks-js/set-state-in-effect` on the navbar's mount effect that initializes `scrolled` from `window.scrollY`.

The effect must read `window` after mount: initializing the state during render would cause an SSR hydration mismatch since the server always renders the unscrolled state. Per the rule's own guidance for this case, suppress it with `react-doctor-disable-next-line`.

https://claude.ai/code/session_01KGeisbDzQUaPdpgVVHYNAJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress `react-doctor` warning on the navbar’s scroll init effect by disabling `react-hooks-js/set-state-in-effect` for the mount read. We read `window` after mount to avoid an SSR hydration mismatch, per the rule’s guidance.

<sup>Written for commit 6023087fca0715694638103619a128cff47922ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`6023087`](https://github.com/usenotra/notra/commit/6023087fca0715694638103619a128cff47922ff). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->