### PR TITLE
feat(onboarding): exclude .edu emails from Slack Connect invites

### DIFF
--- a/apps/dashboard/src/lib/onboarding-agent.ts
+++ b/apps/dashboard/src/lib/onboarding-agent.ts
@@ -26,6 +26,7 @@ import {
   resolveCompanyDomain,
   resolveReachableWebsiteUrl,
 } from "@/lib/onboarding/company-domain";
+import { isEduEmail } from "@/lib/onboarding/edu-email";
 import { buildOnboardingAgentMessage } from "@/lib/onboarding/onboarding-agent-message";
 import {
   eveCreateSessionResponseSchema,
@@ -180,7 +181,12 @@ export async function sendOnboardingSlackInvite({
   email,
   organizationName,
 }: OnboardingSlackInviteInput): Promise<OnboardingSlackInviteResult> {
-  if (!hasSlackConnectConfigured() || isFreeEmail(email.trim().toLowerCase())) {
+  const normalizedEmail = email.trim().toLowerCase();
+  if (
+    !hasSlackConnectConfigured() ||
+    isFreeEmail(normalizedEmail) ||
+    isEduEmail(normalizedEmail)
+  ) {
     return { invited: false };
   }
 

--- a/apps/dashboard/src/lib/onboarding/edu-email.ts
+++ b/apps/dashboard/src/lib/onboarding/edu-email.ts
@@ -1,0 +1,6 @@
+const EDU_DOMAIN_PATTERN = /\.edu(\.[a-z]{2,3})?$/;
+
+export function isEduEmail(email: string): boolean {
+  const domain = email.trim().toLowerCase().split("@").at(-1) ?? "";
+  return EDU_DOMAIN_PATTERN.test(domain);
+}

--- a/apps/dashboard/src/lib/onboarding/edu-email.ts
+++ b/apps/dashboard/src/lib/onboarding/edu-email.ts
@@ -1,4 +1,4 @@
-const EDU_DOMAIN_PATTERN = /\.edu(\.[a-z]{2,3})?$/;
+const EDU_DOMAIN_PATTERN = /\.edu(\.[a-z]{2})?$/;
 
 export function isEduEmail(email: string): boolean {
   const domain = email.trim().toLowerCase().split("@").at(-1) ?? "";


### PR DESCRIPTION
Onboarding Slack Connect invites already skip free-email providers; this adds `.edu` addresses (including country variants like `.edu.au`) to the exclusion via a new `isEduEmail` helper in `lib/onboarding/edu-email.ts`.

https://claude.ai/code/session_01MKBsg8M7uoCpgD8XRTe8sK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Slack Connect invites for `.edu` email addresses during onboarding to avoid inviting academic domains. Adds an `isEduEmail` helper that normalizes emails and matches `.edu` or `.edu.[cc]` (two-letter country codes like `.edu.au`) alongside the existing free-email check.

<sup>Written for commit 2abb4e36abd3238b31c4b97967e107c2dedee582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`2abb4e3`](https://github.com/usenotra/notra/commit/2abb4e36abd3238b31c4b97967e107c2dedee582). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->