### PR TITLE
perf(analytics): X API cost controls + databuddy feature flag

### DIFF
--- a/apps/dashboard/scripts/register-analytics-schedule.ts
+++ b/apps/dashboard/scripts/register-analytics-schedule.ts
@@ -1,8 +1,8 @@
 import { getAppUrl } from "@notra/ai/qstash/triggers";
 import { Client as QStashClient } from "@upstash/qstash";
 
-const HOURLY_CRON = "0 * * * *";
-const SCHEDULE_ID = "social-analytics-sync-hourly";
+const TWICE_DAILY_CRON = "0 6,18 * * *";
+const SCHEDULE_ID = "social-analytics-sync";
 
 const token = process.env.QSTASH_TOKEN;
 if (!token) {
@@ -15,12 +15,12 @@ const destination = `${getAppUrl()}/api/workflows/social-analytics-sync`;
 const result = await client.schedules.create({
   scheduleId: SCHEDULE_ID,
   destination,
-  cron: HOURLY_CRON,
+  cron: TWICE_DAILY_CRON,
   body: JSON.stringify({}),
   headers: { "Content-Type": "application/json" },
 });
 
 console.log(
-  `Registered schedule ${result.scheduleId ?? SCHEDULE_ID} -> ${destination} (${HOURLY_CRON})`
+  `Registered schedule ${result.scheduleId ?? SCHEDULE_ID} -> ${destination} (${TWICE_DAILY_CRON})`
 );
 process.exit(0);

--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -29,8 +29,13 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Fragment, memo } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { SOCIAL_ANALYTICS_FLAG_KEY } from "@/constants/analytics";
 import { IRIS_FLAG_KEY, IRIS_NAV_LINK } from "@/constants/iris";
 import type { NavMainCategory, NavMainItem } from "@/types/components/nav";
+import {
+  filterAnalyticsNavItems,
+  isAnalyticsVisibleInNav,
+} from "@/utils/analytics-flag";
 import { filterIrisNavItems, isIrisVisibleInNav } from "@/utils/iris-flag";
 import { resolveActiveNavLink } from "@/utils/nav";
 import { CollapsibleSidebarGroup } from "./collapsible-nav-group";
