### PR TITLE
fix(onboarding-agent): cache eve vercel build output in turbo

### DIFF
--- a/apps/onboarding-agent/vercel.json
+++ b/apps/onboarding-agent/vercel.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore @notra/onboarding-agent"
-}

--- a/apps/onboarding-agent/vercel.json
+++ b/apps/onboarding-agent/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx turbo-ignore @notra/onboarding-agent"
+}

--- a/turbo.json
+++ b/turbo.json
@@ -83,7 +83,12 @@
     },
     "@notra/onboarding-agent#build": {
       "dependsOn": ["^build"],
-      "outputs": [".output/**", ".eve/compile/**", ".eve/discovery/**"]
+      "outputs": [
+        ".output/**",
+        ".vercel/output/**",
+        ".eve/compile/**",
+        ".eve/discovery/**"
+      ]
     },
     "check-types": {
       "dependsOn": ["transit"]


### PR DESCRIPTION
## Why

Every cache-hit ("FULL TURBO") Vercel deploy of `notra-onboarding-agent` fails with **"No Output Directory named .output found"** (e.g. the #599 production deploy, and all preview deploys on `feat/expand-automation-suggestions`).

Root cause: `eve build` writes its deployable output to `.vercel/output`, but the `@notra/onboarding-agent#build` task in `turbo.json` doesn't declare it as an output. On a cache miss the fresh build leaves `.vercel/output` on disk and the deploy succeeds; on a cache hit turbo only restores the declared outputs, so `.vercel/output` is missing and the deploy errors.

## What

Adds `.vercel/output/**` to the `@notra/onboarding-agent#build` outputs.

Unnecessary rebuilds on dashboard-only commits are handled by Vercel's built-in Skip Deployments (already enabled on the project); it only falls through when `bun.lock` changes, and with this fix those builds are cache hits that now deploy successfully instead of erroring.

https://claude.ai/code/session_01Ujew4pwC4SzbGh6KxUF4Cg

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`d56fa1d`](https://github.com/usenotra/notra/commit/d56fa1d764709ea130eca0bc7184d77d019ae7cf). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->