### PR TITLE
feat(web): use kibo-ui color picker on repo star video page

### DIFF
--- a/apps/console/src/components/integrations/integration-form.tsx
+++ b/apps/console/src/components/integrations/integration-form.tsx
@@ -28,6 +28,7 @@ import {
   PopoverTrigger,
 } from "@notra/ui/components/ui/popover";
 import { Textarea } from "@notra/ui/components/ui/textarea";
+import { rgbaToHex } from "@notra/utils/color";
 import { openMcpOAuthPopup } from "@notra/utils/oauth-popup";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { cn } from "cnfast";
@@ -52,7 +53,6 @@ import {
   applyPhraseDraftChange,
   authChoiceToAuthType,
   buildInitialPhraseDrafts,
-  rgbaToHex,
 } from "@/lib/integrations/form";
 import { createHeaderRow } from "@/lib/integrations/headers";
 import { isManualTool, mergeManualTools } from "@/lib/integrations/tool-io";

--- a/apps/console/src/lib/integrations/form.ts
+++ b/apps/console/src/lib/integrations/form.ts
@@ -126,17 +126,6 @@ export function getInitialApiKeyStyle(server?: McpServer): ApiKeyStyle {
   return hasStoredBearerHeader(server) ? "bearer" : "headers";
 }
 
