### PR TITLE
style(settings): match account input rounding

### DIFF
--- a/apps/dashboard/src/components/settings/login-details-section.tsx
+++ b/apps/dashboard/src/components/settings/login-details-section.tsx
@@ -91,7 +91,7 @@ export function LoginDetailsSection({
         <div className="space-y-2">
           <Label>Email</Label>
           <div className="flex items-center gap-2">
-            <div className="flex-1 truncate rounded-md border bg-muted/50 px-3 py-2 text-sm">
+            <div className="flex-1 truncate rounded-lg border bg-muted/50 px-3 py-2 text-sm">
               {email}
             </div>
             <HugeiconsIcon


### PR DESCRIPTION
### Description
Updates the read-only email field in **Login Details** from `rounded-md` to `rounded-lg`, matching the input rounding used in **Your Profile** and the other account settings fields.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the read-only email field in Login Details to use `rounded-lg`, matching the input rounding across account settings. This aligns with Your Profile and improves visual consistency.

<sup>Written for commit 2e19bd3c89a999ff5f145587a82f3828d3891ae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`2e19bd3`](https://github.com/usenotra/notra/commit/2e19bd3c89a999ff5f145587a82f3828d3891ae6). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->