### PR TITLE
fix(security): allow Brand.dev image assets

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -116,6 +116,10 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
+        hostname: "media.brand.dev",
+      },
+      {
+        protocol: "https",
         hostname: "**.r2.cloudflarestorage.com",
       },
       {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -127,7 +127,7 @@ const nextConfig: NextConfig = {
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' databuddy.cc *.databuddy.cc",
             "style-src 'self' 'unsafe-inline'",
             "font-src 'self'",
-            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com media.marblecms.com *.r2.dev cdn.usenotra.com pbs.twimg.com abs.twimg.com",
+            "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io images.marblecms.com media.marblecms.com media.brand.dev *.r2.dev cdn.usenotra.com pbs.twimg.com abs.twimg.com",
             "connect-src 'self' databuddy.cc *.databuddy.cc *.inth.app *.c15t.com *.c15t.dev",
             "frame-src 'none'",
             "frame-ancestors 'none'",
@@ -161,6 +161,10 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "media.marblecms.com",
+      },
+      {
+        protocol: "https",
+        hostname: "media.brand.dev",
       },
       {
         protocol: "https",


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Brand.dev image assets by whitelisting `https://media.brand.dev` in our image security config. Added `media.brand.dev` to the CSP `img-src` in `apps/web` and to Next.js `images.remotePatterns` in both `apps/web` and `apps/dashboard` to prevent blocked or broken images.

<sup>Written for commit 8b1f83aec4ea1adb3e63f5638bf891e07cc28dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

