### PR TITLE
fix(dashboard): make wizard stepper steps clickable and back button visible

### DIFF
--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -40,7 +40,11 @@ import {
   type CreateContentFormValues,
   createContentFormSchema,
 } from "@/schemas/content/create-content-form";
-import type { IntegrationOption, WizardStep } from "@/types/content/create";
+import type {
+  IntegrationOption,
+  StepProgressProps,
+  WizardStep,
+} from "@/types/content/create";
 import type { PrSelection, ReleaseSelection } from "@/types/content/preview";
 import {
   prSelectionFromKey,
@@ -724,6 +728,17 @@ export function CreateContentDialog({
     }
   }, [step]);
 
+  const goToStep = useCallback(
+    (idx: number) => {
+      const target = STEP_ORDER[idx];
+      if (target !== undefined && idx < STEP_ORDER.indexOf(step)) {
+        setAttemptedAdvance(false);
+        setStep(target);
+      }
+    },
+    [step]
+  );
+
   const buildSelectedItems = useCallback((): SelectedItems => {
     if (!selectionsTouchedRef.current) {
       return undefined;
@@ -917,7 +932,7 @@ export function CreateContentDialog({
               <ResponsiveDialogTitle className="text-base">
                 {STEP_TITLES[step]}
               </ResponsiveDialogTitle>
-              <StepProgress activeIndex={stepIndex} />
+              <StepProgress activeIndex={stepIndex} onStepSelect={goToStep} />
             </div>
           </ResponsiveDialogHeader>
 
@@ -1023,9 +1038,8 @@ export function CreateContentDialog({
                     <Button
                       disabled={mutation.isPending}
                       onClick={goBack}
-                      size="sm"
                       type="button"
-                      variant="ghost"
+                      variant="outline"
                     >
                       <HugeiconsIcon
                         className="size-3.5"
@@ -1114,18 +1128,14 @@ export function CreateContentDialog({
   );
 }
 
-interface StepProgressProps {
-  activeIndex: number;
-}
-
-function StepProgress({ activeIndex }: StepProgressProps) {
+function StepProgress({ activeIndex, onStepSelect }: StepProgressProps) {
   return (
     <div className="flex items-center gap-2">
       {STEP_ORDER.map((stepKey, idx) => {
         const isCompleted = idx < activeIndex;
         const isActive = idx === activeIndex;
-        return (
-          <div className="flex items-center gap-2" key={stepKey}>
+        const indicator = (
+          <>
             <div
               className={cn(
                 "flex size-5 shrink-0 items-center justify-center rounded-full font-medium text-[10px] transition-colors",
@@ -1150,6 +1160,21 @@ function StepProgress({ activeIndex }: StepProgressProps) {
             >
               {STEP_LABELS[stepKey]}
             </span>
+          </>
+        );
+        return (
+          <div className="flex items-center gap-2" key={stepKey}>
+            {isCompleted ? (
+              <button
+                className="-m-1 flex cursor-pointer items-center gap-2 rounded-md p-1 transition-colors hover:bg-muted"
+                onClick={() => onStepSelect(idx)}
+                type="button"
+              >
+                {indicator}
+              </button>
+            ) : (
+              <div className="flex items-center gap-2">{indicator}</div>
+            )}
             {idx < STEP_ORDER.length - 1 && (
               <div
                 className={cn(

--- a/apps/dashboard/src/types/content/create.ts
+++ b/apps/dashboard/src/types/content/create.ts
@@ -72,6 +72,11 @@ export interface BrandIdentitiesStepProps {
   organizationId: string;
 }
 
+export interface StepProgressProps {
+  activeIndex: number;
+  onStepSelect: (index: number) => void;
+}
+
 export interface SelectionState {
   commits: Set<string>;
   prs: Set<string>;


### PR DESCRIPTION
## Summary

Two UX fixes in the create content wizard:

- Completed steps in the header stepper are now clickable and navigate back to that step. Only steps before the current one are interactive, so validation for advancing is unchanged, and jumping back clears any pending validation warning.
- The footer Back button is now a full-size outline button instead of a small ghost button, so it has a visible border and matches the Continue button's height.

`StepProgressProps` moved to `types/content/create.ts` since the stepper's props changed.

## Screenshots

| Activity step (new Back button) | Hovering completed "Formats" step | After clicking it (selection preserved) |
| --- | --- | --- |
| ![activity step](https://github.com/usenotra/notra/blob/pr-assets/wizard-stepper-back/wizard-stepper/2-activity-step.png?raw=true) | ![hover formats](https://github.com/usenotra/notra/blob/pr-assets/wizard-stepper-back/wizard-stepper/3-activity-hover-formats.png?raw=true) | ![back on formats](https://github.com/usenotra/notra/blob/pr-assets/wizard-stepper-back/wizard-stepper/4-back-on-formats.png?raw=true) |

https://claude.ai/code/session_01JSVXYHgaCSsx4iFzYVY2Mh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made completed steps in the create content wizard stepper clickable to navigate back. Updated the footer Back button to a full-size outline button for better visibility and consistency with Continue.

- **Bug Fixes**
  - Stepper: Only previous steps are clickable; jumping back clears any pending validation.
  - Footer: Back button now uses the outline variant and matches Continue’s height.

- **Refactors**
  - Moved `StepProgressProps` to `@/types/content/create` and added `onStepSelect`.

<sup>Written for commit 9fffe3cb74163fa517c93628d91069c703781302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`9fffe3c`](https://github.com/usenotra/notra/commit/9fffe3cb74163fa517c93628d91069c703781302). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->