### PR TITLE
fix(chat): prefetch new chat route

### DIFF
--- a/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
+++ b/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
@@ -343,7 +343,11 @@ export function ChatHistoryNav() {
               <SidebarMenuButton
                 className="cursor-pointer"
                 render={
-                  <Link href={`/${slug}/chat`} replace={isOnChatRoute}>
+                  <Link
+                    href={`/${slug}/chat`}
+                    prefetch={true}
+                    replace={isOnChatRoute}
+                  >
                     <HugeiconsIcon icon={Add01Icon} />
                     <span>New chat</span>
                   </Link>


### PR DESCRIPTION
### Description
Fully prefetches the New Chat destination to reduce click-time RSC fetches while the configured 180-second prefetch cache remains fresh.
 right now it can take up to 1.6s (approx) when pressing the "new chat" button after the page was in the bg for a longer time

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetches the New Chat route to cut click-time delays and make opening a new chat feel instant. Sets `prefetch={true}` on the New Chat `Link` to `/${slug}/chat` to fully preload the route and avoid RSC fetches on click, eliminating ~1.6s waits while the 180s cache is warm.

<sup>Written for commit d019b048ffa46ca012b610ba4d6bf48fc0f17393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`d019b04`](https://github.com/usenotra/notra/commit/d019b048ffa46ca012b610ba4d6bf48fc0f17393). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->