### PR TITLE
feat(geo): conversation sequences — multi-turn prompt tracking

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { EmptyState } from "@/components/empty-state";
+import { ConversationsCard } from "@/components/geo/conversations-card";
 import { PromptManager } from "@/components/geo/prompt-manager";
 import { PromptResultsCard } from "@/components/geo/prompt-results-card";
 import { WebsiteGenerateCard } from "@/components/geo/website-generate-card";
@@ -67,6 +68,7 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
           </p>
         </header>
         <PromptManager organizationId={organizationId} />
+        <ConversationsCard organizationId={organizationId} />
         <WebsiteGenerateCard compact organizationId={organizationId} />
         <PromptResultsCard results={promptResults?.results ?? []} />
       </div>

--- a/apps/dashboard/src/components/geo/conversation-builder-dialog.tsx
+++ b/apps/dashboard/src/components/geo/conversation-builder-dialog.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { Cancel01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { Button } from "@notra/ui/components/ui/button";
+import { Input } from "@notra/ui/components/ui/input";
+import { Label } from "@notra/ui/components/ui/label";
+import { Loader2Icon } from "lucide-react";
+import { useId, useState } from "react";
+import { GEO_PROMPT_MIN_LENGTH, GEO_SEQUENCE_MAX_TURNS } from "@/constants/geo";
+import {
+  useGeoSequenceCreate,
+  useGeoSequenceUpdate,
+} from "@/lib/hooks/use-geo";
+import type { ConversationBuilderDialogProps } from "@/types/geo";
+
+export function ConversationBuilderDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  sequence,
+}: ConversationBuilderDialogProps) {
+  const nameId = useId();
+  const create = useGeoSequenceCreate(organizationId);
+  const update = useGeoSequenceUpdate(organizationId);
+  const [name, setName] = useState(sequence?.name ?? "");
+  const [steps, setSteps] = useState<string[]>(
+    sequence && sequence.steps.length > 0 ? sequence.steps : [""]
+  );
+
+  const pending = create.isPending || update.isPending;
+  const validSteps = steps
+    .map((step) => step.trim())
+    .filter((step) => step.length >= GEO_PROMPT_MIN_LENGTH);
+  const canSave = name.trim().length > 0 && validSteps.length > 0 && !pending;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setName(sequence?.name ?? "");
+      setSteps(sequence && sequence.steps.length > 0 ? sequence.steps : [""]);
+    }
+    onOpenChange(next);
+  };
+
+  const handleSave = async () => {
+    if (!canSave) {
+      return;
+    }
+    if (sequence) {
+      await update.mutateAsync({
+        sequenceId: sequence.id,
+        name: name.trim(),
+        steps: validSteps,
+      });
+    } else {
+      await create.mutateAsync({ name: name.trim(), steps: validSteps });
+      setName("");
+      setSteps([""]);
+    }
+    onOpenChange(false);
+  };
+
+  return (
+    <ResponsiveDialog onOpenChange={handleOpenChange} open={open}>
+      <ResponsiveDialogContent className="sm:max-w-lg">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>
+            {sequence ? `Edit ${sequence.name}` : "New conversation"}
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            A real buyer conversation: an opening question and the follow-ups
+            that decide the purchase. Every turn is checked for your brand.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <div className="space-y-4 px-4 md:px-0">
+          <div className="space-y-1.5">
+            <Label htmlFor={nameId}>Name</Label>
+            <Input
+              id={nameId}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Changelog tool research"
+              value={name}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Turns</Label>
+            <div className="space-y-2">
+              {steps.map((step, index) => (
+                <div
+                  className="flex items-start gap-2"
+                  key={`turn-${index.toString()}`}
+                >
+                  <span className="mt-2 w-5 shrink-0 text-right text-muted-foreground text-xs tabular-nums">
+                    {index + 1}
+                  </span>
+                  <div className="min-w-0 flex-1 rounded-2xl rounded-tl-sm border border-border bg-muted/40 px-3 py-2">
+                    <textarea
+                      className="block w-full resize-none bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                      onChange={(event) =>
+                        setSteps((previous) =>
+                          previous.map((item, itemIndex) =>
+                            itemIndex === index ? event.target.value : item
+                          )
+                        )
+                      }
+                      placeholder={
+                        index === 0
+                          ? "What is the best tool to automate changelogs?"
+                          : "Which of those is the cheapest?"
+                      }
+                      rows={2}
+                      value={step}
+                    />
+                  </div>
+                  {steps.length > 1 && (
+                    <Button
+                      aria-label={`Remove turn ${index + 1}`}
+                      className="mt-1 shrink-0"
+                      onClick={() =>
+                        setSteps((previous) =>
+                          previous.filter((_, itemIndex) => itemIndex !== index)
+                        )
+                      }
+                      size="icon"
+                      type="button"
+                      variant="ghost"
+                    >
+                      <HugeiconsIcon icon={Cancel01Icon} size={14} />
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+            {steps.length < GEO_SEQUENCE_MAX_TURNS && (
+              <Button
+                className="ml-7"
+                onClick={() => setSteps((previous) => [...previous, ""])}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <HugeiconsIcon icon={PlusSignIcon} size={14} />
+                Add follow-up
+              </Button>
+            )}
+          </div>
+        </div>
+        <ResponsiveDialogFooter>
+          <Button disabled={!canSave} onClick={handleSave} type="button">
+            {pending && <Loader2Icon className="size-4 animate-spin" />}
+            {sequence ? "Save changes" : "Create conversation"}
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/apps/dashboard/src/components/geo/conversation-results-dialog.tsx
+++ b/apps/dashboard/src/components/geo/conversation-results-dialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { useMemo } from "react";
+import { EngineIcon } from "@/components/geo/engine-icon";
+import { useGeoSequenceResults } from "@/lib/hooks/use-geo";
+import type {
+  ConversationResultsDialogProps,
+  GeoSequenceTurnResult,
+} from "@/types/geo";
+import { engineFamilyLabel, engineFamilyOf } from "@/utils/geo-charts";
+import { buildSequenceTurnGroups } from "@/utils/geo-sequences";
+
+function EngineResult({ result }: { result: GeoSequenceTurnResult }) {
+  const label = engineFamilyLabel(engineFamilyOf(result.engine));
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-xs"
+      title={result.excerpt}
+    >
+      <EngineIcon className="size-3.5" engine={result.engine} />
+      {label}
+      {result.mentioned ? (
+        <span className="font-medium text-emerald-600 tabular-nums dark:text-emerald-400">
+          {result.position !== null ? `#${result.position}` : "Mentioned"}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">Absent</span>
+      )}
+    </span>
+  );
+}
+
+export function ConversationResultsDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  sequence,
+}: ConversationResultsDialogProps) {
+  const { data, isLoading } = useGeoSequenceResults(
+    organizationId,
+    open ? sequence?.id : undefined
+  );
+
+  const turns = useMemo(
+    () => buildSequenceTurnGroups(data?.results ?? [], sequence?.id),
+    [data, sequence]
+  );
+
+  if (!sequence) {
+    return null;
+  }
+
+  return (
+    <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
+      <ResponsiveDialogContent className="sm:max-w-2xl">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>{sequence.name}</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Where your brand shows up as the conversation unfolds.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <div className="max-h-[60svh] space-y-4 overflow-y-auto px-4 md:px-0">
+          {isLoading && <Skeleton className="h-40 w-full" />}
+          {!isLoading && turns.length === 0 && (
+            <p className="py-8 text-center text-muted-foreground text-sm">
+              No results yet. Run a scan to play this conversation against the
+              engines.
+            </p>
+          )}
+          {turns.map(([turn, results]) => (
+            <div className="flex items-start gap-2" key={turn}>
+              <span className="mt-2 w-5 shrink-0 text-right text-muted-foreground text-xs tabular-nums">
+                {turn}
+              </span>
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="rounded-2xl rounded-tl-sm border border-border bg-muted/40 px-3 py-2 text-sm">
+                  {results[0]?.prompt}
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {results.map((result) => (
+                    <EngineResult
+                      key={`${result.turn}-${result.engine}`}
+                      result={result}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/apps/dashboard/src/components/geo/conversations-card.tsx
+++ b/apps/dashboard/src/components/geo/conversations-card.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { Cancel01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@notra/ui/components/ui/button";
+import { Switch } from "@notra/ui/components/ui/switch";
+import { useState } from "react";
+import { ConversationBuilderDialog } from "@/components/geo/conversation-builder-dialog";
+import { ConversationResultsDialog } from "@/components/geo/conversation-results-dialog";
+import {
+  InstrumentEmpty,
+  InstrumentSection,
+} from "@/components/instrument/instrument-module";
+import {
+  useGeoSequenceDelete,
+  useGeoSequences,
+  useGeoSequenceUpdate,
+} from "@/lib/hooks/use-geo";
+import type { ConversationsCardProps, GeoPromptSequence } from "@/types/geo";
+
+export function ConversationsCard({ organizationId }: ConversationsCardProps) {
+  const { data } = useGeoSequences(organizationId);
+  const update = useGeoSequenceUpdate(organizationId);
+  const remove = useGeoSequenceDelete(organizationId);
+  const [builderOpen, setBuilderOpen] = useState(false);
+  const [editing, setEditing] = useState<GeoPromptSequence | null>(null);
+  const [viewing, setViewing] = useState<GeoPromptSequence | null>(null);
+
+  const sequences = data?.sequences ?? [];
+
+  return (
+    <InstrumentSection
+      action={
+        <Button
+          onClick={() => {
+            setEditing(null);
+            setBuilderOpen(true);
+          }}
+          size="sm"
+          variant="outline"
+        >
+          <HugeiconsIcon icon={PlusSignIcon} size={14} />
+          New conversation
+        </Button>
+      }
+      eyebrow={
+        sequences.length > 0
+          ? `Conversations (${sequences.length.toLocaleString()})`
+          : "Conversations"
+      }
+    >
+      {sequences.length === 0 ? (
+        <InstrumentEmpty
+          className="h-32"
+          message="Track multi-turn conversations: an opening question plus the follow-ups where buying decisions happen"
+          seed="geo-conversations"
+        />
+      ) : (
+        <div className="divide-y divide-border/60">
+          {sequences.map((sequence) => (
+            <div className="flex items-center gap-3 py-2.5" key={sequence.id}>
+              <button
+                className="min-w-0 flex-1 text-left"
+                onClick={() => setViewing(sequence)}
+                type="button"
+              >
+                <p className="truncate font-medium text-sm">{sequence.name}</p>
+                <p className="truncate text-muted-foreground text-xs">
+                  {sequence.steps.length}{" "}
+                  {sequence.steps.length === 1 ? "turn" : "turns"} ·{" "}
+                  {sequence.steps[0]}
+                </p>
+              </button>
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  onClick={() => {
+                    setEditing(sequence);
+                    setBuilderOpen(true);
+                  }}
+                  size="sm"
+                  variant="ghost"
+                >
+                  Edit
+                </Button>
+                <Switch
+                  checked={sequence.enabled}
+                  disabled={update.isPending}
+                  onCheckedChange={(enabled) =>
+                    update.mutate({ sequenceId: sequence.id, enabled })
+                  }
+                />
+                <Button
+                  aria-label={`Delete ${sequence.name}`}
+                  disabled={remove.isPending}
+                  onClick={() => remove.mutate({ sequenceId: sequence.id })}
+                  size="icon"
+                  variant="ghost"
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} size={16} />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <ConversationBuilderDialog
+        key={editing?.id ?? "new"}
+        onOpenChange={(next) => {
+          setBuilderOpen(next);
+          if (!next) {
+            setEditing(null);
+          }
+        }}
+        open={builderOpen}
+        organizationId={organizationId}
+        sequence={editing}
+      />
+      <ConversationResultsDialog
+        onOpenChange={(next) => {
+          if (!next) {
+            setViewing(null);
+          }
+        }}
+        open={viewing !== null}
+        organizationId={organizationId}
+        sequence={viewing}
+      />
+    </InstrumentSection>
+  );
+}

--- a/apps/dashboard/src/constants/geo.ts
+++ b/apps/dashboard/src/constants/geo.ts
@@ -109,7 +109,9 @@ export const GEO_MODEL_USAGE_FETCH_TIMEOUT_MS = 20_000;
 export const GEO_MODEL_USAGE_DEFAULT_LIMIT = 12;
 
 export const GEO_MAX_PROMPTS = 8;
+export const GEO_MAX_SEQUENCES = 10;
 export const GEO_COMPETITOR_SHARE_LIMIT = 50;
+export const GEO_SEQUENCE_MAX_TURNS = 5;
 export const GEO_GROUNDED_MAX_PROMPTS = 6;
 export const GEO_GROUNDED_MAX_SEARCHES = 3;
 export const GEO_ANSWER_MAX_TOKENS = 600;

--- a/apps/dashboard/src/lib/geo/errors.ts
+++ b/apps/dashboard/src/lib/geo/errors.ts
@@ -50,6 +50,16 @@ export class GeoProjectCreateFailedError extends Data.TaggedError(
   "GeoProjectCreateFailedError"
 )<Record<string, never>> {}
 
+export class GeoSequenceNotFoundError extends Data.TaggedError(
+  "GeoSequenceNotFoundError"
+)<{
+  readonly sequenceId: string;
+}> {}
+
+export class GeoSequenceCreateFailedError extends Data.TaggedError(
+  "GeoSequenceCreateFailedError"
+)<Record<string, never>> {}
+
 export type GeoRouterError =
   | GeoDatabaseError
   | GeoDiscoveryError
@@ -58,4 +68,6 @@ export type GeoRouterError =
   | GeoPromptCreateFailedError
   | GeoPromptNotFoundError
   | GeoScanStartError
+  | GeoSequenceCreateFailedError
+  | GeoSequenceNotFoundError
   | GeoSettingsMissingError;

--- a/apps/dashboard/src/lib/geo/mappers.ts
+++ b/apps/dashboard/src/lib/geo/mappers.ts
@@ -9,6 +9,8 @@ import type {
   GeoProject,
   GeoProjectRow,
   GeoPromptRow,
+  GeoPromptSequence,
+  GeoPromptSequenceRow,
   GeoSettings,
   GeoSettingsRow,
   GeoTrackedPrompt,
@@ -48,6 +50,16 @@ export function toGeoCompetitor(row: GeoCompetitorRow): GeoCompetitor {
     synonyms: row.synonyms,
     kind: row.kind,
     color: row.color,
+  };
+}
+
+export function toGeoSequence(row: GeoPromptSequenceRow): GeoPromptSequence {
+  return {
+    id: row.id,
+    name: row.name,
+    steps: row.steps,
+    enabled: row.enabled,
+    createdAt: row.createdAt.toISOString(),
   };
 }
 

--- a/apps/dashboard/src/lib/geo/scan.ts
+++ b/apps/dashboard/src/lib/geo/scan.ts
@@ -3,7 +3,12 @@ import { ingestGeoMentionChecks } from "@notra/analytics/tinybird/client";
 import type { GeoMentionCheckRow } from "@notra/analytics/tinybird/datasources";
 import { toClickHouseDateTime } from "@notra/analytics/utils/datetime";
 import { db } from "@notra/db/drizzle";
-import { brandSettings, geoPrompts, geoSettings } from "@notra/db/schema";
+import {
+  brandSettings,
+  geoPromptSequences,
+  geoPrompts,
+  geoSettings,
+} from "@notra/db/schema";
 import { generateText, type ModelMessage, Output, stepCountIs } from "ai";
 import { and, asc, eq } from "drizzle-orm";
 import { Effect } from "effect";
@@ -20,7 +25,9 @@ import {
   GEO_LANGUAGE_MAX_PROMPTS,
   GEO_MAX_LANGUAGES,
   GEO_MAX_PROMPTS,
+  GEO_MAX_SEQUENCES,
   GEO_SCAN_CONCURRENCY,
+  GEO_SEQUENCE_MAX_TURNS,
   GEO_TRANSLATION_MAX_TOKENS,
 } from "@/constants/geo";
 import { geoSkip } from "@/lib/geo/effect";
@@ -42,6 +49,7 @@ import type {
   GeoJudgeResult,
   GeoPromptDefinition,
   GeoScanResult,
+  GeoSequenceDefinition,
   GeoSettings,
   GeoSettingsRow,
 } from "@/types/geo";
@@ -361,6 +369,34 @@ const runGeoScanForProject = Effect.fn("geo.runScanProject")(function* (
     (result): result is GeoMentionCheckRow => result !== null
   );
 
+  const sequenceRows = yield* Effect.tryPromise({
+    try: () =>
+      db.query.geoPromptSequences.findMany({
+        columns: { id: true, steps: true },
+        where: and(
+          eq(geoPromptSequences.projectId, settingsRow.projectId),
+          eq(geoPromptSequences.enabled, true)
+        ),
+        orderBy: [asc(geoPromptSequences.createdAt)],
+        limit: GEO_MAX_SEQUENCES,
+      }),
+    catch: (cause) =>
+      new GeoScanError({ message: "Failed to load GEO sequences", cause }),
+  });
+
+  const sequencePairs = sequenceRows.flatMap((sequence) =>
+    groundedEngines.map((grounded) => ({ sequence, grounded }))
+  );
+  const sequenceResults = yield* Effect.forEach(
+    sequencePairs,
+    (pair) =>
+      runGeoSequenceCheck(context, pair.sequence, pair.grounded).pipe(
+        geoSkip(`sequence failed for ${pair.grounded.key}/${pair.sequence.id}`)
+      ),
+    { concurrency: GEO_SCAN_CONCURRENCY }
+  );
+  rows.push(...sequenceResults.filter((result) => result !== null).flat());
+
   yield* Effect.tryPromise({
     try: () => ingestGeoMentionChecks(rows),
     catch: (cause) =>
@@ -373,6 +409,43 @@ const runGeoScanForProject = Effect.fn("geo.runScanProject")(function* (
     mentions: rows.filter((row) => row.mentioned).length,
   };
   return completed;
+});
+
+const runGeoSequenceCheck = Effect.fn("geo.runSequenceCheck")(function* (
+  context: GeoCheckContext,
+  sequence: GeoSequenceDefinition,
+  grounded: GeoGroundedEngine
+) {
+  const rows: GeoMentionCheckRow[] = [];
+  const messages: ModelMessage[] = [];
+  const steps = sequence.steps.slice(0, GEO_SEQUENCE_MAX_TURNS);
+
+  for (const [index, step] of steps.entries()) {
+    messages.push({ role: "user", content: step });
+    const answer = yield* askGroundedConversation(grounded, messages);
+    messages.push({ role: "assistant", content: answer });
+    const judged = yield* judgeAnswer(context, step, answer);
+
+    rows.push({
+      organization_id: context.organizationId,
+      project_id: context.projectId,
+      scan_id: context.scanId,
+      engine: grounded.key,
+      prompt_id: `sequence-${sequence.id}`,
+      sequence_id: sequence.id,
+      turn: index + 1,
+      prompt: step,
+      captured_at: context.capturedAt,
+      mentioned: judged.mentioned,
+      position: normalizePosition(judged.position),
+      sentiment: judged.sentiment,
+      competitors: judged.competitors.slice(0, MAX_JUDGE_COMPETITORS),
+      excerpt: judged.excerpt.slice(0, GEO_EXCERPT_MAX_LENGTH),
+      language: "English",
+    });
+  }
+
+  return rows;
 });
 
 export const runGeoScan = Effect.fn("geo.runScan")(function* (

--- a/apps/dashboard/src/lib/geo/sequences.ts
+++ b/apps/dashboard/src/lib/geo/sequences.ts
@@ -1,0 +1,157 @@
+import {
+  isTinybirdConfigured,
+  queryGeoSequenceResults,
+} from "@notra/analytics/tinybird/client";
+import { db } from "@notra/db/drizzle";
+import { geoPromptSequences } from "@notra/db/schema";
+import { and, asc, eq } from "drizzle-orm";
+import { Effect } from "effect";
+import { geoDb, geoQuery } from "@/lib/geo/effect";
+import {
+  GeoSequenceCreateFailedError,
+  GeoSequenceNotFoundError,
+} from "@/lib/geo/errors";
+import { toGeoSequence, toNullableNumber } from "@/lib/geo/mappers";
+import {
+  geoScopeParams,
+  requireGeoProject,
+  resolveGeoScope,
+} from "@/lib/geo/projects";
+import type {
+  GeoScopeInput,
+  GeoSequenceCreateInput,
+  GeoSequenceResultsResponse,
+  GeoSequencesResponse,
+  GeoSequenceUpdateInput,
+} from "@/types/geo";
+
+export const listGeoSequences = Effect.fn("geo.sequencesList")(function* (
+  input: GeoScopeInput
+) {
+  const scope = yield* resolveGeoScope(input);
+  if (!scope.projectId) {
+    const emptyResponse: GeoSequencesResponse = { sequences: [] };
+    return emptyResponse;
+  }
+
+  const projectId = scope.projectId;
+  const rows = yield* geoDb("sequences lookup failed", () =>
+    db.query.geoPromptSequences.findMany({
+      where: eq(geoPromptSequences.projectId, projectId),
+      orderBy: [asc(geoPromptSequences.createdAt)],
+    })
+  );
+
+  const response: GeoSequencesResponse = {
+    sequences: rows.map(toGeoSequence),
+  };
+  return response;
+});
+
+export const createGeoSequence = Effect.fn("geo.sequenceCreate")(function* (
+  input: GeoScopeInput,
+  sequence: GeoSequenceCreateInput
+) {
+  const scope = yield* requireGeoProject(input);
+  const rows = yield* geoDb("sequence create failed", () =>
+    db
+      .insert(geoPromptSequences)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: scope.organizationId,
+        projectId: scope.projectId,
+        name: sequence.name,
+        steps: sequence.steps,
+      })
+      .returning()
+  );
+
+  const row = rows.at(0);
+  if (!row) {
+    return yield* Effect.fail(new GeoSequenceCreateFailedError({}));
+  }
+
+  return toGeoSequence(row);
+});
+
+export const updateGeoSequence = Effect.fn("geo.sequenceUpdate")(function* (
+  input: GeoScopeInput,
+  update: GeoSequenceUpdateInput
+) {
+  const rows = yield* geoDb("sequence update failed", () =>
+    db
+      .update(geoPromptSequences)
+      .set({
+        ...(update.name === undefined ? {} : { name: update.name }),
+        ...(update.steps === undefined ? {} : { steps: update.steps }),
+        ...(update.enabled === undefined ? {} : { enabled: update.enabled }),
+      })
+      .where(
+        and(
+          eq(geoPromptSequences.id, update.sequenceId),
+          eq(geoPromptSequences.organizationId, input.organizationId)
+        )
+      )
+      .returning()
+  );
+
+  const row = rows.at(0);
+  if (!row) {
+    return yield* Effect.fail(
+      new GeoSequenceNotFoundError({ sequenceId: update.sequenceId })
+    );
+  }
+
+  return toGeoSequence(row);
+});
+
+export const deleteGeoSequence = Effect.fn("geo.sequenceDelete")(function* (
+  input: GeoScopeInput,
+  sequenceId: string
+) {
+  const rows = yield* geoDb("sequence delete failed", () =>
+    db
+      .delete(geoPromptSequences)
+      .where(
+        and(
+          eq(geoPromptSequences.id, sequenceId),
+          eq(geoPromptSequences.organizationId, input.organizationId)
+        )
+      )
+      .returning()
+  );
+
+  if (!rows.at(0)) {
+    return yield* Effect.fail(new GeoSequenceNotFoundError({ sequenceId }));
+  }
+
+  return { success: true };
+});
+
+export const loadGeoSequenceResults = Effect.fn("geo.sequenceResults")(
+  function* (input: GeoScopeInput, sequenceId: string | undefined) {
+    const scope = yield* resolveGeoScope(input);
+    const result = yield* geoQuery("sequence results query failed", () =>
+      queryGeoSequenceResults({
+        ...geoScopeParams(scope),
+        sequence_id: sequenceId ?? "",
+      })
+    );
+
+    const response: GeoSequenceResultsResponse = {
+      configured: isTinybirdConfigured(),
+      results: (result?.data ?? []).map((row) => ({
+        sequenceId: row.sequence_id,
+        turn: Number(row.turn),
+        engine: row.engine,
+        prompt: row.prompt,
+        mentioned: row.mentioned,
+        position: toNullableNumber(row.position),
+        sentiment: row.sentiment,
+        excerpt: row.excerpt,
+        lastCheckedAt: row.last_checked_at,
+      })),
+    };
+    return response;
+  }
+);

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -23,7 +23,13 @@ import type {
   GeoPromptCreateInput,
   GeoPromptDeleteInput,
   GeoPromptResultsResponse,
+  GeoPromptSequence,
   GeoPromptToggleInput,
+  GeoSequenceCreateInput,
+  GeoSequenceDeleteInput,
+  GeoSequenceResultsResponse,
+  GeoSequencesResponse,
+  GeoSequenceUpdateInput,
   GeoSettingsResponse,
   GeoSettingsUpsertInput,
   GeoTimeseriesResponse,
@@ -72,6 +78,18 @@ async function invalidatePromptQueries(
 ) {
   await queryClient.invalidateQueries({
     queryKey: dashboardOrpc.geo.promptsList.queryKey({
+      input: { organizationId, projectId },
+    }),
+  });
+}
+
+async function invalidateSequenceQueries(
+  queryClient: QueryClient,
+  organizationId: string,
+  projectId: string | undefined
+) {
+  await queryClient.invalidateQueries({
+    queryKey: dashboardOrpc.geo.sequencesList.queryKey({
       input: { organizationId, projectId },
     }),
   });
@@ -466,6 +484,92 @@ export function useGeoProjectCreate(organizationId: string) {
     },
     onError: (error) => {
       toast.error(toErrorMessage(error, "Failed to create project"));
+    },
+  });
+}
+
+export function useGeoSequences(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  return useQuery<GeoSequencesResponse>({
+    ...dashboardOrpc.geo.sequencesList.queryOptions({
+      input: { organizationId, projectId },
+    }),
+    enabled: !!organizationId,
+    meta: { errorMessage: "Failed to load conversations" },
+  });
+}
+
+export function useGeoSequenceResults(
+  organizationId: string,
+  sequenceId?: string
+) {
+  const { projectId } = useGeoProjectScope();
+  return useQuery<GeoSequenceResultsResponse>({
+    ...dashboardOrpc.geo.sequenceResults.queryOptions({
+      input: { organizationId, projectId, sequenceId },
+    }),
+    enabled: !!organizationId,
+    meta: { errorMessage: "Failed to load conversation results" },
+  });
+}
+
+export function useGeoSequenceCreate(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: GeoSequenceCreateInput): Promise<GeoPromptSequence> =>
+      dashboardOrpc.geo.sequencesCreate.call({
+        ...input,
+        organizationId,
+        projectId,
+      }),
+    onSuccess: async () => {
+      await invalidateSequenceQueries(queryClient, organizationId, projectId);
+      toast.success("Conversation added");
+    },
+    onError: (error) => {
+      toast.error(toErrorMessage(error, "Failed to add conversation"));
+    },
+  });
+}
+
+export function useGeoSequenceUpdate(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: GeoSequenceUpdateInput): Promise<GeoPromptSequence> =>
+      dashboardOrpc.geo.sequencesUpdate.call({
+        ...input,
+        organizationId,
+        projectId,
+      }),
+    onSuccess: async () => {
+      await invalidateSequenceQueries(queryClient, organizationId, projectId);
+    },
+    onError: (error) => {
+      toast.error(toErrorMessage(error, "Failed to update conversation"));
+    },
+  });
+}
+
+export function useGeoSequenceDelete(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (
+      input: GeoSequenceDeleteInput
+    ): Promise<{ success: boolean }> =>
+      dashboardOrpc.geo.sequencesDelete.call({
+        ...input,
+        organizationId,
+        projectId,
+      }),
+    onSuccess: async () => {
+      await invalidateSequenceQueries(queryClient, organizationId, projectId);
+      toast.success("Conversation removed");
+    },
+    onError: (error) => {
+      toast.error(toErrorMessage(error, "Failed to remove conversation"));
     },
   });
 }

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -28,6 +28,13 @@ import {
 } from "@/lib/geo/programs";
 import { createGeoProject, listGeoProjects } from "@/lib/geo/projects";
 import {
+  createGeoSequence,
+  deleteGeoSequence,
+  listGeoSequences,
+  loadGeoSequenceResults,
+  updateGeoSequence,
+} from "@/lib/geo/sequences";
+import {
   buildGeoAppUrl,
   buildGeoIngestUrl,
   buildGeoSnippet,
@@ -49,6 +56,10 @@ import {
   geoPromptCreateInputSchema,
   geoPromptDeleteInputSchema,
   geoPromptToggleInputSchema,
+  geoSequenceCreateInputSchema,
+  geoSequenceDeleteInputSchema,
+  geoSequenceResultsInputSchema,
+  geoSequenceUpdateInputSchema,
   geoSettingsUpsertInputSchema,
   geoTimeseriesInputSchema,
   geoTrafficJourneysInputSchema,
@@ -195,6 +206,23 @@ export const geoRouter = {
       geoHandler((input) =>
         toggleGeoPrompt(input.organizationId, input.promptId, input.enabled)
       )
+    ),
+  sequencesList: authorizedProcedure
+    .input(geoOrganizationInputSchema)
+    .handler(geoHandler((input) => listGeoSequences(input))),
+  sequencesCreate: authorizedProcedure
+    .input(geoSequenceCreateInputSchema)
+    .handler(geoHandler((input) => createGeoSequence(input, input))),
+  sequencesUpdate: authorizedProcedure
+    .input(geoSequenceUpdateInputSchema)
+    .handler(geoHandler((input) => updateGeoSequence(input, input))),
+  sequencesDelete: authorizedProcedure
+    .input(geoSequenceDeleteInputSchema)
+    .handler(geoHandler((input) => deleteGeoSequence(input, input.sequenceId))),
+  sequenceResults: authorizedProcedure
+    .input(geoSequenceResultsInputSchema)
+    .handler(
+      geoHandler((input) => loadGeoSequenceResults(input, input.sequenceId))
     ),
   projectsList: authorizedProcedure
     .input(geoOrganizationInputSchema)

--- a/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
+++ b/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
@@ -12,6 +12,10 @@ export function toGeoOrpcError(failure: GeoRouterError): Error {
       return notFound("Project not found");
     case "GeoProjectCreateFailedError":
       return badRequest("Failed to create project");
+    case "GeoSequenceNotFoundError":
+      return notFound("Conversation not found");
+    case "GeoSequenceCreateFailedError":
+      return badRequest("Failed to create conversation");
     case "GeoSettingsMissingError":
       return badRequest("Configure your brand tracking settings first");
     case "GeoDiscoveryError":

--- a/apps/dashboard/src/schemas/geo.ts
+++ b/apps/dashboard/src/schemas/geo.ts
@@ -17,6 +17,7 @@ import {
   GEO_MAX_LANGUAGES,
   GEO_PROMPT_MAX_LENGTH,
   GEO_PROMPT_MIN_LENGTH,
+  GEO_SEQUENCE_MAX_TURNS,
 } from "@/constants/geo";
 import { normalizeCompetitorDomain } from "@/lib/geo/domain";
 import { publicWebsiteUrlSchema } from "@/schemas/url";
@@ -101,6 +102,31 @@ export const geoCompetitorDetailInputSchema = geoOrganizationInputSchema.extend(
 
 export const geoTranslationResultSchema = object({
   translations: array(string().min(1)),
+});
+
+export const geoSequenceCreateInputSchema = geoOrganizationInputSchema.extend({
+  name: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
+  steps: array(string().trim().min(MIN_PROMPT_LENGTH).max(MAX_PROMPT_LENGTH))
+    .min(1)
+    .max(GEO_SEQUENCE_MAX_TURNS),
+});
+
+export const geoSequenceUpdateInputSchema = geoOrganizationInputSchema.extend({
+  sequenceId: string().min(1),
+  name: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
+  steps: array(string().trim().min(MIN_PROMPT_LENGTH).max(MAX_PROMPT_LENGTH))
+    .min(1)
+    .max(GEO_SEQUENCE_MAX_TURNS)
+    .optional(),
+  enabled: boolean().optional(),
+});
+
+export const geoSequenceDeleteInputSchema = geoOrganizationInputSchema.extend({
+  sequenceId: string().min(1),
+});
+
+export const geoSequenceResultsInputSchema = geoOrganizationInputSchema.extend({
+  sequenceId: string().min(1).optional(),
 });
 
 export const geoProjectCreateInputSchema = object({

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -247,6 +247,80 @@ export interface GeoTrackedPromptsResponse {
   prompts: GeoTrackedPrompt[];
 }
 
+export interface GeoPromptSequence {
+  id: string;
+  name: string;
+  steps: string[];
+  enabled: boolean;
+  createdAt: string;
+}
+
+export interface GeoPromptSequenceRow {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  name: string;
+  steps: string[];
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface GeoSequencesResponse {
+  sequences: GeoPromptSequence[];
+}
+
+export interface GeoSequenceCreateInput {
+  name: string;
+  steps: string[];
+}
+
+export interface GeoSequenceUpdateInput {
+  sequenceId: string;
+  name?: string;
+  steps?: string[];
+  enabled?: boolean;
+}
+
+export interface GeoSequenceDeleteInput {
+  sequenceId: string;
+}
+
+export interface GeoSequenceTurnResult {
+  sequenceId: string;
+  turn: number;
+  engine: string;
+  prompt: string;
+  mentioned: boolean;
+  position: number | null;
+  sentiment: string | null;
+  excerpt: string;
+  lastCheckedAt: string;
+}
+
+export interface GeoSequenceResultsResponse {
+  configured: boolean;
+  results: GeoSequenceTurnResult[];
+}
+
+export interface ConversationsCardProps {
+  organizationId: string;
+}
+
+export interface ConversationBuilderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  sequence: GeoPromptSequence | null;
+}
+
+export interface ConversationResultsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  sequence: GeoPromptSequence | null;
+}
+
 export interface GeoScanPayload {
   organizationId: string;
   projectId?: string;
@@ -277,6 +351,11 @@ export interface GeoCheckContext {
   capturedAt: string;
   companyName: string;
   aliases: string[];
+}
+
+export interface GeoSequenceDefinition {
+  id: string;
+  steps: string[];
 }
 
 export interface GeoBrandContext {

--- a/apps/dashboard/src/utils/geo-sequences.ts
+++ b/apps/dashboard/src/utils/geo-sequences.ts
@@ -1,0 +1,17 @@
+import type { GeoSequenceTurnResult } from "@/types/geo";
+
+export function buildSequenceTurnGroups(
+  results: readonly GeoSequenceTurnResult[],
+  sequenceId: string | undefined
+): [number, GeoSequenceTurnResult[]][] {
+  const grouped = new Map<number, GeoSequenceTurnResult[]>();
+  for (const result of results) {
+    if (result.sequenceId !== sequenceId) {
+      continue;
+    }
+    const entries = grouped.get(result.turn) ?? [];
+    entries.push(result);
+    grouped.set(result.turn, entries);
+  }
+  return [...grouped.entries()].sort(([left], [right]) => left - right);
+}


### PR DESCRIPTION
Stacked on #657. Splits the conversation-sequences feature out of the main GEO PR into its own reviewable unit.

**What's here (app layer):**
- `ConversationsCard` + builder/results dialogs on the GEO prompts page
- `lib/geo/sequences.ts` (CRUD + results loading) and `utils/geo-sequences.ts`
- `geo.sequences*` oRPC procedures, Zod schemas, hooks, error mapping
- Scan-engine integration: enabled sequences run as multi-turn grounded conversations during each GEO scan, judged per turn

**Deliberately left in the base PR (#657):** the `geo_prompt_sequences` table (migration 0063 is already applied to staging/preview DBs — re-splitting applied migrations is not worth the risk) and the `geoSequenceResults` Tinybird pipe (deploys are declarative and additive).

Merge order: #657 first, then this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds conversation sequences to GEO so teams can create, edit, enable, and track multi-turn buyer conversations, then view per-turn engine results. Sequences run during scans as grounded chats, with brand checks at each turn.

- **New Features**
  - UI: `ConversationsCard` with builder and results dialogs on the GEO prompts page.
  - API & Hooks: CRUD and results via `geo.sequences*` oRPC procedures, Zod schemas, React hooks, and error mapping.
  - Scan Engine: Executes enabled sequences across grounded engines; judges each turn and ingests results.
  - Validation & Limits: `GEO_MAX_SEQUENCES` and `GEO_SEQUENCE_MAX_TURNS` enforced, plus prompt length checks and turn grouping utility.

<sup>Written for commit 97321fb806a6dc668225b335ef99af212dcc77c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

