### PR TITLE
chore(dashboard): remove deprecated experimental.useCache flag

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -9,7 +9,6 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     turbopackFileSystemCacheForDev: false,
-    useCache: true,
     optimizePackageImports: ["@hugeicons/core-free-icons", "lucide-react"],
     staleTimes: {
       dynamic: 30,


### PR DESCRIPTION
### Description
Removes the deprecated `experimental.useCache` flag from the dashboard Next.js config to silence the Next 16 build warning. Nothing in the repo uses the `"use cache"` directive, so the flag was dead config; enabling the top-level `cacheComponents` option instead would opt the app into full Cache Components/PPR mode, which is a separate migration.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed deprecated `experimental.useCache` from `apps/dashboard/next.config.ts` to silence Next 16 build warnings. The app doesn’t use the `"use cache"` directive, so behavior stays the same and we avoid opting into Cache Components/PPR.

<sup>Written for commit 00e26dfac28d62180b590d68cde00c2bbb4e0c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

