### PR TITLE
fix(workflows): shared-secret auth for the non-Vercel API caller

### DIFF
--- a/apps/api/src/utils/internal-workflow.ts
+++ b/apps/api/src/utils/internal-workflow.ts
@@ -21,8 +21,8 @@ export async function startDashboardWorkflow(
   url: string,
   payload: unknown
 ): Promise<string> {
-  const secret = process.env.INTERNAL_WORKFLOW_SECRET;
-  const token = secret ?? (await getVercelOidcToken().catch(() => null));
+  const secret = process.env.INTERNAL_WORKFLOW_SECRET?.trim();
+  const token = secret || (await getVercelOidcToken().catch(() => null));
   const headers: Record<string, string> = {
     "content-type": "application/json",
   };

--- a/apps/api/src/utils/internal-workflow.ts
+++ b/apps/api/src/utils/internal-workflow.ts
@@ -21,7 +21,8 @@ export async function startDashboardWorkflow(
   url: string,
   payload: unknown
 ): Promise<string> {
-  const token = await getVercelOidcToken().catch(() => null);
+  const secret = process.env.INTERNAL_WORKFLOW_SECRET;
+  const token = secret ?? (await getVercelOidcToken().catch(() => null));
   const headers: Record<string, string> = {
     "content-type": "application/json",
   };

--- a/apps/dashboard/src/lib/workflows/internal-auth.ts
+++ b/apps/dashboard/src/lib/workflows/internal-auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import {
   extractBearerToken,
   localDev,
@@ -6,6 +7,19 @@ import {
   verifyVercelOidc,
 } from "eve/channels/auth";
 import { ALLOWED_VERCEL_ENVIRONMENTS } from "@/constants/internal-auth";
+
+function matchesInternalWorkflowSecret(token: string | null): boolean {
+  const secret = process.env.INTERNAL_WORKFLOW_SECRET;
+  if (!(secret && token)) {
+    return false;
+  }
+  const expected = Buffer.from(secret);
+  const provided = Buffer.from(token);
+  if (expected.length !== provided.length) {
+    return false;
+  }
+  return timingSafeEqual(expected, provided);
+}
 
 function getApiEnvironment(): VercelSubjectEnvironment {
   const configured = process.env.API_VERCEL_ENVIRONMENT;
@@ -18,10 +32,14 @@ function getApiEnvironment(): VercelSubjectEnvironment {
 export async function verifyInternalWorkflowRequest(
   request: Request
 ): Promise<boolean> {
+  const token = extractBearerToken(request.headers.get("authorization"));
+  if (matchesInternalWorkflowSecret(token)) {
+    return true;
+  }
+
   const teamSlug = process.env.DASHBOARD_VERCEL_TEAM_SLUG;
   const projectName = process.env.API_VERCEL_PROJECT_NAME;
   if (teamSlug && projectName) {
-    const token = extractBearerToken(request.headers.get("authorization"));
     const result = await verifyVercelOidc(token, {
       subjects: [
         vercelSubject({


### PR DESCRIPTION
The API runs as a Docker container off-Vercel, so it can never obtain a Vercel OIDC token. Without this fix, every API-triggered workflow start (on-demand content, brand analysis) hits the dashboard's fail-closed internal endpoints and gets a 401 in production.

## How it works
- `apps/api`: `startDashboardWorkflow` sends `Authorization: Bearer $INTERNAL_WORKFLOW_SECRET` when the env var is set; if it isn't, it still tries Vercel OIDC (so nothing breaks if the API ever moves to Vercel — OIDC then takes over with zero secrets).
- `apps/dashboard`: `verifyInternalWorkflowRequest` accepts the shared secret first (constant-time comparison via `timingSafeEqual`), then falls through to the existing OIDC subject-pinned verification, then the loopback-only local-dev fallback (disabled on Vercel deployments).

## Deploy
Set `INTERNAL_WORKFLOW_SECRET` to the same long random value on the API host and the dashboard Vercel project.

https://claude.ai/code/session_0121Y9WpoRt78R6zAn3zZheS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the off‑Vercel API to start dashboard workflows using a shared‑secret Bearer token, fixing production 401s. Keeps Vercel OIDC as a fallback when available.

- **Bug Fixes**
  - API: `startDashboardWorkflow` uses `Authorization: Bearer $INTERNAL_WORKFLOW_SECRET` when the secret is non‑empty (trimmed); otherwise falls back to Vercel OIDC.
  - Dashboard: `verifyInternalWorkflowRequest` accepts the shared secret via constant‑time check, then falls back to OIDC, then local‑dev loopback.

- **Migration**
  - Set `INTERNAL_WORKFLOW_SECRET` to the same long random value on the API host and the dashboard Vercel project.

<sup>Written for commit e20c8b9062a4e1b283edcc7bc062f33f3778b40b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

2 issues found.

<sub>Written for commit [`e20c8b9`](https://github.com/usenotra/notra/commit/e20c8b9062a4e1b283edcc7bc062f33f3778b40b). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->