### PR TITLE
chore: mark drizzle migration artifacts as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+packages/db/migrations/** linguist-generated=true


### PR DESCRIPTION
Marks everything under `packages/db/migrations/` (migration SQL, `meta/*_snapshot.json`, `meta/_journal.json`) as `linguist-generated`, so GitHub collapses these files in PR diffs and excludes them from language stats.

Drizzle regenerates a full ~9k-line schema snapshot alongside every migration, which otherwise dominates review diffs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `.gitattributes` rule to mark Drizzle migration artifacts under `packages/db/migrations/**` as generated. GitHub will collapse the large schema snapshots in PR diffs and exclude them from language stats.

<sup>Written for commit 0bf3d08b7f5b860cb73effbd562c857a878147e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`0bf3d08`](https://github.com/usenotra/notra/commit/0bf3d08b7f5b860cb73effbd562c857a878147e5). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->