### PR TITLE
chore: add code organization skill

### DIFF
--- a/.agents/skills/code-organization/SKILL.md
+++ b/.agents/skills/code-organization/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: code-organization
+description: Repo file-organization convention for TypeScript projects. ALWAYS use this when creating new files or deciding where code goes — types, schemas, validation, utility/helper functions, constants, enums, and config literals each belong in their own dedicated folder, not inline next to feature code or dumped in one grab-bag file. Use whenever you add a type/interface, a validation schema, a util/helper, a constant, or are asked where something should live, how to structure the repo, or to organize/refactor file layout.
+---
+
+# code-organization
+
+Where each kind of code goes. Apply this **every time** you create a file or
+add a type, schema, helper, or constant. Don't inline them next to feature
+code and don't pile unrelated things into one file.
+
+## Layout
+
+Each category gets its **own dedicated folder**. Files inside a folder are
+grouped by domain (e.g. `user`, `post`), not by individual symbol.
+
+```
+src/
+  types/        type & interface definitions        types/user.ts
+  schemas/      validation schemas (zod, yup, etc.) schemas/user.ts
+  utils/        helper / utility functions          utils/format.ts
+  constants/    constant values, enums, config      constants/routes.ts
+```
+
+## Rules
+
+1. **One folder per category** — `types/`, `schemas/`, `utils/`, `constants/`.
+   A new type goes in `types/`, never inline in the file that uses it or
+   alongside a component.
+
+2. **Group files by domain inside a folder.** All user-related types live in
+   `types/user.ts`; all user-related constants in `constants/user.ts`. Split a
+   file once it covers clearly separate domains — not per symbol.
+
+3. **Functions get their own file.** A reusable helper lives in `utils/` in a
+   file named for what it does (`utils/format.ts`, `utils/slugify.ts`). Keep one
+   focused concern per file; don't accumulate a `utils/index.ts` junk drawer.
+
+4. **No barrel files.** Do **not** add `index.ts` re-export barrels. Import
+   directly from the specific file:
+
+   ```ts
+   import { formatDate } from "@/utils/format";   // ✓
+   import { formatDate } from "@/utils";           // ✗ no barrel
+   ```
+
+   This keeps imports explicit and avoids circular-import and tree-shaking
+   surprises.
+
+5. **Types vs schemas are separate concerns.** `types/` holds pure TypeScript
+   type/interface declarations. `schemas/` holds runtime validation schemas. If
+   a type is derived from a schema, infer it in `types/` and import the schema —
+   keep the validator in `schemas/`.
+
+## Where does it go?
+
+| You're adding… | Folder | Example file |
+|---|---|---|
+| `type` / `interface` | `types/` | `types/user.ts` |
+| validation / parse schema | `schemas/` | `schemas/user.ts` |
+| pure helper function | `utils/` | `utils/format.ts` |
+| constant, enum, config literal | `constants/` | `constants/routes.ts` |
+| React component, route, feature code | feature dir | `user/profile.tsx` |
+
+## Gotchas
+
+- **A one-off type still goes in `types/`.** "It's only used here" is not a
+  reason to inline it — consistency is the point. The next person looks in
+  `types/` first.
+- **Don't create a barrel to shorten imports.** Rule 4 is deliberate; longer
+  import paths are the trade-off, and they're worth it.
+- **`utils/` is not a dumping ground.** If a helper is specific to one feature
+  and never reused, it can live with that feature — `utils/` is for genuinely
+  shared helpers.
+- **Match the existing folder names in the repo** if it already has `types/` /
+  `lib/` / `helpers/`. Follow what's there rather than introducing a parallel
+  set of folders.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,12 @@
       "skillPath": "c15t/SKILL.md",
       "computedHash": "031b918ecb7f15c96e690412c79e2ebb8f4a2bcea5c5fac3d87d9752d4153660"
     },
+    "code-organization": {
+      "source": "mezotv/skills",
+      "sourceType": "github",
+      "skillPath": "skills/code-organization/SKILL.md",
+      "computedHash": "9d48ef5f26fc218cb82554eac0b205ff38de6c6d57a905281957f95d94b9c90d"
+    },
     "eve": {
       "source": "vercel/eve",
       "sourceType": "github",


### PR DESCRIPTION
### Description
add code organization skill by the big dominik

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `code-organization` skill documenting a clear folder convention for TypeScript projects and registers it in `skills-lock.json`. This keeps types, schemas, utils, and constants in dedicated folders and avoids barrels.

- **New Features**
  - Added `.agents/skills/code-organization/SKILL.md` with layout for `types/`, `schemas/`, `utils/`, and `constants/`, plus examples.
  - Rules: group by domain, one function per file, no barrel `index.ts`, separate types from runtime schemas.
  - Updated `skills-lock.json` to include the new `code-organization` skill.

<sup>Written for commit c546f00c592a5711c2fd560874cf9e8ca176515d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`c546f00`](https://github.com/usenotra/notra/commit/c546f00c592a5711c2fd560874cf9e8ca176515d). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->