-const HEX_CHANNEL_MAX = 255;
-
-export function rgbaToHex(channels: readonly number[]) {
-  const toHex = (channel: number | undefined) =>
-    Math.round(Math.min(Math.max(channel ?? 0, 0), HEX_CHANNEL_MAX))
-      .toString(16)
-      .padStart(2, "0");
-
-  return `#${toHex(channels[0])}${toHex(channels[1])}${toHex(channels[2])}`;
-}
-
 export function getIntegrationInitials(name: string) {
   return name.trim().slice(0, 2).toUpperCase() || "?";
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@notra/email": "workspace:*",
     "@notra/kiwi": "workspace:*",
     "@notra/ui": "workspace:*",
+    "@notra/utils": "workspace:*",
     "@paper-design/shaders-react": "^0.0.77",
     "@remotion/bundler": "4.0.487",
     "@remotion/fonts": "4.0.487",

--- a/apps/web/src/components/star-video/star-video-preview.tsx
+++ b/apps/web/src/components/star-video/star-video-preview.tsx
@@ -16,11 +16,12 @@ import {
 } from "@notra/ui/components/ui/popover";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { cn } from "@notra/ui/lib/utils";
+import { rgbaToHex } from "@notra/utils/color";
 import { Player } from "@remotion/player";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { normalizeHex, rgbaToHex } from "@/lib/star-video/color";
+import { normalizeHex } from "@/lib/star-video/color";
 import { parseRepoInput } from "@/lib/star-video/parse-repo";
 import {
   DEFAULT_BACKGROUND_COLOR,

--- a/apps/web/src/components/star-video/star-video-preview.tsx
+++ b/apps/web/src/components/star-video/star-video-preview.tsx
@@ -2,13 +2,25 @@
 
 import { Download04Icon, StarIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ColorPicker,
+  ColorPickerEyeDropper,
+  ColorPickerHue,
+  ColorPickerSelection,
+} from "@notra/ui/components/kibo-ui/color-picker";
 import { CtaButton } from "@notra/ui/components/shared/cta-button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@notra/ui/components/ui/popover";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { cn } from "@notra/ui/lib/utils";
 import { Player } from "@remotion/player";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { normalizeHex, rgbaToHex } from "@/lib/star-video/color";
 import { parseRepoInput } from "@/lib/star-video/parse-repo";
 import {
   DEFAULT_BACKGROUND_COLOR,
@@ -19,22 +31,6 @@ import {
 } from "@/remotion/star-video/constants";
 import { StarVideo } from "@/remotion/star-video/star-video";
 import type { RepoStarData, StarVideoInputProps } from "@/types/star-video";
-
-const HEX_COLOR = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
-
-function normalizeHex(input: string): string | null {
-  if (!HEX_COLOR.test(input)) {
-    return null;
-  }
-  const hex = input.slice(1);
-  if (hex.length === 3) {
-    return `#${hex
-      .split("")
-      .map((char) => char + char)
-      .join("")}`.toLowerCase();
-  }
-  return `#${hex}`.toLowerCase();
-}
 
 const BACKGROUND_PRESETS = [
   { value: DEFAULT_BACKGROUND_COLOR, label: "Mint" },
@@ -117,6 +113,10 @@ export function StarVideoPreview() {
       setBgParam(normalized);
     },
     [setBgParam]
+  );
+
+  const isCustomBackground = !BACKGROUND_PRESETS.some(
+    (preset) => preset.value === backgroundColor
   );
 
   const inputProps = useMemo<StarVideoInputProps | null>(() => {
@@ -234,20 +234,37 @@ export function StarVideoPreview() {
                 type="button"
               />
             ))}
-            <label
-              className="flex size-7 cursor-pointer items-center justify-center overflow-hidden rounded-full border border-[#1E1E1E1A] dark:border-white/15"
-              htmlFor="star-video-bg"
-              style={{ backgroundColor }}
-            >
-              <input
+            <Popover>
+              <PopoverTrigger
                 aria-label="Custom background color"
-                className="sr-only"
-                id="star-video-bg"
-                onChange={(event) => applyBackground(event.target.value)}
-                type="color"
-                value={backgroundColor}
+                aria-pressed={isCustomBackground}
+                className={cn(
+                  "size-7 cursor-pointer rounded-full border transition-transform hover:scale-110",
+                  isCustomBackground
+                    ? "border-[#1E1E1E] ring-2 ring-[#1E1E1E1A] dark:border-white dark:ring-white/20"
+                    : "border-[#1E1E1E1A] bg-[conic-gradient(from_180deg,#FF6B6B,#FFD93D,#6BCB77,#4D96FF,#B983FF,#FF6B6B)] dark:border-white/15"
+                )}
+                style={isCustomBackground ? { backgroundColor } : undefined}
+                type="button"
               />
-            </label>
+              <PopoverContent align="start" className="w-64">
+                <ColorPicker
+                  className="flex flex-col gap-3"
+                  defaultValue={backgroundColor}
+                  onChange={(value) => {
+                    if (Array.isArray(value)) {
+                      applyBackground(rgbaToHex(value));
+                    }
+                  }}
+                >
+                  <ColorPickerSelection className="h-32 rounded-md" />
+                  <div className="flex items-center gap-2">
+                    <ColorPickerEyeDropper />
+                    <ColorPickerHue className="flex-1" />
+                  </div>
+                </ColorPicker>
+              </PopoverContent>
+            </Popover>
           </div>
         </div>
 

--- a/apps/web/src/lib/star-video/color.ts
+++ b/apps/web/src/lib/star-video/color.ts
@@ -1,0 +1,25 @@
+const HEX_COLOR = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+const HEX_CHANNEL_MAX = 255;
+
+export function normalizeHex(input: string): string | null {
+  if (!HEX_COLOR.test(input)) {
+    return null;
+  }
+  const hex = input.slice(1);
+  if (hex.length === 3) {
+    return `#${hex
+      .split("")
+      .map((char) => char + char)
+      .join("")}`.toLowerCase();
+  }
+  return `#${hex}`.toLowerCase();
+}
+
+export function rgbaToHex(channels: readonly number[]): string {
+  const toHex = (channel: number | undefined) =>
+    Math.round(Math.min(Math.max(channel ?? 0, 0), HEX_CHANNEL_MAX))
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${toHex(channels[0])}${toHex(channels[1])}${toHex(channels[2])}`;
+}

--- a/apps/web/src/lib/star-video/color.ts
+++ b/apps/web/src/lib/star-video/color.ts
@@ -1,5 +1,4 @@
 const HEX_COLOR = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
-const HEX_CHANNEL_MAX = 255;
 
 export function normalizeHex(input: string): string | null {
   if (!HEX_COLOR.test(input)) {
@@ -13,13 +12,4 @@ export function normalizeHex(input: string): string | null {
       .join("")}`.toLowerCase();
   }
   return `#${hex}`.toLowerCase();
-}
-
-export function rgbaToHex(channels: readonly number[]): string {
-  const toHex = (channel: number | undefined) =>
-    Math.round(Math.min(Math.max(channel ?? 0, 0), HEX_CHANNEL_MAX))
-      .toString(16)
-      .padStart(2, "0");
-
-  return `#${toHex(channels[0])}${toHex(channels[1])}${toHex(channels[2])}`;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -226,6 +226,7 @@
         "@notra/email": "workspace:*",
         "@notra/kiwi": "workspace:*",
         "@notra/ui": "workspace:*",
+        "@notra/utils": "workspace:*",
         "@paper-design/shaders-react": "^0.0.77",
         "@remotion/bundler": "4.0.487",
         "@remotion/fonts": "4.0.487",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,8 @@
     "./url": "./src/url.ts",
     "./callback-url": "./src/callback-url.ts",
     "./oauth-popup": "./src/oauth-popup.ts",
-    "./slugify": "./src/slugify.ts"
+    "./slugify": "./src/slugify.ts",
+    "./color": "./src/color.ts"
   },
   "devDependencies": {
     "@notra/typescript-config": "workspace:*",

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -1,0 +1,10 @@
+const HEX_CHANNEL_MAX = 255;
+
+export function rgbaToHex(channels: readonly number[]): string {
+  const toHex = (channel: number | undefined) =>
+    Math.round(Math.min(Math.max(channel ?? 0, 0), HEX_CHANNEL_MAX))
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${toHex(channels[0])}${toHex(channels[1])}${toHex(channels[2])}`;
+}


### PR DESCRIPTION
Replaces the native `<input type="color">` custom-color swatch on the Repo Star Video page with the kibo-ui `ColorPicker` from `@notra/ui` (saturation/lightness area, hue slider, eye dropper) inside a popover, matching the existing pattern in the console integration form.

- Custom swatch opens a popover with the kibo-ui picker; picked colors sync to the `bg` query param as before
- Trigger shows a rainbow gradient by default and the active color (with selected ring) when a non-preset color is chosen
- Moved `normalizeHex` and added `rgbaToHex` in `lib/star-video/color.ts`

https://claude.ai/code/session_01SeGRAsQP932ubzZLrMhGzw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the native color input with the `ColorPicker` from `@notra/ui` in a popover on the Repo Star Video page for a richer, consistent color picking experience. Selections still update the `bg` query param.

- **New Features**
  - Popover color picker with saturation/lightness, hue slider, and eye dropper; trigger shows a rainbow gradient by default and the chosen custom color with a selection ring.

- **Refactors**
  - Moved `normalizeHex` to `apps/web/src/lib/star-video/color.ts`; promoted `rgbaToHex` to shared `@notra/utils/color` and updated imports in web and console (added `@notra/utils` dep to `apps/web`).

<sup>Written for commit 51cc4a9bc96cfa5f380f4ae49f91df1fbfcbd2ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`51cc4a9`](https://github.com/usenotra/notra/commit/51cc4a9bc96cfa5f380f4ae49f91df1fbfcbd2ff). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->