### PR TITLE
fix(web): match footer height and wordmark size to Paper design

### DIFF
--- a/apps/web/src/components/footer-section.tsx
+++ b/apps/web/src/components/footer-section.tsx
@@ -64,14 +64,14 @@ export default function FooterSection() {
         <Image
           alt=""
           aria-hidden="true"
-          className="h-auto w-[135%] min-w-[60rem] max-w-none translate-y-[20%] dark:opacity-40"
+          className="h-auto w-[121.4%] min-w-[60rem] max-w-[126rem] translate-y-[23%] dark:opacity-40"
           height={536}
           src="/marketing/landing/footer-wordmark.svg"
           width={1748}
         />
       </div>
 
-      <div className="relative mx-auto flex w-full max-w-[87rem] flex-col px-6 pb-36 md:px-8 md:pb-52">
+      <div className="relative mx-auto flex w-full max-w-[87rem] flex-col px-6 pb-64 md:px-8 md:pb-[30rem]">
         <div className="flex flex-col gap-12 py-7 lg:flex-row lg:items-start lg:justify-between lg:gap-24">
           <div className="flex w-full max-w-[18.5rem] flex-col gap-7">
             <div className="flex flex-col gap-2.5">

--- a/apps/web/src/components/footer-section.tsx
+++ b/apps/web/src/components/footer-section.tsx
@@ -75,9 +75,11 @@ export default function FooterSection() {
         <div className="flex flex-col gap-12 py-7 lg:flex-row lg:items-start lg:justify-between lg:gap-24">
           <div className="flex w-full max-w-[18.5rem] flex-col gap-7">
             <div className="flex flex-col gap-2.5">
-              <div className="flex items-center gap-1">
-                <NotraMark className="size-10.5 shrink-0" />
-                <span className="font-display font-semibold text-[1.25rem] text-foreground leading-[1.14] tracking-[-0.015em]">
+              <div className="flex items-center gap-2">
+                <span className="flex size-10 items-center justify-center rounded-lg dark:inset-shadow-sm dark:inset-shadow-white/8 dark:bg-[#F6F3F1] dark:shadow-black/40 dark:shadow-sm dark:ring-1 dark:ring-white/10">
+                  <NotraMark className="size-7 shrink-0" />
+                </span>
+                <span className="font-display font-semibold text-foreground text-lg leading-[1.14] tracking-[-0.015em]">
                   Notra
                 </span>
               </div>


### PR DESCRIPTION
## Summary

The desktop footer was too short and the giant "notra" wordmark rose into the legal links and link columns, making them hard to read. Measured the intended layout in the Paper FOOTER artboard and matched the code to it:

- Bottom padding: `pb-36 md:pb-52` → `pb-64 md:pb-[30rem]`, matching the ~477px of clear space below the link columns in the design (also removes the smaller overlap on mobile)
- Wordmark: `w-[135%]` with 20% cutoff → `w-[121.4%]` with 23% cutoff per the design (1748px at a 1440 viewport), plus `max-w-[126rem]` so it can't creep back into the content on very wide screens

## Screenshots (1440px)

| Light | Dark |
| --- | --- |
| ![footer light](https://github.com/usenotra/notra/blob/pr-assets/footer-fix/footer-fix/footer-after-light.png?raw=true) | ![footer dark](https://github.com/usenotra/notra/blob/pr-assets/footer-fix/footer-fix/footer-after.png?raw=true) |

https://claude.ai/code/session_01XptTez9THYLqBNJ6wN25Ty

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the footer layout to match the Paper design. Increases footer height, updates the notra wordmark, and aligns the footer logo and dark chip with the navbar.

- **Bug Fixes**
  - Increased bottom padding across breakpoints to provide clear space below the link columns.
  - Adjusted wordmark width and vertical offset, and added a max width to prevent it from creeping into content on very wide screens.
  - Matched the footer logo size and dark-mode chip style to the navbar and tweaked spacing for balance.

<sup>Written for commit 6339c3bb68f0d0cff852ed4104e71515b553db37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`6339c3b`](https://github.com/usenotra/notra/commit/6339c3bb68f0d0cff852ed4104e71515b553db37). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->