### PR TITLE
refactor: replace isRecord type guards with zod schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -364,6 +364,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "drizzle-orm": "^0.45.2",
         "pg": "^8.20.0",
+        "zod": "^4.3.4",
       },
       "devDependencies": {
         "@notra/typescript-config": "*",
@@ -405,6 +406,7 @@
       "version": "0.0.1",
       "dependencies": {
         "opentype.js": "^2.0.0",
+        "zod": "^4.3.4",
       },
       "devDependencies": {
         "@notra/typescript-config": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",
     "drizzle-orm": "^0.45.2",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "zod": "^4.3.4"
   },
   "devDependencies": {
     "@notra/typescript-config": "*",

--- a/packages/db/src/schemas/supermemory.ts
+++ b/packages/db/src/schemas/supermemory.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const brandReferenceMetadataSchema = z.looseObject({
+  tweetId: z.string().optional(),
+});
+
+export const supermemoryDocumentResponseSchema = z.looseObject({
+  id: z.string(),
+});

--- a/packages/db/src/utils/supermemory.ts
+++ b/packages/db/src/utils/supermemory.ts
@@ -5,16 +5,16 @@ import {
   SUPERMEMORY_CUSTOM_ID_HASH_LENGTH,
   SUPERMEMORY_REQUEST_TIMEOUT_MS,
 } from "../constants/supermemory";
+import {
+  brandReferenceMetadataSchema,
+  supermemoryDocumentResponseSchema,
+} from "../schemas/supermemory";
 import type {
   BrandReferenceMemoryLink,
   BrandReferenceMemoryPayload,
   DeleteBrandReferenceMemoryInput,
   SupermemorySearchResult,
 } from "../types/supermemory";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function getApiKey() {
   return process.env.SUPERMEMORY_API_KEY;
@@ -116,9 +116,9 @@ export function buildBrandReferenceMemoryPayload(input: {
     sourceUrl: string | null;
   };
 }) {
-  const tweetId = isRecord(input.reference.metadata)
-    ? input.reference.metadata.tweetId
-    : null;
+  const metadata = brandReferenceMetadataSchema.safeParse(
+    input.reference.metadata
+  );
   return {
     organizationId: input.organizationId,
     voiceId: input.voiceId,
@@ -127,7 +127,7 @@ export function buildBrandReferenceMemoryPayload(input: {
     content: input.reference.content,
     note: input.reference.note,
     applicableTo: input.reference.applicableTo,
-    tweetId: typeof tweetId === "string" ? tweetId : null,
+    tweetId: metadata.success ? (metadata.data.tweetId ?? null) : null,
     sourceUrl: input.reference.sourceUrl,
   } satisfies BrandReferenceMemoryPayload;
 }
@@ -185,19 +185,17 @@ export async function createBrandReferenceMemory(
     );
   }
 
-  const data: unknown = await response.json();
-  if (!isRecord(data)) {
+  const data = supermemoryDocumentResponseSchema.safeParse(
+    await response.json()
+  );
+  if (!data.success) {
     throw new Error(
       "Supermemory returned an invalid reference memory response"
     );
   }
 
-  if (typeof data.id !== "string") {
-    throw new Error("Supermemory did not return a document ID");
-  }
-
   return {
-    documentId: data.id,
+    documentId: data.data.id,
     memoryId: null,
   };
 }

--- a/packages/kiwi/package.json
+++ b/packages/kiwi/package.json
@@ -22,6 +22,7 @@
     "typescript": "5.9.2"
   },
   "dependencies": {
-    "opentype.js": "^2.0.0"
+    "opentype.js": "^2.0.0",
+    "zod": "^4.3.4"
   }
 }

--- a/packages/kiwi/src/codecs/kiwi.ts
+++ b/packages/kiwi/src/codecs/kiwi.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/suspicious/noBitwiseOperators: Kiwi binary encoding requires explicit bitwise operations.
 import { KIND_ENUM, KIND_MESSAGE, KIND_STRUCT } from "../constants/kiwi";
+import { kiwiRecordSchema } from "../schemas/kiwi";
 import type { Definition, FieldDef, KiwiValue } from "../types/kiwi";
 
 export type { Definition, FieldDef, KiwiValue } from "../types/kiwi";
@@ -344,14 +345,11 @@ function arrayValue(value: KiwiValue): KiwiValue[] {
 }
 
 function objectValue(value: KiwiValue): Record<string, KiwiValue> {
-  if (!isKiwiRecord(value)) {
+  const parsed = kiwiRecordSchema.safeParse(value);
+  if (!parsed.success) {
     throw new Error(`cannot encode ${String(value)} as object`);
   }
-  return value;
-}
-
-function isKiwiRecord(value: KiwiValue): value is Record<string, KiwiValue> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  return parsed.data;
 }
 
 export function decodeValue(

--- a/packages/kiwi/src/schemas/kiwi.ts
+++ b/packages/kiwi/src/schemas/kiwi.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const kiwiRecordSchema = z.record(z.string(), z.unknown());


### PR DESCRIPTION
## Summary
- Removes the hand-rolled `isRecord` guard in `packages/db/src/utils/supermemory.ts` and the `isKiwiRecord` guard in `packages/kiwi/src/codecs/kiwi.ts`.
- Replaces them with zod schemas placed in each package's `schemas/` folder (`packages/db/src/schemas/supermemory.ts`, `packages/kiwi/src/schemas/kiwi.ts`), following the repo code-organization convention.
- Supermemory metadata `tweetId` extraction and the create-document response are now validated with `safeParse` instead of manual `typeof` checks.
- Adds `zod` as a dependency to `@notra/db` and `@notra/kiwi`.

## Testing
- `bun run check-types` passes in both packages.
- `bun x ultracite check` clean on all touched files.

https://claude.ai/code/session_01KKmp4ENJmiyytBGxBampWB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced manual type guards with `zod` schemas in `@notra/db` and `@notra/kiwi` for safer, centralized runtime validation. Supermemory metadata and document responses now use `safeParse` instead of typeof checks.

- **Refactors**
  - Removed `isRecord` and `isKiwiRecord`; added `brandReferenceMetadataSchema`, `supermemoryDocumentResponseSchema`, and `kiwiRecordSchema`.
  - Validated Supermemory `tweetId` metadata and create-document response with `safeParse`.
  - Placed schemas in each package’s `src/schemas/` folder to match repo conventions.

- **Dependencies**
  - Added `zod@^4.3.4` to `@notra/db` and `@notra/kiwi`.

<sup>Written for commit 81d02f6363705301a96fd59fd652b7afe3eccfbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

4 issues found.

<sub>Written for commit [`81d02f6`](https://github.com/usenotra/notra/commit/81d02f6363705301a96fd59fd652b7afe3eccfbc). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->