### PR TITLE
feat(billing): $5 signup credits for company emails + free tier gating

### DIFF
--- a/apps/api/src/middleware/subscription.ts
+++ b/apps/api/src/middleware/subscription.ts
@@ -7,12 +7,13 @@ import { getOrganizationId } from "../utils/auth";
 const RESTRICTED_METHODS = new Set(["POST", "PUT", "PATCH"]);
 
 const PAID_OR_LEGACY_PLAN_IDS = new Set([
-  "free",
   "basic",
   "basic_yearly",
   "pro",
   "pro_yearly",
 ]);
+
+const AI_CREDITS_FEATURE_ID = "ai_credits";
 
 export function subscriptionMiddleware() {
   return async (c: Context, next: Next) => {
@@ -43,14 +44,23 @@ export function subscriptionMiddleware() {
         customerId: orgId,
       });
 
-      const hasActivePlan = customer.subscriptions.some(
+      let hasAccess = customer.subscriptions.some(
         (subscription) =>
           !subscription.addOn &&
           subscription.status === "active" &&
           PAID_OR_LEGACY_PLAN_IDS.has(subscription.planId)
       );
 
-      if (!hasActivePlan) {
+      if (!hasAccess) {
+        const check = await autumn.check({
+          customerId: orgId,
+          featureId: AI_CREDITS_FEATURE_ID,
+          requiredBalance: 1,
+        });
+        hasAccess = check.allowed === true;
+      }
+
+      if (!hasAccess) {
         return c.json({ error: "Active subscription required" }, 402);
       }
     } catch {

--- a/apps/dashboard/src/app/api/workflows/onboarding-agent/route.ts
+++ b/apps/dashboard/src/app/api/workflows/onboarding-agent/route.ts
@@ -9,6 +9,7 @@ import {
   AGENT_RUN_HARD_LIMIT_POLLS,
   AGENT_RUN_SOFT_LIMIT_POLLS,
 } from "@/constants/onboarding-agent";
+import { grantSignupCredits } from "@/lib/billing/grant-signup-credits";
 import {
   getOnboardingAgentState,
   releaseOnboardingAgentReservation,
@@ -49,6 +50,13 @@ export const { POST } = serve<OnboardingAgentWorkflowPayload>(
           sendOnboardingSlackInvite({ email, organizationName })
         );
         log.set({ slackInvited: invite.invited });
+      }
+
+      if (email) {
+        const credits = await context.run("grant-signup-credits", () =>
+          grantSignupCredits({ email, organizationId })
+        );
+        log.set({ signupCreditsGranted: credits.granted });
       }
 
       const { sessionId } = await context.run("start-session", () =>

--- a/apps/dashboard/src/components/auth/signup-form.tsx
+++ b/apps/dashboard/src/components/auth/signup-form.tsx
@@ -14,7 +14,6 @@ import { AuthOrDivider } from "@/components/auth/auth-or-divider";
 import { AuthPasswordField } from "@/components/auth/auth-password-field";
 import { AuthSocialButtons } from "@/components/auth/auth-social-buttons";
 import { SignupCreditsBanner } from "@/components/auth/signup-credits-banner";
-import { SHOW_SIGNUP_CREDITS_BANNER } from "@/constants/signup-credits";
 import { authClient } from "@/lib/auth/client";
 import { errorMessageOr } from "@/lib/utils";
 import { signupSchema } from "@/schemas/auth/credentials";
@@ -170,7 +169,7 @@ export function SignupForm({
     <div className="flex w-full flex-col gap-5">
       <AuthFormHeader description={description} title={title} />
 
-      {SHOW_SIGNUP_CREDITS_BANNER && <SignupCreditsBanner />}
+      <SignupCreditsBanner />
 
       <div className="grid gap-4">
         <AuthSocialButtons

--- a/apps/dashboard/src/components/dashboard/sidebar-trial-expired.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-trial-expired.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FEATURES, PAID_OR_LEGACY_PLAN_IDS } from "@notra/ai/billing/features";
 import { SidebarGroup } from "@notra/ui/components/ui/sidebar";
 import { useCustomer } from "autumn-js/react";
 import Link from "next/link";
@@ -10,7 +11,7 @@ export function SidebarTrialExpired() {
   const { activeOrganization } = useOrganizationsContext();
   const slug = activeOrganization?.slug ?? "";
   const { data: customer, isLoading } = useCustomer({
-    expand: ["subscriptions.plan"],
+    expand: ["balances.feature", "subscriptions.plan"],
   });
 
   if (isLoading || !customer) {
@@ -18,10 +19,17 @@ export function SidebarTrialExpired() {
   }
 
   const hasActiveSubscription = customer.subscriptions.some(
-    (subscription) => !subscription.addOn && subscription.status === "active"
+    (subscription) =>
+      !subscription.addOn &&
+      subscription.status === "active" &&
+      PAID_OR_LEGACY_PLAN_IDS.has(subscription.planId)
   );
 
-  if (hasActiveSubscription) {
+  const aiCredits = customer.balances?.[FEATURES.AI_CREDITS];
+  const hasCreditsBalance =
+    typeof aiCredits?.remaining === "number" && aiCredits.remaining > 0;
+
+  if (hasActiveSubscription || hasCreditsBalance) {
     return null;
   }
 

--- a/apps/dashboard/src/constants/signup-credits.ts
+++ b/apps/dashboard/src/constants/signup-credits.ts
@@ -1,1 +1,3 @@
-export const SHOW_SIGNUP_CREDITS_BANNER = false;
+export const SIGNUP_CREDITS_GRANT_CENTS = 500;
+
+export const SIGNUP_CREDITS_BALANCE_PREFIX = "signup-credits";

--- a/apps/dashboard/src/lib/billing/grant-signup-credits.ts
+++ b/apps/dashboard/src/lib/billing/grant-signup-credits.ts
@@ -1,0 +1,36 @@
+import { autumn } from "@notra/ai/billing/autumn";
+import { FEATURES } from "@notra/ai/billing/features";
+import { isFreeEmail } from "free-email-domains-list";
+import {
+  SIGNUP_CREDITS_BALANCE_PREFIX,
+  SIGNUP_CREDITS_GRANT_CENTS,
+} from "@/constants/signup-credits";
+import type {
+  SignupCreditsGrantInput,
+  SignupCreditsGrantResult,
+} from "@/types/billing/signup-credits";
+
+export async function grantSignupCredits({
+  email,
+  organizationId,
+}: SignupCreditsGrantInput): Promise<SignupCreditsGrantResult> {
+  if (!autumn || isFreeEmail(email.trim().toLowerCase())) {
+    return { granted: false };
+  }
+
+  try {
+    await autumn.balances.create({
+      balanceId: `${SIGNUP_CREDITS_BALANCE_PREFIX}-${organizationId}`,
+      customerId: organizationId,
+      featureId: FEATURES.AI_CREDITS,
+      includedGrant: SIGNUP_CREDITS_GRANT_CENTS,
+    });
+    return { granted: true };
+  } catch (error) {
+    console.error(
+      `[Onboarding Agent] Signup credits grant failed for ${organizationId}`,
+      error
+    );
+    return { granted: false };
+  }
+}

--- a/apps/dashboard/src/lib/billing/grant-signup-credits.ts
+++ b/apps/dashboard/src/lib/billing/grant-signup-credits.ts
@@ -18,19 +18,19 @@ export async function grantSignupCredits({
     return { granted: false };
   }
 
-  try {
-    await autumn.balances.create({
-      balanceId: `${SIGNUP_CREDITS_BALANCE_PREFIX}-${organizationId}`,
-      customerId: organizationId,
-      featureId: FEATURES.AI_CREDITS,
-      includedGrant: SIGNUP_CREDITS_GRANT_CENTS,
-    });
-    return { granted: true };
-  } catch (error) {
-    console.error(
-      `[Onboarding Agent] Signup credits grant failed for ${organizationId}`,
-      error
-    );
+  const existing = await autumn.check({
+    customerId: organizationId,
+    featureId: FEATURES.AI_CREDITS,
+  });
+  if (existing.balance != null) {
     return { granted: false };
   }
+
+  await autumn.balances.create({
+    balanceId: `${SIGNUP_CREDITS_BALANCE_PREFIX}-${organizationId}`,
+    customerId: organizationId,
+    featureId: FEATURES.AI_CREDITS,
+    includedGrant: SIGNUP_CREDITS_GRANT_CENTS,
+  });
+  return { granted: true };
 }

--- a/apps/dashboard/src/lib/billing/grant-signup-credits.ts
+++ b/apps/dashboard/src/lib/billing/grant-signup-credits.ts
@@ -1,5 +1,8 @@
 import { autumn } from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
+import { db } from "@notra/db/drizzle";
+import { members, users } from "@notra/db/schema";
+import { and, eq, ne } from "drizzle-orm";
 import { isFreeEmail } from "free-email-domains-list";
 import {
   SIGNUP_CREDITS_BALANCE_PREFIX,
@@ -14,7 +17,31 @@ export async function grantSignupCredits({
   email,
   organizationId,
 }: SignupCreditsGrantInput): Promise<SignupCreditsGrantResult> {
-  if (!autumn || isFreeEmail(email.trim().toLowerCase())) {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (!autumn || isFreeEmail(normalizedEmail)) {
+    return { granted: false };
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.email, normalizedEmail),
+    columns: { id: true, emailVerified: true },
+  });
+
+  if (!user?.emailVerified) {
+    return { granted: false };
+  }
+
+  const otherOwnedOrganization = await db.query.members.findFirst({
+    where: and(
+      eq(members.userId, user.id),
+      eq(members.role, "owner"),
+      ne(members.organizationId, organizationId)
+    ),
+    columns: { id: true },
+  });
+
+  if (otherOwnedOrganization) {
     return { granted: false };
   }
 

--- a/apps/dashboard/src/lib/billing/subscription.ts
+++ b/apps/dashboard/src/lib/billing/subscription.ts
@@ -1,7 +1,34 @@
 import { autumn } from "@notra/ai/billing/autumn";
-import { PAID_OR_LEGACY_PLAN_IDS } from "@notra/ai/billing/features";
+import { FEATURES, PAID_OR_LEGACY_PLAN_IDS } from "@notra/ai/billing/features";
 import { ORPCError } from "@orpc/server";
 import { internalServerError, paymentRequired } from "@/lib/orpc/utils/errors";
+
+async function hasAiCreditsBalance(organizationId: string): Promise<boolean> {
+  if (!autumn) {
+    return false;
+  }
+
+  const data = await autumn.check({
+    customerId: organizationId,
+    featureId: FEATURES.AI_CREDITS,
+    requiredBalance: 1,
+  });
+
+  return data.allowed === true;
+}
+
+async function hasAiCreditsGrant(organizationId: string): Promise<boolean> {
+  if (!autumn) {
+    return false;
+  }
+
+  const data = await autumn.check({
+    customerId: organizationId,
+    featureId: FEATURES.AI_CREDITS,
+  });
+
+  return data.balance != null;
+}
 
 export async function assertActiveSubscription(
   organizationId: string
@@ -10,19 +37,23 @@ export async function assertActiveSubscription(
     return;
   }
 
-  let hasActivePlan = false;
+  let hasAccess = false;
 
   try {
     const customer = await autumn.customers.getOrCreate({
       customerId: organizationId,
     });
 
-    hasActivePlan = customer.subscriptions.some(
+    hasAccess = customer.subscriptions.some(
       (subscription) =>
         !subscription.addOn &&
         subscription.status === "active" &&
         PAID_OR_LEGACY_PLAN_IDS.has(subscription.planId)
     );
+
+    if (!hasAccess) {
+      hasAccess = await hasAiCreditsBalance(organizationId);
+    }
   } catch (error) {
     if (error instanceof ORPCError) {
       throw error;
@@ -30,7 +61,7 @@ export async function assertActiveSubscription(
     throw internalServerError("Failed to verify subscription status");
   }
 
-  if (!hasActivePlan) {
+  if (!hasAccess) {
     throw paymentRequired("Active subscription required");
   }
 }
@@ -47,10 +78,16 @@ export async function hasPaidSubscriptionHistory(
       customerId: organizationId,
     });
 
-    return customer.subscriptions.some(
+    const hasHistory = customer.subscriptions.some(
       (subscription) =>
         !subscription.addOn && PAID_OR_LEGACY_PLAN_IDS.has(subscription.planId)
     );
+
+    if (hasHistory) {
+      return true;
+    }
+
+    return await hasAiCreditsGrant(organizationId);
   } catch {
     return true;
   }

--- a/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
+++ b/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
@@ -22,15 +22,6 @@ export async function checkWorkflowAiCredits(
       ACTIVE_PAID_PLAN_IDS.has(subscription.planId)
   );
 
-  if (!hasActivePaidPlan) {
-    return {
-      allowed: false,
-      reason: "no_active_paid_plan",
-      shouldNotify: false,
-      balanceRemaining: null,
-    };
-  }
-
   let data: CheckResponse | null = null;
   try {
     data = await autumn.check({
@@ -46,6 +37,15 @@ export async function checkWorkflowAiCredits(
     typeof data?.balance?.remaining === "number" ? data.balance.remaining : 0;
 
   if (!data?.allowed || balanceRemaining <= 0) {
+    if (!hasActivePaidPlan) {
+      return {
+        allowed: false,
+        reason: "no_active_paid_plan",
+        shouldNotify: false,
+        balanceRemaining: null,
+      };
+    }
+
     return {
       allowed: false,
       reason: "insufficient_ai_credits",

--- a/apps/dashboard/src/types/billing/signup-credits.ts
+++ b/apps/dashboard/src/types/billing/signup-credits.ts
@@ -1,0 +1,8 @@
+export interface SignupCreditsGrantInput {
+  email: string;
+  organizationId: string;
+}
+
+export interface SignupCreditsGrantResult {
+  granted: boolean;
+}

--- a/packages/ai/src/billing/features.ts
+++ b/packages/ai/src/billing/features.ts
@@ -18,7 +18,6 @@ export const PLANS = {
 } as const;
 
 export const PAID_OR_LEGACY_PLAN_IDS: Set<string> = new Set([
-  PLANS.FREE,
   PLANS.BASIC,
   PLANS.BASIC_YEARLY,
   PLANS.PRO,


### PR DESCRIPTION
## What

Gives companies $5 in AI credits when they sign up with a work email, and moves the app from a basic/pro-only gate to a free-tier model.

- **$5 voucher**: new `grant-signup-credits` step in the onboarding-agent workflow (next to the Slack Connect invite) creates a one-time standalone Autumn balance of 500 credit-cents via `autumn.balances.create`, keyed by a stable `balanceId` so retries cannot double-grant. Uses the same `isFreeEmail` gating as the Slack invite, so a gmail signup with a company website gets no voucher.
- **Free tier**: `"free"` removed from `PAID_OR_LEGACY_PLAN_IDS` (dashboard + public API middleware). Access checks are now: active paid plan OR `ai_credits` remaining >= 1.
- **Routing**: `hasPaidSubscriptionHistory` falls back to "an ai_credits balance record exists", so orgs that burned through the grant still land in the read-only dashboard instead of being bounced back into the onboarding/pricing gate, while never-granted free orgs keep going through onboarding.
- **Workflow credits gate**: balance check now decides first, so credit-granted orgs without a paid plan can actually spend their credits.
- **Sidebar read-only banner**: keys off paid plans + credits balance instead of any active subscription, so it still shows once the auto-attached free plan exists.
- **Signup page**: `SHOW_SIGNUP_CREDITS_BANNER` flag removed; the $5 banner always renders.

## Autumn dashboard prerequisites (manual)

- Free plan: enable **auto-enable** in Plan Settings so it attaches to every new customer (sandbox + production).
- Free plan items: integrations/references/team member/workflows/log retention only. **No `ai_credits` item on the plan** since a plan-included credits balance would make every free org look credit-granted and skip the onboarding funnel.

## Notes

- Self-serve onboarding path omits the email from the workflow payload, so it skips Slack and the grant (pre-existing gap, unchanged).
- Brief race: users land on /onboarding/pricing a few seconds before the grant settles; revisiting /onboarding then routes to the dashboard.

https://claude.ai/code/session_016t4TFoCGdiZjSL1fPXqcHm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give company email signups a one-time $5 credit and move to a free-tier model that allows access with a positive `ai_credits` balance or an active paid plan.

- **New Features**
  - Added `grant-signup-credits` to onboarding: creates a one-time 500-cent `ai_credits` balance via `autumn.balances.create`, keyed by a stable `balanceId`. Idempotent and retryable (skips if any `ai_credits` balance exists; lets errors bubble). Requires a verified email, a non-free domain, and that this is the user’s first owned org.
  - Updated access checks in API middleware and dashboard: removed `"free"` from `PAID_OR_LEGACY_PLAN_IDS`; allow access with an active paid plan or `ai_credits` > 0.
  - Routing: `hasPaidSubscriptionHistory` falls back to any `ai_credits` balance record so exhausted-grant orgs reach the read-only dashboard.
  - Workflow gating: checks `ai_credits` first so granted orgs without a paid plan can spend credits.
  - UI: “trial expired” hides if paid or credits exist; signup credits banner always renders.

- **Migration**
  - In Autumn, enable auto-attach for the free plan (sandbox + production).
  - Ensure the free plan has no `ai_credits` item.

<sup>Written for commit 373a8a004062c3de4292aa2a29980fa556fa8087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`373a8a0`](https://github.com/usenotra/notra/commit/373a8a004062c3de4292aa2a29980fa556fa8087). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->