### PR TITLE
feat(chat): add MCP tools to context picker

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -72,17 +72,14 @@ import {
 } from "@/components/chat/chat-input";
 import { ChatQueue, type QueuedMessage } from "@/components/chat/chat-queue";
 import { ChatSuggestions } from "@/components/chat/chat-suggestions";
-import {
-  getReferenceDisplay,
-  parseReferenceValue,
-  renderTextWithIntegrationReferences,
-} from "@/components/chat/integration-reference";
+import { renderTextWithIntegrationReferences } from "@/components/chat/integration-reference";
 import {
   UserMessageActions,
   UserMessageEditor,
 } from "@/components/chat/user-message-actions";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { TOOL_TIMER_THRESHOLD_SECONDS } from "@/constants/chat-tool-timer";
+import { INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX } from "@/constants/integration-reference";
 import { localStorageKeys } from "@/constants/storage";
 import { authClient } from "@/lib/auth/client";
 import { useElapsedSeconds } from "@/lib/hooks/use-elapsed-seconds";
@@ -105,6 +102,10 @@ import {
 import { updateWasStoppedByUser } from "@/utils/chat-state";
 import { formatLongDate, getGreeting } from "@/utils/dashboard-greeting";
 import { formatElapsedSeconds } from "@/utils/format-elapsed-seconds";
+import {
+  getReferenceDisplay,
+  parseReferenceValue,
+} from "@/utils/integration-reference";
 import { getOutputTypeLabel } from "@/utils/output-types";
 
 const BlogChangelogPreview = dynamic(
@@ -1038,7 +1039,7 @@ function StandaloneChatPageClient({
 
   const toDisplayText = useCallback((serialized: string) => {
     return serialized.replace(
-      /@?integration\/(?:github\/[^/\s]+\/[^/\s]+\/[^/\s]+|linear\/[^/\s]+)/g,
+      INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX,
       (match) => {
         const item = parseReferenceValue(match);
         return item ? getReferenceDisplay(item) : match;
@@ -1544,7 +1545,8 @@ function StandaloneChatPageClient({
 
       const hasInlineReference =
         text.includes("integration/github/") ||
-        text.includes("integration/linear/");
+        text.includes("integration/linear/") ||
+        text.includes("integration/mcp/");
 
       if (hasInlineReference) {
         return (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -83,6 +83,7 @@ import { INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX } from "@/constants/integration
 import { localStorageKeys } from "@/constants/storage";
 import { authClient } from "@/lib/auth/client";
 import { useElapsedSeconds } from "@/lib/hooks/use-elapsed-seconds";
+import { getMcpIconUrls } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import { isImageMimeType } from "@/lib/upload/mime";
 import { cn } from "@/lib/utils";
@@ -439,6 +440,12 @@ function StandaloneChatPageClient({
   const organizationId = organization?.id ?? "";
   const { data: session } = authClient.useSession();
   const queryClient = useQueryClient();
+  const { data: customMcpData } = useQuery(
+    dashboardOrpc.integrations.mcp.list.queryOptions({
+      input: { organizationId },
+      enabled: Boolean(organizationId),
+    })
+  );
   const { data: mcpStoreData } = useQuery(
     dashboardOrpc.integrations.mcp.storeList.queryOptions({
       input: { organizationId },
@@ -447,22 +454,32 @@ function StandaloneChatPageClient({
   );
   const mcpLogosByConnectionId = useMemo(
     () =>
-      new Map(
-        (mcpStoreData?.integrations ?? []).flatMap((integration) =>
+      new Map([
+        ...(customMcpData?.servers ?? []).map(
+          (server) =>
+            [
+              server.id,
+              getMcpIconUrls({
+                darkUrl: server.logoDarkUrl,
+                lightUrl: server.logoLightUrl,
+              }),
+            ] as const
+        ),
+        ...(mcpStoreData?.integrations ?? []).flatMap((integration) =>
           integration.connection
             ? [
                 [
                   integration.connection.id,
-                  {
+                  getMcpIconUrls({
                     darkUrl: integration.logoDarkUrl,
                     lightUrl: integration.logoLightUrl,
-                  },
+                  }),
                 ] as const,
               ]
             : []
-        )
-      ),
-    [mcpStoreData?.integrations]
+        ),
+      ]),
+    [customMcpData?.servers, mcpStoreData?.integrations]
   );
   const [pendingMessageId, setPendingMessageId] = useState<string | null>(null);
   const isHydrated = useSyncExternalStore(
@@ -1554,7 +1571,7 @@ function StandaloneChatPageClient({
             className="wrap-break-word size-full whitespace-pre-wrap"
             key={`${messageId}-text-${index}`}
           >
-            {renderTextWithIntegrationReferences(text)}
+            {renderTextWithIntegrationReferences(text, mcpLogosByConnectionId)}
           </div>
         );
       }

--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from "@notra/ui/lib/utils";
 import { CheckIcon, XIcon } from "lucide-react";
 import { type ReactNode, useState } from "react";
+import { McpIcon } from "@/components/integrations/mcp-icon";
 import { TOOL_TIMER_THRESHOLD_SECONDS } from "@/constants/chat-tool-timer";
 import { useElapsedSeconds } from "@/lib/hooks/use-elapsed-seconds";
 import {
@@ -43,11 +44,7 @@ import {
 } from "./chat-tool-block/mcp/utils";
 import { ToolOutputImages } from "./chat-tool-block/tool-output-images";
 import { collectToolOutputImages } from "./chat-tool-block/tool-output-images/utils";
-import type {
-  ChatToolBlockProps,
-  McpToolIconProps,
-  ToolCopy,
-} from "./chat-tool-block/types";
+import type { ChatToolBlockProps, ToolCopy } from "./chat-tool-block/types";
 
 function firstStringValue<T extends object>(
   values: T,
@@ -733,7 +730,7 @@ export function ChatToolBlock({
   if (isMcp) {
     const mcpIconUrls = getMcpToolIconUrls(toolMetadata);
     toolIcon = (
-      <McpToolIcon
+      <McpIcon
         darkUrl={
           iconUrl ?? mcpLogoDarkUrl ?? mcpLogoLightUrl ?? mcpIconUrls.darkUrl
         }
@@ -820,24 +817,5 @@ export function ChatToolBlock({
         </div>
       </CollapsibleContent>
     </Collapsible>
-  );
-}
-
-function McpToolIcon({ darkUrl, lightUrl }: McpToolIconProps) {
-  return (
-    <span className="relative size-4 shrink-0">
-      <Avatar className="size-4 rounded-sm after:hidden dark:hidden">
-        <AvatarImage className="rounded-sm" src={lightUrl} />
-        <AvatarFallback className="rounded-sm bg-transparent">
-          <HugeiconsIcon className="size-3" icon={CpuIcon} />
-        </AvatarFallback>
-      </Avatar>
-      <Avatar className="hidden size-4 rounded-sm after:hidden dark:flex">
-        <AvatarImage className="rounded-sm" src={darkUrl} />
-        <AvatarFallback className="rounded-sm bg-transparent">
-          <HugeiconsIcon className="size-3" icon={CpuIcon} />
-        </AvatarFallback>
-      </Avatar>
-    </span>
   );
 }

--- a/apps/dashboard/src/components/ai/chat-tool-block/mcp/utils.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/mcp/utils.ts
@@ -1,6 +1,6 @@
-import { getMcpFaviconUrl } from "@/lib/integrations/mcp";
+import { getMcpFaviconUrl, getMcpIconUrls } from "@/lib/integrations/mcp";
 import { mcpToolMetadataSchema } from "@/schemas/ai/chat-tool-block";
-import type { McpToolIconUrls } from "../types";
+import type { McpIconUrls } from "@/types/integrations/mcp";
 import {
   MCP_TOOL_NAME_REGEX,
   NON_ALPHANUMERIC_WORD_SEPARATOR_REGEX,
@@ -74,16 +74,13 @@ export function getMcpToolActionPhrase(
   return normalizedPhrase || undefined;
 }
 
-export function getMcpToolIconUrls(toolMetadata: unknown): McpToolIconUrls {
+export function getMcpToolIconUrls(toolMetadata: unknown): McpIconUrls {
   const notraMetadata = getNotraMcpMetadata(toolMetadata);
-  const fallbackUrl = getMcpFaviconUrl(notraMetadata?.serverUrl);
-  const lightLogo = notraMetadata?.logoLightUrl?.trim() || undefined;
-  const darkLogo = notraMetadata?.logoDarkUrl?.trim() || undefined;
-
-  return {
-    lightUrl: lightLogo ?? darkLogo ?? fallbackUrl,
-    darkUrl: darkLogo ?? lightLogo ?? fallbackUrl,
-  };
+  return getMcpIconUrls({
+    lightUrl: notraMetadata?.logoLightUrl,
+    darkUrl: notraMetadata?.logoDarkUrl,
+    fallbackUrl: getMcpFaviconUrl(notraMetadata?.serverUrl),
+  });
 }
 
 export function getMcpToolServerId(toolMetadata: unknown) {

--- a/apps/dashboard/src/components/ai/chat-tool-block/types.ts
+++ b/apps/dashboard/src/components/ai/chat-tool-block/types.ts
@@ -24,10 +24,3 @@ export interface ChatToolBlockProps {
   mcpLogoLightUrl?: string | null;
   toolMetadata?: unknown;
 }
-
-export interface McpToolIconUrls {
-  darkUrl?: string;
-  lightUrl?: string;
-}
-
-export type McpToolIconProps = McpToolIconUrls;

--- a/apps/dashboard/src/components/chat/chat-input-context-row.tsx
+++ b/apps/dashboard/src/components/chat/chat-input-context-row.tsx
@@ -1,4 +1,8 @@
-import { Cancel01Icon, TextSelectionIcon } from "@hugeicons/core-free-icons";
+import {
+  Cancel01Icon,
+  CpuIcon,
+  TextSelectionIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ContextItem, TextSelection } from "@notra/ai/types/chat";
 import { Github } from "@notra/ui/components/ui/svgs/github";
@@ -20,15 +24,21 @@ function ContextBadge({
   const label =
     item.type === "github-repo"
       ? `${item.owner}/${item.repo}`
-      : item.teamName || "Linear";
+      : item.type === "linear-team"
+        ? item.teamName || "Linear"
+        : item.name;
+  const icon =
+    item.type === "github-repo" ? (
+      <Github className="size-3.5" />
+    ) : item.type === "linear-team" ? (
+      <Linear className="size-3.5" />
+    ) : (
+      <HugeiconsIcon className="size-3.5" icon={CpuIcon} />
+    );
 
   return (
     <div className="flex shrink-0 items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-foreground text-xs">
-      {item.type === "github-repo" ? (
-        <Github className="size-3.5" />
-      ) : (
-        <Linear className="size-3.5" />
-      )}
+      {icon}
       <span className="font-medium">{label}</span>
       <button
         aria-label={`Remove ${label} from context`}

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -5,7 +5,6 @@ import {
   AtIcon,
   Attachment01Icon,
   Cancel01Icon,
-  CpuIcon,
   File02Icon,
   StopIcon,
   Upload04Icon,
@@ -73,12 +72,14 @@ import {
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
+import { McpIcon } from "@/components/integrations/mcp-icon";
 import {
   MAX_CHAT_ATTACHMENTS,
   MAX_CHAT_FILE_SIZE,
   MIME_DISPLAY_LABELS,
   PASTE_TO_ATTACHMENT_THRESHOLD,
 } from "@/constants/upload";
+import { getMcpIconUrls } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import {
   dragEventHasFiles,
@@ -95,7 +96,7 @@ import {
 } from "@/lib/upload/mime";
 import type {
   ChatContextOption,
-  McpSourceIconProps,
+  ChatContextOptionContentProps,
 } from "@/types/components/chat-input";
 import type { GitHubRepository } from "@/types/integrations";
 import { AttachmentPreviewDialog } from "./attachment-preview";
@@ -104,6 +105,7 @@ import {
   buildFragmentFromReferencedText,
   buildIntegrationReferenceElement,
   hydrateLinearReferenceTeamNames,
+  hydrateMcpReferenceIcons,
   INTEGRATION_REFERENCE_SELECTOR,
   isIntegrationReferenceElement,
   parseIntegrationReferenceElement,
@@ -112,6 +114,7 @@ import {
 } from "./integration-reference";
 
 const GENERIC_PASTED_IMAGE_NAME_RE = /^image\.(jpe?g|png|gif|webp)$/i;
+const CHAT_CREDITS_EMPTY_MESSAGE = "No chat credits left.";
 
 export const AVAILABLE_MODELS = [
   {
@@ -195,47 +198,6 @@ export function ModelIcon({
   return <ClaudeAiIcon className={className} />;
 }
 
-function McpSourceIcon({
-  logoLightUrl,
-  logoDarkUrl,
-  className = "size-4",
-}: McpSourceIconProps) {
-  const lightLogo = logoLightUrl ?? logoDarkUrl;
-  const darkLogo = logoDarkUrl ?? logoLightUrl;
-
-  if (lightLogo && darkLogo) {
-    return (
-      <>
-        <Image
-          alt=""
-          aria-hidden="true"
-          className={`${className} rounded-sm object-contain dark:hidden`}
-          height={20}
-          src={lightLogo}
-          width={20}
-        />
-        <Image
-          alt=""
-          aria-hidden="true"
-          className={`${className} hidden rounded-sm object-contain dark:block`}
-          height={20}
-          src={darkLogo}
-          width={20}
-        />
-      </>
-    );
-  }
-
-  return (
-    <span
-      aria-hidden="true"
-      className={`${className} flex shrink-0 items-center justify-center text-violet-600 dark:text-violet-400`}
-    >
-      <HugeiconsIcon className="size-full" icon={CpuIcon} />
-    </span>
-  );
-}
-
 const THINKING_LEVELS = ["off", "low", "medium", "high"] as const;
 export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 
@@ -297,12 +259,14 @@ function getSubmitTooltipText({
   isLoading,
   isQueued,
   isStopping,
+  isUsageBlocked,
 }: {
   canQueue: boolean;
   isEmpty: boolean;
   isLoading: boolean;
   isQueued: boolean;
   isStopping: boolean;
+  isUsageBlocked: boolean;
 }): string {
   if (isLoading && isStopping) {
     return "Stopping...";
@@ -313,10 +277,26 @@ function getSubmitTooltipText({
   if (isLoading && isEmpty) {
     return "Stop generating";
   }
+  if (isUsageBlocked) {
+    return CHAT_CREDITS_EMPTY_MESSAGE;
+  }
   if (canQueue) {
     return "Enter to queue this message. It will send once the AI finishes.";
   }
   return "Enter to send. Shift+Enter for a new line.";
+}
+
+function getContextPickerDisabledReason(
+  isLoading: boolean,
+  isQueued: boolean
+): string | null {
+  if (isQueued) {
+    return "Cancel the pending message before changing tools or context.";
+  }
+  if (isLoading) {
+    return "Wait for the current response before changing tools or context.";
+  }
+  return null;
 }
 
 function contextItemsEqual(a: ContextItem, b: ContextItem): boolean {
@@ -333,6 +313,24 @@ function contextItemsEqual(a: ContextItem, b: ContextItem): boolean {
     return a.integrationId === b.integrationId;
   }
   return false;
+}
+
+function ChatContextOptionContent({ option }: ChatContextOptionContentProps) {
+  return (
+    <>
+      {option.kind === "github" && <Github className="size-4 shrink-0" />}
+      {option.kind === "linear" && <Linear className="size-4 shrink-0" />}
+      {option.kind === "mcp" && (
+        <McpIcon darkUrl={option.logoDarkUrl} lightUrl={option.logoLightUrl} />
+      )}
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm">{option.label}</span>
+        <span className="truncate text-muted-foreground text-xs">
+          {option.description}
+        </span>
+      </span>
+    </>
+  );
 }
 
 interface ChatInputAdvancedProps {
@@ -431,6 +429,10 @@ export function ChatInputAdvanced({
     useState<ChatAttachment | null>(null);
   const isUploading = pendingUploads.length > 0;
   const isQueued = pendingSend !== null;
+  const contextPickerDisabledReason = getContextPickerDisabledReason(
+    isLoading,
+    isQueued
+  );
   const attachmentsRef = useRef(attachments);
   const pendingUploadsRef = useRef(pendingUploads);
 
@@ -718,9 +720,10 @@ export function ChatInputAdvanced({
     remainingChatCredits > 0 &&
     remainingChatCredits <= 10;
   const isUsageBlocked = checkResult ? checkResult.allowed === false : false;
-  const limitMessage = "No chat credits left.";
   const usageLimitError =
-    externalError ?? internalError ?? (isUsageBlocked ? limitMessage : null);
+    externalError ??
+    internalError ??
+    (isUsageBlocked ? CHAT_CREDITS_EMPTY_MESSAGE : null);
 
   const clearError = useCallback(() => {
     setInternalError(null);
@@ -874,6 +877,19 @@ export function ChatInputAdvanced({
   const mcpToolOptions = useMemo(
     () => contextOptions.filter((option) => option.kind === "mcp"),
     [contextOptions]
+  );
+  const mcpIconsByIntegrationId = useMemo(
+    () =>
+      new Map(
+        mcpToolOptions.map((option) => [
+          option.contextItem.integrationId,
+          getMcpIconUrls({
+            lightUrl: option.logoLightUrl,
+            darkUrl: option.logoDarkUrl,
+          }),
+        ])
+      ),
+    [mcpToolOptions]
   );
 
   const isInContext = useCallback(
@@ -1073,13 +1089,21 @@ export function ChatInputAdvanced({
       if (!draft) {
         return;
       }
-      editor.append(buildFragmentFromReferencedText(draft));
+      editor.append(
+        buildFragmentFromReferencedText(draft, mcpIconsByIntegrationId)
+      );
       setIsEmpty(draft.trim().length === 0);
       syncContextFromDOM();
     } catch {
       // noop
     }
-  }, [draftStorageKey, initialValue, readEditorText, syncContextFromDOM]);
+  }, [
+    draftStorageKey,
+    initialValue,
+    mcpIconsByIntegrationId,
+    readEditorText,
+    syncContextFromDOM,
+  ]);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -1090,6 +1114,14 @@ export function ChatInputAdvanced({
       syncContextFromDOM();
     }
   }, [enabledLinearIntegrations, syncContextFromDOM]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || mcpIconsByIntegrationId.size === 0) {
+      return;
+    }
+    hydrateMcpReferenceIcons(editor, mcpIconsByIntegrationId);
+  }, [mcpIconsByIntegrationId]);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -1141,7 +1173,13 @@ export function ChatInputAdvanced({
       replaceRange.setStart(anchor.node, anchor.offset);
       replaceRange.setEnd(cursor.startContainer, cursor.startOffset);
 
-      const chip = buildIntegrationReferenceElement(option.contextItem);
+      const chip = buildIntegrationReferenceElement(
+        option.contextItem,
+        getMcpIconUrls({
+          lightUrl: option.logoLightUrl,
+          darkUrl: option.logoDarkUrl,
+        })
+      );
       insertChipAndSpace(chip, replaceRange);
 
       mentionAnchorRef.current = null;
@@ -1152,11 +1190,12 @@ export function ChatInputAdvanced({
   );
 
   const insertChipAtCursor = useCallback(
-    (item: ContextItem) => {
+    (option: ChatContextOption) => {
       const editor = editorRef.current;
       if (!editor) {
         return;
       }
+      const item = option.contextItem;
       if (contextRef.current.some((c) => contextItemsEqual(c, item))) {
         return;
       }
@@ -1174,7 +1213,13 @@ export function ChatInputAdvanced({
         range.selectNodeContents(editor);
         range.collapse(false);
       }
-      const chip = buildIntegrationReferenceElement(item);
+      const chip = buildIntegrationReferenceElement(
+        item,
+        getMcpIconUrls({
+          lightUrl: option.logoLightUrl,
+          darkUrl: option.logoDarkUrl,
+        })
+      );
       insertChipAndSpace(chip, range);
     },
     [insertChipAndSpace]
@@ -1209,45 +1254,51 @@ export function ChatInputAdvanced({
     [onRemoveContext, readEditorText]
   );
 
-  const insertTextAtRange = useCallback((text: string, targetRange?: Range) => {
-    const editor = editorRef.current;
-    if (!editor) {
-      return;
-    }
+  const insertTextAtRange = useCallback(
+    (text: string, targetRange?: Range) => {
+      const editor = editorRef.current;
+      if (!editor) {
+        return;
+      }
 
-    const selection = window.getSelection();
-    let range: Range | null = null;
+      const selection = window.getSelection();
+      let range: Range | null = null;
 
-    if (
-      targetRange?.startContainer.isConnected &&
-      editor.contains(targetRange.startContainer)
-    ) {
-      range = targetRange;
-    } else if (selection && selection.rangeCount > 0) {
-      range = selection.getRangeAt(0);
-    }
+      if (
+        targetRange?.startContainer.isConnected &&
+        editor.contains(targetRange.startContainer)
+      ) {
+        range = targetRange;
+      } else if (selection && selection.rangeCount > 0) {
+        range = selection.getRangeAt(0);
+      }
 
-    if (!range) {
-      return;
-    }
+      if (!range) {
+        return;
+      }
 
-    range.deleteContents();
+      range.deleteContents();
 
-    const fragment = buildFragmentFromReferencedText(text);
-    const lastNode = fragment.lastChild;
-    range.insertNode(fragment);
+      const fragment = buildFragmentFromReferencedText(
+        text,
+        mcpIconsByIntegrationId
+      );
+      const lastNode = fragment.lastChild;
+      range.insertNode(fragment);
 
-    const after = document.createRange();
-    if (lastNode) {
-      after.setStartAfter(lastNode);
-    } else {
-      after.setStart(range.endContainer, range.endOffset);
-    }
-    after.collapse(true);
-    selection?.removeAllRanges();
-    selection?.addRange(after);
-    editor.dispatchEvent(new Event("input", { bubbles: true }));
-  }, []);
+      const after = document.createRange();
+      if (lastNode) {
+        after.setStartAfter(lastNode);
+      } else {
+        after.setStart(range.endContainer, range.endOffset);
+      }
+      after.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(after);
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    [mcpIconsByIntegrationId]
+  );
 
   const clearComposer = useCallback(() => {
     const editor = editorRef.current;
@@ -1288,7 +1339,7 @@ export function ChatInputAdvanced({
         return false;
       }
       if (isUsageBlocked) {
-        setInternalError(limitMessage);
+        setInternalError(CHAT_CREDITS_EMPTY_MESSAGE);
         return false;
       }
       if (customer) {
@@ -1297,7 +1348,7 @@ export function ChatInputAdvanced({
           requiredBalance: 1,
         });
         if (result?.allowed === false) {
-          setInternalError(limitMessage);
+          setInternalError(CHAT_CREDITS_EMPTY_MESSAGE);
           return false;
         }
       }
@@ -1350,7 +1401,7 @@ export function ChatInputAdvanced({
       }
       clearError();
       if (isUsageBlocked) {
-        setInternalError(limitMessage);
+        setInternalError(CHAT_CREDITS_EMPTY_MESSAGE);
         return;
       }
       if (customer) {
@@ -1359,7 +1410,7 @@ export function ChatInputAdvanced({
           requiredBalance: 1,
         });
         if (result?.allowed === false) {
-          setInternalError(limitMessage);
+          setInternalError(CHAT_CREDITS_EMPTY_MESSAGE);
           return;
         }
       }
@@ -1380,7 +1431,7 @@ export function ChatInputAdvanced({
         return;
       }
       if (isUsageBlocked) {
-        setInternalError(limitMessage);
+        setInternalError(CHAT_CREDITS_EMPTY_MESSAGE);
         return;
       }
       clearError();
@@ -1785,11 +1836,11 @@ export function ChatInputAdvanced({
                   <div className="relative flex min-w-0 flex-1 cursor-text transition-colors [--lh:1lh]">
                     {/* biome-ignore lint/a11y/useSemanticElements: rich mention editor requires a contentEditable host instead of a native textarea. */}
                     <div
-                      aria-disabled={isUsageBlocked || isQueued}
+                      aria-disabled={isQueued}
                       aria-label="Send a message"
                       aria-multiline="true"
                       className="wrap-anywhere relative max-h-50 min-h-12 w-full min-w-0 overflow-y-auto whitespace-pre-wrap rounded-t-[12px] px-3 py-2 text-foreground text-sm leading-6 caret-foreground outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 data-[empty=true]:before:pointer-events-none data-[empty=true]:before:absolute data-[empty=true]:before:top-2 data-[empty=true]:before:left-3 data-[empty=true]:before:text-muted-foreground data-[empty=true]:before:content-[attr(data-placeholder)]"
-                      contentEditable={!(isUsageBlocked || isQueued)}
+                      contentEditable={!isQueued}
                       data-empty={isEmpty ? "true" : "false"}
                       data-placeholder={
                         isLoading
@@ -1818,9 +1869,7 @@ export function ChatInputAdvanced({
                       ref={editorRef}
                       role="textbox"
                       suppressContentEditableWarning
-                      tabIndex={
-                        isLoading || isUsageBlocked || isQueued ? -1 : 0
-                      }
+                      tabIndex={isLoading || isQueued ? -1 : 0}
                     />
                   </div>
                 </div>
@@ -1861,26 +1910,7 @@ export function ChatInputAdvanced({
                                   }}
                                   type="button"
                                 >
-                                  {option.kind === "github" && (
-                                    <Github className="size-4 shrink-0" />
-                                  )}
-                                  {option.kind === "linear" && (
-                                    <Linear className="size-4 shrink-0" />
-                                  )}
-                                  {option.kind === "mcp" && (
-                                    <McpSourceIcon
-                                      logoDarkUrl={option.logoDarkUrl}
-                                      logoLightUrl={option.logoLightUrl}
-                                    />
-                                  )}
-                                  <span className="flex min-w-0 flex-1 flex-col">
-                                    <span className="truncate text-sm">
-                                      {option.label}
-                                    </span>
-                                    <span className="truncate text-muted-foreground text-xs">
-                                      {option.description}
-                                    </span>
-                                  </span>
+                                  <ChatContextOptionContent option={option} />
                                   {inContext && (
                                     <span className="shrink-0 text-emerald-600 text-xs dark:text-emerald-400">
                                       Added
@@ -2054,129 +2084,138 @@ export function ChatInputAdvanced({
                   </PopoverContent>
                 </Popover>
 
-                <Popover
-                  modal
-                  onOpenChange={setIsContextPickerOpen}
-                  open={isContextPickerOpen}
-                >
-                  <PopoverTrigger
+                <Tooltip>
+                  <TooltipTrigger
                     render={
-                      <button
-                        aria-controls={contextPickerId}
-                        aria-expanded={isContextPickerOpen}
-                        aria-haspopup="listbox"
-                        aria-label="Add tools or context"
-                        className="flex items-center gap-1.5 rounded-lg border border-border border-dashed px-2.5 py-1.5 font-medium text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                        disabled={isLoading || isQueued}
-                        role="combobox"
-                        type="button"
-                      />
+                      contextPickerDisabledReason ? (
+                        // biome-ignore lint/a11y/useSemanticElements: a real button would illegally nest the disabled popover trigger button.
+                        <span
+                          aria-disabled="true"
+                          aria-label="Add tools or context"
+                          className="inline-flex cursor-not-allowed"
+                          role="button"
+                          tabIndex={0}
+                        />
+                      ) : (
+                        <span className="inline-flex" />
+                      )
                     }
                   >
-                    <HugeiconsIcon className="size-3.5" icon={AtIcon} />
-                    Tools & context
-                  </PopoverTrigger>
-                  <PopoverContent
-                    align="start"
-                    className="w-80 p-0"
-                    id={contextPickerId}
-                    showBackdrop
-                    sideOffset={6}
-                  >
-                    <Command>
-                      <CommandInput placeholder="Search tools and context..." />
-                      <CommandList>
-                        <CommandEmpty>
-                          No matching tools or context found.
-                        </CommandEmpty>
-                        {integrationContextOptions.length > 0 && (
-                          <CommandGroup heading="Context">
-                            {integrationContextOptions.map((option) => {
-                              const inContext = isInContext(option.contextItem);
-                              return (
-                                <CommandItem
-                                  data-checked={inContext}
-                                  key={option.id}
-                                  keywords={[option.searchText]}
-                                  onSelect={() => {
-                                    if (inContext) {
-                                      removeChipForItem(option.contextItem);
-                                    } else {
-                                      insertChipAtCursor(option.contextItem);
-                                    }
-                                    setIsContextPickerOpen(false);
-                                  }}
-                                  value={option.id}
-                                >
-                                  {option.kind === "github" ? (
-                                    <Github className="size-4 shrink-0" />
-                                  ) : (
-                                    <Linear className="size-4 shrink-0" />
-                                  )}
-                                  <span className="flex min-w-0 flex-1 flex-col">
-                                    <span className="truncate text-sm">
-                                      {option.label}
-                                    </span>
-                                    <span className="truncate text-muted-foreground text-xs">
-                                      {option.description}
-                                    </span>
-                                  </span>
-                                </CommandItem>
-                              );
-                            })}
-                          </CommandGroup>
-                        )}
-                        {mcpToolOptions.length > 0 && (
-                          <CommandGroup heading="MCP tools">
-                            {mcpToolOptions.map((option) => {
-                              const inContext = isInContext(option.contextItem);
-                              return (
-                                <CommandItem
-                                  data-checked={inContext}
-                                  key={option.id}
-                                  keywords={[option.searchText]}
-                                  onSelect={() => {
-                                    if (inContext) {
-                                      removeChipForItem(option.contextItem);
-                                    } else {
-                                      insertChipAtCursor(option.contextItem);
-                                    }
-                                    setIsContextPickerOpen(false);
-                                  }}
-                                  value={option.id}
-                                >
-                                  <McpSourceIcon
-                                    logoDarkUrl={option.logoDarkUrl}
-                                    logoLightUrl={option.logoLightUrl}
-                                  />
-                                  <span className="flex min-w-0 flex-1 flex-col">
-                                    <span className="truncate text-sm">
-                                      {option.label}
-                                    </span>
-                                    <span className="truncate text-muted-foreground text-xs">
-                                      {option.description}
-                                    </span>
-                                  </span>
-                                </CommandItem>
-                              );
-                            })}
-                          </CommandGroup>
-                        )}
-                      </CommandList>
-                      {organizationSlug && (
-                        <div className="border-border border-t p-1">
-                          <Link
-                            className="flex items-center rounded-sm px-2 py-1.5 text-muted-foreground text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
-                            href={`/${organizationSlug}/integrations`}
-                            onClick={() => setIsContextPickerOpen(false)}
-                          >
-                            Manage integrations
-                          </Link>
-                        </div>
-                      )}
-                    </Command>
-                  </PopoverContent>
-                </Popover>
+                    <Popover
+                      modal
+                      onOpenChange={setIsContextPickerOpen}
+                      open={isContextPickerOpen}
+                    >
+                      <PopoverTrigger
+                        render={
+                          <button
+                            aria-controls={contextPickerId}
+                            aria-expanded={isContextPickerOpen}
+                            aria-haspopup="listbox"
+                            aria-label="Add tools or context"
+                            className="flex items-center gap-1.5 rounded-lg border border-border border-dashed px-2.5 py-1.5 font-medium text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                            disabled={isLoading || isQueued}
+                            role="combobox"
+                            type="button"
+                          />
+                        }
+                      >
+                        <HugeiconsIcon className="size-3.5" icon={AtIcon} />
+                        Tools & context
+                      </PopoverTrigger>
+                      <PopoverContent
+                        align="start"
+                        className="w-80 p-0"
+                        id={contextPickerId}
+                        showBackdrop
+                        sideOffset={6}
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search tools and context..." />
+                          <CommandList>
+                            <CommandEmpty>
+                              No matching tools or context found.
+                            </CommandEmpty>
+                            {integrationContextOptions.length > 0 && (
+                              <CommandGroup heading="Context">
+                                {integrationContextOptions.map((option) => {
+                                  const inContext = isInContext(
+                                    option.contextItem
+                                  );
+                                  return (
+                                    <CommandItem
+                                      data-checked={inContext}
+                                      key={option.id}
+                                      keywords={[option.searchText]}
+                                      onSelect={() => {
+                                        if (inContext) {
+                                          removeChipForItem(option.contextItem);
+                                        } else {
+                                          insertChipAtCursor(option);
+                                        }
+                                        setIsContextPickerOpen(false);
+                                      }}
+                                      value={option.id}
+                                    >
+                                      <ChatContextOptionContent
+                                        option={option}
+                                      />
+                                    </CommandItem>
+                                  );
+                                })}
+                              </CommandGroup>
+                            )}
+                            {mcpToolOptions.length > 0 && (
+                              <CommandGroup heading="MCP tools">
+                                {mcpToolOptions.map((option) => {
+                                  const inContext = isInContext(
+                                    option.contextItem
+                                  );
+                                  return (
+                                    <CommandItem
+                                      data-checked={inContext}
+                                      key={option.id}
+                                      keywords={[option.searchText]}
+                                      onSelect={() => {
+                                        if (inContext) {
+                                          removeChipForItem(option.contextItem);
+                                        } else {
+                                          insertChipAtCursor(option);
+                                        }
+                                        setIsContextPickerOpen(false);
+                                      }}
+                                      value={option.id}
+                                    >
+                                      <ChatContextOptionContent
+                                        option={option}
+                                      />
+                                    </CommandItem>
+                                  );
+                                })}
+                              </CommandGroup>
+                            )}
+                          </CommandList>
+                          {organizationSlug && (
+                            <div className="border-border border-t p-1">
+                              <Link
+                                className="flex items-center rounded-sm px-2 py-1.5 text-muted-foreground text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
+                                href={`/${organizationSlug}/integrations`}
+                                onClick={() => setIsContextPickerOpen(false)}
+                              >
+                                Manage integrations
+                              </Link>
+                            </div>
+                          )}
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                  </TooltipTrigger>
+                  {contextPickerDisabledReason && (
+                    <TooltipContent>
+                      {contextPickerDisabledReason}
+                    </TooltipContent>
+                  )}
+                </Tooltip>
 
                 <Tooltip>
                   <TooltipTrigger
@@ -2220,13 +2259,13 @@ export function ChatInputAdvanced({
                     submitDisabled = false;
                   } else if (isLoading && isEmpty) {
                     submitDisabled = !onStop || isStopping;
+                  } else if (isUsageBlocked) {
+                    submitDisabled = true;
                   } else if (canQueue) {
                     submitDisabled = false;
                   } else {
                     submitDisabled =
-                      isUsageBlocked ||
-                      hasUnsupportedAttachmentsForModel ||
-                      !hasAnyContent;
+                      hasUnsupportedAttachmentsForModel || !hasAnyContent;
                   }
                   let submitOnClick: (() => void) | undefined;
                   if (isQueued) {
@@ -2241,11 +2280,10 @@ export function ChatInputAdvanced({
                       <TooltipTrigger
                         render={
                           <Button
-                            className="group/button h-7 shrink-0 rounded-lg bg-muted px-1.5 transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                            disabled={submitDisabled}
-                            onClick={submitOnClick}
+                            aria-disabled={submitDisabled}
+                            className="group/button h-7 shrink-0 rounded-lg bg-muted px-1.5 transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:active:scale-100 aria-disabled:hover:bg-muted dark:aria-disabled:hover:bg-input/30"
+                            onClick={submitDisabled ? undefined : submitOnClick}
                             size="sm"
-                            tabIndex={0}
                             type="button"
                             variant="outline"
                           />
@@ -2268,6 +2306,7 @@ export function ChatInputAdvanced({
                           isLoading,
                           isQueued,
                           isStopping,
+                          isUsageBlocked,
                         })}
                       </TooltipContent>
                     </Tooltip>

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -2,10 +2,10 @@
 
 import {
   AiBrain01Icon,
-  ArrowRight01Icon,
   AtIcon,
   Attachment01Icon,
   Cancel01Icon,
+  CpuIcon,
   File02Icon,
   StopIcon,
   Upload04Icon,
@@ -37,10 +37,6 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
 import {
@@ -68,6 +64,7 @@ import {
   type Ref,
   useCallback,
   useEffect,
+  useId,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -82,7 +79,6 @@ import {
   MIME_DISPLAY_LABELS,
   PASTE_TO_ATTACHMENT_THRESHOLD,
 } from "@/constants/upload";
-import { INPUT_SOURCES } from "@/lib/integrations/catalog";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import {
   dragEventHasFiles,
@@ -97,6 +93,10 @@ import {
   isAllowedChatMimeType,
   isImageMimeType,
 } from "@/lib/upload/mime";
+import type {
+  ChatContextOption,
+  McpSourceIconProps,
+} from "@/types/components/chat-input";
 import type { GitHubRepository } from "@/types/integrations";
 import { AttachmentPreviewDialog } from "./attachment-preview";
 import type { QueuedMessage } from "./chat-queue";
@@ -195,6 +195,47 @@ export function ModelIcon({
   return <ClaudeAiIcon className={className} />;
 }
 
+function McpSourceIcon({
+  logoLightUrl,
+  logoDarkUrl,
+  className = "size-4",
+}: McpSourceIconProps) {
+  const lightLogo = logoLightUrl ?? logoDarkUrl;
+  const darkLogo = logoDarkUrl ?? logoLightUrl;
+
+  if (lightLogo && darkLogo) {
+    return (
+      <>
+        <Image
+          alt=""
+          aria-hidden="true"
+          className={`${className} rounded-sm object-contain dark:hidden`}
+          height={20}
+          src={lightLogo}
+          width={20}
+        />
+        <Image
+          alt=""
+          aria-hidden="true"
+          className={`${className} hidden rounded-sm object-contain dark:block`}
+          height={20}
+          src={darkLogo}
+          width={20}
+        />
+      </>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={`${className} flex shrink-0 items-center justify-center text-violet-600 dark:text-violet-400`}
+    >
+      <HugeiconsIcon className="size-full" icon={CpuIcon} />
+    </span>
+  );
+}
+
 const THINKING_LEVELS = ["off", "low", "medium", "high"] as const;
 export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 
@@ -288,6 +329,9 @@ function contextItemsEqual(a: ContextItem, b: ContextItem): boolean {
   if (a.type === "linear-team" && b.type === "linear-team") {
     return a.integrationId === b.integrationId;
   }
+  if (a.type === "mcp-server" && b.type === "mcp-server") {
+    return a.integrationId === b.integrationId;
+  }
   return false;
 }
 
@@ -356,10 +400,12 @@ export function ChatInputAdvanced({
   draftStorageKey,
   ref,
 }: ChatInputAdvancedProps) {
+  const contextPickerId = useId();
   const currentModel =
     AVAILABLE_MODELS.find((availableModel) => availableModel.id === model) ??
     AVAILABLE_MODELS[0];
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
+  const [isContextPickerOpen, setIsContextPickerOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [isEmpty, setIsEmpty] = useState(true);
   const [internalError, setInternalError] = useState<string | null>(null);
@@ -687,6 +733,18 @@ export function ChatInputAdvanced({
       enabled: !!organizationId,
     })
   );
+  const { data: customMcpData } = useQuery(
+    dashboardOrpc.integrations.mcp.list.queryOptions({
+      input: { organizationId: organizationId ?? "" },
+      enabled: !!organizationId,
+    })
+  );
+  const { data: mcpStoreData } = useQuery(
+    dashboardOrpc.integrations.mcp.storeList.queryOptions({
+      input: { organizationId: organizationId ?? "" },
+      enabled: !!organizationId,
+    })
+  );
 
   const enabledRepos = useMemo(() => {
     const result: Array<GitHubRepository & { integrationId: string }> = [];
@@ -723,49 +781,104 @@ export function ChatInputAdvanced({
     return result;
   }, [integrationsData?.integrations]);
 
-  const enabledGranolaIntegrations = useMemo(() => {
-    const result: Array<{ id: string; displayName: string }> = [];
-    for (const integration of integrationsData?.integrations ?? []) {
-      if (integration.type === "granola" && integration.enabled) {
-        result.push({
-          id: integration.id,
-          displayName: integration.displayName,
-        });
-      }
+  const contextOptions = useMemo(() => {
+    const options: ChatContextOption[] = [];
+
+    for (const repo of enabledRepos) {
+      const label = `${repo.owner}/${repo.repo}`;
+      options.push({
+        id: `github-${repo.id}`,
+        kind: "github",
+        label,
+        description: "GitHub repository",
+        searchText: `${label} GitHub repository`,
+        contextItem: {
+          type: "github-repo",
+          owner: repo.owner,
+          repo: repo.repo,
+          integrationId: repo.integrationId,
+        },
+      });
     }
-    return result;
-  }, [integrationsData?.integrations]);
 
-  type MentionItem =
-    | { kind: "github"; data: GitHubRepository & { integrationId: string } }
-    | {
-        kind: "linear";
-        data: {
-          id: string;
-          displayName: string;
-          integrationId: string;
-          teamName?: string | null;
-        };
-      };
+    for (const integration of enabledLinearIntegrations) {
+      options.push({
+        id: `linear-${integration.integrationId}`,
+        kind: "linear",
+        label: integration.displayName,
+        description: "Linear team",
+        searchText: `${integration.displayName} ${integration.teamName ?? ""} Linear team`,
+        contextItem: {
+          type: "linear-team",
+          integrationId: integration.integrationId,
+          teamName: integration.teamName ?? undefined,
+        },
+      });
+    }
 
-  const isRepoInContext = useCallback(
-    (repo: GitHubRepository & { integrationId: string }) =>
-      context.some(
-        (c) =>
-          c.type === "github-repo" &&
-          c.owner === repo.owner &&
-          c.repo === repo.repo
-      ),
-    [context]
+    for (const server of customMcpData?.servers ?? []) {
+      if (!server.enabled) {
+        continue;
+      }
+      const toolLabel = `${server.indexedToolCount} ${server.indexedToolCount === 1 ? "tool" : "tools"}`;
+      options.push({
+        id: `mcp-${server.id}`,
+        kind: "mcp",
+        label: server.name,
+        description: `Custom MCP server · ${toolLabel}`,
+        searchText: `${server.name} ${server.description ?? ""} custom MCP ${toolLabel}`,
+        contextItem: {
+          type: "mcp-server",
+          integrationId: server.id,
+          name: server.name,
+        },
+        logoLightUrl: server.logoLightUrl,
+        logoDarkUrl: server.logoDarkUrl,
+      });
+    }
+
+    for (const integration of mcpStoreData?.integrations ?? []) {
+      const connection = integration.connection;
+      if (!(integration.connected && connection?.enabled)) {
+        continue;
+      }
+      const toolLabel = `${connection.indexedToolCount} ${connection.indexedToolCount === 1 ? "tool" : "tools"}`;
+      options.push({
+        id: `mcp-${connection.id}`,
+        kind: "mcp",
+        label: integration.name,
+        description: `Marketplace MCP server · ${toolLabel}`,
+        searchText: `${integration.name} ${integration.description ?? ""} ${integration.author ?? ""} marketplace MCP ${toolLabel}`,
+        contextItem: {
+          type: "mcp-server",
+          integrationId: connection.id,
+          name: integration.name,
+        },
+        logoLightUrl: integration.logoLightUrl,
+        logoDarkUrl: integration.logoDarkUrl,
+      });
+    }
+
+    return options;
+  }, [
+    customMcpData?.servers,
+    enabledLinearIntegrations,
+    enabledRepos,
+    mcpStoreData?.integrations,
+  ]);
+
+  const integrationContextOptions = useMemo(
+    () => contextOptions.filter((option) => option.kind !== "mcp"),
+    [contextOptions]
+  );
+  const mcpToolOptions = useMemo(
+    () => contextOptions.filter((option) => option.kind === "mcp"),
+    [contextOptions]
   );
 
-  const isLinearInContext = useCallback(
-    (integration: { integrationId: string }) =>
-      context.some(
-        (c) =>
-          c.type === "linear-team" &&
-          c.integrationId === integration.integrationId
-      ),
+  const isInContext = useCallback(
+    (item: ContextItem) =>
+      context.some((contextItem) => contextItemsEqual(contextItem, item)),
     [context]
   );
 
@@ -773,20 +886,11 @@ export function ChatInputAdvanced({
     if (mentionQuery === null) {
       return [];
     }
-    const q = mentionQuery.toLowerCase();
-    const items: MentionItem[] = [];
-    for (const repo of enabledRepos) {
-      if (`${repo.owner}/${repo.repo}`.toLowerCase().includes(q)) {
-        items.push({ kind: "github", data: repo });
-      }
-    }
-    for (const integration of enabledLinearIntegrations) {
-      if (integration.displayName.toLowerCase().includes(q)) {
-        items.push({ kind: "linear", data: integration });
-      }
-    }
-    return items;
-  }, [mentionQuery, enabledRepos, enabledLinearIntegrations]);
+    const q = mentionQuery.trim().toLowerCase();
+    return contextOptions.filter((option) =>
+      option.searchText.toLowerCase().includes(q)
+    );
+  }, [contextOptions, mentionQuery]);
 
   const readEditorText = useCallback(() => {
     const editor = editorRef.current;
@@ -1018,7 +1122,7 @@ export function ChatInputAdvanced({
   }, [initialValue]);
 
   const insertMention = useCallback(
-    (item: MentionItem) => {
+    (option: ChatContextOption) => {
       const editor = editorRef.current;
       const anchor = mentionAnchorRef.current;
       if (!editor || !anchor) {
@@ -1033,25 +1137,11 @@ export function ChatInputAdvanced({
         return;
       }
 
-      const contextItem: ContextItem =
-        item.kind === "github"
-          ? {
-              type: "github-repo",
-              owner: item.data.owner,
-              repo: item.data.repo,
-              integrationId: item.data.integrationId,
-            }
-          : {
-              type: "linear-team",
-              integrationId: item.data.integrationId,
-              teamName: item.data.teamName ?? undefined,
-            };
-
       const replaceRange = document.createRange();
       replaceRange.setStart(anchor.node, anchor.offset);
       replaceRange.setEnd(cursor.startContainer, cursor.startOffset);
 
-      const chip = buildIntegrationReferenceElement(contextItem);
+      const chip = buildIntegrationReferenceElement(option.contextItem);
       insertChipAndSpace(chip, replaceRange);
 
       mentionAnchorRef.current = null;
@@ -1704,7 +1794,7 @@ export function ChatInputAdvanced({
                       data-placeholder={
                         isLoading
                           ? "Queue a message while AI is working..."
-                          : "Send a message... (type @ to add context)"
+                          : "Send a message... (type @ for tools and context)"
                       }
                       onBlur={() => {
                         setIsFocused(false);
@@ -1736,56 +1826,68 @@ export function ChatInputAdvanced({
                 </div>
                 {mentionQuery !== null && (
                   <div
-                    className="absolute bottom-full left-1 z-50 mb-1 w-56"
+                    className="absolute bottom-full left-1 z-50 mb-1 w-72"
                     ref={mentionListRef}
                   >
                     <div className="max-h-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md">
-                      <div className="px-2 py-1.5 font-semibold text-xs">
-                        Integrations
-                      </div>
                       {filteredMentionItems.length > 0 ? (
                         <>
-                          {filteredMentionItems.map((item, idx) => {
-                            const key =
-                              item.kind === "github"
-                                ? item.data.id
-                                : item.data.integrationId;
-                            const inContext =
-                              item.kind === "github"
-                                ? isRepoInContext(item.data)
-                                : isLinearInContext(item.data);
-                            const label =
-                              item.kind === "github"
-                                ? `${item.data.owner}/${item.data.repo}`
-                                : item.data.displayName;
+                          {filteredMentionItems.map((option, idx) => {
+                            const inContext = isInContext(option.contextItem);
+                            const previousOption =
+                              filteredMentionItems[idx - 1];
+                            const startsGroup =
+                              idx === 0 ||
+                              (previousOption?.kind === "mcp") !==
+                                (option.kind === "mcp");
                             return (
-                              <button
-                                className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-none transition-colors ${
-                                  idx === mentionIndex
-                                    ? "bg-accent text-accent-foreground"
-                                    : "text-popover-foreground hover:bg-accent hover:text-accent-foreground"
-                                }`}
-                                key={key}
-                                onMouseDown={(e) => {
-                                  e.preventDefault();
-                                  insertMention(item);
-                                }}
-                                type="button"
-                              >
-                                {item.kind === "github" ? (
-                                  <Github className="size-4" />
-                                ) : (
-                                  <Linear className="size-4" />
+                              <div key={option.id}>
+                                {startsGroup && (
+                                  <div className="px-2 py-1.5 font-semibold text-xs">
+                                    {option.kind === "mcp"
+                                      ? "MCP tools"
+                                      : "Context"}
+                                  </div>
                                 )}
-                                <span className="truncate text-sm">
-                                  {label}
-                                </span>
-                                {inContext && (
-                                  <span className="ml-auto text-emerald-600 text-xs dark:text-emerald-400">
-                                    Added
+                                <button
+                                  className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-none transition-colors ${
+                                    idx === mentionIndex
+                                      ? "bg-accent text-accent-foreground"
+                                      : "text-popover-foreground hover:bg-accent hover:text-accent-foreground"
+                                  }`}
+                                  onMouseDown={(event) => {
+                                    event.preventDefault();
+                                    insertMention(option);
+                                  }}
+                                  type="button"
+                                >
+                                  {option.kind === "github" && (
+                                    <Github className="size-4 shrink-0" />
+                                  )}
+                                  {option.kind === "linear" && (
+                                    <Linear className="size-4 shrink-0" />
+                                  )}
+                                  {option.kind === "mcp" && (
+                                    <McpSourceIcon
+                                      logoDarkUrl={option.logoDarkUrl}
+                                      logoLightUrl={option.logoLightUrl}
+                                    />
+                                  )}
+                                  <span className="flex min-w-0 flex-1 flex-col">
+                                    <span className="truncate text-sm">
+                                      {option.label}
+                                    </span>
+                                    <span className="truncate text-muted-foreground text-xs">
+                                      {option.description}
+                                    </span>
                                   </span>
-                                )}
-                              </button>
+                                  {inContext && (
+                                    <span className="shrink-0 text-emerald-600 text-xs dark:text-emerald-400">
+                                      Added
+                                    </span>
+                                  )}
+                                </button>
+                              </div>
                             );
                           })}
                           {organizationSlug && (
@@ -1806,21 +1908,18 @@ export function ChatInputAdvanced({
                       ) : (
                         <div className="flex flex-col items-center gap-1 px-3 py-4 text-center">
                           <span className="text-muted-foreground text-xs">
-                            {enabledRepos.length === 0 &&
-                            enabledLinearIntegrations.length === 0
-                              ? "No integrations connected"
+                            {contextOptions.length === 0
+                              ? "No context or MCP tools connected"
                               : "No matches found"}
                           </span>
-                          {enabledRepos.length === 0 &&
-                            enabledLinearIntegrations.length === 0 &&
-                            organizationSlug && (
-                              <Link
-                                className="text-primary text-xs hover:underline"
-                                href={`/${organizationSlug}/integrations`}
-                              >
-                                Connect integrations
-                              </Link>
-                            )}
+                          {contextOptions.length === 0 && organizationSlug && (
+                            <Link
+                              className="text-primary text-xs hover:underline"
+                              href={`/${organizationSlug}/integrations`}
+                            >
+                              Connect integrations
+                            </Link>
+                          )}
                         </div>
                       )}
                     </div>
@@ -1955,276 +2054,129 @@ export function ChatInputAdvanced({
                   </PopoverContent>
                 </Popover>
 
-                <DropdownMenu>
-                  <DropdownMenuTrigger
+                <Popover
+                  modal
+                  onOpenChange={setIsContextPickerOpen}
+                  open={isContextPickerOpen}
+                >
+                  <PopoverTrigger
                     render={
                       <button
+                        aria-controls={contextPickerId}
+                        aria-expanded={isContextPickerOpen}
+                        aria-haspopup="listbox"
+                        aria-label="Add tools or context"
                         className="flex items-center gap-1.5 rounded-lg border border-border border-dashed px-2.5 py-1.5 font-medium text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
                         disabled={isLoading || isQueued}
+                        role="combobox"
                         type="button"
                       />
                     }
                   >
                     <HugeiconsIcon className="size-3.5" icon={AtIcon} />
-                    Context
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="w-56">
-                    <DropdownMenuGroup>
-                      <DropdownMenuLabel>Integrations</DropdownMenuLabel>
-                    </DropdownMenuGroup>
-                    {INPUT_SOURCES.map((integration) => {
-                      const isGitHub = integration.id === "github";
-                      const isLinear = integration.id === "linear";
-                      const isGranola = integration.id === "granola";
-                      const isAvailable = integration.available;
-
-                      if (isGitHub && isAvailable && enabledRepos.length > 0) {
-                        return (
-                          <DropdownMenuSub key={integration.id}>
-                            <DropdownMenuSubTrigger className="grid grid-cols-[1rem_3.5rem_1fr_1rem]">
-                              <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
-                                {integration.icon}
-                              </span>
-                              <span className="truncate text-foreground">
-                                {integration.name}
-                              </span>
-                              <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
-                                {enabledRepos.length}
-                              </span>
-                            </DropdownMenuSubTrigger>
-                            <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                              <DropdownMenuGroup>
-                                <DropdownMenuLabel>
-                                  Select Repository
-                                </DropdownMenuLabel>
-                              </DropdownMenuGroup>
-                              {enabledRepos.map((repo) => {
-                                const inContext = isRepoInContext(repo);
-                                return (
-                                  <DropdownMenuItem
-                                    key={repo.id}
-                                    onClick={() => {
-                                      const item: ContextItem = {
-                                        type: "github-repo",
-                                        owner: repo.owner,
-                                        repo: repo.repo,
-                                        integrationId: repo.integrationId,
-                                      };
-                                      if (inContext) {
-                                        removeChipForItem(item);
-                                      } else {
-                                        insertChipAtCursor(item);
-                                      }
-                                    }}
-                                  >
-                                    <Github className="size-4" />
-                                    <span className="truncate">
-                                      {repo.owner}/{repo.repo}
-                                    </span>
-                                    {inContext && (
-                                      <span className="ml-auto text-emerald-600 text-xs dark:text-emerald-400">
-                                        Added
-                                      </span>
-                                    )}
-                                  </DropdownMenuItem>
-                                );
-                              })}
-                              {organizationSlug && (
-                                <>
-                                  <DropdownMenuSeparator />
-                                  <DropdownMenuItem
-                                    render={
-                                      <Link
-                                        href={`/${organizationSlug}/integrations/github`}
-                                      />
+                    Tools & context
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="start"
+                    className="w-80 p-0"
+                    id={contextPickerId}
+                    showBackdrop
+                    sideOffset={6}
+                  >
+                    <Command>
+                      <CommandInput placeholder="Search tools and context..." />
+                      <CommandList>
+                        <CommandEmpty>
+                          No matching tools or context found.
+                        </CommandEmpty>
+                        {integrationContextOptions.length > 0 && (
+                          <CommandGroup heading="Context">
+                            {integrationContextOptions.map((option) => {
+                              const inContext = isInContext(option.contextItem);
+                              return (
+                                <CommandItem
+                                  data-checked={inContext}
+                                  key={option.id}
+                                  keywords={[option.searchText]}
+                                  onSelect={() => {
+                                    if (inContext) {
+                                      removeChipForItem(option.contextItem);
+                                    } else {
+                                      insertChipAtCursor(option.contextItem);
                                     }
-                                  >
-                                    Manage repositories
-                                  </DropdownMenuItem>
-                                </>
-                              )}
-                            </DropdownMenuSubContent>
-                          </DropdownMenuSub>
-                        );
-                      }
-
-                      if (
-                        isLinear &&
-                        isAvailable &&
-                        enabledLinearIntegrations.length > 0
-                      ) {
-                        return (
-                          <DropdownMenuSub key={integration.id}>
-                            <DropdownMenuSubTrigger className="grid grid-cols-[1rem_3.5rem_1fr_1rem]">
-                              <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
-                                {integration.icon}
-                              </span>
-                              <span className="truncate text-foreground">
-                                {integration.name}
-                              </span>
-                              <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
-                                {enabledLinearIntegrations.length}
-                              </span>
-                            </DropdownMenuSubTrigger>
-                            <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                              <DropdownMenuGroup>
-                                <DropdownMenuLabel>
-                                  Select Integration
-                                </DropdownMenuLabel>
-                              </DropdownMenuGroup>
-                              {enabledLinearIntegrations.map((li) => {
-                                const inContext = isLinearInContext(li);
-                                return (
-                                  <DropdownMenuItem
-                                    key={li.id}
-                                    onClick={() => {
-                                      const item: ContextItem = {
-                                        type: "linear-team",
-                                        integrationId: li.integrationId,
-                                        teamName: li.teamName ?? undefined,
-                                      };
-                                      if (inContext) {
-                                        removeChipForItem(item);
-                                      } else {
-                                        insertChipAtCursor(item);
-                                      }
-                                    }}
-                                  >
-                                    <Linear className="size-4" />
-                                    <span className="truncate">
-                                      {li.displayName}
+                                    setIsContextPickerOpen(false);
+                                  }}
+                                  value={option.id}
+                                >
+                                  {option.kind === "github" ? (
+                                    <Github className="size-4 shrink-0" />
+                                  ) : (
+                                    <Linear className="size-4 shrink-0" />
+                                  )}
+                                  <span className="flex min-w-0 flex-1 flex-col">
+                                    <span className="truncate text-sm">
+                                      {option.label}
                                     </span>
-                                    {inContext && (
-                                      <span className="ml-auto text-emerald-600 text-xs dark:text-emerald-400">
-                                        Added
-                                      </span>
-                                    )}
-                                  </DropdownMenuItem>
-                                );
-                              })}
-                              {organizationSlug && (
-                                <>
-                                  <DropdownMenuSeparator />
-                                  <DropdownMenuItem
-                                    render={
-                                      <Link
-                                        href={`/${organizationSlug}/integrations/linear`}
-                                      />
+                                    <span className="truncate text-muted-foreground text-xs">
+                                      {option.description}
+                                    </span>
+                                  </span>
+                                </CommandItem>
+                              );
+                            })}
+                          </CommandGroup>
+                        )}
+                        {mcpToolOptions.length > 0 && (
+                          <CommandGroup heading="MCP tools">
+                            {mcpToolOptions.map((option) => {
+                              const inContext = isInContext(option.contextItem);
+                              return (
+                                <CommandItem
+                                  data-checked={inContext}
+                                  key={option.id}
+                                  keywords={[option.searchText]}
+                                  onSelect={() => {
+                                    if (inContext) {
+                                      removeChipForItem(option.contextItem);
+                                    } else {
+                                      insertChipAtCursor(option.contextItem);
                                     }
-                                  >
-                                    Manage Linear
-                                  </DropdownMenuItem>
-                                </>
-                              )}
-                            </DropdownMenuSubContent>
-                          </DropdownMenuSub>
-                        );
-                      }
-
-                      if (
-                        isGranola &&
-                        isAvailable &&
-                        enabledGranolaIntegrations.length > 0 &&
-                        organizationSlug
-                      ) {
-                        return (
-                          <DropdownMenuItem
-                            className="grid grid-cols-[1rem_3.5rem_1fr_1rem]"
-                            key={integration.id}
-                            render={
-                              <Link
-                                href={`/${organizationSlug}/integrations/granola`}
-                              />
-                            }
+                                    setIsContextPickerOpen(false);
+                                  }}
+                                  value={option.id}
+                                >
+                                  <McpSourceIcon
+                                    logoDarkUrl={option.logoDarkUrl}
+                                    logoLightUrl={option.logoLightUrl}
+                                  />
+                                  <span className="flex min-w-0 flex-1 flex-col">
+                                    <span className="truncate text-sm">
+                                      {option.label}
+                                    </span>
+                                    <span className="truncate text-muted-foreground text-xs">
+                                      {option.description}
+                                    </span>
+                                  </span>
+                                </CommandItem>
+                              );
+                            })}
+                          </CommandGroup>
+                        )}
+                      </CommandList>
+                      {organizationSlug && (
+                        <div className="border-border border-t p-1">
+                          <Link
+                            className="flex items-center rounded-sm px-2 py-1.5 text-muted-foreground text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
+                            href={`/${organizationSlug}/integrations`}
+                            onClick={() => setIsContextPickerOpen(false)}
                           >
-                            <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
-                              {integration.icon}
-                            </span>
-                            <span className="truncate text-foreground">
-                              {integration.name}
-                            </span>
-                            <span className="justify-self-center text-emerald-600 text-xs dark:text-emerald-400">
-                              {enabledGranolaIntegrations.length}
-                            </span>
-                            <HugeiconsIcon
-                              className="size-4 text-muted-foreground"
-                              icon={ArrowRight01Icon}
-                              strokeWidth={2}
-                            />
-                          </DropdownMenuItem>
-                        );
-                      }
-
-                      if (
-                        (isGitHub || isLinear || isGranola) &&
-                        isAvailable &&
-                        organizationSlug
-                      ) {
-                        return (
-                          <DropdownMenuItem
-                            className="grid grid-cols-[1rem_3.5rem_1fr_1rem]"
-                            key={integration.id}
-                            render={
-                              <Link
-                                href={`/${organizationSlug}/integrations/${integration.href}`}
-                              />
-                            }
-                          >
-                            <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
-                              {integration.icon}
-                            </span>
-                            <span className="truncate text-foreground">
-                              {integration.name}
-                            </span>
-                            <span className="justify-self-center text-muted-foreground text-xs">
-                              Setup
-                            </span>
-                            <HugeiconsIcon
-                              className="size-4 text-muted-foreground"
-                              icon={ArrowRight01Icon}
-                              strokeWidth={2}
-                            />
-                          </DropdownMenuItem>
-                        );
-                      }
-
-                      return (
-                        <DropdownMenuItem
-                          className="opacity-60"
-                          disabled
-                          key={integration.id}
-                        >
-                          <span className="size-4 shrink-0 text-foreground [&_svg]:size-4">
-                            {integration.icon}
-                          </span>
-                          <span className="text-foreground">
-                            {integration.name}
-                          </span>
-                          <span className="ml-auto text-muted-foreground text-xs">
-                            Soon
-                          </span>
-                          <HugeiconsIcon
-                            className="size-4 text-muted-foreground"
-                            icon={ArrowRight01Icon}
-                            strokeWidth={2}
-                          />
-                        </DropdownMenuItem>
-                      );
-                    })}
-                    {organizationSlug && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          render={
-                            <Link href={`/${organizationSlug}/integrations`} />
-                          }
-                        >
-                          Manage integrations
-                        </DropdownMenuItem>
-                      </>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                            Manage integrations
+                          </Link>
+                        </div>
+                      )}
+                    </Command>
+                  </PopoverContent>
+                </Popover>
 
                 <Tooltip>
                   <TooltipTrigger

--- a/apps/dashboard/src/components/chat/integration-reference.tsx
+++ b/apps/dashboard/src/components/chat/integration-reference.tsx
@@ -5,7 +5,9 @@ import { Github } from "@notra/ui/components/ui/svgs/github";
 import { Linear } from "@notra/ui/components/ui/svgs/linear";
 import { Fragment, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { McpIcon } from "@/components/integrations/mcp-icon";
 import { INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX } from "@/constants/integration-reference";
+import type { McpIconUrls } from "@/types/integrations/mcp";
 import {
   getIntegrationReferenceValue,
   getReferenceDisplay,
@@ -43,6 +45,7 @@ const LINEAR_ICON_MARKUP = renderToStaticMarkup(
 const MCP_ICON_MARKUP = renderToStaticMarkup(
   <HugeiconsIcon className="size-full" icon={CpuIcon} />
 );
+
 function getReferenceKind(item: ContextItem): ReferenceKind {
   if (item.type === "github-repo") {
     return "github";
@@ -89,16 +92,67 @@ function appendReferenceData(span: HTMLSpanElement, item: ContextItem): void {
   }
 }
 
-function createReferenceIcon(kind: ReferenceKind): HTMLSpanElement {
+function createReferenceIcon(
+  kind: ReferenceKind,
+  mcpIcon?: McpIconUrls
+): HTMLSpanElement {
   const icon = document.createElement("span");
   icon.setAttribute("aria-hidden", "true");
   icon.className = getReferenceIconWrapperClass(kind);
+
+  const lightLogo = mcpIcon?.lightUrl ?? mcpIcon?.darkUrl;
+  const darkLogo = mcpIcon?.darkUrl ?? mcpIcon?.lightUrl;
+  if (kind === "mcp" && lightLogo && darkLogo) {
+    const lightImage = document.createElement("img");
+    lightImage.alt = "";
+    lightImage.className = "size-full rounded-sm object-contain dark:hidden";
+    lightImage.src = lightLogo;
+
+    const darkImage = document.createElement("img");
+    darkImage.alt = "";
+    darkImage.className =
+      "hidden size-full rounded-sm object-contain dark:block";
+    darkImage.src = darkLogo;
+
+    let didFallback = false;
+    const showFallbackIcon = () => {
+      if (didFallback) {
+        return;
+      }
+      didFallback = true;
+      icon.innerHTML = MCP_ICON_MARKUP;
+    };
+    lightImage.addEventListener("error", showFallbackIcon, { once: true });
+    darkImage.addEventListener("error", showFallbackIcon, { once: true });
+
+    icon.append(lightImage, darkImage);
+    return icon;
+  }
+
   icon.innerHTML = getReferenceIconMarkup(kind);
   return icon;
 }
 
-function ReferenceIcon({ kind }: { kind: ReferenceKind }) {
+function ReferenceIcon({
+  kind,
+  mcpIcon,
+}: {
+  kind: ReferenceKind;
+  mcpIcon?: McpIconUrls;
+}) {
   const iconWrapperClass = getReferenceIconWrapperClass(kind);
+
+  if (kind === "mcp" && (mcpIcon?.lightUrl || mcpIcon?.darkUrl)) {
+    return (
+      <span aria-hidden="true" className={iconWrapperClass}>
+        <McpIcon
+          className="size-full"
+          darkUrl={mcpIcon.darkUrl}
+          lightUrl={mcpIcon.lightUrl}
+        />
+      </span>
+    );
+  }
 
   return (
     <span
@@ -111,7 +165,8 @@ function ReferenceIcon({ kind }: { kind: ReferenceKind }) {
 }
 
 export function buildIntegrationReferenceElement(
-  item: ContextItem
+  item: ContextItem,
+  mcpIcon?: McpIconUrls
 ): HTMLSpanElement {
   const span = document.createElement("span");
   span.contentEditable = "false";
@@ -120,7 +175,7 @@ export function buildIntegrationReferenceElement(
   span.dataset.value = getIntegrationReferenceValue(item);
   appendReferenceData(span, item);
 
-  const icon = createReferenceIcon(getReferenceKind(item));
+  const icon = createReferenceIcon(getReferenceKind(item), mcpIcon);
   const label = document.createElement("span");
   label.className = REFERENCE_LABEL_CLASS;
   label.textContent = getReferenceDisplay(item);
@@ -163,8 +218,37 @@ export function hydrateLinearReferenceTeamNames(
   return changed;
 }
 
+export function hydrateMcpReferenceIcons(
+  root: HTMLElement,
+  iconsByIntegrationId: ReadonlyMap<string, McpIconUrls>
+): boolean {
+  let changed = false;
+  const chips = root.querySelectorAll<HTMLElement>(
+    INTEGRATION_REFERENCE_SELECTOR
+  );
+
+  for (const chip of chips) {
+    if (chip.dataset.kind !== "mcp") {
+      continue;
+    }
+    const integrationId = chip.dataset.integrationId;
+    if (!integrationId) {
+      continue;
+    }
+    const iconUrls = iconsByIntegrationId.get(integrationId);
+    if (!(iconUrls?.lightUrl || iconUrls?.darkUrl)) {
+      continue;
+    }
+    chip.firstElementChild?.replaceWith(createReferenceIcon("mcp", iconUrls));
+    changed = true;
+  }
+
+  return changed;
+}
+
 export function buildFragmentFromReferencedText(
-  text: string
+  text: string,
+  mcpIconsByIntegrationId?: ReadonlyMap<string, McpIconUrls>
 ): DocumentFragment {
   const fragment = document.createDocumentFragment();
   const segments = text.split(INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX);
@@ -176,7 +260,11 @@ export function buildFragmentFromReferencedText(
 
     const referenceItem = parseReferenceValue(segment);
     if (referenceItem) {
-      fragment.append(buildIntegrationReferenceElement(referenceItem));
+      const mcpIcon =
+        referenceItem.type === "mcp-server"
+          ? mcpIconsByIntegrationId?.get(referenceItem.integrationId)
+          : undefined;
+      fragment.append(buildIntegrationReferenceElement(referenceItem, mcpIcon));
       continue;
     }
 
@@ -222,7 +310,10 @@ export function parseIntegrationReferenceElement(
   return null;
 }
 
-export function renderTextWithIntegrationReferences(text: string): ReactNode[] {
+export function renderTextWithIntegrationReferences(
+  text: string,
+  mcpIconsByIntegrationId?: ReadonlyMap<string, McpIconUrls>
+): ReactNode[] {
   const nodes: ReactNode[] = [];
   let keySeed = 0;
   const segments = text.split(INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX);
@@ -234,11 +325,16 @@ export function renderTextWithIntegrationReferences(text: string): ReactNode[] {
 
     const referenceItem = parseReferenceValue(segment);
     if (referenceItem) {
+      const mcpIcon =
+        referenceItem.type === "mcp-server"
+          ? mcpIconsByIntegrationId?.get(referenceItem.integrationId)
+          : undefined;
       nodes.push(
         <IntegrationReference
           display={getReferenceDisplay(referenceItem)}
           key={`ref-${segment}-${keySeed++}`}
           kind={getReferenceKind(referenceItem)}
+          mcpIcon={mcpIcon}
           value={getIntegrationReferenceValue(referenceItem)}
         />
       );
@@ -311,12 +407,14 @@ interface IntegrationReferenceProps {
   value: string;
   display: string;
   kind: ReferenceKind;
+  mcpIcon?: McpIconUrls;
 }
 
 function IntegrationReference({
   value,
   display,
   kind,
+  mcpIcon,
 }: IntegrationReferenceProps) {
   return (
     <span
@@ -325,7 +423,7 @@ function IntegrationReference({
       data-integration-reference="true"
       data-value={value}
     >
-      <ReferenceIcon kind={kind} />
+      <ReferenceIcon kind={kind} mcpIcon={mcpIcon} />
       <span className={REFERENCE_LABEL_CLASS}>{display}</span>
     </span>
   );

--- a/apps/dashboard/src/components/chat/integration-reference.tsx
+++ b/apps/dashboard/src/components/chat/integration-reference.tsx
@@ -12,8 +12,6 @@ import {
   parseReferenceValue,
 } from "@/utils/integration-reference";
 
-export { getReferenceDisplay, parseReferenceValue };
-
 const REFERENCE_ATTR = "data-integration-reference";
 
 export const INTEGRATION_REFERENCE_SELECTOR =

--- a/apps/dashboard/src/components/chat/integration-reference.tsx
+++ b/apps/dashboard/src/components/chat/integration-reference.tsx
@@ -1,8 +1,18 @@
+import { CpuIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { ContextItem } from "@notra/ai/types/chat";
 import { Github } from "@notra/ui/components/ui/svgs/github";
 import { Linear } from "@notra/ui/components/ui/svgs/linear";
 import { Fragment, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX } from "@/constants/integration-reference";
+import {
+  getIntegrationReferenceValue,
+  getReferenceDisplay,
+  parseReferenceValue,
+} from "@/utils/integration-reference";
+
+export { getReferenceDisplay, parseReferenceValue };
 
 const REFERENCE_ATTR = "data-integration-reference";
 
@@ -21,7 +31,10 @@ const REFERENCE_GITHUB_ICON_WRAPPER_CLASS =
 const REFERENCE_LINEAR_ICON_WRAPPER_CLASS =
   "inline-flex size-[1.04em] shrink-0 items-center justify-center text-indigo-500 dark:text-indigo-400";
 
-type ReferenceKind = "github" | "linear";
+const REFERENCE_MCP_ICON_WRAPPER_CLASS =
+  "inline-flex size-[1.04em] shrink-0 items-center justify-center text-violet-600 dark:text-violet-400";
+
+type ReferenceKind = "github" | "linear" | "mcp";
 
 const GITHUB_ICON_MARKUP = renderToStaticMarkup(
   <Github className="size-full" />
@@ -29,26 +42,30 @@ const GITHUB_ICON_MARKUP = renderToStaticMarkup(
 const LINEAR_ICON_MARKUP = renderToStaticMarkup(
   <Linear className="size-full" />
 );
-const GITHUB_REFERENCE_VALUE_PATTERN =
-  /^@?integration\/github\/([^/\s]+)\/([^/\s]+)\/([^/\s]+)$/;
-const LINEAR_REFERENCE_VALUE_PATTERN = /^@?integration\/linear\/([^/\s]+)$/;
-
+const MCP_ICON_MARKUP = renderToStaticMarkup(
+  <HugeiconsIcon className="size-full" icon={CpuIcon} />
+);
 function getReferenceKind(item: ContextItem): ReferenceKind {
-  return item.type === "github-repo" ? "github" : "linear";
+  if (item.type === "github-repo") {
+    return "github";
+  }
+  return item.type === "linear-team" ? "linear" : "mcp";
 }
 
 function getReferenceIconWrapperClass(kind: ReferenceKind): string {
-  return kind === "github"
-    ? REFERENCE_GITHUB_ICON_WRAPPER_CLASS
-    : REFERENCE_LINEAR_ICON_WRAPPER_CLASS;
+  if (kind === "github") {
+    return REFERENCE_GITHUB_ICON_WRAPPER_CLASS;
+  }
+  return kind === "linear"
+    ? REFERENCE_LINEAR_ICON_WRAPPER_CLASS
+    : REFERENCE_MCP_ICON_WRAPPER_CLASS;
 }
 
 function getReferenceIconMarkup(kind: ReferenceKind): string {
   if (kind === "github") {
     return GITHUB_ICON_MARKUP;
   }
-
-  return LINEAR_ICON_MARKUP;
+  return kind === "linear" ? LINEAR_ICON_MARKUP : MCP_ICON_MARKUP;
 }
 
 function appendReferenceData(span: HTMLSpanElement, item: ContextItem): void {
@@ -57,6 +74,13 @@ function appendReferenceData(span: HTMLSpanElement, item: ContextItem): void {
     span.dataset.owner = item.owner;
     span.dataset.repo = item.repo;
     span.dataset.integrationId = item.integrationId;
+    return;
+  }
+
+  if (item.type === "mcp-server") {
+    span.dataset.kind = "mcp";
+    span.dataset.integrationId = item.integrationId;
+    span.dataset.name = item.name;
     return;
   }
 
@@ -88,20 +112,6 @@ function ReferenceIcon({ kind }: { kind: ReferenceKind }) {
   );
 }
 
-function getReferenceValue(item: ContextItem): string {
-  if (item.type === "github-repo") {
-    return `@integration/github/${item.integrationId}/${item.owner}/${item.repo}`;
-  }
-  return `@integration/linear/${item.integrationId}`;
-}
-
-export function getReferenceDisplay(item: ContextItem): string {
-  if (item.type === "github-repo") {
-    return `@${item.owner}/${item.repo}`;
-  }
-  return `@${item.teamName ?? "Linear"}`;
-}
-
 export function buildIntegrationReferenceElement(
   item: ContextItem
 ): HTMLSpanElement {
@@ -109,7 +119,7 @@ export function buildIntegrationReferenceElement(
   span.contentEditable = "false";
   span.className = REFERENCE_CONTAINER_CLASS;
   span.setAttribute(REFERENCE_ATTR, "true");
-  span.dataset.value = getReferenceValue(item);
+  span.dataset.value = getIntegrationReferenceValue(item);
   appendReferenceData(span, item);
 
   const icon = createReferenceIcon(getReferenceKind(item));
@@ -155,14 +165,11 @@ export function hydrateLinearReferenceTeamNames(
   return changed;
 }
 
-const REFERENCE_TOKEN_SPLIT_REGEX =
-  /(@?integration\/(?:github\/[^/\s]+\/[^/\s]+\/[^/\s]+|linear\/[^/\s]+))/g;
-
 export function buildFragmentFromReferencedText(
   text: string
 ): DocumentFragment {
   const fragment = document.createDocumentFragment();
-  const segments = text.split(REFERENCE_TOKEN_SPLIT_REGEX);
+  const segments = text.split(INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX);
 
   for (const segment of segments) {
     if (!segment) {
@@ -207,37 +214,20 @@ export function parseIntegrationReferenceElement(
     }
     return { type: "linear-team", integrationId, teamName };
   }
-  return null;
-}
-
-export function parseReferenceValue(value: string): ContextItem | null {
-  const trimmed = value.trim();
-
-  const githubMatch = trimmed.match(GITHUB_REFERENCE_VALUE_PATTERN);
-  if (githubMatch) {
-    const [, integrationId, owner, repo] = githubMatch;
-    if (integrationId && owner && repo) {
-      return { type: "github-repo", integrationId, owner, repo };
+  if (kind === "mcp") {
+    const { integrationId, name } = el.dataset;
+    if (!(integrationId && name)) {
+      return null;
     }
+    return { type: "mcp-server", integrationId, name };
   }
-
-  const linearMatch = trimmed.match(LINEAR_REFERENCE_VALUE_PATTERN);
-  if (linearMatch) {
-    const [, integrationId] = linearMatch;
-    if (integrationId) {
-      return { type: "linear-team", integrationId };
-    }
-  }
-
   return null;
 }
 
 export function renderTextWithIntegrationReferences(text: string): ReactNode[] {
   const nodes: ReactNode[] = [];
   let keySeed = 0;
-  const segments = text.split(
-    /(@?integration\/(?:github\/[^/\s]+\/[^/\s]+\/[^/\s]+|linear\/[^/\s]+))/g
-  );
+  const segments = text.split(INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX);
 
   segments.forEach((segment, segmentIndex) => {
     if (!segment) {
@@ -251,7 +241,7 @@ export function renderTextWithIntegrationReferences(text: string): ReactNode[] {
           display={getReferenceDisplay(referenceItem)}
           key={`ref-${segment}-${keySeed++}`}
           kind={getReferenceKind(referenceItem)}
-          value={getReferenceValue(referenceItem)}
+          value={getIntegrationReferenceValue(referenceItem)}
         />
       );
       return;

--- a/apps/dashboard/src/components/integrations/mcp-icon.tsx
+++ b/apps/dashboard/src/components/integrations/mcp-icon.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { CpuIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
+import { cn } from "@notra/ui/lib/utils";
+import { getMcpIconUrls } from "@/lib/integrations/mcp";
+import type { McpIconProps } from "@/types/integrations/mcp";
+
+export function McpIcon({ darkUrl, lightUrl, className }: McpIconProps) {
+  const iconUrls = getMcpIconUrls({ darkUrl, lightUrl });
+
+  return (
+    <span className={cn("relative size-4 shrink-0", className)}>
+      <Avatar className="size-full rounded-sm after:hidden dark:hidden">
+        <AvatarImage
+          className="rounded-sm object-contain"
+          src={iconUrls.lightUrl ?? undefined}
+        />
+        <AvatarFallback className="rounded-sm bg-transparent">
+          <HugeiconsIcon className="size-[75%]" icon={CpuIcon} />
+        </AvatarFallback>
+      </Avatar>
+      <Avatar className="hidden size-full rounded-sm after:hidden dark:flex">
+        <AvatarImage
+          className="rounded-sm object-contain"
+          src={iconUrls.darkUrl ?? undefined}
+        />
+        <AvatarFallback className="rounded-sm bg-transparent">
+          <HugeiconsIcon className="size-[75%]" icon={CpuIcon} />
+        </AvatarFallback>
+      </Avatar>
+    </span>
+  );
+}

--- a/apps/dashboard/src/constants/integration-reference.ts
+++ b/apps/dashboard/src/constants/integration-reference.ts
@@ -1,0 +1,11 @@
+export const GITHUB_REFERENCE_VALUE_PATTERN =
+  /^@?integration\/github\/([^/\s]+)\/([^/\s]+)\/([^/\s]+)$/;
+
+export const LINEAR_REFERENCE_VALUE_PATTERN =
+  /^@?integration\/linear\/([^/\s]+)$/;
+
+export const MCP_REFERENCE_VALUE_PATTERN =
+  /^@?integration\/mcp\/([^/\s]+)\/([^/\s]+)$/;
+
+export const INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX =
+  /(@?integration\/(?:github\/[^/\s]+\/[^/\s]+\/[^/\s]+|linear\/[^/\s]+|mcp\/[^/\s]+\/[^/\s]+))/g;

--- a/apps/dashboard/src/lib/integrations/catalog.tsx
+++ b/apps/dashboard/src/lib/integrations/catalog.tsx
@@ -7,7 +7,7 @@ import { Linear } from "@notra/ui/components/ui/svgs/linear";
 import { Raycast } from "@notra/ui/components/ui/svgs/raycast";
 import type { IntegrationConfig } from "@/types/integrations/catalog";
 
-export const INPUT_SOURCES: readonly IntegrationConfig[] = [
+const INPUT_SOURCES: readonly IntegrationConfig[] = [
   {
     id: "github",
     name: "GitHub",

--- a/apps/dashboard/src/lib/integrations/mcp.ts
+++ b/apps/dashboard/src/lib/integrations/mcp.ts
@@ -2,6 +2,10 @@ import {
   type AddMcpServerFormValues,
   MCP_URL_PROTOCOL_REGEX,
 } from "@/schemas/integrations";
+import type {
+  GetMcpIconUrlsInput,
+  McpIconUrls,
+} from "@/types/integrations/mcp";
 
 export const MCP_ACCENT_COLOR = "#9333EA";
 
@@ -25,6 +29,21 @@ export function getMcpFaviconUrl(url: string | null | undefined) {
   } catch {
     return undefined;
   }
+}
+
+export function getMcpIconUrls({
+  lightUrl,
+  darkUrl,
+  fallbackUrl,
+}: GetMcpIconUrlsInput): McpIconUrls {
+  const normalizedLightUrl = lightUrl?.trim() || undefined;
+  const normalizedDarkUrl = darkUrl?.trim() || undefined;
+  const normalizedFallbackUrl = fallbackUrl?.trim() || undefined;
+
+  return {
+    lightUrl: normalizedLightUrl ?? normalizedDarkUrl ?? normalizedFallbackUrl,
+    darkUrl: normalizedDarkUrl ?? normalizedLightUrl ?? normalizedFallbackUrl,
+  };
 }
 
 export function getMcpFormErrorMessage(error: unknown) {

--- a/apps/dashboard/src/types/components/chat-input.ts
+++ b/apps/dashboard/src/types/components/chat-input.ts
@@ -35,3 +35,22 @@ export interface ChatInputProps {
 }
 
 export type EnabledRepo = GitHubRepository & { integrationId: string };
+
+export type ChatContextOptionKind = "github" | "linear" | "mcp";
+
+export interface ChatContextOption {
+  id: string;
+  kind: ChatContextOptionKind;
+  label: string;
+  description: string;
+  searchText: string;
+  contextItem: ContextItem;
+  logoLightUrl?: string | null;
+  logoDarkUrl?: string | null;
+}
+
+export interface McpSourceIconProps {
+  logoLightUrl?: string | null;
+  logoDarkUrl?: string | null;
+  className?: string;
+}

--- a/apps/dashboard/src/types/components/chat-input.ts
+++ b/apps/dashboard/src/types/components/chat-input.ts
@@ -49,8 +49,6 @@ export interface ChatContextOption {
   logoDarkUrl?: string | null;
 }
 
-export interface McpSourceIconProps {
-  logoLightUrl?: string | null;
-  logoDarkUrl?: string | null;
-  className?: string;
+export interface ChatContextOptionContentProps {
+  option: ChatContextOption;
 }

--- a/apps/dashboard/src/types/integrations/mcp.ts
+++ b/apps/dashboard/src/types/integrations/mcp.ts
@@ -12,6 +12,19 @@ export type McpTestStatus = "idle" | "testing" | "success" | "error";
 
 export type McpDialogStatus = "idle" | "testing" | "creating" | "redirecting";
 
+export interface McpIconUrls {
+  darkUrl?: string | null;
+  lightUrl?: string | null;
+}
+
+export interface McpIconProps extends McpIconUrls {
+  className?: string;
+}
+
+export interface GetMcpIconUrlsInput extends McpIconUrls {
+  fallbackUrl?: string | null;
+}
+
 export interface McpConnectionTestStatusProps {
   message: string;
   status: McpTestStatus;

--- a/apps/dashboard/src/utils/integration-reference.ts
+++ b/apps/dashboard/src/utils/integration-reference.ts
@@ -1,0 +1,63 @@
+import type { ContextItem } from "@notra/ai/types/chat";
+import {
+  GITHUB_REFERENCE_VALUE_PATTERN,
+  LINEAR_REFERENCE_VALUE_PATTERN,
+  MCP_REFERENCE_VALUE_PATTERN,
+} from "@/constants/integration-reference";
+
+export function getIntegrationReferenceValue(item: ContextItem): string {
+  if (item.type === "github-repo") {
+    return `@integration/github/${item.integrationId}/${item.owner}/${item.repo}`;
+  }
+  if (item.type === "mcp-server") {
+    return `@integration/mcp/${item.integrationId}/${encodeURIComponent(item.name)}`;
+  }
+  return `@integration/linear/${item.integrationId}`;
+}
+
+export function getReferenceDisplay(item: ContextItem): string {
+  if (item.type === "github-repo") {
+    return `@${item.owner}/${item.repo}`;
+  }
+  return item.type === "linear-team"
+    ? `@${item.teamName ?? "Linear"}`
+    : `@${item.name}`;
+}
+
+export function parseReferenceValue(value: string): ContextItem | null {
+  const trimmed = value.trim();
+
+  const githubMatch = trimmed.match(GITHUB_REFERENCE_VALUE_PATTERN);
+  if (githubMatch) {
+    const [, integrationId, owner, repo] = githubMatch;
+    if (integrationId && owner && repo) {
+      return { type: "github-repo", integrationId, owner, repo };
+    }
+  }
+
+  const linearMatch = trimmed.match(LINEAR_REFERENCE_VALUE_PATTERN);
+  if (linearMatch) {
+    const [, integrationId] = linearMatch;
+    if (integrationId) {
+      return { type: "linear-team", integrationId };
+    }
+  }
+
+  const mcpMatch = trimmed.match(MCP_REFERENCE_VALUE_PATTERN);
+  if (mcpMatch) {
+    const [, integrationId, encodedName] = mcpMatch;
+    if (integrationId && encodedName) {
+      try {
+        return {
+          type: "mcp-server",
+          integrationId,
+          name: decodeURIComponent(encodedName),
+        };
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/ai/src/integrations/mcp-tool-index.ts
+++ b/packages/ai/src/integrations/mcp-tool-index.ts
@@ -29,11 +29,13 @@ import {
 } from "../constants/mcp-tool-index";
 import type { McpRequestAuth } from "../types/mcp-oauth";
 import type {
+  GetSessionActivatedMcpToolsParams,
   IndexedMcpTool,
   McpSessionSurface,
   McpToolActionPhrases,
   McpToolDefinition,
   McpToolIndexTransaction,
+  QuerySessionActivatedMcpToolsParams,
 } from "../types/mcp-tool-index";
 import { publicMcpRuntimeFetch } from "../utils/mcp-fetch";
 import { createMcpToolFingerprint } from "../utils/mcp-tool-fingerprint";
@@ -430,23 +432,25 @@ export async function hasActiveIndexedMcpToolsForOrganization({
   return (row?.value ?? 0) > 0;
 }
 
-export async function getSessionActivatedMcpTools({
+export async function getSessionActivatedMcpTools(
+  params: GetSessionActivatedMcpToolsParams
+) {
+  return querySessionActivatedMcpTools({ database: db, ...params });
+}
+
+async function querySessionActivatedMcpTools({
+  database,
   organizationId,
   sessionId,
   surface,
   serverIntegrationIds,
-}: {
-  organizationId: string;
-  sessionId: string;
-  surface: McpSessionSurface;
-  serverIntegrationIds?: string[];
-}) {
+}: QuerySessionActivatedMcpToolsParams) {
   if (serverIntegrationIds?.length === 0) {
     return [];
   }
 
   const now = new Date();
-  return db
+  return database
     .select({
       activation: mcpSessionToolActivations,
       tool: mcpToolIndex,
@@ -527,10 +531,13 @@ export async function activateSessionMcpTools({
   }
 
   let tools = await getToolsByIds(organizationId, uniqueToolIds);
+  const allowedServerIntegrationIds = serverIntegrationIds
+    ? new Set(serverIntegrationIds)
+    : null;
   if (
-    serverIntegrationIds &&
+    allowedServerIntegrationIds &&
     tools.some(
-      (tool) => !serverIntegrationIds.includes(tool.serverIntegrationId)
+      (tool) => !allowedServerIntegrationIds.has(tool.serverIntegrationId)
     )
   ) {
     throw new Error(
@@ -565,34 +572,40 @@ export async function activateSessionMcpTools({
     throw new Error("One or more MCP tools are unavailable.");
   }
 
-  const existing = await getSessionActivatedMcpTools({
-    organizationId,
-    sessionId,
-    surface,
-    serverIntegrationIds,
-  });
-  const existingIds = new Set(existing.map((tool) => tool.id));
-  const newCount = activeTools.filter(
-    (tool) => !existingIds.has(tool.id)
-  ).length;
-  if (existing.length + newCount > MCP_SESSION_ACTIVE_TOOL_LIMIT) {
-    throw new Error(
-      `This session can activate at most ${MCP_SESSION_ACTIVE_TOOL_LIMIT} MCP tools. Deactivate unused tools first.`
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`mcp-session-tool-activation:${organizationId}:${sessionId}:${surface}`}, 0))`
     );
-  }
 
-  for (const tool of activeTools) {
-    await db
+    const existing = await querySessionActivatedMcpTools({
+      database: tx,
+      organizationId,
+      sessionId,
+      surface,
+    });
+    const existingIds = new Set(existing.map((tool) => tool.id));
+    const newCount = activeTools.filter(
+      (tool) => !existingIds.has(tool.id)
+    ).length;
+    if (existing.length + newCount > MCP_SESSION_ACTIVE_TOOL_LIMIT) {
+      throw new Error(
+        `This session can activate at most ${MCP_SESSION_ACTIVE_TOOL_LIMIT} MCP tools. Deactivate unused tools first.`
+      );
+    }
+
+    await tx
       .insert(mcpSessionToolActivations)
-      .values({
-        id: `mcpa_${nanoid()}`,
-        organizationId,
-        sessionId,
-        surface,
-        mcpToolIndexId: tool.id,
-        runtimeToolName: tool.runtimeToolName,
-        sourceQuery: sourceQuery ?? null,
-      })
+      .values(
+        activeTools.map((tool) => ({
+          id: `mcpa_${nanoid()}`,
+          organizationId,
+          sessionId,
+          surface,
+          mcpToolIndexId: tool.id,
+          runtimeToolName: tool.runtimeToolName,
+          sourceQuery: sourceQuery ?? null,
+        }))
+      )
       .onConflictDoUpdate({
         target: [
           mcpSessionToolActivations.organizationId,
@@ -601,17 +614,18 @@ export async function activateSessionMcpTools({
           mcpSessionToolActivations.mcpToolIndexId,
         ],
         set: {
-          runtimeToolName: tool.runtimeToolName,
-          sourceQuery: sourceQuery ?? null,
+          runtimeToolName: sql`excluded.runtime_tool_name`,
+          sourceQuery: sql`excluded.source_query`,
         },
       });
-  }
 
-  return getSessionActivatedMcpTools({
-    organizationId,
-    sessionId,
-    surface,
-    serverIntegrationIds,
+    return querySessionActivatedMcpTools({
+      database: tx,
+      organizationId,
+      sessionId,
+      surface,
+      serverIntegrationIds,
+    });
   });
 }
 

--- a/packages/ai/src/integrations/mcp-tool-index.ts
+++ b/packages/ai/src/integrations/mcp-tool-index.ts
@@ -434,11 +434,17 @@ export async function getSessionActivatedMcpTools({
   organizationId,
   sessionId,
   surface,
+  serverIntegrationIds,
 }: {
   organizationId: string;
   sessionId: string;
   surface: McpSessionSurface;
+  serverIntegrationIds?: string[];
 }) {
+  if (serverIntegrationIds?.length === 0) {
+    return [];
+  }
+
   const now = new Date();
   return db
     .select({
@@ -468,6 +474,9 @@ export async function getSessionActivatedMcpTools({
         eq(mcpToolIndex.status, "active"),
         eq(mcpServerIntegrations.enabled, true),
         eq(mcpServerIntegrations.resourceType, "connection"),
+        serverIntegrationIds
+          ? inArray(mcpToolIndex.serverIntegrationId, serverIntegrationIds)
+          : undefined,
         or(
           isNull(mcpSessionToolActivations.expiresAt),
           gt(mcpSessionToolActivations.expiresAt, now)
@@ -498,12 +507,14 @@ export async function activateSessionMcpTools({
   surface,
   toolIds,
   sourceQuery,
+  serverIntegrationIds,
 }: {
   organizationId: string;
   sessionId: string;
   surface: McpSessionSurface;
   toolIds: string[];
   sourceQuery?: string;
+  serverIntegrationIds?: string[];
 }) {
   const uniqueToolIds = Array.from(new Set(toolIds));
   if (uniqueToolIds.length === 0) {
@@ -516,6 +527,16 @@ export async function activateSessionMcpTools({
   }
 
   let tools = await getToolsByIds(organizationId, uniqueToolIds);
+  if (
+    serverIntegrationIds &&
+    tools.some(
+      (tool) => !serverIntegrationIds.includes(tool.serverIntegrationId)
+    )
+  ) {
+    throw new Error(
+      "One or more MCP tools are outside the selected server context."
+    );
+  }
   const staleIntegrationIds = new Set(
     tools
       .filter((tool) => tool.status === "stale")
@@ -548,6 +569,7 @@ export async function activateSessionMcpTools({
     organizationId,
     sessionId,
     surface,
+    serverIntegrationIds,
   });
   const existingIds = new Set(existing.map((tool) => tool.id));
   const newCount = activeTools.filter(
@@ -585,7 +607,12 @@ export async function activateSessionMcpTools({
       });
   }
 
-  return getSessionActivatedMcpTools({ organizationId, sessionId, surface });
+  return getSessionActivatedMcpTools({
+    organizationId,
+    sessionId,
+    surface,
+    serverIntegrationIds,
+  });
 }
 
 export async function deactivateSessionMcpTools({

--- a/packages/ai/src/integrations/mcp-tool-index.ts
+++ b/packages/ai/src/integrations/mcp-tool-index.ts
@@ -16,6 +16,7 @@ import {
   isNull,
   notInArray,
   or,
+  type SQL,
   sql,
 } from "drizzle-orm";
 import { customAlphabet } from "nanoid";
@@ -635,28 +636,73 @@ export async function deactivateSessionMcpTools({
   surface,
   toolIds,
   runtimeToolNames,
+  serverIntegrationIds,
 }: {
   organizationId: string;
   sessionId: string;
   surface: McpSessionSurface;
   toolIds?: string[];
   runtimeToolNames?: string[];
+  serverIntegrationIds?: string[];
 }) {
+  if (serverIntegrationIds?.length === 0) {
+    return { deactivated: 0 };
+  }
+
   const conditions = [
     eq(mcpSessionToolActivations.organizationId, organizationId),
     eq(mcpSessionToolActivations.sessionId, sessionId),
     eq(mcpSessionToolActivations.surface, surface),
   ];
 
-  if (toolIds?.length) {
-    conditions.push(inArray(mcpSessionToolActivations.mcpToolIndexId, toolIds));
-  } else if (runtimeToolNames?.length) {
+  if (serverIntegrationIds) {
+    const selectedServerToolIds = db
+      .select({ id: mcpToolIndex.id })
+      .from(mcpToolIndex)
+      .where(
+        and(
+          eq(mcpToolIndex.organizationId, organizationId),
+          inArray(mcpToolIndex.serverIntegrationId, serverIntegrationIds)
+        )
+      );
     conditions.push(
-      inArray(mcpSessionToolActivations.runtimeToolName, runtimeToolNames)
+      inArray(mcpSessionToolActivations.mcpToolIndexId, selectedServerToolIds)
     );
-  } else {
+  }
+
+  const requestedToolConditions: SQL[] = [];
+  if (toolIds?.length) {
+    requestedToolConditions.push(
+      inArray(mcpSessionToolActivations.mcpToolIndexId, toolIds)
+    );
+  }
+  if (runtimeToolNames?.length) {
+    const currentRuntimeNameToolIds = db
+      .select({ id: mcpToolIndex.id })
+      .from(mcpToolIndex)
+      .where(
+        and(
+          eq(mcpToolIndex.organizationId, organizationId),
+          inArray(mcpToolIndex.runtimeToolName, runtimeToolNames)
+        )
+      );
+    const runtimeNameCondition = or(
+      inArray(mcpSessionToolActivations.runtimeToolName, runtimeToolNames),
+      inArray(
+        mcpSessionToolActivations.mcpToolIndexId,
+        currentRuntimeNameToolIds
+      )
+    );
+    if (runtimeNameCondition) {
+      requestedToolConditions.push(runtimeNameCondition);
+    }
+  }
+
+  const requestedToolCondition = or(...requestedToolConditions);
+  if (!requestedToolCondition) {
     return { deactivated: 0 };
   }
+  conditions.push(requestedToolCondition);
 
   const deleted = await db
     .delete(mcpSessionToolActivations)

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -103,6 +103,7 @@ export async function orchestrateStandaloneChat(
   const hasGitHub = hasEnabledGitHubIntegration(validatedIntegrations);
   const hasLinear = hasEnabledLinearIntegration(validatedIntegrations);
   const hasMcp = (await getEnabledMcpServerCount(organizationId)) > 0;
+  const mcpContext = context.filter((item) => item.type === "mcp-server");
 
   const lastUserMessage = getLastUserMessage(messages);
   const hasNonTextPartsOnLatestTurn = lastUserMessageHasNonTextParts(messages);
@@ -183,6 +184,10 @@ export async function orchestrateStandaloneChat(
           surface: "standalone-chat",
           baseActiveToolNames: notraToolRuntime.getActiveToolNames(),
           tools,
+          serverIntegrationIds:
+            mcpContext.length > 0
+              ? mcpContext.map((item) => item.integrationId)
+              : undefined,
         });
 
   const descriptions = lazyMcpRuntime
@@ -201,8 +206,6 @@ export async function orchestrateStandaloneChat(
   const linearContext = hasLinearToolsActive
     ? getLinearContextFromIntegrations(validatedIntegrations)
     : [];
-  const mcpContext = context.filter((item) => item.type === "mcp-server");
-
   const systemPrompt = getStandaloneChatPrompt({
     skillSummaries: await getStandaloneSkillSummaries(organizationId),
     repoContext,

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -201,14 +201,17 @@ export async function orchestrateStandaloneChat(
   const linearContext = hasLinearToolsActive
     ? getLinearContextFromIntegrations(validatedIntegrations)
     : [];
+  const mcpContext = context.filter((item) => item.type === "mcp-server");
 
   const systemPrompt = getStandaloneChatPrompt({
     skillSummaries: await getStandaloneSkillSummaries(organizationId),
     repoContext,
     linearContext,
+    mcpContext,
     toolDescriptions: descriptions,
     hasGitHubEnabled: hasGitHubToolsActive,
     hasLinearEnabled: hasLinearToolsActive,
+    hasMcpEnabled: hasMcp,
     timezone,
   });
 

--- a/packages/ai/src/prompts/standalone-chat.ts
+++ b/packages/ai/src/prompts/standalone-chat.ts
@@ -7,10 +7,12 @@ export function getStandaloneChatPrompt(params: StandaloneChatPromptParams) {
   const {
     repoContext,
     linearContext,
+    mcpContext,
     skillSummaries,
     toolDescriptions,
     hasGitHubEnabled,
     hasLinearEnabled,
+    hasMcpEnabled,
     timezone,
   } = params;
 
@@ -31,6 +33,11 @@ export function getStandaloneChatPrompt(params: StandaloneChatPromptParams) {
   const linearSection =
     hasLinearEnabled && linearContext?.length
       ? `\n\n## Linear Integration\nSource of truth identifiers for Linear context:\n${linearContext.map((c) => `- ${formatLinearContext(c)}`).join("\n")}\n\nWhen working with Linear data, call Linear tools (getLinearIssues, getLinearProjects, getLinearCycles) using integrationId.`
+      : "";
+
+  const mcpSection =
+    hasMcpEnabled && mcpContext?.length
+      ? `\n\n## MCP Server Context\nSource of truth identifiers for selected MCP servers:\n${mcpContext.map((c) => `- ${formatMcpContext(c)}`).join("\n")}\n\nWhen using an attached MCP server, call searchMcpTools with its serverIntegrationId to constrain tool discovery, then activate the matching tools before calling them.`
       : "";
 
   const { formatted: currentDate, timezone: resolvedTimezone } =
@@ -67,7 +74,7 @@ export function getStandaloneChatPrompt(params: StandaloneChatPromptParams) {
     - When creating posts, activate and use the matching create tool instead of only outputting content as text.
     - When you create a post, tell the user the post title and that it was saved as a draft.
     - Brand identity and source names do not need to match. When creating content from GitHub, Linear, or another connected source, apply the selected brand voice to whatever source the user selected. Never refuse, skip, or tell the user the source belongs to a different product because a repository, integration, owner, team, or workspace name differs from the brand identity.
-    ${capabilitiesSection}${integrationResolutionSection}${githubSection}${linearSection}
+    ${capabilitiesSection}${integrationResolutionSection}${githubSection}${linearSection}${mcpSection}
   `;
 }
 
@@ -89,4 +96,10 @@ function formatLinearContext(
     ? `displayName: ${context.displayName}; `
     : "";
   return `${team}${displayName}integrationId: ${context.integrationId}`;
+}
+
+function formatMcpContext(
+  context: NonNullable<StandaloneChatPromptParams["mcpContext"]>[number]
+) {
+  return `name: ${context.name}; serverIntegrationId: ${context.integrationId}`;
 }

--- a/packages/ai/src/schemas/standalone-chat.ts
+++ b/packages/ai/src/schemas/standalone-chat.ts
@@ -13,6 +13,11 @@ export const standaloneChatContextSchema = z.discriminatedUnion("type", [
     integrationId: z.string(),
     teamName: z.string().optional(),
   }),
+  z.object({
+    type: z.literal("mcp-server"),
+    integrationId: z.string(),
+    name: z.string().trim().min(1).max(200),
+  }),
 ]);
 
 export type StandaloneChatContextItem = z.infer<

--- a/packages/ai/src/tools/mcp-lazy.ts
+++ b/packages/ai/src/tools/mcp-lazy.ts
@@ -117,6 +117,19 @@ export async function createLazyMcpRuntime({
     }
   };
 
+  const reconcileActiveTools = (mcpTools: ActivatedMcpTool[]) => {
+    const nextActiveMcpToolNames = new Set(
+      mcpTools.map((tool) => tool.runtimeToolName)
+    );
+    for (const runtimeToolName of activeMcpToolNames) {
+      if (!nextActiveMcpToolNames.has(runtimeToolName)) {
+        activeMcpToolNames.delete(runtimeToolName);
+        activeToolNames.delete(runtimeToolName);
+      }
+    }
+    setActiveTools(mcpTools);
+  };
+
   Object.assign(tools, {
     searchMcpTools: tool({
       description:
@@ -226,7 +239,7 @@ export async function createLazyMcpRuntime({
           surface,
           serverIntegrationIds,
         });
-        setActiveTools(active);
+        reconcileActiveTools(active);
         return {
           activeTools: active.map((activeTool) => ({
             toolId: activeTool.id,
@@ -261,28 +274,15 @@ export async function createLazyMcpRuntime({
           surface,
           toolIds,
           runtimeToolNames,
+          serverIntegrationIds,
         });
-        for (const runtimeToolName of runtimeToolNames ?? []) {
-          activeMcpToolNames.delete(runtimeToolName);
-          activeToolNames.delete(runtimeToolName);
-        }
-        if (toolIds?.length) {
-          const active = await getSessionActivatedMcpTools({
-            organizationId,
-            sessionId,
-            surface,
-            serverIntegrationIds,
-          });
-          const nextActiveNames = new Set(
-            active.map((activeTool) => activeTool.runtimeToolName)
-          );
-          for (const runtimeToolName of activeMcpToolNames) {
-            if (!nextActiveNames.has(runtimeToolName)) {
-              activeMcpToolNames.delete(runtimeToolName);
-              activeToolNames.delete(runtimeToolName);
-            }
-          }
-        }
+        const active = await getSessionActivatedMcpTools({
+          organizationId,
+          sessionId,
+          surface,
+          serverIntegrationIds,
+        });
+        reconcileActiveTools(active);
         return result;
       },
     }),

--- a/packages/ai/src/tools/mcp-lazy.ts
+++ b/packages/ai/src/tools/mcp-lazy.ts
@@ -60,7 +60,11 @@ export async function createLazyMcpRuntime({
   surface,
   baseActiveToolNames,
   tools: sharedTools,
+  serverIntegrationIds,
 }: LazyMcpRuntimeParams): Promise<LazyMcpRuntime> {
+  const allowedServerIntegrationIds = serverIntegrationIds
+    ? new Set(serverIntegrationIds)
+    : null;
   const clients: McpClientRegistry = new Map();
   const retiredClients: RetiredMcpClients = new Set();
   const hasActiveIndexedTools = await hasActiveIndexedMcpToolsForOrganization({
@@ -80,6 +84,7 @@ export async function createLazyMcpRuntime({
     organizationId,
     sessionId,
     surface,
+    serverIntegrationIds,
   });
   const activeMcpToolNames = new Set(
     activatedTools.map((tool) => tool.runtimeToolName)
@@ -122,12 +127,50 @@ export async function createLazyMcpRuntime({
         serverIntegrationId: z.string().min(1).optional(),
       }),
       execute: async ({ query, limit, serverIntegrationId }) => {
-        const results = await searchMcpToolIndex({
-          organizationId,
-          query,
-          limit: limit ?? MCP_SEARCH_LIMIT_DEFAULT,
-          serverIntegrationId,
-        });
+        if (
+          serverIntegrationId &&
+          allowedServerIntegrationIds &&
+          !allowedServerIntegrationIds.has(serverIntegrationId)
+        ) {
+          throw new Error(
+            "That MCP server is outside the selected server context."
+          );
+        }
+
+        const boundedLimit = limit ?? MCP_SEARCH_LIMIT_DEFAULT;
+        let scopedServerIntegrationIds: string[] | null = null;
+        if (allowedServerIntegrationIds) {
+          scopedServerIntegrationIds = serverIntegrationId
+            ? [serverIntegrationId]
+            : Array.from(allowedServerIntegrationIds);
+        }
+        const results = scopedServerIntegrationIds
+          ? (
+              await Promise.all(
+                scopedServerIntegrationIds.map((scopedServerIntegrationId) =>
+                  searchMcpToolIndex({
+                    organizationId,
+                    query,
+                    limit: boundedLimit,
+                    serverIntegrationId: scopedServerIntegrationId,
+                  })
+                )
+              )
+            )
+              .flat()
+              .filter(
+                (result, index, allResults) =>
+                  allResults.findIndex(
+                    (candidate) => candidate.id === result.id
+                  ) === index
+              )
+              .slice(0, boundedLimit)
+          : await searchMcpToolIndex({
+              organizationId,
+              query,
+              limit: boundedLimit,
+              serverIntegrationId,
+            });
         return {
           results: results.map((result) => ({
             toolId: result.id,
@@ -155,6 +198,7 @@ export async function createLazyMcpRuntime({
           surface,
           toolIds,
           sourceQuery: reason,
+          serverIntegrationIds,
         });
         setActiveTools(activated);
 
@@ -180,6 +224,7 @@ export async function createLazyMcpRuntime({
           organizationId,
           sessionId,
           surface,
+          serverIntegrationIds,
         });
         setActiveTools(active);
         return {
@@ -226,6 +271,7 @@ export async function createLazyMcpRuntime({
             organizationId,
             sessionId,
             surface,
+            serverIntegrationIds,
           });
           const nextActiveNames = new Set(
             active.map((activeTool) => activeTool.runtimeToolName)

--- a/packages/ai/src/types/mcp-runtime.ts
+++ b/packages/ai/src/types/mcp-runtime.ts
@@ -18,6 +18,7 @@ export interface LazyMcpRuntimeParams {
   baseActiveToolNames: string[];
   tools?: Record<string, Tool>;
   maxRuntimeTools?: number;
+  serverIntegrationIds?: string[];
 }
 
 export interface LazyMcpRuntime {

--- a/packages/ai/src/types/mcp-tool-index.ts
+++ b/packages/ai/src/types/mcp-tool-index.ts
@@ -10,6 +10,19 @@ export type McpToolDefinition = McpListToolsResult["tools"][number];
 export type McpToolIndexTransaction = Parameters<
   Parameters<typeof db.transaction>[0]
 >[0];
+export type McpToolIndexDatabase = typeof db | McpToolIndexTransaction;
+
+export interface GetSessionActivatedMcpToolsParams {
+  organizationId: string;
+  sessionId: string;
+  surface: McpSessionSurface;
+  serverIntegrationIds?: string[];
+}
+
+export interface QuerySessionActivatedMcpToolsParams
+  extends GetSessionActivatedMcpToolsParams {
+  database: McpToolIndexDatabase;
+}
 
 export interface IndexedMcpTool {
   id: string;

--- a/packages/ai/src/types/orchestration.ts
+++ b/packages/ai/src/types/orchestration.ts
@@ -75,7 +75,16 @@ export interface LinearContextItem {
   teamName?: string;
 }
 
-export type ContextItem = GitHubContextItem | LinearContextItem;
+export interface McpServerContextItem {
+  type: "mcp-server";
+  integrationId: string;
+  name: string;
+}
+
+export type ContextItem =
+  | GitHubContextItem
+  | LinearContextItem
+  | McpServerContextItem;
 
 export interface RoutingDecision {
   complexity: "simple" | "complex";

--- a/packages/ai/src/types/prompts.ts
+++ b/packages/ai/src/types/prompts.ts
@@ -50,9 +50,14 @@ export interface StandaloneChatPromptParams {
     teamName?: string;
     displayName?: string;
   }>;
+  mcpContext?: Array<{
+    integrationId: string;
+    name: string;
+  }>;
   toolDescriptions?: string[];
   hasGitHubEnabled: boolean;
   hasLinearEnabled: boolean;
+  hasMcpEnabled: boolean;
   timezone?: string;
 }
 


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Loom](https://www.loom.com/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MCP servers to the chat context picker and @-mentions so users can include MCP tools alongside GitHub and Linear. Tool discovery/activation/deactivation is limited to selected servers, and MCP chips and inline references render with server logos (CPU fallback).

- **New Features**
  - Context picker lists MCP servers under “MCP tools” with search, grouping, tool counts; button renamed to “Tools & context” and shows a tooltip when disabled.
  - “@” mentions show GitHub repos, Linear teams, and MCP servers; grouped UI, selecting inserts a chip and toggles context; input hint is “type @ for tools and context”.
  - Added MCP reference tokens: `@integration/mcp/{integrationId}/{encodedName}`; chips and inline text render with server logos (dark/light) via `McpIcon` with CPU fallback and icon hydration.
  - Orchestration, runtime, and prompt include MCP context (`mcpContext`, `hasMcpEnabled`); MCP tool search/activation/deactivation is scoped to selected server `integrationId`s (supports multiple servers with deduped results).

- **Refactors**
  - Replaced dropdown with `Popover` + `Command` combobox; unified context option model and filtering across GitHub, Linear, and MCP; improved disabled states and a11y for context controls and submit.
  - Centralized reference parsing/formatting in `@/utils/integration-reference` and regex in `@/constants/integration-reference`; updated components to use them; removed obsolete `INPUT_SOURCES` export.
  - Serialized MCP session activations with advisory locking and batch upserts to prevent race conditions and duplicates; enforced selected-server scope during activation.

<sup>Written for commit c0f39c2eaae32b7f4e8511d128ea59ac93516b37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

1 issue found.

<sub>Written for commit [`c0f39c2`](https://github.com/usenotra/notra/commit/c0f39c2eaae32b7f4e8511d128ea59ac93516b37). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->