### PR TITLE
fix(dashboard): widen header search bar trigger

### DIFF
--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -255,7 +255,7 @@ export function SiteHeader() {
           </Breadcrumb>
         </div>
         <button
-          className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 hidden w-56 cursor-pointer items-center gap-2 rounded-lg border bg-background/60 px-3 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-muted/60 md:flex"
+          className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 hidden w-80 cursor-pointer items-center gap-2 rounded-lg border bg-background/60 px-3 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-muted/60 md:flex"
           onClick={() => setCommandPaletteOpen(true)}
           type="button"
         >


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens the header command palette trigger to improve discoverability and increase the click target on desktop. Previously the trigger width was `w-56` (14rem); it is now `w-80` (20rem). Mobile behavior is unchanged (`md:flex` still controls visibility), and the trigger remains centered.

- Review notes
  - Verify centering and no overlap with the breadcrumb on md+ viewports.
  - Confirm hover/transition styles and click behavior still open the command palette.
  - Check for unintended header layout shifts at common widths (1024px, 1280px).

<sup>Written for commit 305802c610bda2cc2c90feed18ea09433c3eb3a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

