### PR TITLE
fix(dashboard): align font source of truth

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -1,14 +1,12 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Noto_Sans } from "next/font/google";
+import { Geist_Mono, Noto_Sans } from "next/font/google";
 import "@/styles/globals.css";
 
 import { Providers } from "@/utils/providers";
 import { SITE_CONFIG } from "../utils/site";
 
-const notoSans = Noto_Sans({ variable: "--font-sans" });
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const notoSans = Noto_Sans({
+  variable: "--font-noto-sans",
   subsets: ["latin"],
 });
 
@@ -43,13 +41,11 @@ export default function RootLayout({
 }>) {
   return (
     <html
-      className={`${notoSans.variable} dark:scheme-dark`}
+      className={`${notoSans.variable} ${geistMono.variable} dark:scheme-dark`}
       lang="en"
       suppressHydrationWarning
     >
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -43,11 +43,7 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.4907 0.2412 292.5809);
-  --font-sans: ui-sans-serif, system-ui, sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, Times New Roman, Times, serif;
-  --font-mono:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
-    Courier New, monospace;
   --radius: 0.5rem;
   --shadow-x: 0px;
   --shadow-y: 4px;
@@ -105,11 +101,7 @@
   --sidebar-accent-foreground: oklch(0.709 0.1592 293.5412);
   --sidebar-border: oklch(0.258 0 0);
   --sidebar-ring: oklch(0.709 0.1592 293.5412);
-  --font-sans: ui-sans-serif, system-ui, sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, Times New Roman, Times, serif;
-  --font-mono:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
-    Courier New, monospace;
   --radius: 0.5rem;
   --shadow-x: 0px;
   --shadow-y: 0px;
@@ -165,8 +157,8 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-mono);
+  --font-sans: var(--font-noto-sans);
+  --font-mono: var(--font-geist-mono);
   --font-serif: var(--font-serif);
 
   --radius-sm: calc(var(--radius) - 4px);


### PR DESCRIPTION
### Description
Aligns the dashboard font configuration around a single source of truth: Noto Sans for regular UI text and Geist Mono for monospace content. Removes the unused Geist Sans loading and conflicting light/dark system-font tokens while preserving the dashboard’s existing sans appearance.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [x] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies dashboard fonts: Noto Sans for UI text and Geist Mono for code. Removes unused Geist Sans and conflicting system-font tokens to keep typography consistent across themes.

- **Refactors**
  - Map `--font-sans` to `--font-noto-sans` and `--font-mono` to `--font-geist-mono` in `globals.css`; remove per-theme fallbacks.
  - Load only `Noto_Sans` and `Geist_Mono` from `next/font/google`; drop `Geist` (sans) import and related body class.
  - Apply font variables on `<html>`; keep `<body>` to `antialiased` only.

<sup>Written for commit 758e9a3300779c10a8d2cb3924564ee08b551932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`758e9a3`](https://github.com/usenotra/notra/commit/758e9a3300779c10a8d2cb3924564ee08b551932). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->