### PR TITLE
fix(dashboard): align organization avatar fallback rounding

### DIFF
--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -150,7 +150,7 @@ function OrgSelectorTrigger({
               className="rounded-lg"
               src={activeOrganization?.logo || undefined}
             />
-            <AvatarFallback className="border bg-sidebar-accent">
+            <AvatarFallback className="rounded-lg bg-sidebar-accent">
               {activeOrganization?.name.charAt(0)}
             </AvatarFallback>
           </Avatar>


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
before:
<img width="172" height="204" alt="image" src="https://github.com/user-attachments/assets/8b5e9d3e-ad3b-4ec1-8c4d-9843ec83f105" />

after:
<img width="160" height="100" alt="image" src="https://github.com/user-attachments/assets/6269b154-b9b6-426c-8f93-c87219b13d35" />


<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the organization avatar fallback with the image in the dashboard sidebar. The fallback initial now uses rounded corners (rounded-lg) and no border, fixing the shape mismatch when logos are missing.

<sup>Written for commit bb807e297e93c6afdb203b7506f882fcd137c57a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

1 issue found.

<sub>Written for commit [`bb807e2`](https://github.com/usenotra/notra/commit/bb807e297e93c6afdb203b7506f882fcd137c57a). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->