### PR TITLE
fix(analytics): disable JSON paths on materialized-view target datasources

### DIFF
--- a/packages/analytics/src/tinybird/datasources.ts
+++ b/packages/analytics/src/tinybird/datasources.ts
@@ -144,6 +144,7 @@ export const socialPostStatsLatest = defineDatasource(
         "provider_account_id",
       ],
     }),
+    jsonPaths: false,
   }
 );
 
@@ -182,6 +183,7 @@ export const socialAccountStatsLatest = defineDatasource(
     engine: engine.aggregatingMergeTree({
       sortingKey: ["organization_id", "provider", "provider_account_id"],
     }),
+    jsonPaths: false,
   }
 );
 
@@ -311,6 +313,7 @@ export const geoTrafficDaily = defineDatasource("geo_traffic_daily", {
     sortingKey: ["organization_id", "visitor_type", "source", "day"],
     partitionKey: "toYYYYMM(day)",
   }),
+  jsonPaths: false,
 });
 
 export const geoTrafficPagesDaily = defineDatasource(
@@ -331,6 +334,7 @@ export const geoTrafficPagesDaily = defineDatasource(
       sortingKey: ["organization_id", "visitor_type", "source", "day", "path"],
       partitionKey: "toYYYYMM(day)",
     }),
+    jsonPaths: false,
   }
 );
 


### PR DESCRIPTION
The production deploy of #656 failed at `tinybird deploy`:

```
Unsupported type in data source with JSONPaths. Unsupported type: AggregateFunction(count).
```

The SDK generates `json:` path annotations for every column by default, but Tinybird rejects JSONPaths on `AggregateFunction` columns. The four aggregate-state datasources (`social_post_stats_latest`, `social_account_stats_latest`, `geo_traffic_daily`, `geo_traffic_pages_daily`) are materialized-view targets and are never ingested directly, so they don't need JSONPaths at all.

Fix: `jsonPaths: false` on those four datasources — the SDK option documented exactly for MV targets.

Verified: `tinybird generate` emits no `json:` annotations for the four MV targets (ingestion datasources keep theirs), and the full generated project builds successfully against tinybird-local. Merging this will let the production deploy (db:migrate already applied cleanly) get past the Tinybird step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable JSONPaths on Tinybird materialized-view target datasources to fix `tinybird deploy` failures on `AggregateFunction` columns, unblocking the production deploy. `tinybird generate` now omits `json:` annotations for MV targets (ingestion datasources unchanged), and the project builds successfully against tinybird-local.

<sup>Written for commit 6ce228a487ba03ba7ed34e0f28b550a7203e93c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

