### PR TITLE
feat(chat): improve image attachment layout

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -35,13 +35,15 @@ import {
   isToolUIPart,
   type ToolUIPart,
 } from "ai";
-import { LazyMotion, m } from "motion/react";
+import { LazyMotion, m, useReducedMotion } from "motion/react";
 import { nanoid } from "nanoid";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { parseAsString, useQueryState } from "nuqs";
 import {
+  Children,
+  type ReactElement,
   type ReactNode,
   useCallback,
   useEffect,
@@ -82,6 +84,7 @@ import { cn } from "@/lib/utils";
 import type {
   CreateToolContentType,
   StandaloneChatPageClientProps,
+  UserImageGridProps,
 } from "@/types/components/chat-page";
 import type { PublishedSocialPost } from "@/types/content/post-social";
 import { handleStandaloneChatError } from "@/utils/chat-error";
@@ -283,6 +286,7 @@ function ChatImageAttachment({
   onClick,
 }: ChatImageAttachmentProps) {
   const [hasError, setHasError] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
 
   if (hasError) {
     return (
@@ -296,21 +300,110 @@ function ChatImageAttachment({
 
   return (
     <button
-      className="my-1 block w-fit overflow-hidden rounded-lg border border-border transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="my-1 block w-fit overflow-hidden rounded-lg border border-border bg-muted/40 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
       onClick={onClick}
       type="button"
     >
       <Image
         alt={filename ?? "attachment"}
-        className="block h-auto max-h-72 w-auto max-w-full"
+        className={cn(
+          "block h-auto max-h-72 w-auto max-w-full transition-opacity duration-300 motion-reduce:transition-none",
+          hasLoaded ? "opacity-100" : "opacity-0"
+        )}
         height={480}
         loading="eager"
         onError={() => setHasError(true)}
+        onLoad={() => setHasLoaded(true)}
         src={url}
         unoptimized
         width={640}
       />
     </button>
+  );
+}
+
+function UserImageGrid({ children }: UserImageGridProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const shouldFocusExpandedImageRef = useRef(false);
+  const reduceMotion = useReducedMotion();
+  const imageItems = Children.toArray(children) as ReactElement[];
+  const hiddenImageCount = Math.max(imageItems.length - 6, 0);
+  const visibleImageCount = isExpanded
+    ? imageItems.length
+    : imageItems.length - hiddenImageCount;
+
+  useEffect(() => {
+    if (!(isExpanded && shouldFocusExpandedImageRef.current)) {
+      return;
+    }
+
+    shouldFocusExpandedImageRef.current = false;
+    const animationFrame = requestAnimationFrame(() => {
+      gridRef.current
+        ?.querySelector<HTMLButtonElement>('[data-image-index="6"] button')
+        ?.focus();
+    });
+
+    return () => cancelAnimationFrame(animationFrame);
+  }, [isExpanded]);
+
+  return (
+    <m.div
+      className="relative flex w-[28rem] max-w-full flex-wrap justify-end gap-1.5"
+      layout={!reduceMotion}
+      ref={gridRef}
+      transition={
+        reduceMotion
+          ? { duration: 0 }
+          : { duration: 0.3, ease: [0.22, 1, 0.36, 1] }
+      }
+    >
+      {imageItems.slice(0, visibleImageCount).map((imageItem, index) => {
+        const isCovered = !isExpanded && hiddenImageCount > 0 && index === 5;
+
+        return (
+          <m.div
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            className="aspect-square w-[calc((100%_-_0.75rem)/3)] [&>*]:m-0 [&>*]:size-full [&_img]:size-full [&_img]:object-cover"
+            data-image-index={index}
+            inert={isCovered ? true : undefined}
+            initial={
+              reduceMotion || index < 6
+                ? false
+                : { opacity: 0, scale: 0.96, y: 8 }
+            }
+            key={imageItem.key}
+            layout={!reduceMotion}
+            transition={
+              reduceMotion
+                ? { duration: 0 }
+                : { duration: 0.3, ease: [0.22, 1, 0.36, 1] }
+            }
+          >
+            {imageItem}
+          </m.div>
+        );
+      })}
+      {!isExpanded && hiddenImageCount > 0 && (
+        <m.button
+          animate={{ opacity: 1 }}
+          aria-label={`Show ${hiddenImageCount} more ${hiddenImageCount === 1 ? "image" : "images"}`}
+          className="absolute right-0 bottom-0 z-10 flex aspect-square w-[calc((100%_-_0.75rem)/3)] items-center justify-center rounded-lg border border-white/15 bg-black/60 font-medium text-white text-xl backdrop-blur-sm transition-colors hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset motion-reduce:transition-none"
+          initial={reduceMotion ? false : { opacity: 0 }}
+          onClick={(event) => {
+            shouldFocusExpandedImageRef.current = event.detail === 0;
+            setIsExpanded(true);
+          }}
+          transition={
+            reduceMotion ? { duration: 0 } : { delay: 0.1, duration: 0.2 }
+          }
+          type="button"
+        >
+          +{hiddenImageCount}
+        </m.button>
+      )}
+    </m.div>
   );
 }
 
@@ -2047,11 +2140,11 @@ function StandaloneChatPageClient({
                                   ) : (
                                     <>
                                       {userImageParts.length > 0 && (
-                                        <div className="flex w-[28rem] max-w-full flex-wrap justify-end gap-1.5 [&>*]:m-0 [&>*]:aspect-square [&>*]:w-[calc((100%_-_0.75rem)/3)] [&_img]:size-full [&_img]:object-cover">
+                                        <UserImageGrid>
                                           {userImageParts.map((part, index) =>
                                             renderPart(part, message.id, index)
                                           )}
-                                        </div>
+                                        </UserImageGrid>
                                       )}
                                       {(userContentParts.length > 0 ||
                                         userFileParts.length > 0) && (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -71,6 +71,7 @@ import {
   UserMessageEditor,
 } from "@/components/chat/user-message-actions";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { MAX_VISIBLE_CHAT_IMAGES } from "@/constants/chat-images";
 import { TOOL_TIMER_THRESHOLD_SECONDS } from "@/constants/chat-tool-timer";
 import { INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX } from "@/constants/integration-reference";
 import { localStorageKeys } from "@/constants/storage";
@@ -327,7 +328,10 @@ function UserImageGrid({ children }: UserImageGridProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const reduceMotion = useReducedMotion();
   const imageItems = Children.toArray(children) as ReactElement[];
-  const hiddenImageCount = Math.max(imageItems.length - 6, 0);
+  const hiddenImageCount = Math.max(
+    imageItems.length - MAX_VISIBLE_CHAT_IMAGES,
+    0
+  );
   const visibleImageCount = isExpanded
     ? imageItems.length
     : imageItems.length - hiddenImageCount;
@@ -339,7 +343,9 @@ function UserImageGrid({ children }: UserImageGridProps) {
 
     const animationFrame = requestAnimationFrame(() => {
       gridRef.current
-        ?.querySelector<HTMLButtonElement>('[data-image-index="6"] button')
+        ?.querySelector<HTMLButtonElement>(
+          `[data-image-index="${MAX_VISIBLE_CHAT_IMAGES}"] button`
+        )
         ?.focus();
     });
 
@@ -358,7 +364,10 @@ function UserImageGrid({ children }: UserImageGridProps) {
       }
     >
       {imageItems.slice(0, visibleImageCount).map((imageItem, index) => {
-        const isCovered = !isExpanded && hiddenImageCount > 0 && index === 5;
+        const isCovered =
+          !isExpanded &&
+          hiddenImageCount > 0 &&
+          index === MAX_VISIBLE_CHAT_IMAGES - 1;
 
         return (
           <m.div
@@ -367,7 +376,7 @@ function UserImageGrid({ children }: UserImageGridProps) {
             data-image-index={index}
             inert={isCovered ? true : undefined}
             initial={
-              reduceMotion || index < 6
+              reduceMotion || index < MAX_VISIBLE_CHAT_IMAGES
                 ? false
                 : { opacity: 0, scale: 0.96, y: 8 }
             }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -2053,19 +2053,25 @@ function StandaloneChatPageClient({
                                           )}
                                         </div>
                                       )}
-                                      {userContentParts.length > 0 && (
+                                      {(userContentParts.length > 0 ||
+                                        userFileParts.length > 0) && (
                                         <MessageContent>
                                           {userContentParts.map((part, index) =>
                                             renderPart(part, message.id, index)
                                           )}
-                                        </MessageContent>
-                                      )}
-                                      {userFileParts.length > 0 && (
-                                        <div className="flex max-w-full flex-wrap justify-end gap-2">
-                                          {userFileParts.map((part, index) =>
-                                            renderPart(part, message.id, index)
+                                          {userFileParts.length > 0 && (
+                                            <div className="flex max-w-full flex-wrap justify-end gap-2">
+                                              {userFileParts.map(
+                                                (part, index) =>
+                                                  renderPart(
+                                                    part,
+                                                    message.id,
+                                                    index
+                                                  )
+                                              )}
+                                            </div>
                                           )}
-                                        </div>
+                                        </MessageContent>
                                       )}
                                     </>
                                   )}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -2045,7 +2045,7 @@ function StandaloneChatPageClient({
                                   ) : (
                                     <>
                                       {userImageParts.length > 0 && (
-                                        <div className="flex w-[28rem] max-w-full flex-wrap justify-end gap-1.5 [&>button]:m-0 [&>button]:aspect-square [&>button]:w-[calc((100%_-_0.75rem)/3)] [&_img]:size-full [&_img]:object-cover">
+                                        <div className="flex w-[28rem] max-w-full flex-wrap justify-end gap-1.5 [&>*]:m-0 [&>*]:aspect-square [&>*]:w-[calc((100%_-_0.75rem)/3)] [&_img]:size-full [&_img]:object-cover">
                                           {userImageParts.map((part, index) =>
                                             renderPart(part, message.id, index)
                                           )}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -1984,6 +1984,7 @@ function StandaloneChatPageClient({
                           ? message.parts.filter(
                               (part) =>
                                 part.type === "file" &&
+                                typeof part.mediaType === "string" &&
                                 isImageMimeType(part.mediaType)
                             )
                           : [];
@@ -1991,7 +1992,8 @@ function StandaloneChatPageClient({
                           ? message.parts.filter(
                               (part) =>
                                 part.type === "file" &&
-                                !isImageMimeType(part.mediaType)
+                                (typeof part.mediaType !== "string" ||
+                                  !isImageMimeType(part.mediaType))
                             )
                           : [];
                         const branches = isUser

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -296,13 +296,13 @@ function ChatImageAttachment({
 
   return (
     <button
-      className="block w-fit overflow-hidden rounded-lg border border-border transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="my-1 block w-fit overflow-hidden rounded-lg border border-border transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       onClick={onClick}
       type="button"
     >
       <Image
         alt={filename ?? "attachment"}
-        className="block h-auto max-h-48 w-auto max-w-56 object-cover"
+        className="block h-auto max-h-72 w-auto max-w-full"
         height={480}
         loading="eager"
         onError={() => setHasError(true)}
@@ -2045,7 +2045,7 @@ function StandaloneChatPageClient({
                                   ) : (
                                     <>
                                       {userImageParts.length > 0 && (
-                                        <div className="flex w-[28rem] max-w-full flex-wrap justify-end gap-1.5 [&>button]:aspect-square [&>button]:w-[calc((100%_-_0.75rem)/3)] [&_img]:size-full [&_img]:object-cover">
+                                        <div className="flex w-[28rem] max-w-full flex-wrap justify-end gap-1.5 [&>button]:m-0 [&>button]:aspect-square [&>button]:w-[calc((100%_-_0.75rem)/3)] [&_img]:size-full [&_img]:object-cover">
                                           {userImageParts.map((part, index) =>
                                             renderPart(part, message.id, index)
                                           )}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -325,7 +325,6 @@ function ChatImageAttachment({
 function UserImageGrid({ children }: UserImageGridProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
-  const shouldFocusExpandedImageRef = useRef(false);
   const reduceMotion = useReducedMotion();
   const imageItems = Children.toArray(children) as ReactElement[];
   const hiddenImageCount = Math.max(imageItems.length - 6, 0);
@@ -334,11 +333,10 @@ function UserImageGrid({ children }: UserImageGridProps) {
     : imageItems.length - hiddenImageCount;
 
   useEffect(() => {
-    if (!(isExpanded && shouldFocusExpandedImageRef.current)) {
+    if (!isExpanded) {
       return;
     }
 
-    shouldFocusExpandedImageRef.current = false;
     const animationFrame = requestAnimationFrame(() => {
       gridRef.current
         ?.querySelector<HTMLButtonElement>('[data-image-index="6"] button')
@@ -391,10 +389,7 @@ function UserImageGrid({ children }: UserImageGridProps) {
           aria-label={`Show ${hiddenImageCount} more ${hiddenImageCount === 1 ? "image" : "images"}`}
           className="absolute right-0 bottom-0 z-10 flex aspect-square w-[calc((100%_-_0.75rem)/3)] items-center justify-center rounded-lg border border-white/15 bg-black/60 font-medium text-white text-xl backdrop-blur-sm transition-colors hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset motion-reduce:transition-none"
           initial={reduceMotion ? false : { opacity: 0 }}
-          onClick={(event) => {
-            shouldFocusExpandedImageRef.current = event.detail === 0;
-            setIsExpanded(true);
-          }}
+          onClick={() => setIsExpanded(true)}
           transition={
             reduceMotion ? { duration: 0 } : { delay: 0.1, duration: 0.2 }
           }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -296,13 +296,13 @@ function ChatImageAttachment({
 
   return (
     <button
-      className="my-1 block w-fit overflow-hidden rounded-lg border border-border transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="block w-fit overflow-hidden rounded-lg border border-border transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       onClick={onClick}
       type="button"
     >
       <Image
         alt={filename ?? "attachment"}
-        className="block h-auto max-h-72 w-auto max-w-full"
+        className="block h-auto max-h-48 w-auto max-w-56 object-cover"
         height={480}
         loading="eager"
         onError={() => setHasError(true)}
@@ -1977,6 +1977,23 @@ function StandaloneChatPageClient({
                         const isUser = message.role === "user";
                         const isEditing =
                           isUser && editingMessageId === message.id;
+                        const userContentParts = isUser
+                          ? message.parts.filter((part) => part.type !== "file")
+                          : message.parts;
+                        const userImageParts = isUser
+                          ? message.parts.filter(
+                              (part) =>
+                                part.type === "file" &&
+                                isImageMimeType(part.mediaType)
+                            )
+                          : [];
+                        const userFileParts = isUser
+                          ? message.parts.filter(
+                              (part) =>
+                                part.type === "file" &&
+                                !isImageMimeType(part.mediaType)
+                            )
+                          : [];
                         const branches = isUser
                           ? messageBranches[message.id]
                           : undefined;
@@ -2007,7 +2024,7 @@ function StandaloneChatPageClient({
                                     "ml-auto overflow-hidden",
                                     isEditing
                                       ? "w-full"
-                                      : "flex w-fit max-w-full"
+                                      : "flex w-fit max-w-full flex-col items-end gap-2"
                                   )}
                                   layout
                                   transition={{
@@ -2026,11 +2043,29 @@ function StandaloneChatPageClient({
                                       }
                                     />
                                   ) : (
-                                    <MessageContent>
-                                      {message.parts.map((part, index) =>
-                                        renderPart(part, message.id, index)
+                                    <>
+                                      {userImageParts.length > 0 && (
+                                        <div className="flex w-[28rem] max-w-full flex-wrap justify-end gap-1.5 [&>button]:aspect-square [&>button]:w-[calc((100%_-_0.75rem)/3)] [&_img]:size-full [&_img]:object-cover">
+                                          {userImageParts.map((part, index) =>
+                                            renderPart(part, message.id, index)
+                                          )}
+                                        </div>
                                       )}
-                                    </MessageContent>
+                                      {userContentParts.length > 0 && (
+                                        <MessageContent>
+                                          {userContentParts.map((part, index) =>
+                                            renderPart(part, message.id, index)
+                                          )}
+                                        </MessageContent>
+                                      )}
+                                      {userFileParts.length > 0 && (
+                                        <div className="flex max-w-full flex-wrap justify-end gap-2">
+                                          {userFileParts.map((part, index) =>
+                                            renderPart(part, message.id, index)
+                                          )}
+                                        </div>
+                                      )}
+                                    </>
                                   )}
                                 </m.div>
                               ) : (

--- a/apps/dashboard/src/constants/chat-images.ts
+++ b/apps/dashboard/src/constants/chat-images.ts
@@ -1,0 +1,1 @@
+export const MAX_VISIBLE_CHAT_IMAGES = 6;

--- a/apps/dashboard/src/types/components/chat-page.ts
+++ b/apps/dashboard/src/types/components/chat-page.ts
@@ -1,6 +1,12 @@
+import type { ReactNode } from "react";
+
 export interface StandaloneChatPageClientProps {
   organizationSlug: string;
   chatId?: string;
+}
+
+export interface UserImageGridProps {
+  children: ReactNode;
 }
 
 export type CreateToolContentType =


### PR DESCRIPTION
### Description
Improves user-message image attachments by rendering them above the text bubble in a compact, right-aligned three-column grid. Images use consistent square thumbnails, while non-image attachments retain their existing file presentation.

### Screenshot/Recording (if applicable)
before:
<img width="634" height="1600" alt="image" src="https://github.com/user-attachments/assets/de41b75c-bc47-4305-b952-694e5aa83c77" />

after:
<img width="965" height="1280" alt="image" src="https://github.com/user-attachments/assets/fc9ba037-fed2-4a0e-909b-5cedfd9aea94" />

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render user image attachments above the message bubble in a compact, right‑aligned 3‑column grid with square thumbnails, fade‑in on load, and an expandable overflow. Text appears below images; file attachments stay in the bubble.

- **New Features**
  - Split user parts into images, text, and other files to control order (images → text → files); keep files in the bubble.
  - Image grid: max width 28rem; 3 columns with square buttons; thumbnails use object-cover and fade in on load; expandable overflow (+N) for >6 images that expands on click, preserves focus on the first revealed image, and respects reduced motion.
  - Scoped thumbnail sizing; preserve a placeholder cell for failed images; guard unknown/missing attachment media types; centralized grid limit via `MAX_VISIBLE_CHAT_IMAGES` in `@/constants/chat-images`.

<sup>Written for commit 08d08f2b08655b4108045326d4bb420f5eb35dee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`08d08f2`](https://github.com/usenotra/notra/commit/08d08f2b08655b4108045326d4bb420f5eb35dee). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->