### PR TITLE
fix(auth): correct GitHub icon color in dark mode

### DIFF
--- a/apps/dashboard/src/components/auth/auth-social-buttons.tsx
+++ b/apps/dashboard/src/components/auth/auth-social-buttons.tsx
@@ -44,7 +44,13 @@ export function AuthSocialButtons({
             {authMethod === provider ? (
               <Loader2Icon className="size-4 animate-spin" />
             ) : (
-              <Icon className="size-4" />
+              <Icon
+                className={
+                  provider === "github"
+                    ? "size-4 dark:[&_path]:fill-[#1e1e1e]"
+                    : "size-4"
+                }
+              />
             )}
             {label}
           </CtaButton>


### PR DESCRIPTION
### Description
Updates the GitHub login icon color in dark mode so it remains clearly visible on the light social login button, without changing the button background.

### Screenshot/Recording (if applicable)
before:
<img width="968" height="288" alt="image" src="https://github.com/user-attachments/assets/093dc1f1-e26b-4678-9e11-97eb143e8f1c" />

after:
<img width="490" height="165" alt="image" src="https://github.com/user-attachments/assets/0b3c188b-43b2-4f1a-a3dc-bb17791d4e13" />

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the GitHub login icon color in dark mode so it stays clearly visible on the light social button. No change to the button background.

- **Bug Fixes**
  - Apply a dark-mode path fill to the GitHub icon: `dark:[&_path]:fill-[#1e1e1e]`.

<sup>Written for commit 3584c8e4c90dd4a916945a531475d4c2bc1d0d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`3584c8e`](https://github.com/usenotra/notra/commit/3584c8e4c90dd4a916945a531475d4c2bc1d0d02). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->