### PR TITLE
fix(dashboard): prevent navigation loading flicker

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "./loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "./loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "./loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/collection/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/collection/[id]/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
 import type { CollectionPageProps } from "@/types/content/collection";
-import Loading from "../../loading";
 import PageClient from "./page-client";
+import { GroupDetailSkeleton } from "./skeleton";
 
 export const metadata: Metadata = {
   title: "Collection",
@@ -15,7 +15,7 @@ async function Page({ params }: CollectionPageProps) {
   const { organization } = await validateOrganizationAccess(slug);
 
   return (
-    <Suspense fallback={<Loading />}>
+    <Suspense fallback={<GroupDetailSkeleton />}>
       <PageClient
         collectionId={id}
         organizationId={organization.id}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/collection/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/collection/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
 import type { CollectionPageProps } from "@/types/content/collection";
+import Loading from "../../loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -14,7 +15,7 @@ async function Page({ params }: CollectionPageProps) {
   const { organization } = await validateOrganizationAccess(slug);
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient
         collectionId={id}
         organizationId={organization.id}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
+import Loading from "../loading";
 import PageClient from "./page-client";
 
 interface PageProps {
@@ -20,7 +21,7 @@ async function Page({ params }: PageProps) {
   const { organization } = await validateOrganizationAccess(slug);
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient
         contentId={id}
         organizationId={organization.id}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "./loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/framer/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/framer/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "../loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getGitHubIntegrationById } from "@notra/ai/integrations/github";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
+import Loading from "../loading";
 import PageClient from "./page-client";
 
 interface PageProps {
@@ -31,7 +32,7 @@ async function Page({ params }: PageProps) {
   const { id } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient integrationId={id} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "./loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/granola/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/granola/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "../loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/linear/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/linear/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getLinearIntegrationById } from "@notra/ai/integrations/linear";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
+import Loading from "../../loading";
 import PageClient from "./page-client";
 
 interface PageProps {
@@ -31,7 +32,7 @@ async function Page({ params }: PageProps) {
   const { id } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient integrationId={id} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/linear/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/linear/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "../loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/mcp/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/mcp/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "../loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "./loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/raycast/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/raycast/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "../loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/layout.tsx
@@ -31,6 +31,7 @@ export default async function OrganizationLayout({
         createdAt: organization.createdAt,
         id: organization.id,
         logo: organization.logo,
+        metadata: organization.metadata ?? undefined,
         name: organization.name,
         slug: organization.slug,
       }}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/layout.tsx
@@ -28,6 +28,7 @@ export default async function OrganizationLayout({
   return (
     <DashboardClientWrapper
       initialActiveOrganization={{
+        createdAt: organization.createdAt,
         id: organization.id,
         logo: organization.logo,
         name: organization.name,

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "./loading";
 import PageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ async function Page({
   const { slug } = await params;
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PageClient organizationSlug={slug} />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/credits/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/credits/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import Loading from "../../loading";
 import CreditsPageClient from "./page-client";
 
 export const metadata: Metadata = {
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function CreditsPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <CreditsPageClient />
     </Suspense>
   );

--- a/apps/dashboard/src/components/providers/organization-provider.tsx
+++ b/apps/dashboard/src/components/providers/organization-provider.tsx
@@ -19,10 +19,7 @@ export type Organization = NonNullable<
   ReturnType<typeof authClient.useListOrganizations>["data"]
 >[number];
 
-export type InitialActiveOrganization = Pick<
-  Organization,
-  "id" | "logo" | "name" | "slug" | "createdAt"
->;
+export type InitialActiveOrganization = Organization;
 
 interface OrganizationsContextValue {
   organizations: Organization[];

--- a/apps/dashboard/src/components/providers/organization-provider.tsx
+++ b/apps/dashboard/src/components/providers/organization-provider.tsx
@@ -83,7 +83,8 @@ export function OrganizationsProvider({
     ],
   });
 
-  const organizations = organizationsData ?? [];
+  const organizations =
+    organizationsData ?? FALLBACK_ORGANIZATIONS_CONTEXT.organizations;
   const isLoading = isLoadingOrgs || isLoadingActive;
   const slugFromPath = useMemo(() => {
     const segments = pathname.split("/").filter(Boolean);

--- a/apps/dashboard/src/components/providers/organization-provider.tsx
+++ b/apps/dashboard/src/components/providers/organization-provider.tsx
@@ -19,12 +19,10 @@ export type Organization = NonNullable<
   ReturnType<typeof authClient.useListOrganizations>["data"]
 >[number];
 
-export interface InitialActiveOrganization {
-  id: string;
-  logo: string | null;
-  name: string;
-  slug: string;
-}
+export type InitialActiveOrganization = Pick<
+  Organization,
+  "id" | "logo" | "name" | "slug" | "createdAt"
+>;
 
 interface OrganizationsContextValue {
   organizations: Organization[];
@@ -113,7 +111,7 @@ export function OrganizationsProvider({
       return null;
     }
 
-    return initialActiveOrganization as Organization;
+    return initialActiveOrganization;
   }, [initialActiveOrganization, slugFromPath]);
   const activeOrganizationForPath =
     !slugFromPath || activeOrganization?.slug === slugFromPath
@@ -246,8 +244,12 @@ export function OrganizationsProvider({
   ]);
 
   const getOrganization = useCallback(
-    (slug: string) => organizations.find((org) => org.slug === slug),
-    [organizations]
+    (slug: string) =>
+      organizations.find((org) => org.slug === slug) ??
+      (resolvedActiveOrganization?.slug === slug
+        ? resolvedActiveOrganization
+        : undefined),
+    [organizations, resolvedActiveOrganization]
   );
 
   const contextValue = useMemo<OrganizationsContextValue>(


### PR DESCRIPTION
### Description
This PR prevents dashboard navigation flicker by keeping route loaders visible until client pages are ready. It also reuses the server-validated organization while client organization data is still loading, avoiding transient empty states.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dashboard navigation flicker by adding consistent Suspense fallbacks and stabilizing organization context resolution. Pages now show a small loading state during route changes instead of flashing content.

- **Bug Fixes**
  - Added `<Suspense fallback={<Loading />}>` across dashboard routes (automation, brand, content, collections, integrations, logs, settings), plus `GroupDetailSkeleton` for collection detail pages to keep transitions smooth.
  - Hardened `OrganizationsProvider`: use a stable fallback organizations list, resolve the active org from the server when missing from the list (including in `getOrganization`), align `InitialActiveOrganization` to the full `Organization` type, and pass `createdAt` and `metadata` from layout.

<sup>Written for commit a0b1370e9dee8724f33737ac74396d6b31305826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`a0b1370`](https://github.com/usenotra/notra/commit/a0b1370e9dee8724f33737ac74396d6b31305826). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->