### PR TITLE
fix(dashboard): use shared create button style for content CTA

### DIFF
--- a/apps/dashboard/src/components/content/create-content-button.tsx
+++ b/apps/dashboard/src/components/content/create-content-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Add01Icon } from "@hugeicons/core-free-icons";
+import { PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import type { ComponentProps } from "react";
@@ -11,7 +11,7 @@ type CreateContentButtonProps = Omit<ComponentProps<typeof Button>, "children">;
 export function CreateContentButton(props: CreateContentButtonProps) {
   return (
     <Button className="gap-1.5" {...props}>
-      <HugeiconsIcon className="size-4" icon={Add01Icon} />
+      <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
       Create Content
       <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
     </Button>

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Add01Icon,
   AlertCircleIcon,
   ArrowLeft01Icon,
   ArrowRight01Icon,
@@ -17,7 +16,6 @@ import {
   ResponsiveDialogTrigger,
 } from "@notra/ui/components/shared/responsive-dialog";
 import { Button } from "@notra/ui/components/ui/button";
-import { Kbd } from "@notra/ui/components/ui/kbd";
 import { cn } from "@notra/ui/lib/utils";
 import { useForm, useStore } from "@tanstack/react-form";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -27,6 +25,7 @@ import { toast } from "sonner";
 import { StepActivity } from "@/components/content/create/step-activity";
 import { StepBrandIdentities } from "@/components/content/create/step-brand-identities";
 import { StepFormats } from "@/components/content/create/step-formats";
+import { CreateContentButton } from "@/components/content/create-content-button";
 import { AddRepositoryDialog } from "@/components/integrations/add-repository-dialog";
 import { LegacyAddIntegrationDialog as AddIntegrationDialog } from "@/components/integrations/legacy/add-integration-dialog";
 import { DEFAULT_DATA_POINTS } from "@/constants/content-preview";
@@ -917,13 +916,7 @@ export function CreateContentDialog({
       <ResponsiveDialog onOpenChange={handleOpenChange} open={open}>
         {!hideTrigger && (
           <ResponsiveDialogTrigger
-            render={
-              <Button className="gap-1.5" disabled={!organizationId}>
-                <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                Create Content
-                <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
-              </Button>
-            }
+            render={<CreateContentButton disabled={!organizationId} />}
           />
         )}
         <ResponsiveDialogContent className="flex h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">


### PR DESCRIPTION
### Description
The Create Content button on `/` and `/content` didn't match the Create Skill button on `/skills`: the `/content` trigger used the raw `Button` primitive (missing the squircle CTA styling), and both used `Add01Icon` instead of `PlusSignIcon`. Now all create CTAs render the shared `CreateContentButton`, which uses the same styled `Button` from `@/components/button` and `PlusSignIcon`, matching the skills page.

### Screenshot/Recording (if applicable)
N/A

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

https://claude.ai/code/session_015bb9cHAZpThTwyxxVmNGgD


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Create Content CTA across the dashboard by using the shared `CreateContentButton` with the squircle styling. Switches the icon to `PlusSignIcon` so Content matches Skills.

- **Bug Fixes**
  - Use `CreateContentButton` as the dialog trigger; keeps styling and hotkey consistent.
  - Replace `Add01Icon` with `PlusSignIcon` in `create-content-button`.

<sup>Written for commit 7209ad290284336524a5ceef61699e38ae927da7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`7209ad2`](https://github.com/usenotra/notra/commit/7209ad290284336524a5ceef61699e38ae927da7). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->