### PR TITLE
fix(dashboard): pin settings navigation in sidebar

### DIFF
--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -143,9 +143,6 @@ export function DashboardSidebar({
                 variants={subpageVariants}
               >
                 <ChatHistoryNav />
-                <div className="mt-auto">
-                  <NavSecondary />
-                </div>
               </m.div>
             )}
             {!(isSettingsRoute || isChatRoute) && (
@@ -163,13 +160,13 @@ export function DashboardSidebar({
                   <SidebarTrialExpired />
                   <SidebarOnboarding />
                   <SidebarUpgrade />
-                  <NavSecondary />
                 </div>
               </m.div>
             )}
           </AnimatePresence>
         </SidebarContent>
         <SidebarFooter>
+          <NavSecondary className="p-0" />
           <NavUser />
         </SidebarFooter>
       </LazyMotion>


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the settings navigation to the sidebar footer so it stays visible across all routes, including Settings and Chat. Move `NavSecondary` to the footer with p-0 and remove its conditional placements to prevent flicker and disappearing states.

<sup>Written for commit 340bf5ee60d9d102e81326231d337615296351db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`340bf5e`](https://github.com/usenotra/notra/commit/340bf5ee60d9d102e81326231d337615296351db). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->