### PR TITLE
feat: integration card dither hover

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
@@ -18,6 +18,7 @@ import { memo, useState } from "react";
 import { Button } from "@/components/button";
 import { AddGranolaIntegrationDialog } from "@/components/integrations/add-granola-integration-dialog";
 import { AddLinearIntegrationDialog } from "@/components/integrations/add-linear-integration-dialog";
+import { IntegrationCardDither } from "@/components/integrations/integration-card-dither";
 import { McpIntegrationCard } from "@/components/integrations/mcp-integration-card";
 import { StoreIntegrationsSection } from "@/components/integrations/store-integrations-section";
 import { PageContainer } from "@/components/layout/container";
@@ -116,6 +117,9 @@ const IntegrationCard = memo(function IntegrationCard({
       }
       disabled={!integration.available}
       heading={integration.name}
+      hoverBackground={
+        <IntegrationCardDither color={integration.accentColor} />
+      }
       icon={integration.icon}
     >
       <p className="line-clamp-2 text-muted-foreground text-sm">

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/page-client.tsx
@@ -18,7 +18,10 @@ import { memo, useState } from "react";
 import { Button } from "@/components/button";
 import { AddGranolaIntegrationDialog } from "@/components/integrations/add-granola-integration-dialog";
 import { AddLinearIntegrationDialog } from "@/components/integrations/add-linear-integration-dialog";
-import { IntegrationCardDither } from "@/components/integrations/integration-card-dither";
+import {
+  IntegrationCardDither,
+  useIntegrationCardDither,
+} from "@/components/integrations/integration-card-dither";
 import { McpIntegrationCard } from "@/components/integrations/mcp-integration-card";
 import { StoreIntegrationsSection } from "@/components/integrations/store-integrations-section";
 import { PageContainer } from "@/components/layout/container";
@@ -73,6 +76,7 @@ const IntegrationCard = memo(function IntegrationCard({
   const showLinearDialog = integration.available && integration.id === "linear";
   const showGranolaDialog =
     integration.available && integration.id === "granola";
+  const dither = useIntegrationCardDither(integration.available);
 
   if (!(organizationId && organizationSlug)) {
     return null;
@@ -118,7 +122,12 @@ const IntegrationCard = memo(function IntegrationCard({
       disabled={!integration.available}
       heading={integration.name}
       hoverBackground={
-        <IntegrationCardDither color={integration.accentColor} />
+        integration.available ? (
+          <IntegrationCardDither
+            active={dither.active}
+            color={integration.accentColor}
+          />
+        ) : null
       }
       icon={integration.icon}
     >
@@ -132,6 +141,7 @@ const IntegrationCard = memo(function IntegrationCard({
     <>
       {integration.available ? (
         <Link
+          {...dither.interactionProps}
           className="h-full rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           href={`/${organizationSlug}/integrations/${integration.href}`}
         >

--- a/apps/dashboard/src/components/integrations/integration-card-dither.tsx
+++ b/apps/dashboard/src/components/integrations/integration-card-dither.tsx
@@ -3,8 +3,11 @@
 import { cn } from "@notra/ui/lib/utils";
 import { useReducedMotion } from "motion/react";
 import dynamic from "next/dynamic";
-import type { HTMLAttributes } from "react";
 import { useEffect, useState } from "react";
+import type {
+  IntegrationCardDitherInteraction,
+  IntegrationCardDitherProps,
+} from "@/types/integrations";
 
 const HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i;
 const FADE_OUT_DURATION = 300;
@@ -15,20 +18,9 @@ const Dithering = dynamic(
   { ssr: false }
 );
 
-interface IntegrationCardDitherProps {
-  active: boolean;
-  color: string;
-}
-
-type DitherInteractionProps = Pick<
-  HTMLAttributes<HTMLElement>,
-  "onBlur" | "onFocus" | "onPointerEnter" | "onPointerLeave"
->;
-
-export function useIntegrationCardDither(enabled = true): {
-  active: boolean;
-  interactionProps: DitherInteractionProps;
-} {
+export function useIntegrationCardDither(
+  enabled = true
+): IntegrationCardDitherInteraction {
   const [pointerActive, setPointerActive] = useState(false);
   const [focusActive, setFocusActive] = useState(false);
 

--- a/apps/dashboard/src/components/integrations/integration-card-dither.tsx
+++ b/apps/dashboard/src/components/integrations/integration-card-dither.tsx
@@ -4,13 +4,14 @@ import { cn } from "@notra/ui/lib/utils";
 import { useReducedMotion } from "motion/react";
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
+import {
+  INTEGRATION_CARD_DITHER_FADE_OUT_DURATION,
+  INTEGRATION_CARD_DITHER_HEX_COLOR_PATTERN,
+} from "@/lib/integrations/constants";
 import type {
   IntegrationCardDitherInteraction,
   IntegrationCardDitherProps,
 } from "@/types/integrations";
-
-const HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i;
-const FADE_OUT_DURATION = 300;
 
 const Dithering = dynamic(
   () =>
@@ -45,7 +46,9 @@ export function IntegrationCardDither({
 }: IntegrationCardDitherProps) {
   const shouldReduceMotion = useReducedMotion();
   const [shouldRender, setShouldRender] = useState(active);
-  const colorFront = HEX_COLOR_PATTERN.test(color) ? `${color}26` : color;
+  const colorFront = INTEGRATION_CARD_DITHER_HEX_COLOR_PATTERN.test(color)
+    ? `${color}26`
+    : color;
 
   useEffect(() => {
     if (active) {
@@ -53,7 +56,10 @@ export function IntegrationCardDither({
       return;
     }
 
-    const timeout = setTimeout(() => setShouldRender(false), FADE_OUT_DURATION);
+    const timeout = setTimeout(
+      () => setShouldRender(false),
+      INTEGRATION_CARD_DITHER_FADE_OUT_DURATION
+    );
     return () => clearTimeout(timeout);
   }, [active]);
 

--- a/apps/dashboard/src/components/integrations/integration-card-dither.tsx
+++ b/apps/dashboard/src/components/integrations/integration-card-dither.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { cn } from "@notra/ui/lib/utils";
 import { useReducedMotion } from "motion/react";
 import dynamic from "next/dynamic";
-import { useEffect, useRef, useState } from "react";
+import type { HTMLAttributes } from "react";
+import { useEffect, useState } from "react";
 
 const HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i;
 const FADE_OUT_DURATION = 300;
@@ -13,74 +15,63 @@ const Dithering = dynamic(
   { ssr: false }
 );
 
-export function IntegrationCardDither({ color }: { color: string }) {
+interface IntegrationCardDitherProps {
+  active: boolean;
+  color: string;
+}
+
+type DitherInteractionProps = Pick<
+  HTMLAttributes<HTMLElement>,
+  "onBlur" | "onFocus" | "onPointerEnter" | "onPointerLeave"
+>;
+
+export function useIntegrationCardDither(enabled = true): {
+  active: boolean;
+  interactionProps: DitherInteractionProps;
+} {
+  const [pointerActive, setPointerActive] = useState(false);
+  const [focusActive, setFocusActive] = useState(false);
+
+  return {
+    active: enabled && (pointerActive || focusActive),
+    interactionProps: {
+      onBlur: (event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setFocusActive(false);
+        }
+      },
+      onFocus: () => setFocusActive(true),
+      onPointerEnter: () => setPointerActive(true),
+      onPointerLeave: () => setPointerActive(false),
+    },
+  };
+}
+
+export function IntegrationCardDither({
+  active,
+  color,
+}: IntegrationCardDitherProps) {
   const shouldReduceMotion = useReducedMotion();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const pointerActiveRef = useRef(false);
-  const focusActiveRef = useRef(false);
-  const [shouldRender, setShouldRender] = useState(false);
+  const [shouldRender, setShouldRender] = useState(active);
   const colorFront = HEX_COLOR_PATTERN.test(color) ? `${color}26` : color;
 
   useEffect(() => {
-    const card = containerRef.current?.closest<HTMLElement>(
-      '[data-slot="title-card"]'
-    );
-    if (!card) {
+    if (active) {
+      setShouldRender(true);
       return;
     }
 
-    const show = () => {
-      clearTimeout(hideTimeoutRef.current);
-      setShouldRender(true);
-    };
-    const hide = () => {
-      clearTimeout(hideTimeoutRef.current);
-      hideTimeoutRef.current = setTimeout(
-        () => setShouldRender(false),
-        FADE_OUT_DURATION
-      );
-    };
-    const hideIfInactive = () => {
-      if (!(pointerActiveRef.current || focusActiveRef.current)) {
-        hide();
-      }
-    };
-    const handlePointerEnter = () => {
-      pointerActiveRef.current = true;
-      show();
-    };
-    const handlePointerLeave = () => {
-      pointerActiveRef.current = false;
-      hideIfInactive();
-    };
-    const handleFocusIn = () => {
-      focusActiveRef.current = true;
-      show();
-    };
-    const handleFocusOut = (event: FocusEvent) => {
-      if (!card.contains(event.relatedTarget as Node | null)) {
-        focusActiveRef.current = false;
-        hideIfInactive();
-      }
-    };
-
-    card.addEventListener("pointerenter", handlePointerEnter);
-    card.addEventListener("pointerleave", handlePointerLeave);
-    card.addEventListener("focusin", handleFocusIn);
-    card.addEventListener("focusout", handleFocusOut);
-
-    return () => {
-      clearTimeout(hideTimeoutRef.current);
-      card.removeEventListener("pointerenter", handlePointerEnter);
-      card.removeEventListener("pointerleave", handlePointerLeave);
-      card.removeEventListener("focusin", handleFocusIn);
-      card.removeEventListener("focusout", handleFocusOut);
-    };
-  }, []);
+    const timeout = setTimeout(() => setShouldRender(false), FADE_OUT_DURATION);
+    return () => clearTimeout(timeout);
+  }, [active]);
 
   return (
-    <div className="h-full w-full" ref={containerRef}>
+    <div
+      className={cn(
+        "h-full w-full opacity-0 transition-opacity duration-300",
+        active && "opacity-100"
+      )}
+    >
       {shouldRender ? (
         <Dithering
           className="-translate-x-1/2 -translate-y-1/2 absolute top-0 left-0 h-[200%] w-[200%]"

--- a/apps/dashboard/src/components/integrations/integration-card-dither.tsx
+++ b/apps/dashboard/src/components/integrations/integration-card-dither.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import dynamic from "next/dynamic";
+import { useEffect, useRef, useState } from "react";
+
+const HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i;
+const FADE_OUT_DURATION = 300;
+
+const Dithering = dynamic(
+  () =>
+    import("@paper-design/shaders-react").then((module_) => module_.Dithering),
+  { ssr: false }
+);
+
+export function IntegrationCardDither({ color }: { color: string }) {
+  const shouldReduceMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const pointerActiveRef = useRef(false);
+  const focusActiveRef = useRef(false);
+  const [shouldRender, setShouldRender] = useState(false);
+  const colorFront = HEX_COLOR_PATTERN.test(color) ? `${color}26` : color;
+
+  useEffect(() => {
+    const card = containerRef.current?.closest<HTMLElement>(
+      '[data-slot="title-card"]'
+    );
+    if (!card) {
+      return;
+    }
+
+    const show = () => {
+      clearTimeout(hideTimeoutRef.current);
+      setShouldRender(true);
+    };
+    const hide = () => {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = setTimeout(
+        () => setShouldRender(false),
+        FADE_OUT_DURATION
+      );
+    };
+    const hideIfInactive = () => {
+      if (!(pointerActiveRef.current || focusActiveRef.current)) {
+        hide();
+      }
+    };
+    const handlePointerEnter = () => {
+      pointerActiveRef.current = true;
+      show();
+    };
+    const handlePointerLeave = () => {
+      pointerActiveRef.current = false;
+      hideIfInactive();
+    };
+    const handleFocusIn = () => {
+      focusActiveRef.current = true;
+      show();
+    };
+    const handleFocusOut = (event: FocusEvent) => {
+      if (!card.contains(event.relatedTarget as Node | null)) {
+        focusActiveRef.current = false;
+        hideIfInactive();
+      }
+    };
+
+    card.addEventListener("pointerenter", handlePointerEnter);
+    card.addEventListener("pointerleave", handlePointerLeave);
+    card.addEventListener("focusin", handleFocusIn);
+    card.addEventListener("focusout", handleFocusOut);
+
+    return () => {
+      clearTimeout(hideTimeoutRef.current);
+      card.removeEventListener("pointerenter", handlePointerEnter);
+      card.removeEventListener("pointerleave", handlePointerLeave);
+      card.removeEventListener("focusin", handleFocusIn);
+      card.removeEventListener("focusout", handleFocusOut);
+    };
+  }, []);
+
+  return (
+    <div className="h-full w-full" ref={containerRef}>
+      {shouldRender ? (
+        <Dithering
+          className="-translate-x-1/2 -translate-y-1/2 absolute top-0 left-0 h-[200%] w-[200%]"
+          colorBack="#00000000"
+          colorFront={colorFront}
+          scale={0.74}
+          shape="wave"
+          size={4}
+          speed={shouldReduceMotion ? 0 : 0.5}
+          type="4x4"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/integrations/mcp-integration-card.tsx
+++ b/apps/dashboard/src/components/integrations/mcp-integration-card.tsx
@@ -9,6 +9,7 @@ import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/button";
+import { IntegrationCardDither } from "@/components/integrations/integration-card-dither";
 import { MCP_ACCENT_COLOR } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { McpIntegrationCardProps } from "@/types/integrations/mcp";
@@ -61,6 +62,7 @@ export function McpIntegrationCard({
           }
           className="h-full cursor-pointer transition-colors hover:bg-muted/80"
           heading="MCP"
+          hoverBackground={<IntegrationCardDither color={MCP_ACCENT_COLOR} />}
           icon={<HugeiconsIcon icon={CpuIcon} />}
         >
           <p className="line-clamp-2 text-muted-foreground text-sm">

--- a/apps/dashboard/src/components/integrations/mcp-integration-card.tsx
+++ b/apps/dashboard/src/components/integrations/mcp-integration-card.tsx
@@ -9,7 +9,10 @@ import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/button";
-import { IntegrationCardDither } from "@/components/integrations/integration-card-dither";
+import {
+  IntegrationCardDither,
+  useIntegrationCardDither,
+} from "@/components/integrations/integration-card-dither";
 import { MCP_ACCENT_COLOR } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { McpIntegrationCardProps } from "@/types/integrations/mcp";
@@ -30,10 +33,12 @@ export function McpIntegrationCard({
 
   const activeCount = data?.servers.length ?? 0;
   const href = `/${organizationSlug}/integrations/mcp`;
+  const dither = useIntegrationCardDither();
 
   return (
     <>
       <Link
+        {...dither.interactionProps}
         className="h-full rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         href={href}
       >
@@ -62,7 +67,12 @@ export function McpIntegrationCard({
           }
           className="h-full cursor-pointer transition-colors hover:bg-muted/80"
           heading="MCP"
-          hoverBackground={<IntegrationCardDither color={MCP_ACCENT_COLOR} />}
+          hoverBackground={
+            <IntegrationCardDither
+              active={dither.active}
+              color={MCP_ACCENT_COLOR}
+            />
+          }
           icon={<HugeiconsIcon icon={CpuIcon} />}
         >
           <p className="line-clamp-2 text-muted-foreground text-sm">

--- a/apps/dashboard/src/components/integrations/store-integration-card.tsx
+++ b/apps/dashboard/src/components/integrations/store-integration-card.tsx
@@ -5,7 +5,10 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { Button } from "@/components/button";
-import { IntegrationCardDither } from "@/components/integrations/integration-card-dither";
+import {
+  IntegrationCardDither,
+  useIntegrationCardDither,
+} from "@/components/integrations/integration-card-dither";
 import { StoreIntegrationLogo } from "@/components/integrations/store-integration-logo";
 import { MCP_ACCENT_COLOR } from "@/lib/integrations/mcp";
 import type { StoreIntegrationCardProps } from "@/types/integrations/mcp";
@@ -16,8 +19,11 @@ export function StoreIntegrationCard({
   onConnect,
   onManage,
 }: StoreIntegrationCardProps) {
+  const dither = useIntegrationCardDither();
+
   return (
     <TitleCard
+      {...dither.interactionProps}
       accentColor={integration.brandColor ?? MCP_ACCENT_COLOR}
       action={
         integration.connected ? (
@@ -53,6 +59,7 @@ export function StoreIntegrationCard({
       heading={integration.name}
       hoverBackground={
         <IntegrationCardDither
+          active={dither.active}
           color={integration.brandColor ?? MCP_ACCENT_COLOR}
         />
       }

--- a/apps/dashboard/src/components/integrations/store-integration-card.tsx
+++ b/apps/dashboard/src/components/integrations/store-integration-card.tsx
@@ -5,6 +5,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { Button } from "@/components/button";
+import { IntegrationCardDither } from "@/components/integrations/integration-card-dither";
 import { StoreIntegrationLogo } from "@/components/integrations/store-integration-logo";
 import { MCP_ACCENT_COLOR } from "@/lib/integrations/mcp";
 import type { StoreIntegrationCardProps } from "@/types/integrations/mcp";
@@ -50,6 +51,11 @@ export function StoreIntegrationCard({
           : "h-full"
       }
       heading={integration.name}
+      hoverBackground={
+        <IntegrationCardDither
+          color={integration.brandColor ?? MCP_ACCENT_COLOR}
+        />
+      }
       icon={<StoreIntegrationLogo integration={integration} />}
       onClick={() => {
         if (integration.connected) {

--- a/apps/dashboard/src/lib/integrations/constants.ts
+++ b/apps/dashboard/src/lib/integrations/constants.ts
@@ -11,3 +11,6 @@ export const INTEGRATION_CATEGORY_TABS = [
   { value: "output", label: "Output" },
   { value: "extension", label: "Extensions" },
 ] as const;
+
+export const INTEGRATION_CARD_DITHER_HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i;
+export const INTEGRATION_CARD_DITHER_FADE_OUT_DURATION = 300;

--- a/apps/dashboard/src/types/integrations.ts
+++ b/apps/dashboard/src/types/integrations.ts
@@ -149,6 +149,21 @@ export interface IntegrationCardProps {
   onUpdate?: () => void;
 }
 
+export interface IntegrationCardDitherProps {
+  active: boolean;
+  color: string;
+}
+
+export type DitherInteractionProps = Pick<
+  React.HTMLAttributes<HTMLElement>,
+  "onBlur" | "onFocus" | "onPointerEnter" | "onPointerLeave"
+>;
+
+export interface IntegrationCardDitherInteraction {
+  active: boolean;
+  interactionProps: DitherInteractionProps;
+}
+
 export interface RepositoryListProps {
   integrationId: string;
   organizationId: string;

--- a/packages/ui/src/components/ui/title-card.tsx
+++ b/packages/ui/src/components/ui/title-card.tsx
@@ -42,7 +42,6 @@ function TitleCard({
         disabled && "cursor-not-allowed",
         className
       )}
-      data-slot="title-card"
       {...props}
     >
       {accentColor && (
@@ -56,10 +55,8 @@ function TitleCard({
       )}
       {hoverBackground && (
         <div
-          className={cn(
-            "pointer-events-none absolute inset-0 -z-10 opacity-0 transition-opacity duration-300",
-            !disabled && "group-hover:opacity-100 group-focus-within:opacity-100"
-          )}
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10"
         >
           {hoverBackground}
         </div>

--- a/packages/ui/src/components/ui/title-card.tsx
+++ b/packages/ui/src/components/ui/title-card.tsx
@@ -8,6 +8,7 @@ interface TitleCardProps extends Omit<React.ComponentProps<"div">, "title"> {
   action?: React.ReactNode;
   footer?: React.ReactNode;
   accentColor?: string;
+  hoverBackground?: React.ReactNode;
   contentClassName?: string;
   footerClassName?: string;
   disabled?: boolean;
@@ -19,6 +20,7 @@ function TitleCard({
   action,
   footer,
   accentColor,
+  hoverBackground,
   className,
   contentClassName,
   footerClassName,
@@ -40,6 +42,7 @@ function TitleCard({
         disabled && "cursor-not-allowed",
         className
       )}
+      data-slot="title-card"
       {...props}
     >
       {accentColor && (
@@ -50,6 +53,16 @@ function TitleCard({
           )}
           style={gradientStyle}
         />
+      )}
+      {hoverBackground && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-0 -z-10 opacity-0 transition-opacity duration-300",
+            !disabled && "group-hover:opacity-100 group-focus-within:opacity-100"
+          )}
+        >
+          {hoverBackground}
+        </div>
       )}
       <div className="flex items-start justify-between gap-4 px-4 py-2.5">
         <div className="flex min-w-0 flex-1 items-center gap-2">


### PR DESCRIPTION
### Description
Adds an animated, brand-colored dither hover effect to integration cards across the catalog, MCP, and integration store.

The shader originates from the top-left of each card, supports pointer and keyboard interactions, respects reduced-motion preferences, and only mounts while a card is active to avoid unnecessary rendering work.

### Screenshot/Recording (if applicable)
https://github.com/user-attachments/assets/0ef45670-e386-48d3-88c8-f437601c59a5

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an animated, brand-colored dither hover effect to integration cards across the catalog, MCP, and store for clearer hover and focus feedback. Respects reduced motion and only renders while active to avoid extra work.

- **New Features**
  - Added `IntegrationCardDither` and `useIntegrationCardDither` for a consistent hover/focus effect with a 300ms fade-out and reduced-motion support (uses `@paper-design/shaders-react`).
  - Wired the effect into the catalog integrations page, MCP card, and store cards; animation originates from the top-left and uses each card’s accent color.
  - Extended `TitleCard` with a `hoverBackground` slot to render non-interactive overlays behind content.

- **Refactors**
  - Centralized dither interaction types for reuse and consistent interaction props across cards.
  - Moved dither constants (fade-out duration, hex color validation) into `lib/integrations/constants` for reuse.

<sup>Written for commit 406f95788b16b8bc004b14424bd59e89859b4865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`406f957`](https://github.com/usenotra/notra/commit/406f95788b16b8bc004b14424bd59e89859b4865). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->