### PR TITLE
feat(dashboard): rework sidebar and topbar layout

### DIFF
--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
 } from "@notra/ui/components/ui/sidebar";
+import { Notra } from "@notra/ui/components/ui/svgs/notra";
 import { cn } from "@notra/ui/lib/utils";
 import {
   AnimatePresence,
@@ -26,7 +27,6 @@ import { ChatHistoryNav } from "./chat-history-nav";
 import { NavMain } from "./nav-main";
 import { NavSecondary } from "./nav-secondary";
 import { NavSettings } from "./nav-settings";
-import { NavUser } from "./nav-user";
 import { OrgSelector } from "./org-selector";
 import { SidebarOnboarding } from "./sidebar-onboarding";
 import { SidebarTrialExpired } from "./sidebar-trial-expired";
@@ -92,7 +92,14 @@ export function DashboardSidebar({
     >
       <LazyMotion features={domAnimation}>
         <SidebarHeader>
-          <OrgSelector />
+          <div className="flex items-center gap-2 px-2 pt-1 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+            <div className="flex size-7 shrink-0 items-center justify-center rounded-lg dark:bg-[#F6F3F1]">
+              <Notra className="size-7 dark:size-5" />
+            </div>
+            <span className="truncate font-semibold text-base group-data-[collapsible=icon]:hidden">
+              Notra
+            </span>
+          </div>
           <AnimatePresence initial={false} mode="popLayout">
             {isSubpage && (
               <m.div
@@ -167,7 +174,7 @@ export function DashboardSidebar({
         </SidebarContent>
         <SidebarFooter>
           <NavSecondary className="p-0" />
-          <NavUser />
+          <OrgSelector />
         </SidebarFooter>
       </LazyMotion>
     </Sidebar>

--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -76,7 +76,7 @@ export function DashboardShell({
         />
         <SidebarInset className="min-h-0 min-w-0 overflow-hidden">
           <SiteHeader />
-          <div className="@container/main flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden overscroll-contain">
+          <div className="@container/main scrollbar-stable flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden overscroll-contain">
             <SubscriptionGate>{children}</SubscriptionGate>
           </div>
         </SidebarInset>

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -48,6 +48,7 @@ import {
   FeedbackForm,
   FeedbackPopover,
 } from "@/components/dashboard/feedback-popover";
+import { NavUser } from "@/components/dashboard/nav-user";
 
 const NON_ORG_PATHS: string[] = [];
 
@@ -255,21 +256,18 @@ export function SiteHeader() {
     : genericBreadcrumbs;
 
   return (
-    <header className="relative flex h-12 shrink-0 items-center gap-2 border-b border-dashed transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
-        <div className="flex min-w-0 flex-1 items-center gap-1 lg:gap-2">
-          <SidebarTrigger className="-ml-1" />
-          <Separator
-            className="mx-2 border-border border-l border-dashed bg-transparent"
-            orientation="vertical"
-          />
+    <header className="relative flex h-12 shrink-0 items-center gap-2 border-b bg-muted/30 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+      <div className="flex h-full w-full items-center gap-1 px-4 lg:gap-2">
+        <div className="flex h-full min-w-0 flex-1 items-center gap-1 lg:gap-2">
+          <SidebarTrigger />
+          <Separator className="mx-2" orientation="vertical" />
           <Breadcrumb className="min-w-0">
             <BreadcrumbList className="min-w-0 flex-nowrap">
               {breadcrumbs}
             </BreadcrumbList>
           </Breadcrumb>
         </div>
-        <div className="flex min-w-0 items-center justify-end gap-2">
+        <div className="flex h-full min-w-0 items-center justify-end gap-2">
           <CreditBalanceButton className="hidden sm:inline-flex" />
           <div className="hidden items-center gap-2 lg:flex">
             <FeedbackPopover
@@ -332,6 +330,8 @@ export function SiteHeader() {
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          <Separator className="mx-2" orientation="vertical" />
+          <NavUser />
           <ResponsiveDialog
             onOpenChange={setMobileFeedbackOpen}
             open={mobileFeedbackOpen}

--- a/apps/dashboard/src/components/dashboard/nav-user.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-user.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  Logout01Icon,
-  Moon02Icon,
-  MoreVerticalCircle01Icon,
-  Sun03Icon,
-  User02Icon,
-} from "@hugeicons/core-free-icons";
+import { Logout01Icon, User02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   Avatar,
@@ -22,17 +16,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
-import { Kbd } from "@notra/ui/components/ui/kbd";
-import {
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  useSidebar,
-} from "@notra/ui/components/ui/sidebar";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
-import { useHotkey } from "@tanstack/react-hotkeys";
 import { useRouter } from "next/navigation";
-import { useTheme } from "next-themes";
 import { useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -46,17 +31,6 @@ const getServerSnapshot = () => false;
 
 export function NavUser() {
   const router = useRouter();
-  const { isMobile, state } = useSidebar();
-  const { setTheme, resolvedTheme } = useTheme();
-  const isCollapsed = state === "collapsed";
-  let dropdownSide: "bottom" | "right" | "top" = "top";
-  if (isMobile) {
-    dropdownSide = "bottom";
-  } else if (isCollapsed) {
-    dropdownSide = "right";
-  }
-  const isDark = resolvedTheme === "dark";
-  const toggleTheme = () => setTheme(isDark ? "light" : "dark");
   const [isSigningOut, setIsSigningOut] = useState(false);
   const hasHydrated = useSyncExternalStore(
     emptySubscribe,
@@ -69,8 +43,6 @@ export function NavUser() {
   const { data: session, isPending } = authClient.useSession();
   const user = session?.user;
   const slug = activeOrganization?.slug ?? "";
-
-  useHotkey("D", toggleTheme);
 
   async function handleSignOut() {
     setIsSigningOut(true);
@@ -90,24 +62,7 @@ export function NavUser() {
   }
 
   if (!hasHydrated || (!user && isPending)) {
-    return (
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuButton disabled size="lg" tooltip={"Account"}>
-            <Skeleton className="size-8 rounded-lg" />
-            {!isCollapsed && (
-              <>
-                <div className="grid flex-1 gap-1 text-left text-sm leading-tight">
-                  <Skeleton className="h-4 w-24" />
-                  <Skeleton className="h-3 w-32" />
-                </div>
-                <Skeleton className="ml-auto size-4" />
-              </>
-            )}
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      </SidebarMenu>
-    );
+    return <Skeleton className="size-7 shrink-0 rounded-lg" />;
   }
 
   if (!user) {
@@ -115,134 +70,89 @@ export function NavUser() {
   }
 
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <SidebarMenuButton
-                className={cn(
-                  "cursor-pointer data-popup-open:bg-sidebar-accent/90 data-popup-open:text-sidebar-accent-foreground data-popup-open:ring-1 data-popup-open:ring-sidebar-border/70",
-                  isCollapsed ? "size-10 min-w-0 justify-center p-1" : ""
-                )}
-                disabled={isSigningOut}
-                size="lg"
-                tooltip={"Account"}
-              >
-                <Avatar className="size-8 rounded-lg after:rounded-lg">
-                  <AvatarImage
-                    alt={user.name}
-                    className="rounded-lg"
-                    src={user.image ?? undefined}
-                  />
-                  <AvatarFallback className="rounded-lg">
-                    {user.name.charAt(0).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                {!isCollapsed && (
-                  <>
-                    <div className="grid flex-1 text-left text-sm leading-tight">
-                      <span
-                        className={cn(
-                          "truncate font-medium transition-[filter] duration-200",
-                          hidePersonalData &&
-                            "select-none blur-[5px] hover:blur-0"
-                        )}
-                      >
-                        {user.name}
-                      </span>
-                      <span
-                        className={cn(
-                          "truncate text-muted-background text-xs transition-[filter] duration-200",
-                          hidePersonalData &&
-                            "select-none blur-[5px] hover:blur-0"
-                        )}
-                      >
-                        {user.email}
-                      </span>
-                    </div>
-                    <HugeiconsIcon
-                      className="ml-auto size-4"
-                      icon={MoreVerticalCircle01Icon}
-                    />
-                  </>
-                )}
-              </SidebarMenuButton>
-            }
-          />
-          <DropdownMenuContent
-            align="end"
-            className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
-            side={dropdownSide}
-            sideOffset={4}
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            aria-label="Account"
+            className="shrink-0 cursor-pointer rounded-lg outline-none ring-sidebar-ring focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 data-popup-open:ring-1 data-popup-open:ring-sidebar-border/70"
+            disabled={isSigningOut}
+            type="button"
           >
-            <DropdownMenuGroup>
-              <DropdownMenuLabel className="p-0 font-normal">
-                <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                  <Avatar className="size-8 rounded-lg after:rounded-lg">
-                    <AvatarImage
-                      alt={user.name}
-                      className="rounded-lg"
-                      src={user.image ?? undefined}
-                    />
-                    <AvatarFallback className="rounded-lg">
-                      {user.name.charAt(0).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span
-                      className={cn(
-                        "truncate font-medium text-foreground transition-[filter] duration-200",
-                        hidePersonalData &&
-                          "select-none blur-[5px] hover:blur-0"
-                      )}
-                    >
-                      {user.name}
-                    </span>
-                    <span
-                      className={cn(
-                        "truncate text-muted-foreground text-xs transition-[filter] duration-200",
-                        hidePersonalData &&
-                          "select-none blur-[5px] hover:blur-0"
-                      )}
-                    >
-                      {user.email}
-                    </span>
-                  </div>
-                </div>
-              </DropdownMenuLabel>
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={() => router.push(`/${slug}/settings/account`)}
-              >
-                <HugeiconsIcon icon={User02Icon} />
-                Account
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={toggleTheme}
-              >
-                <HugeiconsIcon icon={isDark ? Sun03Icon : Moon02Icon} />
-                {isDark ? "Light Mode" : "Dark Mode"}
-                <Kbd className="ml-auto">D</Kbd>
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              className="cursor-pointer"
-              disabled={isSigningOut}
-              onClick={handleSignOut}
-              variant="destructive"
-            >
-              <HugeiconsIcon icon={Logout01Icon} />
-              {isSigningOut ? "Signing out..." : "Log Out"}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </SidebarMenuItem>
-    </SidebarMenu>
+            <Avatar className="size-7 rounded-lg after:rounded-lg">
+              <AvatarImage
+                alt={user.name}
+                className="rounded-lg"
+                src={user.image ?? undefined}
+              />
+              <AvatarFallback className="rounded-lg">
+                {user.name.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+          </button>
+        }
+      />
+      <DropdownMenuContent
+        align="end"
+        className="min-w-56 rounded-lg"
+        side="bottom"
+        sideOffset={4}
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="p-0 font-normal">
+            <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+              <Avatar className="size-8 rounded-lg after:rounded-lg">
+                <AvatarImage
+                  alt={user.name}
+                  className="rounded-lg"
+                  src={user.image ?? undefined}
+                />
+                <AvatarFallback className="rounded-lg">
+                  {user.name.charAt(0).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span
+                  className={cn(
+                    "truncate font-medium text-foreground transition-[filter] duration-200",
+                    hidePersonalData && "select-none blur-[5px] hover:blur-0"
+                  )}
+                >
+                  {user.name}
+                </span>
+                <span
+                  className={cn(
+                    "truncate text-muted-foreground text-xs transition-[filter] duration-200",
+                    hidePersonalData && "select-none blur-[5px] hover:blur-0"
+                  )}
+                >
+                  {user.email}
+                </span>
+              </div>
+            </div>
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => router.push(`/${slug}/settings/account`)}
+          >
+            <HugeiconsIcon icon={User02Icon} />
+            Account
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="cursor-pointer"
+          disabled={isSigningOut}
+          onClick={handleSignOut}
+          variant="destructive"
+        >
+          <HugeiconsIcon icon={Logout01Icon} />
+          {isSigningOut ? "Signing out..." : "Log Out"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import {
-  ArrowDown01Icon,
+  ArrowUp01Icon,
+  Moon02Icon,
   PlusSignIcon,
+  Settings01Icon,
+  Sun03Icon,
   Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -21,6 +24,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
+import { Kbd } from "@notra/ui/components/ui/kbd";
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -28,10 +32,12 @@ import {
   useSidebar,
 } from "@notra/ui/components/ui/sidebar";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
 import dynamic from "next/dynamic";
 import { usePathname, useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
 import { useEffect, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth/client";
@@ -172,7 +178,7 @@ function OrgSelectorTrigger({
                   </Badge>
                 ) : null}
               </div>
-              <HugeiconsIcon className="ml-auto" icon={ArrowDown01Icon} />
+              <HugeiconsIcon className="ml-auto" icon={ArrowUp01Icon} />
             </>
           )}
         </SidebarMenuButton>
@@ -250,12 +256,17 @@ export function OrgSelector() {
   const queryClient = useQueryClient();
   const { isMobile, state } = useSidebar();
   const isCollapsed = state === "collapsed";
-  const dropdownSide = isMobile ? "bottom" : isCollapsed ? "right" : "bottom";
+  const dropdownSide = isMobile ? "bottom" : isCollapsed ? "right" : "top";
+  const { setTheme, resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+  const toggleTheme = () => setTheme(isDark ? "light" : "dark");
   const { activeOrganization, organizations, isLoading } =
     useOrganizationsContext();
   const { data: customer } = useCustomer({
     expand: ["subscriptions.plan"],
   });
+
+  useHotkey("D", toggleTheme);
 
   const [isPending, startTransition] = useTransition();
   const [isSwitching, setIsSwitching] = useState(false);
@@ -388,6 +399,24 @@ export function OrgSelector() {
             >
               <HugeiconsIcon icon={PlusSignIcon} />
               Create Organization
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onClick={() =>
+                router.push(`/${activeOrganization?.slug}/settings/account`)
+              }
+            >
+              <HugeiconsIcon icon={Settings01Icon} />
+              Settings
+            </DropdownMenuItem>
+
+            <DropdownMenuItem className="cursor-pointer" onClick={toggleTheme}>
+              <HugeiconsIcon icon={isDark ? Sun03Icon : Moon02Icon} />
+              {isDark ? "Light Mode" : "Dark Mode"}
+              <Kbd className="ml-auto">D</Kbd>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -181,8 +181,7 @@
     @apply border-border outline-ring/50;
   }
   html,
-  body,
-  [data-slot="sidebar-inset"] {
+  body {
     scrollbar-gutter: stable;
   }
   body {


### PR DESCRIPTION
## Summary

Reworks the dashboard chrome around a brand-first sidebar and a profile-in-topbar layout.

**Sidebar**
- Header now shows the Notra mark + wordmark instead of the org selector. In dark mode the mark sits on the cream tile from the brand assets (matches favicon / dark wordmark treatment); in light mode it renders plain.
- Org selector moved to the footer next to the Settings link. Its dropdown opens upward, the trigger chevron points up, and it gains Settings and the Light/Dark Mode toggle (keeps the D hotkey, now registered in OrgSelector).

**Topbar**
- User profile moved to the far right as an avatar-only trigger with a full-height separator before it, mirroring the sidebar-trigger cell on the left. Dropdown keeps account info, Account link, and Log Out (dark mode item moved to the org selector).
- Solid full-height vertical separators and a solid bottom border instead of dashed, subtle bg-muted/30 tint on the header.
- Trigger and avatar cells are spaced symmetrically (16px per side, verified against the rendered DOM).

**Fix**
- scrollbar-gutter: stable was applied to the whole SidebarInset, reserving a phantom scrollbar width that pushed the header content away from the box edge. The gutter now lives on the inner scroll container only (new scrollbar-stable utility usage), so the header spans the full box width and content still does not shift when a scrollbar appears.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the dashboard layout with a brand-first sidebar header and an avatar-only profile in the topbar for better hierarchy and symmetry. Moved the org selector and theme toggle to the sidebar footer and fixed header width shifts caused by scrollbar guttering.

- **New Features**
  - Sidebar: Notra mark + wordmark in the header; org selector moved to the footer with an upward-opening menu, `Settings`, and Light/Dark Mode toggle (hotkey D).
  - Topbar: Avatar-only account trigger on the far right with full-height separators and a solid bottom border; account info, Account, and Log Out preserved.

- **Bug Fixes**
  - Scoped `scrollbar-gutter` to the inner scroll container via `scrollbar-stable`, preventing the header from being pushed inward and eliminating content shifts.

<sup>Written for commit b5de4974b1fc5956107f38e334fe72ee3234039b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

