### PR TITLE
fix(chat): align integration statuses

### DIFF
--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -1978,7 +1978,7 @@ export function ChatInputAdvanced({
                               <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
                                 {integration.icon}
                               </span>
-                              <span className="text-foreground">
+                              <span className="truncate text-foreground">
                                 {integration.name}
                               </span>
                               <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
@@ -2052,7 +2052,7 @@ export function ChatInputAdvanced({
                               <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
                                 {integration.icon}
                               </span>
-                              <span className="text-foreground">
+                              <span className="truncate text-foreground">
                                 {integration.name}
                               </span>
                               <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
@@ -2133,7 +2133,7 @@ export function ChatInputAdvanced({
                             <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
                               {integration.icon}
                             </span>
-                            <span className="text-foreground">
+                            <span className="truncate text-foreground">
                               {integration.name}
                             </span>
                             <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
@@ -2166,7 +2166,7 @@ export function ChatInputAdvanced({
                             <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
                               {integration.icon}
                             </span>
-                            <span className="text-foreground">
+                            <span className="truncate text-foreground">
                               {integration.name}
                             </span>
                             <span className="justify-self-center text-muted-foreground text-xs">

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -1974,14 +1974,14 @@ export function ChatInputAdvanced({
                       if (isGitHub && isAvailable && enabledRepos.length > 0) {
                         return (
                           <DropdownMenuSub key={integration.id}>
-                            <DropdownMenuSubTrigger>
+                            <DropdownMenuSubTrigger className="grid grid-cols-[1rem_3.5rem_1fr_1rem]">
                               <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
                                 {integration.icon}
                               </span>
                               <span className="text-foreground">
                                 {integration.name}
                               </span>
-                              <span className="ml-auto text-emerald-600 text-xs dark:text-emerald-400">
+                              <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
                                 {enabledRepos.length}
                               </span>
                             </DropdownMenuSubTrigger>
@@ -2048,14 +2048,14 @@ export function ChatInputAdvanced({
                       ) {
                         return (
                           <DropdownMenuSub key={integration.id}>
-                            <DropdownMenuSubTrigger>
+                            <DropdownMenuSubTrigger className="grid grid-cols-[1rem_3.5rem_1fr_1rem]">
                               <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
                                 {integration.icon}
                               </span>
                               <span className="text-foreground">
                                 {integration.name}
                               </span>
-                              <span className="ml-auto text-emerald-600 text-xs dark:text-emerald-400">
+                              <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
                                 {enabledLinearIntegrations.length}
                               </span>
                             </DropdownMenuSubTrigger>
@@ -2122,6 +2122,7 @@ export function ChatInputAdvanced({
                       ) {
                         return (
                           <DropdownMenuItem
+                            className="grid grid-cols-[1rem_3.5rem_1fr_1rem]"
                             key={integration.id}
                             render={
                               <Link
@@ -2135,7 +2136,7 @@ export function ChatInputAdvanced({
                             <span className="text-foreground">
                               {integration.name}
                             </span>
-                            <span className="ml-auto text-emerald-600 text-xs dark:text-emerald-400">
+                            <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
                               {enabledGranolaIntegrations.length}
                             </span>
                             <HugeiconsIcon
@@ -2154,6 +2155,7 @@ export function ChatInputAdvanced({
                       ) {
                         return (
                           <DropdownMenuItem
+                            className="grid grid-cols-[1rem_3.5rem_1fr_1rem]"
                             key={integration.id}
                             render={
                               <Link
@@ -2167,7 +2169,7 @@ export function ChatInputAdvanced({
                             <span className="text-foreground">
                               {integration.name}
                             </span>
-                            <span className="ml-auto text-muted-foreground text-xs">
+                            <span className="justify-self-center text-muted-foreground text-xs">
                               Setup
                             </span>
                             <HugeiconsIcon


### PR DESCRIPTION
### Description
Aligns integration status values in the chat Context menu so GitHub and Linear counts, the Granola count, and the Setup label share the same centered column while chevrons remain right-aligned.

### Screenshot/Recording (if applicable)
<img width="497" height="263" alt="image" src="https://github.com/user-attachments/assets/41bedee3-94c0-4481-90fc-1ac92200f217" />


<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align integration status values in the chat context menu: GitHub, Linear, and Granola counts and the Setup label now use a centered column, with chevrons right-aligned. Truncates integration labels to prevent wrapping/overflow and keep the menu tidy.

<sup>Written for commit caf99212ce1d272a420ac3eafa34f4ac26cd6417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`caf9921`](https://github.com/usenotra/notra/commit/caf99212ce1d272a420ac3eafa34f4ac26cd6417). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->