### PR TITLE
style: format iris-billing track call

### DIFF
--- a/packages/ai/src/utils/iris-billing.ts
+++ b/packages/ai/src/utils/iris-billing.ts
@@ -86,17 +86,20 @@ export const trackIrisRunUsage = Effect.fn("iris.billing.track")(function* (
   const tracked = yield* Effect.result(
     Effect.tryPromise({
       try: () =>
-        client.track({
-          customerId: input.organizationId,
-          featureId: FEATURES.AI_CREDITS,
-          value: billedCents,
-          properties: {
-            source: IRIS_USAGE_SOURCE,
-            run_id: input.runId,
-            cost_cents: billedCents,
-            raw_cost_cents: input.costCents,
+        client.track(
+          {
+            customerId: input.organizationId,
+            featureId: FEATURES.AI_CREDITS,
+            value: billedCents,
+            properties: {
+              source: IRIS_USAGE_SOURCE,
+              run_id: input.runId,
+              cost_cents: billedCents,
+              raw_cost_cents: input.costCents,
+            },
           },
-        }, { headers: { "Idempotency-Key": `iris-run-${input.runId}` } }),
+          { headers: { "Idempotency-Key": `iris-run-${input.runId}` } }
+        ),
       catch: (cause) => cause,
     })
   );


### PR DESCRIPTION
Formatting fix from `bun run format` (ultracite/biome): reformats the multi-line `client.track` call in `packages/ai/src/utils/iris-billing.ts`. No behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformatted the multi-line `client.track` call in `packages/ai/src/utils/iris-billing.ts` to comply with `biome` formatting. No behavior changes.

<sup>Written for commit d3cccc020a49f3588cfbbcc5c8164899413fa130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- compai-code-review:start -->
## Summary by Comp AI

No blocking issues found.

<sub>Written for commit [`d3cccc0`](https://github.com/usenotra/notra/commit/d3cccc020a49f3588cfbbcc5c8164899413fa130). New commits will trigger a re-review. Generated by [Comp AI](https://trycomp.ai).</sub>
<!-- compai-code-review:end -->