### PR TITLE
fix(logs): smooth filter transitions

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/data-table.tsx
@@ -21,6 +21,7 @@ import type { DataTableProps } from "@/types/logs/data-table";
 
 export function DataTable<TData>({
   columns,
+  contentKey,
   data,
   page,
   totalPages,
@@ -45,7 +46,14 @@ export function DataTable<TData>({
   return (
     <div>
       <div className="overflow-hidden rounded-lg border border-border/80 border-b-border/40 bg-muted/80 shadow-2xs">
-        <Table>
+        <Table aria-busy={isLoading} className="table-fixed">
+          <colgroup>
+            <col className="w-[40%]" />
+            <col className="w-[24%]" />
+            <col className="w-[16%]" />
+            <col className="w-[17%]" />
+            <col className="w-[3%]" />
+          </colgroup>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -62,7 +70,10 @@ export function DataTable<TData>({
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody>
+          <TableBody
+            className="animate-[logs-table-content-fade_100ms_ease-out] motion-reduce:animate-none"
+            key={contentKey}
+          >
             {isLoading && (
               <TableRow>
                 <TableCell

--- a/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/logs/page-client.tsx
@@ -21,7 +21,7 @@ import {
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
 import { useDebouncedCallback } from "@tanstack/react-pacer";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
 import {
   parseAsInteger,
@@ -30,7 +30,6 @@ import {
   useQueryState,
 } from "nuqs";
 import { useState } from "react";
-import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
@@ -119,7 +118,22 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
       },
     }),
     enabled: !!organizationId,
+    placeholderData: keepPreviousData,
   });
+
+  const logs = data?.logs ?? [];
+  const contentKey = JSON.stringify(
+    logs.map((log) => [
+      log.id,
+      log.title,
+      log.integrationType,
+      log.status,
+      log.statusCode,
+      log.errorMessage,
+      log.createdAt,
+      log.referenceId,
+    ])
+  );
 
   const filtersActive =
     source !== "all" || status !== "all" || search.length > 0;
@@ -167,15 +181,34 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             />
             <Input
               aria-label="Search logs"
-              className="pl-8"
+              autoComplete="off"
+              className="pr-8 pl-8"
+              name="log-search"
               onChange={(e) => {
                 setSearchInput(e.target.value);
                 commitSearch(e.target.value);
               }}
               placeholder="Search by title or error message"
-              type="search"
+              type="text"
               value={searchInput}
             />
+            {searchInput.length > 0 && (
+              <button
+                aria-label="Clear search"
+                className="-translate-y-1/2 absolute top-1/2 right-1 flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={() => {
+                  setSearchInput("");
+                  commitSearch("");
+                }}
+                type="button"
+              >
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  className="size-3.5"
+                  icon={Cancel01Icon}
+                />
+              </button>
+            )}
           </div>
           <Select
             onValueChange={(value) => {
@@ -217,19 +250,6 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
               ))}
             </SelectContent>
           </Select>
-          {filtersActive && (
-            <Button
-              aria-label="Clear all filters"
-              className="h-8 shrink-0 gap-1.5 px-2.5 font-normal text-muted-foreground text-xs hover:bg-transparent hover:text-foreground"
-              onClick={resetFilters}
-              size="sm"
-              type="button"
-              variant="ghost"
-            >
-              <HugeiconsIcon className="size-3.5" icon={Cancel01Icon} />
-              Reset
-            </Button>
-          )}
         </div>
 
         {organizationId && isPending ? (
@@ -237,7 +257,8 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
         ) : (
           <DataTable
             columns={columns}
-            data={data?.logs ?? []}
+            contentKey={contentKey}
+            data={logs}
             emptyState={
               filtersActive
                 ? {

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -321,6 +321,12 @@
   }
 }
 
+@keyframes logs-table-content-fade {
+  from {
+    opacity: 0.72;
+  }
+}
+
 @keyframes thinking-letter {
   0%,
   100% {

--- a/apps/dashboard/src/types/logs/data-table.ts
+++ b/apps/dashboard/src/types/logs/data-table.ts
@@ -10,6 +10,7 @@ export interface DataTableEmptyState {
 export interface DataTableProps<TData> {
   // biome-ignore lint/suspicious/noExplicitAny: TanStack Table columns have varying value types
   columns: ColumnDef<TData, any>[];
+  contentKey: string;
   data: TData[];
   page: number;
   totalPages: number;


### PR DESCRIPTION
### Description
Improves the Logs filtering experience with stable table columns, a custom search clear button, and a subtle 100 ms content fade when displayed results change. Keeps the existing 150 ms search debounce and avoids layout shifts, loading flicker, and bouncy animations.

### Screenshot/Recording (if applicable)
https://cap.so/s/ybcvvrekvrqvy9w

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths Logs filter transitions to remove flicker and layout shifts. Adds a subtle 100 ms content fade, stable column widths, and a built-in search clear button.

- **UI Improvements**
  - Stabilized table layout with `table-fixed` and a `<colgroup>` for fixed column widths; set `aria-busy` during loads.
  - Faded new results in using the `logs-table-content-fade` animation keyed by a new `contentKey` prop; respects motion-reduce.
  - Preserved previous results while fetching with `keepPreviousData` from `@tanstack/react-query` to avoid empty flashes.
  - Enhanced search input: added a clear button, disabled autocomplete, switched to `type="text"`, and kept the 150 ms debounce via `@tanstack/react-pacer`.

<sup>Written for commit 0e3077321923ee98d21171a01e3158f2e762021e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`0e30773`](https://github.com/usenotra/notra/commit/0e3077321923ee98d21171a01e3158f2e762021e). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->