### PR TITLE
fix(dashboard): stabilize sidebar collapse animation

### DIFF
--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -91,11 +91,11 @@ export function DashboardSidebar({
     >
       <LazyMotion features={domAnimation}>
         <SidebarHeader>
-          <div className="flex items-center gap-2 px-2 pt-1 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+          <div className="flex items-center gap-2 px-2 pt-1">
             <div className="flex size-7 shrink-0 items-center justify-center rounded-lg dark:bg-[#F6F3F1]">
               <Notra className="size-7 dark:size-5" />
             </div>
-            <span className="truncate font-semibold text-base group-data-[collapsible=icon]:hidden">
+            <span className="truncate font-semibold text-base transition-opacity duration-100 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[state=expanded]:delay-200">
               Notra
             </span>
           </div>

--- a/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
+++ b/apps/dashboard/src/components/dashboard/collapsible-nav-group.tsx
@@ -34,7 +34,11 @@ export function CollapsibleSidebarGroup({
       <SidebarGroup>
         <SidebarGroupLabel
           render={
-            <CollapsibleTrigger className="w-full cursor-pointer hover:text-sidebar-foreground [&[data-panel-open]>svg]:rotate-0">
+            <CollapsibleTrigger
+              aria-hidden={isIconMode}
+              className="w-full cursor-pointer hover:text-sidebar-foreground [&[data-panel-open]>svg]:rotate-0"
+              tabIndex={isIconMode ? -1 : undefined}
+            >
               {label}
               <HugeiconsIcon
                 className="-rotate-90 ml-1 size-3.5! text-sidebar-foreground/50 transition-transform"

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -326,7 +326,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 	return (
 		<main
 			className={cn(
-				"relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-xs md:peer-data-[variant=inset]:border",
+				"relative flex w-full flex-1 flex-col bg-background transition-[margin] duration-200 ease-linear md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-xs md:peer-data-[variant=inset]:border",
 				className,
 			)}
 			data-slot="sidebar-inset"
@@ -447,7 +447,7 @@ function SidebarGroupLabel({
 		props: mergeProps<"div">(
 			{
 				className: cn(
-					"flex h-8 shrink-0 items-center rounded-md px-2 font-medium text-sidebar-foreground/70 text-xs outline-hidden ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+					"flex h-8 shrink-0 items-center rounded-md px-2 font-medium text-sidebar-foreground/70 text-xs outline-hidden ring-sidebar-ring transition-[margin,opacity] [transition-duration:200ms,100ms] ease-linear focus-visible:ring-2 group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0 group-data-[state=expanded]:[transition-delay:0ms,200ms] [&>svg]:size-4 [&>svg]:shrink-0",
 					className,
 				),
 			},
@@ -522,7 +522,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-	"peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-inset active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-sidebar-accent data-active:font-medium data-active:text-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
+	"peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-inset active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-sidebar-accent data-active:font-medium data-active:text-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! group-data-[collapsible=icon]:[&>span]:opacity-0 group-data-[state=expanded]:[&>span]:delay-200 [&>span]:transition-opacity [&>span]:duration-100 [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
### Description
Fixes the sidebar collapse animation by keeping the Notra logo aligned with the navigation icons, synchronizing layout transitions, and preventing labels from clipping during expansion.

### Screenshot/Recording (if applicable)
before:
https://github.com/user-attachments/assets/30b3d37c-762c-4920-b168-78161999a619

after:
https://github.com/user-attachments/assets/2303cd94-6cab-4d9c-9204-1ead28c0634d

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized the dashboard sidebar collapse/expand animation to keep the Notra logo aligned and stop label flicker. Improved accessibility by removing hidden groups from the tab order in icon mode.

- **Bug Fixes**
  - Synced margin transitions in `SidebarInset` to match sidebar motion.
  - Faded and delayed header and menu labels to prevent clipping and flicker.
  - Kept header layout consistent during collapse to keep the logo aligned.
  - Removed collapsed group triggers from tab order and disabled their pointer events.

<sup>Written for commit 9f62c309d682936832a3add443e81fc40968d672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

