### PR TITLE
fix(dashboard): widen command palette search bar

### DIFF
--- a/apps/dashboard/src/components/command-palette/command-palette.tsx
+++ b/apps/dashboard/src/components/command-palette/command-palette.tsx
@@ -416,7 +416,7 @@ export function CommandPalette() {
   return (
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent
-        className="top-[18%] w-[calc(100%-2rem)] max-w-[640px]! translate-y-0 gap-0 overflow-hidden rounded-xl! border border-border/60 p-0! shadow-2xl sm:max-w-[640px]!"
+        className="top-[18%] w-[calc(100%-2rem)] max-w-[45rem]! translate-y-0 gap-0 overflow-hidden rounded-xl! border border-border/60 p-0! shadow-2xl sm:max-w-[45rem]!"
         showCloseButton={false}
       >
         <DialogHeader className="sr-only">


### PR DESCRIPTION
Widens the command palette search dialog at the top from 40rem to 45rem max width. It stays centered, just gains a bit of room on each side.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens the dashboard command palette dialog from a 640px max width to 45rem, giving more room for results and longer queries while keeping it centered and responsive.

<sup>Written for commit a2a90ea35132d9b55cd2aefed2957f6b834b7669. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

