### PR TITLE
feat(api-keys): add loading skeleton

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -51,6 +51,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@notra/ui/components/ui/select";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import {
   Table,
   TableBody,
@@ -125,6 +126,8 @@ const EDIT_FORM_DEFAULTS: ApiKeyFormValues = {
   scopes: [...API_KEY_DEFAULT_SCOPES],
   expiration: "never",
 };
+
+const API_KEY_SKELETON_ROWS = ["row-1", "row-2", "row-3"];
 
 interface ApiKeyEditForm {
   // TanStack Form's Field component carries deep generics that are local to the
@@ -309,14 +312,30 @@ function ApiKeysTableContent({
 }) {
   if (isPending) {
     return (
-      <TableRow>
-        <TableCell
-          className="h-24 text-center text-muted-foreground"
-          colSpan={6}
-        >
-          Loading…
-        </TableCell>
-      </TableRow>
+      <>
+        {API_KEY_SKELETON_ROWS.map((row) => (
+          <TableRow key={row}>
+            <TableCell>
+              <Skeleton className="h-4 w-32" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-28" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-24" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-20" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-24" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="size-8 rounded-md" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </>
     );
   }
 


### PR DESCRIPTION
### Description
Replaces the plain `Loading…` state on the API Keys page with animated skeleton rows that match the table layout. This keeps the loading experience consistent with other dashboard pages and prevents the table from appearing empty while API keys are being fetched.

### Screenshot/Recording (if applicable)
<img width="561" height="132" alt="image" src="https://github.com/user-attachments/assets/2ac7bbe2-ff22-40a3-a38c-555e4c3586c7" />

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the plain “Loading…” message on the API Keys table with animated skeleton rows from `@notra/ui` that match the table layout. This makes the loading state consistent across the dashboard and avoids an empty table while API keys load.

<sup>Written for commit 9f7fdf366d8a82834feff54c4d834b9a0d86f9ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`9f7fdf3`](https://github.com/usenotra/notra/commit/9f7fdf366d8a82834feff54c4d834b9a0d86f9ba). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->