### PR TITLE
fix(dashboard): refresh billing state and org-scoped queries on workspace switch

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -73,6 +73,7 @@ import { TOOL_TIMER_THRESHOLD_SECONDS } from "@/constants/chat-tool-timer";
 import { INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX } from "@/constants/integration-reference";
 import { localStorageKeys } from "@/constants/storage";
 import { authClient } from "@/lib/auth/client";
+import { emitAutumnRefresh } from "@/lib/billing/autumn-refresh";
 import { useElapsedSeconds } from "@/lib/hooks/use-elapsed-seconds";
 import { getMcpIconUrls } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
@@ -514,7 +515,7 @@ function StandaloneChatPageClient({
       }
 
       setPendingMessageId(null);
-      queryClient.invalidateQueries({ queryKey: ["autumn", "customer"] });
+      emitAutumnRefresh();
       queryClient.invalidateQueries({
         queryKey: ["chat-sessions", organizationId],
       });

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -58,6 +58,7 @@ import { IMAGE_EXPORT_TARGETS } from "@/constants/image-export";
 import { LINKEDIN_BRAND_PRIMARY } from "@/constants/linkedin";
 import { localStorageKeys } from "@/constants/storage";
 import { TWITTER_BRAND_COLOR } from "@/constants/twitter";
+import { emitAutumnRefresh } from "@/lib/billing/autumn-refresh";
 import {
   copyImageAsFigma,
   copyImageAsPaper,
@@ -499,7 +500,7 @@ export default function PageClient({
     }),
     onFinish: () => {
       clearSelection();
-      queryClient.invalidateQueries({ queryKey: ["autumn", "customer"] });
+      emitAutumnRefresh();
     },
     onError: (err) => {
       console.error("Error editing content:", err);

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/credits/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/credits/page-client.tsx
@@ -43,6 +43,7 @@ import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { CreditTopupModal } from "@/components/billing/credit-topup-modal";
 import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   CREDIT_RANGE_LABELS,
   CREDIT_RANGES,
@@ -152,11 +153,13 @@ export default function CreditsPageClient() {
   const eventsLimit = 20;
   const eventsOffset = Math.max(0, page - 1) * eventsLimit;
   const autumnClient = useAutumnClient({ caller: "CreditsPageClient" });
+  const { activeOrganization } = useOrganizationsContext();
   const { data: eventsData, isLoading: eventsLoading } = useQuery({
     queryKey: [
       "autumn",
       "events",
       "list",
+      activeOrganization?.id,
       FEATURES.AI_CREDITS,
       eventsOffset,
       eventsLimit,
@@ -169,6 +172,7 @@ export default function CreditsPageClient() {
       };
       return autumnClient.listEvents(params);
     },
+    enabled: Boolean(activeOrganization?.id),
   });
 
   const hasMore = hasMorePaginatedResults(eventsData, eventsLimit);

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/credits/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/credits/page-client.tsx
@@ -44,6 +44,7 @@ import { CreditTopupModal } from "@/components/billing/credit-topup-modal";
 import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { authClient } from "@/lib/auth/client";
 import {
   CREDIT_RANGE_LABELS,
   CREDIT_RANGES,
@@ -154,6 +155,10 @@ export default function CreditsPageClient() {
   const eventsOffset = Math.max(0, page - 1) * eventsLimit;
   const autumnClient = useAutumnClient({ caller: "CreditsPageClient" });
   const { activeOrganization } = useOrganizationsContext();
+  const { data: session } = authClient.useSession();
+  const sessionMatchesOrganization =
+    Boolean(activeOrganization?.id) &&
+    session?.session.activeOrganizationId === activeOrganization?.id;
   const { data: eventsData, isLoading: eventsLoading } = useQuery({
     queryKey: [
       "autumn",
@@ -172,7 +177,7 @@ export default function CreditsPageClient() {
       };
       return autumnClient.listEvents(params);
     },
-    enabled: Boolean(activeOrganization?.id),
+    enabled: sessionMatchesOrganization,
   });
 
   const hasMore = hasMorePaginatedResults(eventsData, eventsLimit);

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -40,6 +40,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { BrailleLoader } from "@/components/braille-loader";
 import { Button } from "@/components/button";
 import { ChatInputContextRow } from "@/components/chat/chat-input-context-row";
+import { useAutumnRefreshListener } from "@/lib/hooks/use-autumn-refresh-listener";
 import { ALL_INTEGRATIONS } from "@/lib/integrations/catalog";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type {
@@ -96,7 +97,9 @@ const ChatInput = ({
   const [internalValue, setInternalValue] = useState("");
   const [internalError, setInternalError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const { check, data: customer } = useCustomer();
+  const { check, data: customer, refetch: refetchCustomer } = useCustomer();
+
+  useAutumnRefreshListener(refetchCustomer);
 
   const checkResult = useMemo(() => {
     if (!customer) {

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -79,6 +79,7 @@ import {
   MIME_DISPLAY_LABELS,
   PASTE_TO_ATTACHMENT_THRESHOLD,
 } from "@/constants/upload";
+import { useAutumnRefreshListener } from "@/lib/hooks/use-autumn-refresh-listener";
 import { getMcpIconUrls } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import {
@@ -693,7 +694,9 @@ export function ChatInputAdvanced({
       document.removeEventListener("drop", onDrop);
     };
   }, [handleFilesSelected]);
-  const { check, data: customer } = useCustomer();
+  const { check, data: customer, refetch: refetchCustomer } = useCustomer();
+
+  useAutumnRefreshListener(refetchCustomer);
 
   const checkResult = useMemo(() => {
     if (!customer) {

--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -313,6 +313,7 @@ export function OrgSelector() {
       }
 
       await setLastVisitedOrganization(org.slug);
+      queryClient.invalidateQueries({ refetchType: "none" });
       await queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.AUTH.activeOrganization,
       });

--- a/apps/dashboard/src/components/providers/autumn-org-provider.tsx
+++ b/apps/dashboard/src/components/providers/autumn-org-provider.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AutumnProvider } from "autumn-js/react";
+import { useRef } from "react";
+import { authClient } from "@/lib/auth/client";
+import type { AutumnOrgProviderProps } from "@/types/components/providers";
+
+const INITIAL_PROVIDER_KEY = "initial-organization";
+const NO_ORGANIZATION_BASELINE = "no-organization";
+
+export function AutumnOrgProvider({ children }: AutumnOrgProviderProps) {
+  const { data: session, isPending } = authClient.useSession();
+  const sessionOrganizationId = session?.session.activeOrganizationId ?? null;
+
+  const lastKnownOrganizationIdRef = useRef<string | null>(null);
+  const baselineOrganizationIdRef = useRef<string | null>(null);
+
+  if (sessionOrganizationId) {
+    lastKnownOrganizationIdRef.current = sessionOrganizationId;
+  }
+
+  if (baselineOrganizationIdRef.current === null && !isPending) {
+    baselineOrganizationIdRef.current =
+      sessionOrganizationId ?? NO_ORGANIZATION_BASELINE;
+  }
+
+  const effectiveOrganizationId =
+    sessionOrganizationId ?? lastKnownOrganizationIdRef.current;
+  const hasSwitchedOrganization =
+    effectiveOrganizationId !== null &&
+    baselineOrganizationIdRef.current !== null &&
+    effectiveOrganizationId !== baselineOrganizationIdRef.current;
+  const providerKey = hasSwitchedOrganization
+    ? effectiveOrganizationId
+    : INITIAL_PROVIDER_KEY;
+
+  return (
+    <AutumnProvider includeCredentials key={providerKey}>
+      {children}
+    </AutumnProvider>
+  );
+}

--- a/apps/dashboard/src/components/providers/autumn-org-provider.tsx
+++ b/apps/dashboard/src/components/providers/autumn-org-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AutumnProvider } from "autumn-js/react";
-import { useRef } from "react";
+import { useState } from "react";
 import { authClient } from "@/lib/auth/client";
 import type { AutumnOrgProviderProps } from "@/types/components/providers";
 
@@ -12,24 +12,32 @@ export function AutumnOrgProvider({ children }: AutumnOrgProviderProps) {
   const { data: session, isPending } = authClient.useSession();
   const sessionOrganizationId = session?.session.activeOrganizationId ?? null;
 
-  const lastKnownOrganizationIdRef = useRef<string | null>(null);
-  const baselineOrganizationIdRef = useRef<string | null>(null);
+  const [lastKnownOrganizationId, setLastKnownOrganizationId] = useState<
+    string | null
+  >(null);
+  const [baselineOrganizationId, setBaselineOrganizationId] = useState<
+    string | null
+  >(null);
 
-  if (sessionOrganizationId) {
-    lastKnownOrganizationIdRef.current = sessionOrganizationId;
+  if (
+    sessionOrganizationId &&
+    sessionOrganizationId !== lastKnownOrganizationId
+  ) {
+    setLastKnownOrganizationId(sessionOrganizationId);
   }
 
-  if (baselineOrganizationIdRef.current === null && !isPending) {
-    baselineOrganizationIdRef.current =
-      sessionOrganizationId ?? NO_ORGANIZATION_BASELINE;
+  if (baselineOrganizationId === null && !isPending) {
+    setBaselineOrganizationId(
+      sessionOrganizationId ?? NO_ORGANIZATION_BASELINE
+    );
   }
 
   const effectiveOrganizationId =
-    sessionOrganizationId ?? lastKnownOrganizationIdRef.current;
+    sessionOrganizationId ?? lastKnownOrganizationId;
   const hasSwitchedOrganization =
     effectiveOrganizationId !== null &&
-    baselineOrganizationIdRef.current !== null &&
-    effectiveOrganizationId !== baselineOrganizationIdRef.current;
+    baselineOrganizationId !== null &&
+    effectiveOrganizationId !== baselineOrganizationId;
   const providerKey = hasSwitchedOrganization
     ? effectiveOrganizationId
     : INITIAL_PROVIDER_KEY;

--- a/apps/dashboard/src/components/providers/organization-provider.tsx
+++ b/apps/dashboard/src/components/providers/organization-provider.tsx
@@ -170,6 +170,7 @@ export function OrganizationsProvider({
           setOptimisticActiveOrg(null);
           lastSyncedSlugRef.current = null;
         } else {
+          queryClient.invalidateQueries({ refetchType: "none" });
           queryClient.invalidateQueries({
             queryKey: QUERY_KEYS.AUTH.activeOrganization,
           });
@@ -217,6 +218,7 @@ export function OrganizationsProvider({
               setOptimisticActiveOrg(null);
               hasAutoSelectedRef.current = false;
             } else {
+              queryClient.invalidateQueries({ refetchType: "none" });
               queryClient.invalidateQueries({
                 queryKey: QUERY_KEYS.AUTH.activeOrganization,
               });
@@ -259,14 +261,6 @@ export function OrganizationsProvider({
     }),
     [organizations, resolvedActiveOrganization, isLoading, getOrganization]
   );
-
-  useEffect(() => {
-    if (!contextValue.activeOrganization?.id) {
-      return;
-    }
-
-    queryClient.invalidateQueries({ queryKey: ["autumn", "customer"] });
-  }, [contextValue.activeOrganization?.id, queryClient]);
 
   return (
     <OrganizationsContext.Provider value={contextValue}>

--- a/apps/dashboard/src/components/settings/attachments/attachments-section.tsx
+++ b/apps/dashboard/src/components/settings/attachments/attachments-section.tsx
@@ -47,15 +47,14 @@ export function AttachmentsSection() {
   const [pendingKey, setPendingKey] = useState<string | null>(null);
   const [confirmKeys, setConfirmKeys] = useState<string[] | null>(null);
 
-  const queryOptions = dashboardOrpc.attachments.list.queryOptions({
-    input: { filter },
-  });
+  const organizationId = activeOrganization?.id ?? "";
 
-  const { data, isLoading } = useQuery({
-    ...queryOptions,
-    queryKey: [...queryOptions.queryKey, activeOrganization?.id],
-    enabled: Boolean(activeOrganization?.id),
-  });
+  const { data, isLoading } = useQuery(
+    dashboardOrpc.attachments.list.queryOptions({
+      input: { filter, organizationId },
+      enabled: Boolean(organizationId),
+    })
+  );
 
   const attachments: AttachmentRow[] = useMemo(() => {
     return (
@@ -78,7 +77,7 @@ export function AttachmentsSection() {
 
   const deleteManyMutation = useMutation({
     mutationFn: async (keys: string[]) => {
-      await dashboardOrpc.attachments.deleteMany.call({ keys });
+      await dashboardOrpc.attachments.deleteMany.call({ keys, organizationId });
     },
     onSuccess: async (_data, keys) => {
       toast.success(

--- a/apps/dashboard/src/components/settings/attachments/attachments-section.tsx
+++ b/apps/dashboard/src/components/settings/attachments/attachments-section.tsx
@@ -24,6 +24,7 @@ import { LoaderCircle } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import { type AttachmentRow, buildAttachmentColumns } from "./columns";
 import { AttachmentsDataTable } from "./data-table";
@@ -40,6 +41,7 @@ const FILTER_LABELS: Record<Filter, string> = {
 
 export function AttachmentsSection() {
   const queryClient = useQueryClient();
+  const { activeOrganization } = useOrganizationsContext();
   const [filter, setFilter] = useState<Filter>("all");
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
   const [pendingKey, setPendingKey] = useState<string | null>(null);
@@ -49,7 +51,11 @@ export function AttachmentsSection() {
     input: { filter },
   });
 
-  const { data, isLoading } = useQuery(queryOptions);
+  const { data, isLoading } = useQuery({
+    ...queryOptions,
+    queryKey: [...queryOptions.queryKey, activeOrganization?.id],
+    enabled: Boolean(activeOrganization?.id),
+  });
 
   const attachments: AttachmentRow[] = useMemo(() => {
     return (

--- a/apps/dashboard/src/lib/billing/autumn-refresh.ts
+++ b/apps/dashboard/src/lib/billing/autumn-refresh.ts
@@ -1,0 +1,16 @@
+import type { AutumnRefreshListener } from "@/types/billing/autumn-refresh";
+
+const listeners = new Set<AutumnRefreshListener>();
+
+export function subscribeToAutumnRefresh(listener: AutumnRefreshListener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function emitAutumnRefresh() {
+  for (const listener of listeners) {
+    listener();
+  }
+}

--- a/apps/dashboard/src/lib/hooks/use-autumn-refresh-listener.ts
+++ b/apps/dashboard/src/lib/hooks/use-autumn-refresh-listener.ts
@@ -1,0 +1,9 @@
+"use client";
+
+import { useEffect } from "react";
+import { subscribeToAutumnRefresh } from "@/lib/billing/autumn-refresh";
+import type { AutumnRefreshListener } from "@/types/billing/autumn-refresh";
+
+export function useAutumnRefreshListener(listener: AutumnRefreshListener) {
+  useEffect(() => subscribeToAutumnRefresh(listener), [listener]);
+}

--- a/apps/dashboard/src/lib/hooks/use-credit-balance.ts
+++ b/apps/dashboard/src/lib/hooks/use-credit-balance.ts
@@ -2,11 +2,18 @@
 
 import { FEATURES } from "@notra/ai/billing/features";
 import { useCustomer } from "autumn-js/react";
+import { useAutumnRefreshListener } from "@/lib/hooks/use-autumn-refresh-listener";
 
 export function useCreditBalance() {
-  const { data: customer, isLoading } = useCustomer({
+  const {
+    data: customer,
+    isLoading,
+    refetch,
+  } = useCustomer({
     expand: ["balances.feature", "subscriptions.plan"],
   });
+
+  useAutumnRefreshListener(refetch);
 
   const hasActiveSubscription =
     customer?.subscriptions?.some(

--- a/apps/dashboard/src/lib/orpc/routers/attachments.ts
+++ b/apps/dashboard/src/lib/orpc/routers/attachments.ts
@@ -31,6 +31,7 @@ type AttachmentFilter = (typeof ATTACHMENT_FILTER)[number];
 const LIST_PAGE_SIZE = 100;
 
 const listInputSchema = z.object({
+  organizationId: z.string().min(1),
   filter: z.enum(ATTACHMENT_FILTER).default("all"),
   cursor: z
     .object({
@@ -41,6 +42,7 @@ const listInputSchema = z.object({
 });
 
 const deleteManyInputSchema = z.object({
+  organizationId: z.string().min(1),
   keys: z.array(z.string().min(1)).min(1).max(500),
 });
 
@@ -132,7 +134,7 @@ export const attachmentsRouter = {
     .handler(async ({ context, input }) => {
       const organizationId = await requireOrganizationAccess(
         context.user.id,
-        context.session?.activeOrganizationId
+        input.organizationId
       );
 
       const filterCondition = buildFilterCondition(
@@ -186,7 +188,7 @@ export const attachmentsRouter = {
     .handler(async ({ context, input }) => {
       const organizationId = await requireOrganizationAccess(
         context.user.id,
-        context.session?.activeOrganizationId
+        input.organizationId
       );
 
       const owned = await db

--- a/apps/dashboard/src/types/billing/autumn-refresh.ts
+++ b/apps/dashboard/src/types/billing/autumn-refresh.ts
@@ -1,0 +1,1 @@
+export type AutumnRefreshListener = () => void;

--- a/apps/dashboard/src/types/components/providers.ts
+++ b/apps/dashboard/src/types/components/providers.ts
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export interface AutumnOrgProviderProps {
+  children: ReactNode;
+}

--- a/apps/dashboard/src/utils/providers.tsx
+++ b/apps/dashboard/src/utils/providers.tsx
@@ -9,11 +9,11 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 import { RealtimeProvider } from "@upstash/realtime/client";
-import { AutumnProvider } from "autumn-js/react";
 import dynamic from "next/dynamic";
 import { ThemeProvider } from "next-themes";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { toast } from "sonner";
+import { AutumnOrgProvider } from "@/components/providers/autumn-org-provider";
 import { PostHogIdentity } from "@/components/providers/posthog-identity";
 import { POSTHOG_PROJECT_TOKEN } from "@/constants/posthog";
 import { useMcpConnectionToast } from "@/lib/hooks/use-mcp-connection-toast";
@@ -87,7 +87,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       {ReactQueryDevtools ? <ReactQueryDevtools initialIsOpen={false} /> : null}
       <ThemeProvider attribute="class" disableTransitionOnChange enableSystem>
         <TooltipProvider>
-          <AutumnProvider includeCredentials>
+          <AutumnOrgProvider>
             <NuqsAdapter>
               <RealtimeProvider
                 api={{ url: "/api/realtime", withCredentials: true }}
@@ -99,7 +99,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
               <DatabuddyAnalytics />
             </NuqsAdapter>
             <Toaster position="top-center" />
-          </AutumnProvider>
+          </AutumnOrgProvider>
         </TooltipProvider>
       </ThemeProvider>
     </QueryClientProvider>


### PR DESCRIPTION
## Problem

Switching workspaces left stale react-query and billing state on screen: the PRO/BASIC badge (and all other plan/credit UI) kept showing the previous workspace's plan, and a few queries served the previous org's data.

Root causes found in an audit of all 62 query call sites:

1. **Autumn state never refreshed.** `autumn-js`'s `AutumnProvider` creates its own internal query client with a bundled copy of react-query. The existing `invalidateQueries({ queryKey: ["autumn", "customer"] })` calls (org switch, post-chat) targeted the app's query client, where that key never exists — a silent no-op. All ~20 `useCustomer`/`useAggregateEvents` call sites (plan badge, sidebar upgrade/trial cards, credit balances, chat feature gating, log retention window) kept the old workspace's state indefinitely.
2. **Two org-dependent queries had no org in their key.** The attachments settings list and the credits event log both resolve the organization from the session server-side, so after a switch the cached previous-org rows were served for up to the 1h `gcTime`.
3. **The switcher only invalidated `["auth", "activeOrganization"]`**, leaving any unscoped keys stale.

## Fix

- **`AutumnOrgProvider`** wraps `AutumnProvider` and remounts it (`key` change) when the session's `activeOrganizationId` changes, dropping its internal cache so every autumn hook refetches for the new workspace. A baseline ref avoids a spurious remount when the session first loads.
- **Org switch now marks the entire app query cache stale** (`invalidateQueries({ refetchType: "none" })`) before refetching the active-organization query — no wasted refetches under old-org keys, but everything refetches on next mount. Applied to the switcher, the URL-slug sync path, and first-org auto-select.
- **Attachments list and credit event log query keys now include the organization id** (with `enabled` guards).
- **Post-chat credit refresh actually works now**: the dead `["autumn", "customer"]` invalidations are replaced by a small refresh bridge (`emitAutumnRefresh`/`subscribeToAutumnRefresh`) that refetches the mounted autumn customer entries (credit balance hook and both chat inputs).
- Removed the no-op autumn invalidation effect from `OrganizationsProvider`.

## Verification

- `tsc --noEmit` clean, biome clean (one pre-existing warning untouched)
- `bun run build` passes (5/5 tasks)

https://claude.ai/code/session_01WhFugPFodiy7HKcEcnP3We

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale billing and org-scoped data after switching workspaces. UI now shows the correct plan, credits, and attachments immediately after a workspace change.

- **Bug Fixes**
  - Added `AutumnOrgProvider` to remount `autumn-js/react`’s `AutumnProvider` on `activeOrganizationId` change, clearing its internal cache; now tracks baseline/last-known org with render-time state to keep renders pure and avoid spurious remounts.
  - On workspace switch (selector, slug sync, auto-select), mark the entire app query cache stale (`invalidateQueries({ refetchType: "none" })`) before refetching `["auth", "activeOrganization"]`.
  - Scoped org-dependent data: attachments list/deleteMany now take an explicit `organizationId` (with membership validation), and the credits event log query includes the org id and is `enabled` only when the session’s org matches the workspace, preventing cross-org cache reuse during optimistic switches.
  - Replaced no-op `["autumn", "customer"]` invalidations with an `emitAutumnRefresh`/`useAutumnRefreshListener` bridge; chat inputs and the credit balance hook subscribe so post-chat updates refresh billing state.
  - Removed the unused autumn invalidation effect from `OrganizationsProvider`.

<sup>Written for commit 7089782558702ed40f8c0e19bd774232f86b5b7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`7089782`](https://github.com/usenotra/notra/commit/7089782558702ed40f8c0e19bd774232f86b5b7c). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->