### PR TITLE
fix(dashboard): link auth page logo to home page

### DIFF
--- a/apps/dashboard/src/app/(auth)/layout.tsx
+++ b/apps/dashboard/src/app/(auth)/layout.tsx
@@ -23,14 +23,17 @@ export default async function AuthLayout({
   return (
     <div className="flex h-screen w-full justify-center lg:grid lg:grid-cols-2">
       <section className="flex h-full min-h-0 w-full flex-col items-center justify-between px-6 py-5 lg:px-10 lg:py-6">
-        <div className="flex w-full items-center gap-2 self-start">
+        <Link
+          className="flex w-full items-center gap-2 self-start"
+          href="https://usenotra.com"
+        >
           <span aria-hidden="true">
             <Notra className="size-7" />
           </span>
           <h1 className="font-semibold text-foreground text-lg tracking-tight">
             Notra
           </h1>
-        </div>
+        </Link>
         <div className="w-full max-w-md">{children}</div>
         <div>
           <p className="px-8 text-center text-muted-foreground text-xs">

--- a/apps/dashboard/src/app/(auth)/layout.tsx
+++ b/apps/dashboard/src/app/(auth)/layout.tsx
@@ -24,7 +24,7 @@ export default async function AuthLayout({
     <div className="flex h-screen w-full justify-center lg:grid lg:grid-cols-2">
       <section className="flex h-full min-h-0 w-full flex-col items-center justify-between px-6 py-5 lg:px-10 lg:py-6">
         <Link
-          className="flex w-full items-center gap-2 self-start"
+          className="flex items-center gap-2 self-start"
           href="https://usenotra.com"
         >
           <span aria-hidden="true">


### PR DESCRIPTION
Wraps the Notra logo + wordmark on the login/signup (and forgot-password) pages in a link to https://usenotra.com so clicking it takes people to the home page.

https://claude.ai/code/session_01MgozgHsbTMGCC78kcx6e21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Notra logo and wordmark on all auth pages clickable, linking to https://usenotra.com. Constrain the link to the branding width so only the logo/wordmark is clickable, not the whole row.

<sup>Written for commit 9b8732106d71f294b33720a5c73d179bd3d8fe22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`9b87321`](https://github.com/usenotra/notra/commit/9b8732106d71f294b33720a5c73d179bd3d8fe22). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->