### PR TITLE
feat(ai): add Claude Opus 5

### DIFF
--- a/apps/dashboard/src/components/chat/assistant-metadata-hover.tsx
+++ b/apps/dashboard/src/components/chat/assistant-metadata-hover.tsx
@@ -20,6 +20,7 @@ import { useShowAgentStats } from "@/lib/hooks/use-privacy-preferences";
 
 const MODEL_LABELS = {
   auto: "Auto",
+  "anthropic/claude-opus-5": "Claude Opus 5",
   "anthropic/claude-opus-4.8": "Claude Opus 4.8",
   "anthropic/claude-sonnet-5": "Claude Sonnet 5",
   "anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
@@ -30,6 +31,7 @@ const MODEL_LABELS = {
 
 const MODEL_CONTEXT_WINDOWS = {
   auto: 1_000_000,
+  "anthropic/claude-opus-5": 1_000_000,
   "anthropic/claude-opus-4.8": 1_000_000,
   "anthropic/claude-sonnet-5": 1_000_000,
   "anthropic/claude-sonnet-4.6": 1_000_000,

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -122,6 +122,13 @@ export const AVAILABLE_MODELS = [
     provider: "auto",
   },
   {
+    id: "anthropic/claude-opus-5",
+    label: "Claude Opus 5",
+    description: "Most advanced reasoning",
+    pricing: "$5 input / $25 output per 1M",
+    provider: "anthropic",
+  },
+  {
     id: "anthropic/claude-opus-4.8",
     label: "Claude Opus 4.8",
     description: "Deepest reasoning",

--- a/packages/ai/src/billing/token-pricing.ts
+++ b/packages/ai/src/billing/token-pricing.ts
@@ -16,7 +16,7 @@ const CLAUDE_SONNET_5_PRICING: ModelPricing = {
   cacheWritePerMillionTokens: 2.5,
 };
 
-const CLAUDE_OPUS_4_8_PRICING: ModelPricing = {
+const CLAUDE_OPUS_PRICING: ModelPricing = {
   inputPerMillionTokens: 5.0,
   outputPerMillionTokens: 25.0,
   cacheReadPerMillionTokens: 0.5,
@@ -24,9 +24,12 @@ const CLAUDE_OPUS_4_8_PRICING: ModelPricing = {
 };
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
-  "opencode/claude-opus-4-8": CLAUDE_OPUS_4_8_PRICING,
-  "anthropic/claude-opus-4.8": CLAUDE_OPUS_4_8_PRICING,
-  "vercel/anthropic/claude-opus-4.8": CLAUDE_OPUS_4_8_PRICING,
+  "opencode/claude-opus-5": CLAUDE_OPUS_PRICING,
+  "anthropic/claude-opus-5": CLAUDE_OPUS_PRICING,
+  "vercel/anthropic/claude-opus-5": CLAUDE_OPUS_PRICING,
+  "opencode/claude-opus-4-8": CLAUDE_OPUS_PRICING,
+  "anthropic/claude-opus-4.8": CLAUDE_OPUS_PRICING,
+  "vercel/anthropic/claude-opus-4.8": CLAUDE_OPUS_PRICING,
   "opencode/claude-sonnet-4-6": CLAUDE_SONNET_4_6_PRICING,
   "anthropic/claude-sonnet-4.6": CLAUDE_SONNET_4_6_PRICING,
   "opencode/claude-sonnet-5": CLAUDE_SONNET_5_PRICING,

--- a/packages/ai/src/billing/token-pricing.ts
+++ b/packages/ai/src/billing/token-pricing.ts
@@ -16,7 +16,14 @@ const CLAUDE_SONNET_5_PRICING: ModelPricing = {
   cacheWritePerMillionTokens: 2.5,
 };
 
-const CLAUDE_OPUS_PRICING: ModelPricing = {
+const CLAUDE_OPUS_5_PRICING: ModelPricing = {
+  inputPerMillionTokens: 5.0,
+  outputPerMillionTokens: 25.0,
+  cacheReadPerMillionTokens: 0.5,
+  cacheWritePerMillionTokens: 6.25,
+};
+
+const CLAUDE_OPUS_4_8_PRICING: ModelPricing = {
   inputPerMillionTokens: 5.0,
   outputPerMillionTokens: 25.0,
   cacheReadPerMillionTokens: 0.5,
@@ -24,12 +31,12 @@ const CLAUDE_OPUS_PRICING: ModelPricing = {
 };
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
-  "opencode/claude-opus-5": CLAUDE_OPUS_PRICING,
-  "anthropic/claude-opus-5": CLAUDE_OPUS_PRICING,
-  "vercel/anthropic/claude-opus-5": CLAUDE_OPUS_PRICING,
-  "opencode/claude-opus-4-8": CLAUDE_OPUS_PRICING,
-  "anthropic/claude-opus-4.8": CLAUDE_OPUS_PRICING,
-  "vercel/anthropic/claude-opus-4.8": CLAUDE_OPUS_PRICING,
+  "opencode/claude-opus-5": CLAUDE_OPUS_5_PRICING,
+  "anthropic/claude-opus-5": CLAUDE_OPUS_5_PRICING,
+  "vercel/anthropic/claude-opus-5": CLAUDE_OPUS_5_PRICING,
+  "opencode/claude-opus-4-8": CLAUDE_OPUS_4_8_PRICING,
+  "anthropic/claude-opus-4.8": CLAUDE_OPUS_4_8_PRICING,
+  "vercel/anthropic/claude-opus-4.8": CLAUDE_OPUS_4_8_PRICING,
   "opencode/claude-sonnet-4-6": CLAUDE_SONNET_4_6_PRICING,
   "anthropic/claude-sonnet-4.6": CLAUDE_SONNET_4_6_PRICING,
   "opencode/claude-sonnet-5": CLAUDE_SONNET_5_PRICING,

--- a/packages/ai/src/schemas/chat.ts
+++ b/packages/ai/src/schemas/chat.ts
@@ -6,6 +6,7 @@ import { standaloneChatContextSchema } from "./standalone-chat";
 
 export const chatModelSchema = z.enum([
   "auto",
+  "anthropic/claude-opus-5",
   "anthropic/claude-opus-4.8",
   "anthropic/claude-sonnet-5",
   "anthropic/claude-sonnet-4.6",


### PR DESCRIPTION
### Description
adds opus 5

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `anthropic/claude-opus-5` across the chat UI, schema, and billing. Users can select the model, see correct info, and pricing is applied consistently.

- New Features
  - UI: Added `anthropic/claude-opus-5` to the model picker with label “Claude Opus 5”, description “Most advanced reasoning”, pricing “$5 input / $25 output per 1M”, and a 1,000,000 token context window in metadata hover.
  - Billing: Defined separate Opus 5 pricing and mapped it to `opencode/claude-opus-5`, `anthropic/claude-opus-5`, and `vercel/anthropic/claude-opus-5`; Opus 4.8 keeps its own pricing.
  - Schema: Extended `chatModelSchema` enum to include `anthropic/claude-opus-5`.

<sup>Written for commit a6e425d0a82dc8189666e083843493c5b15e1fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

3 issues found.

<sub>Written for commit [`a6e425d`](https://github.com/usenotra/notra/commit/a6e425d0a82dc8189666e083843493c5b15e1fa7). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->