### PR TITLE
fix(web): increase hero headline font weight on desktop

### DIFF
--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -25,7 +25,7 @@ export function HeroSection() {
         <div className="relative flex h-full w-full flex-col items-center">
           <div className="flex flex-col items-center gap-8 px-6 pt-14 pb-2 sm:gap-10 sm:pt-24 lg:pt-[7.5rem]">
             <div className="flex flex-col items-center gap-7">
-              <h1 className="max-w-[56.875rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.08] tracking-[-0.015em] sm:text-[3.25rem] lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
+              <h1 className="max-w-[56.875rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.08] tracking-[-0.015em] sm:text-[3.25rem] lg:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
                 {HERO_HEADLINE_SEGMENTS.map((segment) => (
                   <span
                     className={cn(segment.accent && "text-primary")}

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -25,7 +25,7 @@ export function HeroSection() {
         <div className="relative flex h-full w-full flex-col items-center">
           <div className="flex flex-col items-center gap-8 px-6 pt-14 pb-2 sm:gap-10 sm:pt-24 lg:pt-[7.5rem]">
             <div className="flex flex-col items-center gap-7">
-              <h1 className="max-w-[56.875rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.08] tracking-[-0.015em] sm:text-[3.25rem] lg:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
+              <h1 className="max-w-[56.875rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.08] tracking-[-0.015em] sm:font-semibold sm:text-[3.25rem] lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
                 {HERO_HEADLINE_SEGMENTS.map((segment) => (
                   <span
                     className={cn(segment.accent && "text-primary")}


### PR DESCRIPTION
Bumps the landing hero headline from `font-medium` to `font-semibold` at the `lg` breakpoint. Mobile and tablet keep the current weight.

https://claude.ai/code/session_01Eae9gH6hNizxSYnbcCay8H

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `font-semibold` to the landing hero headline from the `sm` breakpoint up (tablet and desktop) for better readability; mobile remains `font-medium`.

<sup>Written for commit 1ef278dec98dea7391d7880f41365dac8808d9e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`b435118`](https://github.com/usenotra/notra/commit/b4351183d16d97effa046954c0d9c062945f1b34). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->