### PR TITLE
fix(dashboard): add dropdown chevron to schedule sources combobox

### DIFF
--- a/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
+++ b/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
@@ -23,6 +23,7 @@ import {
   ComboboxEmpty,
   ComboboxItem,
   ComboboxList,
+  ComboboxTrigger,
   useComboboxAnchor,
 } from "@notra/ui/components/ui/combobox";
 import { Input } from "@notra/ui/components/ui/input";
@@ -492,6 +493,7 @@ export function CreateScheduleDialog({
                                 );
                               })}
                               <ComboboxChipsInput placeholder="Search integrations" />
+                              <ComboboxTrigger className="ml-auto flex shrink-0 items-center self-center" />
                             </ComboboxChips>
                             <ComboboxContent anchor={comboboxAnchor.current}>
                               <ComboboxEmpty>


### PR DESCRIPTION
The Sources field in the create schedule dialog used the chips-style combobox, which rendered as a plain search input with no visual hint that it opens a list. This adds the `ComboboxTrigger` chevron at the end of the chips container so the field reads as a dropdown, matching the other selects in the form.

https://claude.ai/code/session_01JEobtSGMp8qGGx4btAuSuj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dropdown chevron to the Sources combobox in the Create Schedule dialog so it reads as a dropdown and matches other selects. Implements `ComboboxTrigger` at the end of the chips container after `ComboboxChipsInput`.

<sup>Written for commit 7f1b3de4506f44cbba3feef12139d753e0a12beb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

1 issue found.

<sub>Written for commit [`7f1b3de`](https://github.com/usenotra/notra/commit/7f1b3de4506f44cbba3feef12139d753e0a12beb). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->