### PR TITLE
feat(dashboard): agent activity sidebar for content chat

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -68,6 +68,7 @@
     "cmdk": "^1.1.1",
     "cnfast": "^0.0.6",
     "date-fns": "^4.1.0",
+    "dompurify": "3.4.12",
     "drizzle-orm": "^0.45.2",
     "effect": "4.0.0-beta.93",
     "eve": "0.19.0",

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import {
-  AiBrain01Icon,
-  ArrowDown01Icon,
-  ArrowReloadHorizontalIcon,
-  X,
-} from "@hugeicons/core-free-icons";
+import { ArrowReloadHorizontalIcon, X } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { chatTransportRequestInputSchema } from "@notra/ai/schemas/chat";
 import type { ContentType } from "@notra/ai/schemas/content";
@@ -23,11 +18,6 @@ import {
   MessageContent,
   MessageResponse,
 } from "@notra/ui/components/ai-elements/message";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@notra/ui/components/ui/collapsible";
 import {
   MessageScroller,
   MessageScrollerButton,
@@ -61,6 +51,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { ChatReasoningBlock } from "@/components/ai/chat-reasoning-block";
 import { ChatToolBlock } from "@/components/ai/chat-tool-block";
 import { getMcpToolServerId } from "@/components/ai/chat-tool-block/mcp/utils";
 import { BrailleLoader } from "@/components/braille-loader";
@@ -135,108 +126,6 @@ const loadMotionFeatures = () =>
 const emptySubscribe = () => () => {
   // no external store to subscribe to; used to detect hydration
 };
-
-const THINKING_LABEL = "Thinking";
-const REASONING_AUTO_CLOSE_DELAY_MS = 1000;
-const REASONING_CONTENT_CLASSNAME =
-  "h-[var(--collapsible-panel-height)] overflow-hidden text-sm text-muted-foreground outline-none transition-[height,opacity] duration-300 ease-out data-[ending-style]:h-0 data-[ending-style]:opacity-0 data-[starting-style]:h-0 data-[starting-style]:opacity-0";
-
-function formatReasoningDurationLabel(durationSeconds: number | null): string {
-  if (!durationSeconds || durationSeconds <= 1) {
-    return "Thought for a moment";
-  }
-
-  return `Thought for ${durationSeconds} seconds`;
-}
-
-function ChatReasoningBlock({
-  children,
-  isStreaming,
-}: {
-  children: string;
-  isStreaming: boolean;
-}) {
-  const [reasoningState, setReasoningState] = useState<{
-    durationSeconds: number | null;
-    isOpen: boolean;
-    wasStreaming: boolean | null;
-  }>({
-    durationSeconds: null,
-    isOpen: false,
-    wasStreaming: null,
-  });
-  const startTimeRef = useRef<number | null>(null);
-
-  if (reasoningState.wasStreaming !== isStreaming) {
-    setReasoningState({
-      durationSeconds: isStreaming ? null : reasoningState.durationSeconds,
-      isOpen: isStreaming ? true : reasoningState.isOpen,
-      wasStreaming: isStreaming,
-    });
-  }
-
-  useEffect(() => {
-    if (isStreaming) {
-      startTimeRef.current = Date.now();
-      return;
-    }
-
-    const durationTimer = window.setTimeout(() => {
-      const startedAt = startTimeRef.current;
-
-      setReasoningState((current) => ({
-        ...current,
-        durationSeconds: startedAt
-          ? Math.max(1, Math.ceil((Date.now() - startedAt) / 1000))
-          : null,
-      }));
-    }, 0);
-
-    const closeTimer = window.setTimeout(() => {
-      setReasoningState((current) => ({ ...current, isOpen: false }));
-    }, REASONING_AUTO_CLOSE_DELAY_MS);
-
-    return () => {
-      window.clearTimeout(durationTimer);
-      window.clearTimeout(closeTimer);
-    };
-  }, [isStreaming]);
-
-  const statusLabel = isStreaming
-    ? THINKING_LABEL
-    : formatReasoningDurationLabel(reasoningState.durationSeconds);
-
-  function handleOpenChange(isOpen: boolean) {
-    setReasoningState((current) => ({ ...current, isOpen }));
-  }
-
-  return (
-    <Collapsible onOpenChange={handleOpenChange} open={reasoningState.isOpen}>
-      <CollapsibleTrigger className="flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground">
-        {isStreaming ? (
-          <BrailleLoader className="text-sm" label={statusLabel} />
-        ) : (
-          <>
-            <HugeiconsIcon className="size-4" icon={AiBrain01Icon} />
-            <span>{statusLabel}</span>
-          </>
-        )}
-        <HugeiconsIcon
-          className={`size-4 transition-transform ${reasoningState.isOpen ? "rotate-180" : "rotate-0"}`}
-          icon={ArrowDown01Icon}
-        />
-      </CollapsibleTrigger>
-      <CollapsibleContent className={REASONING_CONTENT_CLASSNAME}>
-        <div className="pt-4">
-          <MessageResponse className="text-muted-foreground text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-            {children}
-          </MessageResponse>
-          <div className="h-3" />
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
-  );
-}
 
 function CreateToolPendingIndicator({
   toolCallId,

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -368,50 +368,60 @@ export default function PageClient({
   }, [handleSave, handleDiscard]);
 
   useEffect(() => {
-    const isWide =
-      isActivityPanelOpen && window.matchMedia("(min-width: 64rem)").matches;
+    const mediaQuery = window.matchMedia("(min-width: 64rem)");
 
-    if ((!hasChanges || isWide) && saveToastIdRef.current) {
-      toast.dismiss(saveToastIdRef.current);
-      saveToastIdRef.current = null;
-    }
+    const syncSaveToast = () => {
+      const isWide = isActivityPanelOpen && mediaQuery.matches;
 
-    if (hasChanges && !isWide && !saveToastIdRef.current) {
-      saveToastIdRef.current = toast.custom(
-        (t) => (
-          <div
-            className="rounded-[14px] border border-border bg-background p-0.5 shadow-sm"
-            data-save-bar
-          >
-            <div className="flex items-center gap-3 rounded-lg bg-background px-4 py-3">
-              <span className="text-muted-foreground text-sm">
-                Unsaved changes
-              </span>
-              <Button
-                onClick={() => {
-                  handleDiscardRef.current?.();
-                  toast.dismiss(t);
-                }}
-                size="sm"
-                variant="ghost"
-              >
-                Discard
-              </Button>
-              <Button
-                onClick={() => {
-                  handleSaveRef.current?.();
-                  toast.dismiss(t);
-                }}
-                size="sm"
-              >
-                Save
-              </Button>
+      if ((!hasChanges || isWide) && saveToastIdRef.current) {
+        toast.dismiss(saveToastIdRef.current);
+        saveToastIdRef.current = null;
+      }
+
+      if (hasChanges && !isWide && !saveToastIdRef.current) {
+        saveToastIdRef.current = toast.custom(
+          (t) => (
+            <div
+              className="rounded-[14px] border border-border bg-background p-0.5 shadow-sm"
+              data-save-bar
+            >
+              <div className="flex items-center gap-3 rounded-lg bg-background px-4 py-3">
+                <span className="text-muted-foreground text-sm">
+                  Unsaved changes
+                </span>
+                <Button
+                  onClick={() => {
+                    handleDiscardRef.current?.();
+                    toast.dismiss(t);
+                  }}
+                  size="sm"
+                  variant="ghost"
+                >
+                  Discard
+                </Button>
+                <Button
+                  onClick={() => {
+                    handleSaveRef.current?.();
+                    toast.dismiss(t);
+                  }}
+                  size="sm"
+                >
+                  Save
+                </Button>
+              </div>
             </div>
-          </div>
-        ),
-        { duration: Number.POSITIVE_INFINITY, position: "bottom-right" }
-      );
-    }
+          ),
+          { duration: Number.POSITIVE_INFINITY, position: "bottom-right" }
+        );
+      }
+    };
+
+    syncSaveToast();
+    mediaQuery.addEventListener("change", syncSaveToast);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncSaveToast);
+    };
   }, [hasChanges, isActivityPanelOpen]);
 
   useEffect(() => {

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -1189,10 +1189,10 @@ export default function PageClient({
           <AnimatePresence initial={false}>
             {isActivityPanelOpen && (
               <m.aside
-                animate={{ opacity: 1, width: "24rem" }}
-                className="hidden min-h-0 shrink-0 overflow-hidden lg:block"
-                exit={{ opacity: 0, width: 0 }}
-                initial={{ opacity: 0, width: 0 }}
+                animate={{ opacity: 1, x: 0 }}
+                className="hidden min-h-0 w-96 shrink-0 overflow-hidden lg:block"
+                exit={{ opacity: 0, x: "100%" }}
+                initial={{ opacity: 0, x: "100%" }}
                 transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
               >
                 <div className="flex h-full min-h-0 w-96 flex-col">

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeft02Icon,
   Download01Icon,
   SentIcon,
+  SidebarRight01Icon,
   TextIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -35,18 +36,24 @@ import {
 } from "@notra/ui/components/ui/tooltip";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { DefaultChatTransport } from "ai";
+import { AnimatePresence, LazyMotion, m } from "motion/react";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import remend from "remend";
 import { toast } from "sonner";
 import ChatInput from "@/components/chat-input";
 import { getContentTypeLabel } from "@/components/content/content-card";
+import { ContentChatActivityPanel } from "@/components/content/content-chat-activity-panel";
 import type { EditorRefHandle } from "@/components/content/editor/plugins/editor-ref-plugin";
 import { ContentEditorSwitch } from "@/components/content/editors";
 import { ImageExportTargetIcon } from "@/components/content/image-export-target-icon";
 import { RecommendationsSection } from "@/components/content/recommendations-section";
+import { RightPanelPortal } from "@/components/dashboard/right-panel-portal";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
-import { CONTENT_TITLE_REGEX } from "@/constants/content-detail";
+import {
+  CONTENT_TITLE_REGEX,
+  SAVE_BAR_SELECTOR,
+} from "@/constants/content-detail";
 import { IMAGE_EXPORT_TARGETS } from "@/constants/image-export";
 import { LINKEDIN_BRAND_PRIMARY } from "@/constants/linkedin";
 import { localStorageKeys } from "@/constants/storage";
@@ -70,9 +77,13 @@ import {
   isImageExportTarget,
 } from "@/utils/image-export";
 import { createLinkedInPostUrl } from "@/utils/linkedin";
+import { shakeElements } from "@/utils/shake-element";
 import { createTwitterPostUrl } from "@/utils/twitter";
 import { useContent } from "../../../../../lib/hooks/use-content";
 import { ContentDetailSkeleton } from "./skeleton";
+
+const loadMotionFeatures = () =>
+  import("@/lib/motion-features").then((mod) => mod.default);
 
 function formatDate(date: Date): string {
   return new Intl.DateTimeFormat(undefined, {
@@ -144,6 +155,7 @@ export default function PageClient({
   const [imageExportTarget, setImageExportTarget] =
     useState<ImageExportTarget>("paper");
 
+  const [isActivityPanelOpen, setIsActivityPanelOpen] = useState(false);
   const saveToastIdRef = useRef<string | number | null>(null);
   const editorRef = useRef<EditorRefHandle | null>(null);
   const imageExportRef = useRef<HTMLDivElement | null>(null);
@@ -228,6 +240,7 @@ export default function PageClient({
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
       event.preventDefault();
       event.returnValue = "";
+      shakeElements(SAVE_BAR_SELECTOR);
     };
 
     window.addEventListener("beforeunload", handleBeforeUnload);
@@ -355,10 +368,21 @@ export default function PageClient({
   }, [handleSave, handleDiscard]);
 
   useEffect(() => {
-    if (hasChanges && !saveToastIdRef.current) {
+    const isWide =
+      isActivityPanelOpen && window.matchMedia("(min-width: 64rem)").matches;
+
+    if ((!hasChanges || isWide) && saveToastIdRef.current) {
+      toast.dismiss(saveToastIdRef.current);
+      saveToastIdRef.current = null;
+    }
+
+    if (hasChanges && !isWide && !saveToastIdRef.current) {
       saveToastIdRef.current = toast.custom(
         (t) => (
-          <div className="rounded-[14px] border border-border bg-background p-0.5 shadow-sm">
+          <div
+            className="rounded-[14px] border border-border bg-background p-0.5 shadow-sm"
+            data-save-bar
+          >
             <div className="flex items-center gap-3 rounded-lg bg-background px-4 py-3">
               <span className="text-muted-foreground text-sm">
                 Unsaved changes
@@ -387,11 +411,8 @@ export default function PageClient({
         ),
         { duration: Number.POSITIVE_INFINITY, position: "bottom-right" }
       );
-    } else if (!hasChanges && saveToastIdRef.current) {
-      toast.dismiss(saveToastIdRef.current);
-      saveToastIdRef.current = null;
     }
-  }, [hasChanges]);
+  }, [hasChanges, isActivityPanelOpen]);
 
   useEffect(() => {
     return () => {
@@ -637,6 +658,7 @@ export default function PageClient({
 
   const handleAiEdit = useCallback(
     async (instruction: string) => {
+      setIsActivityPanelOpen(true);
       await sendMessage(
         { text: instruction },
         {
@@ -663,9 +685,35 @@ export default function PageClient({
     ]
   );
 
+  const saveBarSection =
+    hasChanges && isActivityPanelOpen ? (
+      <div
+        className={`pointer-events-none fixed bottom-4 left-0 z-50 hidden lg:right-96 lg:block ${sidebarState === "collapsed" ? "lg:left-14" : "lg:left-64"}`}
+      >
+        <div className="pointer-events-auto mx-auto w-full max-w-xl px-4">
+          <div
+            className="rounded-[14px] border border-border bg-background p-0.5 shadow-sm"
+            data-save-bar
+          >
+            <div className="flex items-center gap-3 rounded-lg bg-background py-2 pr-2 pl-4">
+              <span className="flex-1 text-muted-foreground text-sm">
+                You have unsaved changes
+              </span>
+              <Button onClick={handleDiscard} size="sm" variant="ghost">
+                Discard
+              </Button>
+              <Button onClick={handleSave} size="sm">
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    ) : null;
+
   const chatInputSection = (
     <div
-      className={`fixed right-0 bottom-0 left-0 mx-auto w-full max-w-2xl px-4 pb-4 md:w-auto ${sidebarState === "collapsed" ? "md:left-14" : "md:left-64"}`}
+      className={`fixed right-0 bottom-0 left-0 mx-auto w-full max-w-2xl px-4 pb-4 md:w-auto ${sidebarState === "collapsed" ? "md:left-14" : "md:left-64"} ${isActivityPanelOpen ? "lg:hidden" : ""}`}
     >
       <ChatInput
         completionMessage={completionMessage}
@@ -923,6 +971,22 @@ export default function PageClient({
                 })()}
             </div>
             <div className="ml-auto flex shrink-0 items-center gap-2">
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      className="hidden lg:inline-flex"
+                      onClick={() => setIsActivityPanelOpen((open) => !open)}
+                      size="icon-sm"
+                      variant={isActivityPanelOpen ? "secondary" : "outline"}
+                    />
+                  }
+                >
+                  <span className="sr-only">Toggle agent activity</span>
+                  <HugeiconsIcon className="size-4" icon={SidebarRight01Icon} />
+                </TooltipTrigger>
+                <TooltipContent>Agent activity</TooltipContent>
+              </Tooltip>
               {content.contentType !== "image" && (
                 <Button
                   disabled={isTogglingStatus}
@@ -1110,6 +1174,52 @@ export default function PageClient({
           <div className="h-24" />
         </div>
       </div>
+      <RightPanelPortal>
+        <LazyMotion features={loadMotionFeatures} strict>
+          <AnimatePresence initial={false}>
+            {isActivityPanelOpen && (
+              <m.aside
+                animate={{ opacity: 1, width: "24rem" }}
+                className="hidden min-h-0 shrink-0 overflow-hidden lg:block"
+                exit={{ opacity: 0, width: 0 }}
+                initial={{ opacity: 0, width: 0 }}
+                transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+              >
+                <div className="flex h-full min-h-0 w-96 flex-col">
+                  <div className="min-h-0 flex-1">
+                    <ContentChatActivityPanel
+                      messages={messages}
+                      onClose={() => setIsActivityPanelOpen(false)}
+                      status={status}
+                    />
+                  </div>
+                  <div className="shrink-0 p-2 pt-1">
+                    <ChatInput
+                      completionMessage={null}
+                      context={context}
+                      error={chatError}
+                      isLoading={
+                        status === "streaming" || status === "submitted"
+                      }
+                      onAddContext={handleAddContext}
+                      onClearError={() => setChatError(null)}
+                      onClearSelection={clearSelection}
+                      onRemoveContext={handleRemoveContext}
+                      onSend={handleAiEdit}
+                      onValueChange={setChatInputValue}
+                      organizationId={organizationId}
+                      organizationSlug={organizationSlug}
+                      selection={selection}
+                      value={chatInputValue}
+                    />
+                  </div>
+                </div>
+              </m.aside>
+            )}
+          </AnimatePresence>
+        </LazyMotion>
+      </RightPanelPortal>
+      {saveBarSection}
       {chatInputSection}
     </>
   );

--- a/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
+++ b/apps/dashboard/src/app/api/organizations/[organizationId]/content/[contentId]/chat/route.ts
@@ -242,6 +242,7 @@ export const POST = withEvlog(async function POST(
     });
 
     return stream.toUIMessageStreamResponse({
+      sendReasoning: true,
       onError: (error) => {
         console.error("[Content Chat] Stream error:", { requestId, error });
         return "An error occurred while processing your request.";

--- a/apps/dashboard/src/components/ai/chat-reasoning-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-reasoning-block.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { AiBrain01Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MessageResponse } from "@notra/ui/components/ai-elements/message";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@notra/ui/components/ui/collapsible";
+import { useEffect, useRef, useState } from "react";
+import { BrailleLoader } from "@/components/braille-loader";
+import {
+  REASONING_AUTO_CLOSE_DELAY_MS,
+  REASONING_CONTENT_CLASSNAME,
+  THINKING_LABEL,
+} from "@/constants/chat-reasoning";
+import type {
+  ChatReasoningBlockProps,
+  ChatReasoningBlockState,
+} from "@/types/components/chat-reasoning-block";
+import { formatReasoningDurationLabel } from "@/utils/format-reasoning-duration";
+
+export function ChatReasoningBlock({
+  children,
+  isStreaming,
+}: ChatReasoningBlockProps) {
+  const [reasoningState, setReasoningState] = useState<ChatReasoningBlockState>(
+    {
+      durationSeconds: null,
+      isOpen: false,
+      wasStreaming: null,
+    }
+  );
+  const startTimeRef = useRef<number | null>(null);
+
+  if (reasoningState.wasStreaming !== isStreaming) {
+    setReasoningState({
+      durationSeconds: isStreaming ? null : reasoningState.durationSeconds,
+      isOpen: isStreaming ? true : reasoningState.isOpen,
+      wasStreaming: isStreaming,
+    });
+  }
+
+  useEffect(() => {
+    if (isStreaming) {
+      startTimeRef.current = Date.now();
+      return;
+    }
+
+    const durationTimer = window.setTimeout(() => {
+      const startedAt = startTimeRef.current;
+
+      setReasoningState((current) => ({
+        ...current,
+        durationSeconds: startedAt
+          ? Math.max(1, Math.ceil((Date.now() - startedAt) / 1000))
+          : null,
+      }));
+    }, 0);
+
+    const closeTimer = window.setTimeout(() => {
+      setReasoningState((current) => ({ ...current, isOpen: false }));
+    }, REASONING_AUTO_CLOSE_DELAY_MS);
+
+    return () => {
+      window.clearTimeout(durationTimer);
+      window.clearTimeout(closeTimer);
+    };
+  }, [isStreaming]);
+
+  const statusLabel = isStreaming
+    ? THINKING_LABEL
+    : formatReasoningDurationLabel(reasoningState.durationSeconds);
+
+  function handleOpenChange(isOpen: boolean) {
+    setReasoningState((current) => ({ ...current, isOpen }));
+  }
+
+  return (
+    <Collapsible onOpenChange={handleOpenChange} open={reasoningState.isOpen}>
+      <CollapsibleTrigger className="flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground">
+        {isStreaming ? (
+          <BrailleLoader className="text-sm" label={statusLabel} />
+        ) : (
+          <>
+            <HugeiconsIcon className="size-4" icon={AiBrain01Icon} />
+            <span>{statusLabel}</span>
+          </>
+        )}
+        <HugeiconsIcon
+          className={`size-4 transition-transform ${reasoningState.isOpen ? "rotate-180" : "rotate-0"}`}
+          icon={ArrowDown01Icon}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className={REASONING_CONTENT_CLASSNAME}>
+        <div className="pt-4">
+          <MessageResponse className="text-muted-foreground text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+            {children}
+          </MessageResponse>
+          <div className="h-3" />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -446,6 +446,8 @@ const TOOL_COPY: Record<string, ToolCopy> = {
     verbs: ["Checking", "Checked"],
     noun: "integrations",
   },
+  getMarkdown: { verbs: ["Reading", "Read"], noun: "document" },
+  editMarkdown: { verbs: ["Editing", "Edited"], noun: "document" },
   listAvailableSkills: { verbs: ["Listing", "Listed"], noun: "skills" },
   getSkillByName: {
     verbs: ["Loading", "Loaded"],

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -146,7 +146,6 @@ const ChatInput = ({
     })
   );
 
-  // Get all enabled repos from all integrations (memoized, single iteration)
   const enabledRepos = useMemo(() => {
     const result: EnabledRepo[] = [];
     for (const integration of integrationsData?.integrations ?? []) {
@@ -198,7 +197,6 @@ const ChatInput = ({
     [onAddContext, onRemoveContext]
   );
 
-  // Resize textarea when controlled value changes
   useEffect(() => {
     if (isControlled) {
       requestAnimationFrame(resizeTextarea);
@@ -218,14 +216,12 @@ const ChatInput = ({
       return;
     }
 
-    // Only check billing if customer data is available (Autumn is configured)
     if (customer) {
       const checkResult = check({
         featureId: FEATURES.AI_CREDITS,
         requiredBalance: 1,
       });
 
-      // Only block if we explicitly got allowed: false (not if check failed)
       if (checkResult?.allowed === false) {
         setInternalError(CHAT_INPUT_LIMIT_MESSAGE);
         return;

--- a/apps/dashboard/src/components/content/content-chat-activity-panel.tsx
+++ b/apps/dashboard/src/components/content/content-chat-activity-panel.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { AiBrain01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@notra/ui/components/ai-elements/message";
+import { Button } from "@notra/ui/components/ui/button";
+import {
+  MessageScroller,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from "@notra/ui/components/ui/message-scroller";
+import { getToolName, isToolUIPart } from "ai";
+import { m } from "motion/react";
+import { ChatReasoningBlock } from "@/components/ai/chat-reasoning-block";
+import { ChatToolBlock } from "@/components/ai/chat-tool-block";
+import { BrailleLoader } from "@/components/braille-loader";
+import type {
+  ContentChatActivityMessageProps,
+  ContentChatActivityPanelProps,
+} from "@/types/components/content-chat-activity-panel";
+
+function ContentChatActivityMessage({
+  message,
+  status,
+}: ContentChatActivityMessageProps) {
+  return (
+    <m.div
+      animate={{ opacity: 1, y: 0 }}
+      initial={{ opacity: 0, y: 8 }}
+      transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+    >
+      <Message from={message.role}>
+        <MessageContent>
+          {message.parts.map((part, index) => {
+            const key = `${message.id}-${index}`;
+
+            if (part.type === "text") {
+              if (!part.text.trim()) {
+                return null;
+              }
+              return <MessageResponse key={key}>{part.text}</MessageResponse>;
+            }
+
+            if (part.type === "reasoning") {
+              if (!part.text.trim()) {
+                return null;
+              }
+              return (
+                <ChatReasoningBlock
+                  isStreaming={
+                    status === "streaming" && part.state === "streaming"
+                  }
+                  key={key}
+                >
+                  {part.text}
+                </ChatReasoningBlock>
+              );
+            }
+
+            if (isToolUIPart(part)) {
+              return (
+                <ChatToolBlock
+                  input={part.input}
+                  key={part.toolCallId}
+                  output={part.output}
+                  state={part.state}
+                  toolCallId={part.toolCallId}
+                  toolName={getToolName(part)}
+                />
+              );
+            }
+
+            return null;
+          })}
+        </MessageContent>
+      </Message>
+    </m.div>
+  );
+}
+
+export function ContentChatActivityPanel({
+  messages,
+  status,
+  onClose,
+}: ContentChatActivityPanelProps) {
+  const showThinkingIndicator = status === "submitted";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-2 py-2 pr-2 pl-4">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon
+            className="size-4 text-muted-foreground"
+            icon={AiBrain01Icon}
+          />
+          <span className="font-medium text-sm">Agent activity</span>
+        </div>
+        <Button onClick={onClose} size="icon-sm" variant="ghost">
+          <span className="sr-only">Close agent activity</span>
+          <HugeiconsIcon className="size-4" icon={Cancel01Icon} />
+        </Button>
+      </div>
+      {messages.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+          <HugeiconsIcon
+            className="size-5 text-muted-foreground"
+            icon={AiBrain01Icon}
+          />
+          <p className="text-muted-foreground text-sm">
+            Ask the assistant to edit this content and every step shows up here
+            as it happens: its thinking, the tools it runs, and its replies.
+          </p>
+        </div>
+      ) : (
+        <MessageScrollerProvider autoScroll>
+          <MessageScroller className="min-h-0 flex-1">
+            <MessageScrollerViewport className="min-w-0 overflow-x-hidden">
+              <MessageScrollerContent className="px-4 py-4">
+                <div className="flex min-w-0 flex-col gap-4">
+                  {messages.map((message) => (
+                    <MessageScrollerItem
+                      key={message.id}
+                      messageId={message.id}
+                      scrollAnchor={message.role === "user"}
+                    >
+                      <ContentChatActivityMessage
+                        message={message}
+                        status={status}
+                      />
+                    </MessageScrollerItem>
+                  ))}
+                  {showThinkingIndicator && (
+                    <BrailleLoader
+                      className="text-muted-foreground text-sm"
+                      label="Thinking"
+                    />
+                  )}
+                </div>
+              </MessageScrollerContent>
+            </MessageScrollerViewport>
+          </MessageScroller>
+        </MessageScrollerProvider>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -8,6 +8,7 @@ import { SiteHeader } from "@/components/dashboard/header";
 import { OnboardingAgentBanner } from "@/components/dashboard/onboarding-agent-banner";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { EVE_BANNER_HEIGHT } from "@/constants/onboarding-agent";
+import { RIGHT_PANEL_PORTAL_ID } from "@/constants/right-panel";
 import {
   useOnboardingAgentBannerDismissal,
   useOnboardingAgentRun,
@@ -79,6 +80,7 @@ export function DashboardShell({
             <SubscriptionGate>{children}</SubscriptionGate>
           </div>
         </SidebarInset>
+        <div className="contents" id={RIGHT_PANEL_PORTAL_ID} />
       </SidebarProvider>
     </div>
   );

--- a/apps/dashboard/src/components/dashboard/right-panel-portal.tsx
+++ b/apps/dashboard/src/components/dashboard/right-panel-portal.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { RIGHT_PANEL_PORTAL_ID } from "@/constants/right-panel";
+import type { RightPanelPortalProps } from "@/types/components/right-panel-portal";
+
+export function RightPanelPortal({ children }: RightPanelPortalProps) {
+  const [target, setTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setTarget(document.getElementById(RIGHT_PANEL_PORTAL_ID));
+  }, []);
+
+  if (!target) {
+    return null;
+  }
+
+  return createPortal(children, target);
+}

--- a/apps/dashboard/src/components/dashboard/right-panel-portal.tsx
+++ b/apps/dashboard/src/components/dashboard/right-panel-portal.tsx
@@ -1,25 +1,25 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { RIGHT_PANEL_PORTAL_ID } from "@/constants/right-panel";
 import type { RightPanelPortalProps } from "@/types/components/right-panel-portal";
 
-function getPortalTarget() {
-  if (typeof document === "undefined") {
-    return null;
-  }
-  return document.getElementById(RIGHT_PANEL_PORTAL_ID);
-}
+const subscribeToPortalTarget = () => () => {
+  // the portal outlet is rendered by the dashboard shell and never swapped
+};
+
+const getPortalTarget = () =>
+  document.getElementById(RIGHT_PANEL_PORTAL_ID) ?? null;
+
+const getServerPortalTarget = () => null;
 
 export function RightPanelPortal({ children }: RightPanelPortalProps) {
-  const [target, setTarget] = useState<HTMLElement | null>(getPortalTarget);
-
-  useEffect(() => {
-    if (!target) {
-      setTarget(getPortalTarget());
-    }
-  }, [target]);
+  const target = useSyncExternalStore(
+    subscribeToPortalTarget,
+    getPortalTarget,
+    getServerPortalTarget
+  );
 
   if (!target) {
     return null;

--- a/apps/dashboard/src/components/dashboard/right-panel-portal.tsx
+++ b/apps/dashboard/src/components/dashboard/right-panel-portal.tsx
@@ -5,12 +5,21 @@ import { createPortal } from "react-dom";
 import { RIGHT_PANEL_PORTAL_ID } from "@/constants/right-panel";
 import type { RightPanelPortalProps } from "@/types/components/right-panel-portal";
 
+function getPortalTarget() {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  return document.getElementById(RIGHT_PANEL_PORTAL_ID);
+}
+
 export function RightPanelPortal({ children }: RightPanelPortalProps) {
-  const [target, setTarget] = useState<HTMLElement | null>(null);
+  const [target, setTarget] = useState<HTMLElement | null>(getPortalTarget);
 
   useEffect(() => {
-    setTarget(document.getElementById(RIGHT_PANEL_PORTAL_ID));
-  }, []);
+    if (!target) {
+      setTarget(getPortalTarget());
+    }
+  }, [target]);
 
   if (!target) {
     return null;

--- a/apps/dashboard/src/constants/chat-reasoning.ts
+++ b/apps/dashboard/src/constants/chat-reasoning.ts
@@ -1,0 +1,4 @@
+export const THINKING_LABEL = "Thinking";
+export const REASONING_AUTO_CLOSE_DELAY_MS = 1000;
+export const REASONING_CONTENT_CLASSNAME =
+  "h-[var(--collapsible-panel-height)] overflow-hidden text-sm text-muted-foreground outline-none transition-[height,opacity] duration-300 ease-out data-[ending-style]:h-0 data-[ending-style]:opacity-0 data-[starting-style]:h-0 data-[starting-style]:opacity-0";

--- a/apps/dashboard/src/constants/content-detail.ts
+++ b/apps/dashboard/src/constants/content-detail.ts
@@ -1,1 +1,2 @@
 export const CONTENT_TITLE_REGEX = /^#\s+(.+)$/m;
+export const SAVE_BAR_SELECTOR = "[data-save-bar]";

--- a/apps/dashboard/src/constants/image-export.ts
+++ b/apps/dashboard/src/constants/image-export.ts
@@ -1,25 +1,5 @@
 export const IMAGE_EXPORT_TARGETS = ["paper", "figma", "wonder"] as const;
 
-export const EXPORT_HTML_FORBIDDEN_SELECTOR =
-  "script, iframe, frame, frameset, object, embed, applet, meta, base, link, form, input, button, textarea, select";
-
-export const EXPORT_HTML_URL_ATTRIBUTES = [
-  "src",
-  "href",
-  "xlink:href",
-  "action",
-  "formaction",
-  "background",
-  "poster",
-  "data",
-] as const;
-
-export const EXPORT_HTML_SAFE_URL_SCHEMES = [
-  "http:",
-  "https:",
-  "data:",
-] as const;
-
 export const IMAGE_EXPORT_TARGET_LABELS: Record<
   (typeof IMAGE_EXPORT_TARGETS)[number],
   string
@@ -28,3 +8,45 @@ export const IMAGE_EXPORT_TARGET_LABELS: Record<
   figma: "Figma",
   wonder: "Wonder",
 };
+
+export const EXPORT_HTML_FORBIDDEN_TAGS = [
+  "script",
+  "iframe",
+  "frame",
+  "frameset",
+  "object",
+  "embed",
+  "applet",
+  "base",
+  "form",
+  "input",
+  "button",
+  "textarea",
+  "select",
+  "animate",
+  "animateMotion",
+  "animateTransform",
+  "set",
+  "handler",
+  "foreignObject",
+];
+
+export const EXPORT_HTML_FORBIDDEN_ATTRIBUTES = [
+  "attributeName",
+  "attributename",
+  "values",
+  "from",
+  "to",
+  "by",
+  "begin",
+  "ping",
+];
+
+export const EXPORT_HTML_DATA_URI_TAGS = ["img", "image"];
+
+export const EXPORT_HTML_IMAGE_URL_ATTRIBUTES = ["src", "href", "xlink:href"];
+
+export const EXPORT_HTML_SAFE_DATA_URL_REGEX =
+  /^data:image\/(?:png|jpe?g|gif|webp|avif|bmp);/i;
+
+export const EXPORT_HTML_DATA_URL_PREFIX = "data:";

--- a/apps/dashboard/src/constants/image-export.ts
+++ b/apps/dashboard/src/constants/image-export.ts
@@ -1,5 +1,25 @@
 export const IMAGE_EXPORT_TARGETS = ["paper", "figma", "wonder"] as const;
 
+export const EXPORT_HTML_FORBIDDEN_SELECTOR =
+  "script, iframe, frame, frameset, object, embed, applet, meta, base, link, form, input, button, textarea, select";
+
+export const EXPORT_HTML_URL_ATTRIBUTES = [
+  "src",
+  "href",
+  "xlink:href",
+  "action",
+  "formaction",
+  "background",
+  "poster",
+  "data",
+] as const;
+
+export const EXPORT_HTML_SAFE_URL_SCHEMES = [
+  "http:",
+  "https:",
+  "data:",
+] as const;
+
 export const IMAGE_EXPORT_TARGET_LABELS: Record<
   (typeof IMAGE_EXPORT_TARGETS)[number],
   string

--- a/apps/dashboard/src/constants/right-panel.ts
+++ b/apps/dashboard/src/constants/right-panel.ts
@@ -1,0 +1,1 @@
+export const RIGHT_PANEL_PORTAL_ID = "dashboard-right-panel";

--- a/apps/dashboard/src/lib/content/image-export.ts
+++ b/apps/dashboard/src/lib/content/image-export.ts
@@ -6,6 +6,7 @@ import {
   downloadBlob,
   sanitizeDownloadFilename,
 } from "@/utils/download";
+import { sanitizeExportHtml } from "@/utils/sanitize-export-html";
 
 function createExportElement(html: string): HTMLDivElement {
   const container = document.createElement("div");
@@ -17,8 +18,7 @@ function createExportElement(html: string): HTMLDivElement {
   container.style.overflow = "hidden";
   container.style.pointerEvents = "none";
 
-  const range = document.createRange();
-  container.replaceChildren(range.createContextualFragment(html));
+  container.replaceChildren(sanitizeExportHtml(html));
   document.body.appendChild(container);
 
   return container;

--- a/apps/dashboard/src/types/components/chat-reasoning-block.ts
+++ b/apps/dashboard/src/types/components/chat-reasoning-block.ts
@@ -1,0 +1,10 @@
+export interface ChatReasoningBlockProps {
+  children: string;
+  isStreaming: boolean;
+}
+
+export interface ChatReasoningBlockState {
+  durationSeconds: number | null;
+  isOpen: boolean;
+  wasStreaming: boolean | null;
+}

--- a/apps/dashboard/src/types/components/content-chat-activity-panel.ts
+++ b/apps/dashboard/src/types/components/content-chat-activity-panel.ts
@@ -1,0 +1,12 @@
+import type { ChatStatus, UIMessage } from "ai";
+
+export interface ContentChatActivityPanelProps {
+  messages: UIMessage[];
+  status: ChatStatus;
+  onClose: () => void;
+}
+
+export interface ContentChatActivityMessageProps {
+  message: UIMessage;
+  status: ChatStatus;
+}

--- a/apps/dashboard/src/types/components/right-panel-portal.ts
+++ b/apps/dashboard/src/types/components/right-panel-portal.ts
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export interface RightPanelPortalProps {
+  children: ReactNode;
+}

--- a/apps/dashboard/src/utils/format-reasoning-duration.ts
+++ b/apps/dashboard/src/utils/format-reasoning-duration.ts
@@ -1,0 +1,9 @@
+export function formatReasoningDurationLabel(
+  durationSeconds: number | null
+): string {
+  if (!durationSeconds || durationSeconds <= 1) {
+    return "Thought for a moment";
+  }
+
+  return `Thought for ${durationSeconds} seconds`;
+}

--- a/apps/dashboard/src/utils/sanitize-export-html.ts
+++ b/apps/dashboard/src/utils/sanitize-export-html.ts
@@ -1,0 +1,84 @@
+import {
+  EXPORT_HTML_FORBIDDEN_SELECTOR,
+  EXPORT_HTML_SAFE_URL_SCHEMES,
+  EXPORT_HTML_URL_ATTRIBUTES,
+} from "@/constants/image-export";
+
+const DATA_URL_PREFIX = "data:";
+const SAFE_DATA_URL_PREFIX = "data:image/";
+const SVG_DATA_URL_PREFIX = "data:image/svg";
+
+function isSafeUrlValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return true;
+  }
+
+  if (trimmed.startsWith("#") || trimmed.startsWith("/")) {
+    return true;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, window.location.origin);
+  } catch {
+    return false;
+  }
+
+  if (
+    !(EXPORT_HTML_SAFE_URL_SCHEMES as readonly string[]).includes(
+      parsed.protocol
+    )
+  ) {
+    return false;
+  }
+
+  if (trimmed.toLowerCase().startsWith(DATA_URL_PREFIX)) {
+    const lowered = trimmed.toLowerCase();
+    return (
+      lowered.startsWith(SAFE_DATA_URL_PREFIX) &&
+      !lowered.startsWith(SVG_DATA_URL_PREFIX)
+    );
+  }
+
+  return true;
+}
+
+function stripUnsafeAttributes(element: Element) {
+  for (const attribute of [...element.attributes]) {
+    const name = attribute.name.toLowerCase();
+
+    if (name.startsWith("on")) {
+      element.removeAttribute(attribute.name);
+      continue;
+    }
+
+    if (
+      (EXPORT_HTML_URL_ATTRIBUTES as readonly string[]).includes(name) &&
+      !isSafeUrlValue(attribute.value)
+    ) {
+      element.removeAttribute(attribute.name);
+    }
+  }
+}
+
+export function sanitizeExportHtml(html: string): DocumentFragment {
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+
+  for (const element of parsed.querySelectorAll(
+    EXPORT_HTML_FORBIDDEN_SELECTOR
+  )) {
+    element.remove();
+  }
+
+  for (const element of parsed.querySelectorAll("*")) {
+    stripUnsafeAttributes(element);
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const node of [...parsed.head.childNodes, ...parsed.body.childNodes]) {
+    fragment.append(document.importNode(node, true));
+  }
+
+  return fragment;
+}

--- a/apps/dashboard/src/utils/sanitize-export-html.ts
+++ b/apps/dashboard/src/utils/sanitize-export-html.ts
@@ -1,83 +1,39 @@
+import DOMPurify from "dompurify";
 import {
-  EXPORT_HTML_FORBIDDEN_SELECTOR,
-  EXPORT_HTML_SAFE_URL_SCHEMES,
-  EXPORT_HTML_URL_ATTRIBUTES,
+  EXPORT_HTML_DATA_URI_TAGS,
+  EXPORT_HTML_DATA_URL_PREFIX,
+  EXPORT_HTML_FORBIDDEN_ATTRIBUTES,
+  EXPORT_HTML_FORBIDDEN_TAGS,
+  EXPORT_HTML_IMAGE_URL_ATTRIBUTES,
+  EXPORT_HTML_SAFE_DATA_URL_REGEX,
 } from "@/constants/image-export";
 
-const DATA_URL_PREFIX = "data:";
-const SAFE_DATA_URL_PREFIX = "data:image/";
-const SVG_DATA_URL_PREFIX = "data:image/svg";
-
-function isSafeUrlValue(value: string): boolean {
-  const trimmed = value.trim();
-  if (trimmed === "") {
-    return true;
-  }
-
-  if (trimmed.startsWith("#") || trimmed.startsWith("/")) {
-    return true;
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed, window.location.origin);
-  } catch {
-    return false;
-  }
-
-  if (
-    !(EXPORT_HTML_SAFE_URL_SCHEMES as readonly string[]).includes(
-      parsed.protocol
-    )
-  ) {
-    return false;
-  }
-
-  if (trimmed.toLowerCase().startsWith(DATA_URL_PREFIX)) {
-    const lowered = trimmed.toLowerCase();
-    return (
-      lowered.startsWith(SAFE_DATA_URL_PREFIX) &&
-      !lowered.startsWith(SVG_DATA_URL_PREFIX)
-    );
-  }
-
-  return true;
-}
-
-function stripUnsafeAttributes(element: Element) {
-  for (const attribute of [...element.attributes]) {
-    const name = attribute.name.toLowerCase();
-
-    if (name.startsWith("on")) {
-      element.removeAttribute(attribute.name);
-      continue;
-    }
-
-    if (
-      (EXPORT_HTML_URL_ATTRIBUTES as readonly string[]).includes(name) &&
-      !isSafeUrlValue(attribute.value)
-    ) {
-      element.removeAttribute(attribute.name);
-    }
-  }
+function isDisallowedDataUrl(value: string): boolean {
+  const trimmed = value.trim().toLowerCase();
+  return (
+    trimmed.startsWith(EXPORT_HTML_DATA_URL_PREFIX) &&
+    !EXPORT_HTML_SAFE_DATA_URL_REGEX.test(trimmed)
+  );
 }
 
 export function sanitizeExportHtml(html: string): DocumentFragment {
-  const parsed = new DOMParser().parseFromString(html, "text/html");
+  const fragment = DOMPurify.sanitize(html, {
+    ADD_DATA_URI_TAGS: EXPORT_HTML_DATA_URI_TAGS,
+    FORBID_ATTR: EXPORT_HTML_FORBIDDEN_ATTRIBUTES,
+    FORBID_TAGS: EXPORT_HTML_FORBIDDEN_TAGS,
+    RETURN_DOM_FRAGMENT: true,
+    WHOLE_DOCUMENT: true,
+  });
 
-  for (const element of parsed.querySelectorAll(
-    EXPORT_HTML_FORBIDDEN_SELECTOR
+  for (const element of fragment.querySelectorAll(
+    EXPORT_HTML_DATA_URI_TAGS.join(", ")
   )) {
-    element.remove();
-  }
-
-  for (const element of parsed.querySelectorAll("*")) {
-    stripUnsafeAttributes(element);
-  }
-
-  const fragment = document.createDocumentFragment();
-  for (const node of [...parsed.head.childNodes, ...parsed.body.childNodes]) {
-    fragment.append(document.importNode(node, true));
+    for (const attribute of EXPORT_HTML_IMAGE_URL_ATTRIBUTES) {
+      const value = element.getAttribute(attribute);
+      if (value && isDisallowedDataUrl(value)) {
+        element.removeAttribute(attribute);
+      }
+    }
   }
 
   return fragment;

--- a/apps/dashboard/src/utils/shake-element.ts
+++ b/apps/dashboard/src/utils/shake-element.ts
@@ -1,0 +1,22 @@
+const SHAKE_KEYFRAMES: Keyframe[] = [
+  { transform: "translateX(0)" },
+  { transform: "translateX(-0.5rem)" },
+  { transform: "translateX(0.4rem)" },
+  { transform: "translateX(-0.3rem)" },
+  { transform: "translateX(0.2rem)" },
+  { transform: "translateX(-0.1rem)" },
+  { transform: "translateX(0)" },
+];
+
+const SHAKE_DURATION_MS = 450;
+
+export function shakeElements(selector: string) {
+  for (const element of document.querySelectorAll(selector)) {
+    if (element instanceof HTMLElement) {
+      element.animate(SHAKE_KEYFRAMES, {
+        duration: SHAKE_DURATION_MS,
+        easing: "ease-in-out",
+      });
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -153,6 +153,7 @@
         "cmdk": "^1.1.1",
         "cnfast": "^0.0.6",
         "date-fns": "^4.1.0",
+        "dompurify": "3.4.12",
         "drizzle-orm": "^0.45.2",
         "effect": "4.0.0-beta.93",
         "eve": "0.19.0",

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -8,7 +8,6 @@ import { createLazyMcpRuntime } from "@notra/ai/tools/mcp-lazy";
 import type {
   AutoThinkingLevel,
   IntegrationFetchers,
-  StreamProviderOptions,
   ValidatedIntegration,
 } from "@notra/ai/types/orchestration";
 import type { PostToolsResult } from "@notra/ai/types/post-tools";
@@ -45,6 +44,7 @@ import {
   getLinearContextFromIntegrations,
   getRepoContextFromIntegrations,
 } from "./standalone-tool-registry";
+import { getThinkingProviderOptions } from "./thinking";
 
 const NOTRA_MANAGER_TOOL_NAMES = [
   "searchNotraTools",
@@ -668,68 +668,6 @@ function stripIncompleteToolParts(messages: UIMessage[]): UIMessage[] {
     }
     return { ...message, parts: filtered };
   });
-}
-
-function getThinkingProviderOptions(
-  modelId: string,
-  enableThinking: boolean,
-  thinkingLevel: "off" | "low" | "medium" | "high"
-): StreamProviderOptions | undefined {
-  if (!enableThinking || thinkingLevel === "off") {
-    return undefined;
-  }
-
-  if (modelId.startsWith("anthropic/")) {
-    if (usesAdaptiveThinking(modelId)) {
-      return {
-        anthropic: {
-          thinking: { type: "adaptive" },
-          output_config: { effort: thinkingLevel },
-        },
-      } satisfies StreamProviderOptions;
-    }
-
-    return {
-      anthropic: {
-        thinking: {
-          type: "enabled",
-          budgetTokens: getAnthropicThinkingBudget(thinkingLevel),
-        },
-      },
-    } satisfies StreamProviderOptions;
-  }
-
-  if (modelId.startsWith("openai/")) {
-    return {
-      openai: {
-        reasoningEffort: thinkingLevel,
-      },
-    } satisfies StreamProviderOptions;
-  }
-
-  return undefined;
-}
-
-function usesAdaptiveThinking(modelId: string): boolean {
-  return (
-    modelId.startsWith("anthropic/claude-opus-") ||
-    modelId.startsWith("anthropic/claude-sonnet-")
-  );
-}
-
-function getAnthropicThinkingBudget(
-  thinkingLevel: "off" | "low" | "medium" | "high"
-): number {
-  switch (thinkingLevel) {
-    case "low":
-      return 1024;
-    case "high":
-      return 8192;
-    case "medium":
-      return 4096;
-    default:
-      return 0;
-  }
 }
 
 async function validateStandaloneIntegrations(

--- a/packages/ai/src/orchestration/orchestrate.ts
+++ b/packages/ai/src/orchestration/orchestrate.ts
@@ -20,6 +20,7 @@ import {
   validateIntegrations,
 } from "./integration-validator";
 import { routeAndSelectModel } from "./router";
+import { getThinkingProviderOptions } from "./thinking";
 import {
   buildToolSet,
   getLinearContextFromIntegrations,
@@ -124,9 +125,16 @@ export async function orchestrateChat(
     }),
     tools,
     stopWhen: stepCountIs(maxSteps),
-    providerOptions: withGatewayDefaults(undefined, {
-      modelId: routingDecision.model,
-    }),
+    providerOptions: withGatewayDefaults(
+      getThinkingProviderOptions(
+        routingDecision.model,
+        true,
+        routingDecision.thinkingLevel ?? "low"
+      ),
+      {
+        modelId: routingDecision.model,
+      }
+    ),
     experimental_telemetry: buildExperimentalTelemetry(telemetryMetadata),
     async onFinish({ totalUsage }) {
       await deps?.onUsage?.(totalUsage, routingDecision.model);

--- a/packages/ai/src/orchestration/router.ts
+++ b/packages/ai/src/orchestration/router.ts
@@ -224,5 +224,6 @@ export async function routeAndSelectModel(
     complexity: decision.complexity,
     requiresTools: decision.requiresTools,
     reasoning: decision.reasoning,
+    thinkingLevel: decision.complexity === "complex" ? "medium" : "low",
   };
 }

--- a/packages/ai/src/orchestration/thinking.ts
+++ b/packages/ai/src/orchestration/thinking.ts
@@ -1,0 +1,64 @@
+import type {
+  AutoThinkingLevel,
+  StreamProviderOptions,
+} from "../types/orchestration";
+
+export function getThinkingProviderOptions(
+  modelId: string,
+  enableThinking: boolean,
+  thinkingLevel: AutoThinkingLevel
+): StreamProviderOptions | undefined {
+  if (!enableThinking || thinkingLevel === "off") {
+    return undefined;
+  }
+
+  if (modelId.startsWith("anthropic/")) {
+    if (usesAdaptiveThinking(modelId)) {
+      return {
+        anthropic: {
+          thinking: { type: "adaptive" },
+          output_config: { effort: thinkingLevel },
+        },
+      } satisfies StreamProviderOptions;
+    }
+
+    return {
+      anthropic: {
+        thinking: {
+          type: "enabled",
+          budgetTokens: getAnthropicThinkingBudget(thinkingLevel),
+        },
+      },
+    } satisfies StreamProviderOptions;
+  }
+
+  if (modelId.startsWith("openai/")) {
+    return {
+      openai: {
+        reasoningEffort: thinkingLevel,
+      },
+    } satisfies StreamProviderOptions;
+  }
+
+  return undefined;
+}
+
+function usesAdaptiveThinking(modelId: string): boolean {
+  return (
+    modelId.startsWith("anthropic/claude-opus-") ||
+    modelId.startsWith("anthropic/claude-sonnet-")
+  );
+}
+
+function getAnthropicThinkingBudget(thinkingLevel: AutoThinkingLevel): number {
+  switch (thinkingLevel) {
+    case "low":
+      return 1024;
+    case "high":
+      return 8192;
+    case "medium":
+      return 4096;
+    default:
+      return 0;
+  }
+}

--- a/packages/ai/src/prompts/content-editor.ts
+++ b/packages/ai/src/prompts/content-editor.ts
@@ -62,7 +62,7 @@ export function getContentEditorChatPrompt(
     - For multi-line content use \\n in content string
     - When user selects text, focus only on that section
     - IMPORTANT: When the user requests edits, you MUST use the editMarkdown tool (no plain-text rewrites)
-    - IMPORTANT: Do NOT output the content of your edits in text. Only use the editMarkdown tool. Keep text responses brief - just explain what you're doing, not the actual content.`;
+    - IMPORTANT: Do NOT output the content of your edits in text. Only use the editMarkdown tool. The edited document itself is shown to the user in the editor, so never repeat it in text.`;
 
   const githubSection =
     hasGitHubEnabled && repoContext?.length
@@ -82,6 +82,13 @@ export function getContentEditorChatPrompt(
 
     ## Current Date
     Today is ${currentDate} (${resolvedTimezone}). Use this when users reference relative dates like "today", "yesterday", "this week", or "last month".
+
+    ## Working in the Open
+    The user sees your full activity in a side panel: your reasoning, every tool call with its inputs and results, and your text responses. Work in the open:
+    - Before calling a tool, say in one short sentence what you are about to do and why (for example "Reading the document to find the intro section").
+    - After a tool finishes, briefly note what you found or changed before moving on.
+    - When you finish, summarize what you did in plain language so the user can follow the conversation without expanding any tool call.
+    - Keep this narration conversational and concise: one or two sentences per step, never a restatement of document content.
 
     ${workflowSection}
 


### PR DESCRIPTION
## What

The chat box on the content detail page previously collapsed all agent work into a one-line status, which made it hard to tell what the agent was actually doing. This PR adds a dedicated **Agent activity sidebar** that streams everything live.

- **New right sidebar** rendered as a true sibling of the content card (portal outlet in the dashboard shell), sitting on the shell background like the left nav. Opens automatically on first message, toggleable from the content header.
- Shows the **full conversation**: user messages, collapsible reasoning blocks ("Thought for N seconds"), every tool call with expandable inputs/outputs (reusing `ChatToolBlock`), and the agent's replies, with auto-scroll.
- The **chat composer moves into the sidebar** while it's open (desktop); the floating bottom bar remains for mobile/closed states.
- **LazyMotion animations**: spring width reveal for the panel, rise-in for messages.
- **Unsaved-changes UX**: while the sidebar is open, the save prompt becomes a Discord-style centered bar over the content card (with a shake when unload is blocked); otherwise the compact bottom-right toast is unchanged.

## Server/AI changes

- Content chat route now streams reasoning (`sendReasoning: true`).
- The orchestrator enables extended thinking, with the level derived from the router's complexity signal (`medium` for complex, `low` otherwise). The thinking provider-options helper was extracted from the standalone orchestrator into shared `packages/ai/src/orchestration/thinking.ts`.
- The content editor prompt gains a "Working in the Open" section so the agent narrates each step (visible in the panel) while still never dumping document content into text.
- `ChatReasoningBlock` was extracted from the standalone chat page into a shared component.

## Notes

- Conversations remain **ephemeral** (client state only) — persistence via `chat_sessions.contentId` was designed but deliberately deferred.
- react-doctor on changed files: 4 findings. The 3 "animating width" errors are a conscious tradeoff (one-shot 350ms user-triggered reveal that lets the content card reflow smoothly; a transform slide would avoid relayout but the card would jump). The remaining warning is the file's pre-existing manual-memoization style.
- Verified: `tsc --noEmit` (dashboard + @notra/ai), Biome, and a production dashboard build all pass.

https://claude.ai/code/session_01RQP3FusXBUdCEvvvpVGHUh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent activity sidebar to the content detail page that streams the assistant’s reasoning, tool calls, and replies live, with a transform slide‑in for smoother performance. Also moves the desktop chat composer into the panel, updates the save UX, and hardens image‑export HTML sanitization using a `dompurify` allowlist.

- New Features
  - Right sidebar streams the full conversation (user messages, collapsible reasoning, tool I/O, replies) with auto‑scroll and subtle animations; opens on first message; toggleable; desktop moves the composer into the panel (mobile keeps bottom bar).
  - Unsaved changes shifts to a centered bar when the panel is open (desktop), with a shake on blocked unload; otherwise the bottom‑right toast remains and stays in sync across breakpoints.

- Refactors
  - Content chat now streams reasoning (`sendReasoning: true`); the router sets a `thinkingLevel` from complexity, and provider options are centralized in `packages/ai/src/orchestration/thinking.ts` and applied in `orchestrate.ts`.
  - Content editor prompt adds a “Working in the Open” section so the assistant narrates steps succinctly without repeating document content.
  - Extracted shared `ChatReasoningBlock` and added a `RightPanelPortal` to render the sidebar as a true sibling of the content card; the panel now slides via transform (no width animation) and the portal outlet is read via `useSyncExternalStore`; improved tool copy for `getMarkdown`/`editMarkdown`.
  - Image export HTML is sanitized with `dompurify` (allowlist) and restricted to safe data URLs for raster images.

<sup>Written for commit 9d253076ff42c5a25ad2ed007964f86c8752410b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`9d25307`](https://github.com/usenotra/notra/commit/9d253076ff42c5a25ad2ed007964f86c8752410b). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->