### PR TITLE
fix(brand): align guideline button icon spacing

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/guidelines-panel.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/guidelines-panel.tsx
@@ -90,11 +90,9 @@ export function GuidelinesPanel({
             size="sm"
           >
             {isRefreshBusy ? (
-              <Loader2Icon className="mr-2 size-4 animate-spin" />
+              <Loader2Icon className="size-4 animate-spin" />
             ) : (
-              <span className="mr-2">
-                <HugeiconsIcon className="size-4" icon={SparklesIcon} />
-              </span>
+              <HugeiconsIcon className="size-4" icon={SparklesIcon} />
             )}
             {isRefreshBusy ? "Generating…" : "Generate Guidelines"}
           </Button>
@@ -184,11 +182,9 @@ export function GuidelinesPanel({
               size="sm"
             >
               {isRefreshBusy ? (
-                <Loader2Icon className="mr-2 size-4 animate-spin" />
+                <Loader2Icon className="size-4 animate-spin" />
               ) : (
-                <span className="mr-2">
-                  <HugeiconsIcon className="size-4" icon={RefreshIcon} />
-                </span>
+                <HugeiconsIcon className="size-4" icon={RefreshIcon} />
               )}
               {isRefreshBusy ? "Refreshing…" : "Refresh Guidelines"}
             </Button>


### PR DESCRIPTION
### Description

Removes the additional right margin from the Brand Guidelines action icons and relies on the shared button component’s built-in gap instead.

This reduces the effective icon-to-label spacing from 12px to the standard 4px for the Generate Guidelines, Refresh Guidelines, and loading states.

### Screenshot/Recording (if applicable)
<img width="1160" height="720" alt="brand-guidelines-spacing-cropped" src="https://github.com/user-attachments/assets/d84f0d0b-412a-49b1-9149-c9d7b56677f4" />
<img width="671" height="142" alt="IMG_6389" src="https://github.com/user-attachments/assets/004af04d-f804-4132-9cb3-fc45fc271d0b" />



<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns icon spacing in Brand Guidelines buttons with the shared button gap. Removes extra margins so Generate Guidelines, Refresh Guidelines, and loading states use the standard 4px icon-to-label spacing.

<sup>Written for commit cc7c3f67c58cdef07a5f39c93a26ff5743764cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`cc7c3f6`](https://github.com/usenotra/notra/commit/cc7c3f67c58cdef07a5f39c93a26ff5743764cee). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->