### PR TITLE
fix(dashboard): remove feedback separator

### DIFF
--- a/apps/dashboard/src/components/dashboard/feedback-popover.tsx
+++ b/apps/dashboard/src/components/dashboard/feedback-popover.tsx
@@ -96,7 +96,7 @@ export function FeedbackForm({
         />
       </div>
 
-      <div className="flex items-center justify-between gap-2 border-border border-t border-dashed p-2.5">
+      <div className="flex items-center justify-between gap-2 p-2.5">
         <div className="flex items-center gap-0.5">
           {FEEDBACK_SENTIMENT_OPTIONS.map((option) => {
             const isActive = sentiment === option.value;


### PR DESCRIPTION
### Description
removed the weird border in the feedback popover

### Screenshot/Recording (if applicable)
before:
<img width="1958" height="1124" alt="image" src="https://github.com/user-attachments/assets/ce109379-b6c9-45bd-95e4-d1d0060404ea" />

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dashed top separator from the dashboard feedback popover footer to clean up the UI and match the design. Layout and functionality are unchanged.

<sup>Written for commit 9d8cf5e6bbfa8855d2e3a27a940d5c4c71cb8384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

1 issue found.

<sub>Written for commit [`9d8cf5e`](https://github.com/usenotra/notra/commit/9d8cf5e6bbfa8855d2e3a27a940d5c4c71cb8384). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->