@@ -191,6 +196,8 @@ export function NavMain() {
   const pathname = usePathname();
   const irisFlag = useFlag(IRIS_FLAG_KEY);
   const irisVisible = isIrisVisibleInNav(irisFlag.on);
+  const analyticsFlag = useFlag(SOCIAL_ANALYTICS_FLAG_KEY);
+  const analyticsVisible = isAnalyticsVisibleInNav(analyticsFlag.on);
 
   if (!activeOrganization?.slug) {
     return null;
@@ -211,7 +218,10 @@ export function NavMain() {
         <Fragment key={category}>
           <NavGroup
             activeLink={activeLink}
-            items={filterIrisNavItems(itemsByCategory[category], irisVisible)}
+            items={filterAnalyticsNavItems(
+              filterIrisNavItems(itemsByCategory[category], irisVisible),
+              analyticsVisible
+            )}
             label={categoryLabels[category]}
             slug={slug}
           />

--- a/apps/dashboard/src/constants/analytics.ts
+++ b/apps/dashboard/src/constants/analytics.ts
@@ -3,6 +3,14 @@ import type {
   PostingActivityLevel,
 } from "@/types/analytics";
 
+export const SOCIAL_ANALYTICS_FLAG_KEY = "social-analytics";
+export const ANALYTICS_NAV_LINK = "/analytics";
+export const ANALYTICS_FLAG_CACHE_TTL_MS = 60_000;
+export const ANALYTICS_FLAG_STALE_TIME_MS = 30_000;
+export const ANALYTICS_FLAG_ERROR_REASON = "ERROR";
+export const ANALYTICS_UNAVAILABLE_DESCRIPTION =
+  "Analytics is not available for this workspace yet.";
+
 export const ANALYTICS_TIMESERIES_DAYS = 30;
 export const ANALYTICS_TOP_POSTS_LIMIT = 8;
 export const TOP_POST_CONTENT_PREVIEW_LENGTH = 96;

--- a/apps/dashboard/src/lib/analytics/access.ts
+++ b/apps/dashboard/src/lib/analytics/access.ts
@@ -1,0 +1,12 @@
+import { ANALYTICS_UNAVAILABLE_DESCRIPTION } from "@/constants/analytics";
+import { isAnalyticsEnabledForOrganization } from "@/lib/analytics/flag";
+import { forbidden } from "@/lib/orpc/utils/errors";
+
+export async function assertAnalyticsEnabled(
+  organizationId: string
+): Promise<void> {
+  const enabled = await isAnalyticsEnabledForOrganization(organizationId);
+  if (!enabled) {
+    throw forbidden(ANALYTICS_UNAVAILABLE_DESCRIPTION);
+  }
+}

--- a/apps/dashboard/src/lib/analytics/constants.ts
+++ b/apps/dashboard/src/lib/analytics/constants.ts
@@ -1,6 +1,8 @@
 export const TWITTER_USER_BATCH_SIZE = 100;
 export const TWITTER_TIMELINE_MAX_RESULTS = 100;
-export const TWITTER_TIMELINE_MAX_PAGES = 5;
+export const TWITTER_TIMELINE_MAX_PAGES = 2;
+export const TWITTER_TIMELINE_WINDOW_DAYS = 7;
+export const DAY_IN_MS = 24 * 60 * 60 * 1000;
 export const TWITTER_USER_FIELDS =
   "public_metrics,verified,verified_type,profile_image_url,name";
 export const TWITTER_TWEET_FIELDS = "text,created_at,public_metrics";

--- a/apps/dashboard/src/lib/analytics/errors.ts
+++ b/apps/dashboard/src/lib/analytics/errors.ts
@@ -38,3 +38,10 @@ export type AnalyticsRouterError =
   | AnalyticsDatabaseError
   | AnalyticsRequestError
   | TrackedAccountNotFoundError;
+
+export class AnalyticsFlagEvaluationError extends Data.TaggedError(
+  "AnalyticsFlagEvaluationError"
+)<{
+  readonly message: string;
+  readonly cause: unknown;
+}> {}

--- a/apps/dashboard/src/lib/analytics/flag.ts
+++ b/apps/dashboard/src/lib/analytics/flag.ts
@@ -1,0 +1,81 @@
+import {
+  createServerFlagsManager,
+  type ServerFlagsManager,
+} from "@databuddy/sdk/node";
+import { Effect } from "effect";
+import {
+  ANALYTICS_FLAG_CACHE_TTL_MS,
+  ANALYTICS_FLAG_ERROR_REASON,
+  ANALYTICS_FLAG_STALE_TIME_MS,
+  SOCIAL_ANALYTICS_FLAG_KEY,
+} from "@/constants/analytics";
+import { AnalyticsFlagEvaluationError } from "@/lib/analytics/errors";
+import type { AnalyticsFlagState } from "@/types/analytics";
+
+const clientId = process.env.NEXT_PUBLIC_DATABUDDY_DASHBOARD_WEBSITE_ID ?? "";
+
+let cachedManager: ServerFlagsManager | null = null;
+
+function getFlagsManager(): ServerFlagsManager | null {
+  if (clientId.length === 0) {
+    return null;
+  }
+
+  if (!cachedManager) {
+    cachedManager = createServerFlagsManager({
+      clientId,
+      autoFetch: false,
+      cacheTtl: ANALYTICS_FLAG_CACHE_TTL_MS,
+      staleTime: ANALYTICS_FLAG_STALE_TIME_MS,
+      skipStorage: true,
+    });
+  }
+
+  return cachedManager;
+}
+
+function resolveAnalyticsFlagState(
+  organizationId: string
+): Effect.Effect<AnalyticsFlagState> {
+  return Effect.gen(function* () {
+    if (process.env.NODE_ENV === "development") {
+      return "enabled";
+    }
+
+    const manager = getFlagsManager();
+    if (!manager) {
+      return "disabled";
+    }
+
+    return yield* Effect.tryPromise({
+      try: () =>
+        manager.getFlag(SOCIAL_ANALYTICS_FLAG_KEY, {
+          organizationId,
+          properties: { organizationId },
+        }),
+      catch: (cause) =>
+        new AnalyticsFlagEvaluationError({
+          message: "Failed to evaluate the analytics feature flag",
+          cause,
+        }),
+    }).pipe(
+      Effect.map((result): AnalyticsFlagState => {
+        if (result.reason === ANALYTICS_FLAG_ERROR_REASON) {
+          return "unavailable";
+        }
+        return result.enabled ? "enabled" : "disabled";
+      }),
+      Effect.catch(() => Effect.succeed<AnalyticsFlagState>("unavailable"))
+    );
+  });
+}
+
+export function isAnalyticsEnabledForOrganization(
+  organizationId: string
+): Promise<boolean> {
+  return Effect.runPromise(
+    resolveAnalyticsFlagState(organizationId).pipe(
+      Effect.map((state) => state === "enabled")
+    )
+  );
+}

--- a/apps/dashboard/src/lib/analytics/twitter-sync.ts
+++ b/apps/dashboard/src/lib/analytics/twitter-sync.ts
@@ -4,8 +4,10 @@ import type {
   SocialPostStatsRow,
 } from "@notra/analytics/tinybird/datasources";
 import {
+  DAY_IN_MS,
   TWITTER_TIMELINE_MAX_PAGES,
   TWITTER_TIMELINE_MAX_RESULTS,
+  TWITTER_TIMELINE_WINDOW_DAYS,
   TWITTER_TWEET_FIELDS,
   TWITTER_USER_BATCH_SIZE,
   TWITTER_USER_FIELDS,
@@ -53,7 +55,7 @@ async function fetchTwitterUsersBatch(
   return users;
 }
 
-async function fetchUserTweets(userId: string) {
+async function fetchUserTweets(userId: string, startTime: Date) {
   const tweets: TwitterTimelineResponse["data"] = [];
   let paginationToken: string | undefined;
 
@@ -61,6 +63,7 @@ async function fetchUserTweets(userId: string) {
     const params = new URLSearchParams({
       max_results: String(TWITTER_TIMELINE_MAX_RESULTS),
       exclude: "replies,retweets",
+      start_time: startTime.toISOString(),
       "tweet.fields": TWITTER_TWEET_FIELDS,
     });
     if (paginationToken) {
@@ -104,6 +107,9 @@ export async function collectTwitterRows(
   const usersByUsername = new Map(
     users.map((user) => [user.username.toLowerCase(), user])
   );
+  const timelineStart = new Date(
+    capturedAt.getTime() - TWITTER_TIMELINE_WINDOW_DAYS * DAY_IN_MS
+  );
 
   for (const account of accounts) {
     const user = usersByUsername.get(account.username.toLowerCase());
@@ -113,7 +119,7 @@ export async function collectTwitterRows(
     rows.accountStats.push(
       buildTwitterAccountStatsRow(account, user, capturedAt)
     );
-    const tweets = await fetchUserTweets(user.id);
+    const tweets = await fetchUserTweets(user.id, timelineStart);
     for (const tweet of tweets) {
       rows.posts.push(buildTweetPostRow(account, tweet, capturedAt));
       rows.postStats.push(buildTweetStatsRow(account, tweet, capturedAt));

--- a/apps/dashboard/src/lib/analytics/twitter-sync.ts
+++ b/apps/dashboard/src/lib/analytics/twitter-sync.ts
@@ -111,18 +111,29 @@ export async function collectTwitterRows(
     capturedAt.getTime() - TWITTER_TIMELINE_WINDOW_DAYS * DAY_IN_MS
   );
 
-  for (const account of accounts) {
-    const user = usersByUsername.get(account.username.toLowerCase());
-    if (!user) {
+  const timelines = await Promise.all(
+    accounts.map(async (account) => {
+      const user = usersByUsername.get(account.username.toLowerCase());
+      if (!user) {
+        return null;
+      }
+      const tweets = await fetchUserTweets(user.id, timelineStart);
+      return { account, user, tweets };
+    })
+  );
+
+  for (const timeline of timelines) {
+    if (!timeline) {
       continue;
     }
     rows.accountStats.push(
-      buildTwitterAccountStatsRow(account, user, capturedAt)
+      buildTwitterAccountStatsRow(timeline.account, timeline.user, capturedAt)
     );
-    const tweets = await fetchUserTweets(user.id, timelineStart);
-    for (const tweet of tweets) {
-      rows.posts.push(buildTweetPostRow(account, tweet, capturedAt));
-      rows.postStats.push(buildTweetStatsRow(account, tweet, capturedAt));
+    for (const tweet of timeline.tweets) {
+      rows.posts.push(buildTweetPostRow(timeline.account, tweet, capturedAt));
+      rows.postStats.push(
+        buildTweetStatsRow(timeline.account, tweet, capturedAt)
+      );
     }
   }
 

--- a/apps/dashboard/src/lib/orpc/routers/analytics.ts
+++ b/apps/dashboard/src/lib/orpc/routers/analytics.ts
@@ -1,3 +1,4 @@
+import { assertAnalyticsEnabled } from "@/lib/analytics/access";
 import {
   loadEngagementTimeseries,
   loadFollowerGrowth,
@@ -43,6 +44,7 @@ export const analyticsRouter = {
         organizationId: input.organizationId,
         user: context.user,
       });
+      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadSocialOverview(input.organizationId),
@@ -58,6 +60,7 @@ export const analyticsRouter = {
           organizationId: input.organizationId,
           user: context.user,
         });
+        await assertAnalyticsEnabled(input.organizationId);
 
         return await runOrpcEffect(
           loadEngagementTimeseries(input.organizationId, {
@@ -78,6 +81,7 @@ export const analyticsRouter = {
         organizationId: input.organizationId,
         user: context.user,
       });
+      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadTopPosts(input.organizationId, input.limit, {
@@ -96,6 +100,7 @@ export const analyticsRouter = {
         organizationId: input.organizationId,
         user: context.user,
       });
+      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadNotraAdoption(input.organizationId),
@@ -111,6 +116,7 @@ export const analyticsRouter = {
           organizationId: input.organizationId,
           user: context.user,
         });
+        await assertAnalyticsEnabled(input.organizationId);
 
         return await runOrpcEffect(
           loadPostingPerformance(input.organizationId, {
@@ -131,6 +137,7 @@ export const analyticsRouter = {
         organizationId: input.organizationId,
         user: context.user,
       });
+      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadLeaderboard(input.organizationId, input.days, {
@@ -150,6 +157,7 @@ export const analyticsRouter = {
           organizationId: input.organizationId,
           user: context.user,
         });
+        await assertAnalyticsEnabled(input.organizationId);
 
         return await runOrpcEffect(
           previewTrackedAccount(input.username),
@@ -165,6 +173,7 @@ export const analyticsRouter = {
         organizationId: input.organizationId,
         user: context.user,
       });
+      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         trackTwitterAccount(input.organizationId, input.username),
@@ -179,6 +188,7 @@ export const analyticsRouter = {
         organizationId: input.organizationId,
         user: context.user,
       });
+      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         untrackTwitterAccount(input.organizationId, input.trackedAccountId),
@@ -193,6 +203,7 @@ export const analyticsRouter = {
         organizationId: input.organizationId,
         user: context.user,
       });
+      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadFollowerGrowth(input.organizationId, {

--- a/apps/dashboard/src/types/analytics.ts
+++ b/apps/dashboard/src/types/analytics.ts
@@ -378,6 +378,8 @@ export interface AnalyticsPageClientProps {
 
 export type AnalyticsProviderFilter = "all" | "twitter" | "linkedin";
 
+export type AnalyticsFlagState = "enabled" | "disabled" | "unavailable";
+
 export interface AccountDetailViewProps {
   organizationSlug: string;
   handle: string;

--- a/apps/dashboard/src/utils/analytics-flag.ts
+++ b/apps/dashboard/src/utils/analytics-flag.ts
@@ -1,0 +1,16 @@
+import { ANALYTICS_NAV_LINK } from "@/constants/analytics";
+import type { NavMainItem } from "@/types/components/nav";
+
+export function isAnalyticsVisibleInNav(flagOn: boolean): boolean {
+  return flagOn || process.env.NODE_ENV === "development";
+}
+
+export function filterAnalyticsNavItems(
+  items: NavMainItem[],
+  analyticsVisible: boolean
+): NavMainItem[] {
+  if (analyticsVisible) {
+    return items;
+  }
+  return items.filter((item) => item.link !== ANALYTICS_NAV_LINK);
+}

--- a/apps/dashboard/src/workflows/steps/social-analytics-steps.ts
+++ b/apps/dashboard/src/workflows/steps/social-analytics-steps.ts
@@ -11,9 +11,30 @@ import {
   trackedSocialAccounts,
 } from "@notra/db/schema";
 import { eq } from "drizzle-orm";
+import { isAnalyticsEnabledForOrganization } from "@/lib/analytics/flag";
 import { buildAccountRow } from "@/lib/analytics/rows";
 import { collectTwitterRows } from "@/lib/analytics/twitter-sync";
 import type { SyncableSocialAccount } from "@/types/analytics";
+
+async function filterFlaggedOrganizations(
+  accounts: SyncableSocialAccount[]
+): Promise<SyncableSocialAccount[]> {
+  const organizationIds = [
+    ...new Set(accounts.map((account) => account.organizationId)),
+  ];
+  const flags = await Promise.all(
+    organizationIds.map(async (organizationId) => ({
+      organizationId,
+      enabled: await isAnalyticsEnabledForOrganization(organizationId),
+    }))
+  );
+  const enabledOrganizations = new Set(
+    flags.filter((flag) => flag.enabled).map((flag) => flag.organizationId)
+  );
+  return accounts.filter((account) =>
+    enabledOrganizations.has(account.organizationId)
+  );
+}
 
 export async function listSyncableAccounts(
   organizationId?: string
@@ -94,7 +115,7 @@ export async function listSyncableAccounts(
       verified: false,
     }));
 
-  return [...connected, ...trackedOnly];
+  return await filterFlaggedOrganizations([...connected, ...trackedOnly]);
 }
 
 export async function snapshotAccountDimensions(

--- a/apps/dashboard/src/workflows/steps/social-analytics-steps.ts
+++ b/apps/dashboard/src/workflows/steps/social-analytics-steps.ts
@@ -28,9 +28,12 @@ async function filterFlaggedOrganizations(
       enabled: await isAnalyticsEnabledForOrganization(organizationId),
     }))
   );
-  const enabledOrganizations = new Set(
-    flags.filter((flag) => flag.enabled).map((flag) => flag.organizationId)
-  );
+  const enabledOrganizations = new Set<string>();
+  for (const flag of flags) {
+    if (flag.enabled) {
+      enabledOrganizations.add(flag.organizationId);
+    }
+  }
   return accounts.filter((account) =>
     enabledOrganizations.has(account.organizationId)
   );


### PR DESCRIPTION
Two changes to stop the X API credit burn (we were reading ~500 posts/account/hour ≈ $72/day/account):

**1. Sync cost optimization** (~30-60× cheaper)
- Timeline fetch now passes `start_time` = 7 days ago — only posts still accruing engagement get re-read; older posts keep their last-known metrics in Tinybird
- Page cap 5 → 2 (200 posts max per account per run, normally 1 page)
- Cadence: hourly → twice daily (`0 6,18 * * *`), schedule id renamed `social-analytics-sync`
- Historical data still accrues: anything ingested while <7d old stays in Tinybird forever, so ranges grow over time

**2. Databuddy feature flag `social-analytics`** (mirrors the `iris` flag pattern)
- Nav item hidden unless the flag is on for the org (always visible in dev)
- All 10 analytics oRPC procedures assert the flag (`403` when off)
- **The sync workflow only fetches accounts belonging to flagged orgs** — unflagged orgs cost $0 in API credits

Ops notes: the old hourly QStash schedule is deleted and the new twice-daily one is registered **paused** — resume it once X API credits are topped up and this PR is deployed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut X API spend by 30–60× and gate Social Analytics behind the `social-analytics` feature flag. Sync only the last 7 days twice daily, process only flagged orgs, and speed up sync with parallel timeline fetch plus a single-pass org flag check.

- **New Features**
  - Add `social-analytics` flag: hides Analytics in nav (always visible in dev), all analytics oRPC routes return 403 when off, and the sync job only targets flagged orgs.
  - Limit timeline fetch to last 7 days via `start_time`.
  - Reduce page cap from 5 to 2 (max 200 posts/account/run).
  - Change sync cadence from hourly to twice daily at 06:00 and 18:00; schedule id is `social-analytics-sync`.
  - Parallelize per-account timeline fetch and evaluate org flags in a single pass to speed up sync.

- **Migration**
  - Old hourly QStash schedule is removed; the new `social-analytics-sync` schedule is registered paused.
  - After deploy and credit top-up, unpause the new schedule.

<sup>Written for commit fde6ebd3a11a1fd1f5f4bb58dd1b31c9eb6ff376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

