### PR TITLE
feat(dashboard): redesign onboarding workspace step with company logo

### DIFF
--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -2,12 +2,8 @@ import { db } from "@notra/db/drizzle";
 import { brandSettings } from "@notra/db/schema";
 import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
-import {
-  getAllUserOrganizations,
-  getLastActiveOrganization,
-  getSession,
-} from "@/lib/auth/actions";
-import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
+import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
+import { redirectIfAnyOrganizationHasPaidHistory } from "@/lib/onboarding/billing-gate";
 
 export default async function OnboardingPage() {
   const session = await getSession();
@@ -16,12 +12,7 @@ export default async function OnboardingPage() {
     redirect("/login");
   }
 
-  const allOrgs = await getAllUserOrganizations();
-  for (const org of allOrgs) {
-    if (await hasPaidSubscriptionHistory(org.id)) {
-      redirect(`/${org.slug}`);
-    }
-  }
+  await redirectIfAnyOrganizationHasPaidHistory();
 
   const organization = await getLastActiveOrganization();
 

--- a/apps/dashboard/src/app/onboarding/pricing/page.tsx
+++ b/apps/dashboard/src/app/onboarding/pricing/page.tsx
@@ -1,10 +1,6 @@
 import { redirect } from "next/navigation";
-import {
-  getAllUserOrganizations,
-  getLastActiveOrganization,
-  getSession,
-} from "@/lib/auth/actions";
-import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
+import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
+import { redirectIfAnyOrganizationHasPaidHistory } from "@/lib/onboarding/billing-gate";
 import { PricingClient } from "../pricing-client";
 
 export default async function OnboardingPricingPage() {
@@ -14,12 +10,7 @@ export default async function OnboardingPricingPage() {
     redirect("/login");
   }
 
-  const allOrgs = await getAllUserOrganizations();
-  for (const org of allOrgs) {
-    if (await hasPaidSubscriptionHistory(org.id)) {
-      redirect(`/${org.slug}`);
-    }
-  }
+  await redirectIfAnyOrganizationHasPaidHistory();
 
   const organization = await getLastActiveOrganization();
   if (!organization) {

--- a/apps/dashboard/src/app/onboarding/workspace/layout.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/layout.tsx
@@ -1,0 +1,37 @@
+import { Notra } from "@notra/ui/components/ui/svgs/notra";
+import Link from "next/link";
+import { AuthBrandPanel } from "@/components/auth/auth-brand-panel";
+
+export default function OnboardingWorkspaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-screen w-full justify-center lg:grid lg:grid-cols-2">
+      <section className="flex h-full min-h-0 w-full flex-col items-center justify-between px-6 py-5 lg:px-10 lg:py-6">
+        <Link
+          className="flex items-center gap-2 self-start"
+          href="https://usenotra.com"
+        >
+          <span aria-hidden="true">
+            <Notra className="size-7" />
+          </span>
+          <span className="font-semibold text-foreground text-lg tracking-tight">
+            Notra
+          </span>
+        </Link>
+        <div className="w-full max-w-md">{children}</div>
+        <div aria-hidden="true" className="h-7" />
+      </section>
+
+      <div className="relative hidden lg:flex">
+        <div className="absolute inset-0 flex items-center justify-center p-8">
+          <div className="corner-squircle relative h-full w-full overflow-hidden rounded-xl supports-[corner-shape:squircle]:rounded-2xl">
+            <AuthBrandPanel />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/onboarding/workspace/page.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/page.tsx
@@ -2,12 +2,8 @@ import { db } from "@notra/db/drizzle";
 import { brandSettings, organizations } from "@notra/db/schema";
 import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
-import {
-  getAllUserOrganizations,
-  getLastActiveOrganization,
-  getSession,
-} from "@/lib/auth/actions";
-import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
+import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
+import { redirectIfAnyOrganizationHasPaidHistory } from "@/lib/onboarding/billing-gate";
 import { WorkspaceForm } from "./workspace-form";
 
 export default async function OnboardingWorkspacePage() {
@@ -17,12 +13,7 @@ export default async function OnboardingWorkspacePage() {
     redirect("/login");
   }
 
-  const allOrgs = await getAllUserOrganizations();
-  for (const org of allOrgs) {
-    if (await hasPaidSubscriptionHistory(org.id)) {
-      redirect(`/${org.slug}`);
-    }
-  }
+  await redirectIfAnyOrganizationHasPaidHistory();
 
   const existing = await getLastActiveOrganization();
   if (existing) {
@@ -40,6 +31,7 @@ export default async function OnboardingWorkspacePage() {
         heardAboutNotraOther: true,
         heardAboutNotraSource: true,
         id: true,
+        logo: true,
         slug: true,
         name: true,
       },

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -14,7 +14,7 @@ import { Textarea } from "@notra/ui/components/ui/textarea";
 import { useForm } from "@tanstack/react-form";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { Loader2Icon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
@@ -73,6 +73,15 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
   const fetchedLogoUrl = logoFile ? null : (companyLogo?.url ?? null);
   const isResuming = !!existingOrg;
 
+  useEffect(() => {
+    const url = logoPreviewUrl;
+    return () => {
+      if (url?.startsWith("blob:")) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, [logoPreviewUrl]);
+
   const handleLogoSelect = (file: File) => {
     const validationError = validateLogoFile(file);
     if (validationError) {
@@ -80,9 +89,6 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
       return;
     }
 
-    if (logoPreviewUrl?.startsWith("blob:")) {
-      URL.revokeObjectURL(logoPreviewUrl);
-    }
     setLogoFile(file);
     setLogoPreviewUrl(URL.createObjectURL(file));
   };
@@ -109,10 +115,14 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
       setIsSubmitting(true);
 
       try {
+        const submittedDomain = extractDomain(value.websiteUrl);
+        const matchesSubmittedDomain =
+          !!submittedDomain && submittedDomain === companyDomain;
+
         await submitWorkspaceForm({
           existingOrg,
           logoFile,
-          logoSourceUrl: fetchedLogoUrl,
+          logoSourceUrl: matchesSubmittedDomain ? fetchedLogoUrl : null,
           value,
         });
         window.location.assign("/onboarding/pricing");

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -14,7 +14,7 @@ import { Textarea } from "@notra/ui/components/ui/textarea";
 import { useForm } from "@tanstack/react-form";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { Loader2Icon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
@@ -26,7 +26,10 @@ import { COMPANY_LOGO_DEBOUNCE_MS } from "@/constants/company-logo";
 import { ONBOARDING_HEARD_ABOUT_NOTRA_OPTIONS } from "@/constants/onboarding";
 import { useCompanyLogo } from "@/lib/hooks/use-onboarding";
 import { extractDomain } from "@/lib/onboarding/company-logo";
-import { validateLogoFile } from "@/lib/onboarding/logo-file";
+import {
+  readFileAsDataUrl,
+  validateLogoFile,
+} from "@/lib/onboarding/logo-file";
 import { submitWorkspaceForm } from "@/lib/onboarding/submit-workspace-form";
 import {
   onboardingWorkspaceFormFieldsSchema,
@@ -73,27 +76,24 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
   const fetchedLogoUrl = logoFile ? null : (companyLogo?.url ?? null);
   const isResuming = !!existingOrg;
 
-  useEffect(() => {
-    if (!logoFile) {
-      return;
-    }
-
-    const url = URL.createObjectURL(logoFile);
-    setLogoPreviewUrl(url);
-
-    return () => {
-      URL.revokeObjectURL(url);
-    };
-  }, [logoFile]);
-
-  const handleLogoSelect = (file: File) => {
+  const handleLogoSelect = async (file: File) => {
     const validationError = validateLogoFile(file);
     if (validationError) {
       toast.error(validationError);
       return;
     }
 
-    setLogoFile(file);
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setLogoFile(file);
+      setLogoPreviewUrl(dataUrl);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not read the selected image."
+      );
+    }
   };
   const existingSource = existingOrg?.heardAboutNotraSource;
   const initialSource = isHeardAboutNotraSource(existingSource)

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CtaButton } from "@notra/ui/components/shared/cta-button";
 import { Input } from "@notra/ui/components/ui/input";
 import { Label } from "@notra/ui/components/ui/label";
 import {
@@ -11,14 +12,21 @@ import {
 } from "@notra/ui/components/ui/select";
 import { Textarea } from "@notra/ui/components/ui/textarea";
 import { useForm } from "@tanstack/react-form";
+import { useDebouncedValue } from "@tanstack/react-pacer";
 import { Loader2Icon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
+import { AuthFormHeader } from "@/components/auth/auth-form-header";
 import { Button } from "@/components/button";
+import { OrgLogoField } from "@/components/onboarding/org-logo-field";
 import { OnboardingProgress } from "@/components/onboarding/progress";
+import { COMPANY_LOGO_DEBOUNCE_MS } from "@/constants/company-logo";
 import { ONBOARDING_HEARD_ABOUT_NOTRA_OPTIONS } from "@/constants/onboarding";
+import { useCompanyLogo } from "@/lib/hooks/use-onboarding";
+import { extractDomain } from "@/lib/onboarding/company-logo";
+import { validateLogoFile } from "@/lib/onboarding/logo-file";
 import { submitWorkspaceForm } from "@/lib/onboarding/submit-workspace-form";
 import {
   onboardingWorkspaceFormFieldsSchema,
@@ -51,7 +59,33 @@ function getValidationMessage(error: unknown) {
 
 export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [logoPreviewUrl, setLogoPreviewUrl] = useState<string | null>(
+    existingOrg?.logo ?? null
+  );
+  const [websiteValue, setWebsiteValue] = useState("");
+  const [debouncedWebsite] = useDebouncedValue(websiteValue, {
+    wait: COMPANY_LOGO_DEBOUNCE_MS,
+  });
+  const companyDomain = extractDomain(debouncedWebsite);
+  const { data: companyLogo, isFetching: isCompanyLogoLoading } =
+    useCompanyLogo(logoFile ? null : companyDomain);
+  const fetchedLogoUrl = logoFile ? null : (companyLogo?.url ?? null);
   const isResuming = !!existingOrg;
+
+  const handleLogoSelect = (file: File) => {
+    const validationError = validateLogoFile(file);
+    if (validationError) {
+      toast.error(validationError);
+      return;
+    }
+
+    if (logoPreviewUrl?.startsWith("blob:")) {
+      URL.revokeObjectURL(logoPreviewUrl);
+    }
+    setLogoFile(file);
+    setLogoPreviewUrl(URL.createObjectURL(file));
+  };
   const existingSource = existingOrg?.heardAboutNotraSource;
   const initialSource = isHeardAboutNotraSource(existingSource)
     ? existingSource
@@ -75,11 +109,16 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
       setIsSubmitting(true);
 
       try {
-        await submitWorkspaceForm({ existingOrg, value });
+        await submitWorkspaceForm({
+          existingOrg,
+          logoFile,
+          logoSourceUrl: fetchedLogoUrl,
+          value,
+        });
         window.location.assign("/onboarding/pricing");
       } catch (err) {
         toast.error(
-          err instanceof Error ? err.message : "Failed to create org"
+          err instanceof Error ? err.message : "Failed to create workspace"
         );
         setIsSubmitting(false);
       }
@@ -87,24 +126,26 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
   });
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-4 py-12">
-      <div className="mb-6">
+    <div className="flex w-full flex-col gap-5">
+      <div className="flex justify-center">
         <OnboardingProgress current={1} />
       </div>
 
-      <div className="space-y-2">
-        <h1 className="font-semibold text-2xl tracking-tight">
-          {isResuming ? "Finish setting up your org" : "Tell us about your org"}
-        </h1>
-        <p className="text-muted-foreground text-sm">
-          {isResuming
-            ? "Your workspace is ready. Add a website if you want us to learn your brand voice automatically."
-            : "Add a website and we'll learn your brand voice while you set up the rest. You can always add it later."}
-        </p>
-      </div>
+      <AuthFormHeader
+        description={
+          isResuming
+            ? "Your workspace is ready. Add your website and we'll pick up your brand voice."
+            : "Add your website and we'll pick up your brand voice from it."
+        }
+        title={
+          isResuming
+            ? "Finish setting up your workspace"
+            : "Set up your workspace"
+        }
+      />
 
       <form
-        className="mt-8 space-y-5"
+        className="mt-2 space-y-5"
         onSubmit={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -119,29 +160,36 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
         >
           {(field) => (
             <div className="grid gap-2">
-              <Label htmlFor="name">
-                Org name <span className="text-destructive">*</span>
-              </Label>
-              <Input
-                aria-invalid={field.state.meta.errors.length > 0}
-                autoFocus={!isResuming}
-                disabled={isSubmitting || isResuming}
-                id="name"
-                onBlur={field.handleBlur}
-                onChange={(e) => {
-                  field.handleChange(e.target.value);
-                  const currentSlug = form.getFieldValue("slug");
-                  if (
-                    !currentSlug ||
-                    currentSlug === slugify(field.state.value)
-                  ) {
-                    form.setFieldValue("slug", slugify(e.target.value));
-                  }
-                }}
-                placeholder="Acme Inc"
-                type="text"
-                value={field.state.value}
-              />
+              <Label htmlFor="name">Name</Label>
+              <div className="flex items-center gap-2">
+                <OrgLogoField
+                  disabled={isSubmitting}
+                  isLoading={isCompanyLogoLoading}
+                  onSelect={handleLogoSelect}
+                  previewUrl={logoPreviewUrl ?? fetchedLogoUrl}
+                />
+                <Input
+                  aria-invalid={field.state.meta.errors.length > 0}
+                  autoFocus={!isResuming}
+                  className="h-11 rounded-xl px-3.5"
+                  disabled={isSubmitting || isResuming}
+                  id="name"
+                  onBlur={field.handleBlur}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value);
+                    const currentSlug = form.getFieldValue("slug");
+                    if (
+                      !currentSlug ||
+                      currentSlug === slugify(field.state.value)
+                    ) {
+                      form.setFieldValue("slug", slugify(e.target.value));
+                    }
+                  }}
+                  placeholder="Acme Inc"
+                  type="text"
+                  value={field.state.value}
+                />
+              </div>
               {field.state.meta.errors.length > 0 ? (
                 <p className="text-destructive text-sm">
                   {getValidationMessage(field.state.meta.errors[0])}
@@ -159,11 +207,10 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
         >
           {(field) => (
             <div className="grid gap-2">
-              <Label htmlFor="slug">
-                Org URL <span className="text-destructive">*</span>
-              </Label>
+              <Label htmlFor="slug">Slug</Label>
               <Input
                 aria-invalid={field.state.meta.errors.length > 0}
+                className="h-11 rounded-xl px-3.5"
                 disabled={isSubmitting || isResuming}
                 id="slug"
                 onBlur={field.handleBlur}
@@ -178,9 +225,51 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
                 </p>
               ) : (
                 <p className="text-muted-foreground text-xs">
-                  app.usenotra.com/{field.state.value || "your-slug"}
+                  This becomes your workspace URL.
                 </p>
               )}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field
+          name="websiteUrl"
+          validators={{
+            onSubmit: onboardingWorkspaceFormFieldsSchema.shape.websiteUrl,
+          }}
+        >
+          {(field) => (
+            <div className="grid gap-2">
+              <Label htmlFor="website">Website</Label>
+              <div
+                className={`flex h-11 w-full flex-row items-center overflow-hidden rounded-xl border transition-colors focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 ${field.state.meta.errors.length > 0 ? "border-destructive" : "border-input"}`}
+              >
+                <label
+                  className="flex h-full items-center border-input border-r bg-muted/30 px-3.5 text-muted-foreground text-sm"
+                  htmlFor="website"
+                >
+                  https://
+                </label>
+                <input
+                  autoFocus={isResuming}
+                  className="h-full flex-1 bg-transparent px-3.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={isSubmitting}
+                  id="website"
+                  onBlur={field.handleBlur}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value);
+                    setWebsiteValue(e.target.value);
+                  }}
+                  placeholder="acme.com"
+                  type="text"
+                  value={field.state.value.replace(WEBSITE_PREFIX_REGEX, "")}
+                />
+              </div>
+              {field.state.meta.errors.length > 0 ? (
+                <p className="text-destructive text-sm">
+                  {getValidationMessage(field.state.meta.errors[0])}
+                </p>
+              ) : null}
             </div>
           )}
         </form.Field>
@@ -235,7 +324,7 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
                 >
                   <SelectTrigger
                     aria-invalid={field.state.meta.errors.length > 0}
-                    className="h-10 w-full"
+                    className="h-11 w-full rounded-xl px-3.5"
                     disabled={isSubmitting || isAttributionLocked}
                     id="heard-about-notra"
                   >
@@ -302,53 +391,9 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
           )}
         </form.Field>
 
-        <form.Field
-          name="websiteUrl"
-          validators={{
-            onChange: onboardingWorkspaceFormFieldsSchema.shape.websiteUrl,
-          }}
-        >
-          {(field) => (
-            <div className="grid gap-2">
-              <Label htmlFor="website">
-                Website{" "}
-                <span className="text-muted-foreground text-xs">
-                  (optional)
-                </span>
-              </Label>
-              <div
-                className={`flex w-full flex-row items-center rounded-md border transition-colors focus-within:border-ring focus-within:ring-ring/50 ${field.state.meta.errors.length > 0 ? "border-destructive" : "border-border"}`}
-              >
-                <label
-                  className="border-border border-r px-2.5 py-1.5 text-muted-foreground text-sm"
-                  htmlFor="website"
-                >
-                  https://
-                </label>
-                <input
-                  autoFocus={isResuming}
-                  className="flex-1 bg-transparent px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                  disabled={isSubmitting}
-                  id="website"
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="acme.com"
-                  type="text"
-                  value={field.state.value.replace(WEBSITE_PREFIX_REGEX, "")}
-                />
-              </div>
-              {field.state.meta.errors.length > 0 ? (
-                <p className="text-destructive text-sm">
-                  {getValidationMessage(field.state.meta.errors[0])}
-                </p>
-              ) : null}
-            </div>
-          )}
-        </form.Field>
-
         <form.Subscribe selector={(state) => [state.canSubmit]}>
           {([canSubmit]) => (
-            <Button
+            <CtaButton
               className="w-full"
               disabled={!canSubmit || isSubmitting}
               type="submit"
@@ -361,7 +406,7 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
               ) : (
                 "Continue"
               )}
-            </Button>
+            </CtaButton>
           )}
         </form.Subscribe>
       </form>

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -74,13 +74,17 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
   const isResuming = !!existingOrg;
 
   useEffect(() => {
-    const url = logoPreviewUrl;
+    if (!logoFile) {
+      return;
+    }
+
+    const url = URL.createObjectURL(logoFile);
+    setLogoPreviewUrl(url);
+
     return () => {
-      if (url?.startsWith("blob:")) {
-        URL.revokeObjectURL(url);
-      }
+      URL.revokeObjectURL(url);
     };
-  }, [logoPreviewUrl]);
+  }, [logoFile]);
 
   const handleLogoSelect = (file: File) => {
     const validationError = validateLogoFile(file);
@@ -90,7 +94,6 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
     }
 
     setLogoFile(file);
-    setLogoPreviewUrl(URL.createObjectURL(file));
   };
   const existingSource = existingOrg?.heardAboutNotraSource;
   const initialSource = isHeardAboutNotraSource(existingSource)

--- a/apps/dashboard/src/components/onboarding/org-logo-field.tsx
+++ b/apps/dashboard/src/components/onboarding/org-logo-field.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Upload01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@notra/ui/components/ui/avatar";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { cn } from "@notra/ui/lib/utils";
+import { useRef } from "react";
+import { ALLOWED_RASTER_MIME_TYPES } from "@/constants/upload";
+import type { OrgLogoFieldProps } from "@/types/onboarding";
+
+const ACCEPTED_LOGO_TYPES = ALLOWED_RASTER_MIME_TYPES.join(",");
+
+export function OrgLogoField({
+  disabled,
+  isLoading,
+  onSelect,
+  previewUrl,
+}: OrgLogoFieldProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (isLoading && !previewUrl) {
+    return <Skeleton className="size-11 shrink-0 rounded-xl" />;
+  }
+
+  return (
+    <>
+      <input
+        accept={ACCEPTED_LOGO_TYPES}
+        className="hidden"
+        disabled={disabled}
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          event.target.value = "";
+          if (file) {
+            onSelect(file);
+          }
+        }}
+        ref={inputRef}
+        type="file"
+      />
+      <button
+        aria-label="Upload logo"
+        className="group/logo shrink-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+        onClick={() => inputRef.current?.click()}
+        type="button"
+      >
+        <Avatar
+          className={cn(
+            "relative size-11 rounded-xl border border-border ring-2 ring-transparent transition-shadow group-hover/logo:ring-muted-foreground/20 group-focus-visible/logo:ring-ring",
+            !previewUrl && "border-dashed"
+          )}
+        >
+          <AvatarImage
+            alt="Logo"
+            className="rounded-xl"
+            src={previewUrl ?? undefined}
+          />
+          <AvatarFallback className="rounded-xl bg-muted/50">
+            <HugeiconsIcon
+              className="size-5 text-muted-foreground"
+              icon={Upload01Icon}
+            />
+          </AvatarFallback>
+          {previewUrl ? (
+            <span className="absolute inset-0 flex items-center justify-center rounded-xl bg-background/80 opacity-0 transition-opacity group-hover/logo:opacity-100">
+              <HugeiconsIcon className="size-5" icon={Upload01Icon} />
+            </span>
+          ) : null}
+        </Avatar>
+      </button>
+    </>
+  );
+}

--- a/apps/dashboard/src/constants/company-logo.ts
+++ b/apps/dashboard/src/constants/company-logo.ts
@@ -1,0 +1,7 @@
+export const COMPANY_LOGO_DEBOUNCE_MS = 500;
+
+export const COMPANY_LOGO_STALE_TIME_MS = 300_000;
+
+export const COMPANY_LOGO_SOURCE_HOSTS = ["media.brand.dev"] as const;
+
+export const COMPANY_LOGO_FETCH_TIMEOUT_MS = 10_000;

--- a/apps/dashboard/src/lib/hooks/use-onboarding.ts
+++ b/apps/dashboard/src/lib/hooks/use-onboarding.ts
@@ -8,6 +8,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { COMPANY_LOGO_STALE_TIME_MS } from "@/constants/company-logo";
 import {
   AGENT_RUN_REFETCH_INTERVAL_MS,
   AGENT_RUN_STALE_TIME_MS,
@@ -32,6 +33,17 @@ export function useOnboardingStatus(
       input: { organizationId },
       enabled: !!organizationId,
       refetchInterval: options?.refetchInterval,
+    })
+  );
+}
+
+export function useCompanyLogo(domain: string | null) {
+  return useQuery(
+    dashboardOrpc.onboarding.companyLogo.queryOptions({
+      input: { domain: domain ?? "" },
+      enabled: !!domain,
+      staleTime: COMPANY_LOGO_STALE_TIME_MS,
+      retry: false,
     })
   );
 }

--- a/apps/dashboard/src/lib/onboarding/billing-gate.ts
+++ b/apps/dashboard/src/lib/onboarding/billing-gate.ts
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+import { getAllUserOrganizations } from "@/lib/auth/actions";
+import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
+
+export async function redirectIfAnyOrganizationHasPaidHistory() {
+  const allOrgs = await getAllUserOrganizations();
+  for (const org of allOrgs) {
+    if (await hasPaidSubscriptionHistory(org.id)) {
+      redirect(`/${org.slug}`);
+    }
+  }
+}

--- a/apps/dashboard/src/lib/onboarding/company-logo.ts
+++ b/apps/dashboard/src/lib/onboarding/company-logo.ts
@@ -1,0 +1,45 @@
+import type { ContextDevBrandLogo } from "@notra/ai/types/context-dev";
+
+const RASTER_URL_REGEX = /\.(png|jpe?g|webp|avif|gif)(\?|$)/i;
+const PROTOCOL_REGEX = /^https?:\/\//i;
+
+export function pickCompanyLogoUrl(
+  logos: ContextDevBrandLogo[] | undefined
+): string | null {
+  if (!logos?.length) {
+    return null;
+  }
+
+  const rasterLogos = logos.filter(
+    (logo) => logo.url && RASTER_URL_REGEX.test(logo.url)
+  );
+  const icons = rasterLogos.filter((logo) => logo.type === "icon");
+
+  const preferred =
+    icons.find((logo) => logo.mode === "has_opaque_background") ??
+    icons.find((logo) => logo.mode === "light") ??
+    icons[0] ??
+    rasterLogos[0];
+
+  return preferred?.url ?? null;
+}
+
+export function extractDomain(input: string): string | null {
+  const trimmed = input.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  const host = trimmed
+    .replace(PROTOCOL_REGEX, "")
+    .split("/")[0]
+    ?.split("?")[0]
+    ?.split("@")
+    .at(-1);
+
+  if (!host || !host.includes(".") || host.endsWith(".")) {
+    return null;
+  }
+
+  return host;
+}

--- a/apps/dashboard/src/lib/onboarding/logo-file.ts
+++ b/apps/dashboard/src/lib/onboarding/logo-file.ts
@@ -5,6 +5,22 @@ import {
 
 const BYTES_PER_MEGABYTE = 1024 * 1024;
 
+export function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Could not read the selected image."));
+      }
+    };
+    reader.onerror = () =>
+      reject(new Error("Could not read the selected image."));
+    reader.readAsDataURL(file);
+  });
+}
+
 export function validateLogoFile(file: File): string | null {
   if (!ALLOWED_RASTER_MIME_TYPES.some((mimeType) => mimeType === file.type)) {
     return "Please choose a JPEG, PNG, GIF, WebP, or AVIF image.";

--- a/apps/dashboard/src/lib/onboarding/logo-file.ts
+++ b/apps/dashboard/src/lib/onboarding/logo-file.ts
@@ -1,0 +1,18 @@
+import {
+  ALLOWED_RASTER_MIME_TYPES,
+  MAX_LOGO_FILE_SIZE,
+} from "@/constants/upload";
+
+const BYTES_PER_MEGABYTE = 1024 * 1024;
+
+export function validateLogoFile(file: File): string | null {
+  if (!ALLOWED_RASTER_MIME_TYPES.some((mimeType) => mimeType === file.type)) {
+    return "Please choose a JPEG, PNG, GIF, WebP, or AVIF image.";
+  }
+
+  if (file.size > MAX_LOGO_FILE_SIZE) {
+    return `Logo image must be less than ${MAX_LOGO_FILE_SIZE / BYTES_PER_MEGABYTE}MB.`;
+  }
+
+  return null;
+}

--- a/apps/dashboard/src/lib/onboarding/submit-workspace-form.ts
+++ b/apps/dashboard/src/lib/onboarding/submit-workspace-form.ts
@@ -4,13 +4,43 @@ import {
   triggerOnboardingBrandAnalysis,
 } from "@/app/onboarding/workspace/actions";
 import { authClient } from "@/lib/auth/client";
+import { dashboardOrpc } from "@/lib/orpc/query";
+import { uploadFile } from "@/lib/upload/client";
 import { generateOrganizationAvatar } from "@/lib/utils";
 import { onboardingWorkspaceSchema } from "@/schemas/onboarding/workspace";
 import type { SubmitWorkspaceFormArgs } from "@/types/onboarding";
 import { setLastVisitedOrganization } from "@/utils/cookies";
 
+async function setOrganizationLogo(organizationId: string, logoUrl: string) {
+  const result = await authClient.organization.update({
+    organizationId,
+    data: { logo: logoUrl },
+  });
+
+  if (result.error) {
+    throw new Error(result.error.message ?? "Failed to set workspace logo");
+  }
+}
+
+async function applyOrganizationLogo(organizationId: string, file: File) {
+  const { url } = await uploadFile({ file, type: "logo" });
+  await setOrganizationLogo(organizationId, url);
+}
+
+async function applyOrganizationLogoFromUrl(
+  organizationId: string,
+  sourceUrl: string
+) {
+  const { publicUrl } = await dashboardOrpc.upload.logoFromUrl.call({
+    sourceUrl,
+  });
+  await setOrganizationLogo(organizationId, publicUrl);
+}
+
 export async function submitWorkspaceForm({
   existingOrg,
+  logoFile,
+  logoSourceUrl,
   value,
 }: SubmitWorkspaceFormArgs) {
   const parsed = onboardingWorkspaceSchema.safeParse(value);
@@ -25,6 +55,11 @@ export async function submitWorkspaceForm({
 
   if (existingOrg) {
     organizationId = existingOrg.id;
+    if (logoFile || logoSourceUrl) {
+      await authClient.organization.setActive({
+        organizationId,
+      });
+    }
   } else {
     const { data, error } = await authClient.organization.create({
       name: parsed.data.name,
@@ -33,7 +68,7 @@ export async function submitWorkspaceForm({
     });
 
     if (error || !data) {
-      throw new Error(error?.message ?? "Failed to create org");
+      throw new Error(error?.message ?? "Failed to create workspace");
     }
 
     organizationId = data.id;
@@ -42,6 +77,21 @@ export async function submitWorkspaceForm({
       organizationId: data.id,
     });
     await setLastVisitedOrganization(data.slug);
+  }
+
+  if (logoFile || logoSourceUrl) {
+    try {
+      if (logoFile) {
+        await applyOrganizationLogo(organizationId, logoFile);
+      } else if (logoSourceUrl) {
+        await applyOrganizationLogoFromUrl(organizationId, logoSourceUrl);
+      }
+    } catch (error) {
+      console.error("[Onboarding] Failed to set organization logo", {
+        organizationId,
+        error,
+      });
+    }
   }
 
   const hasAttribution = Boolean(

--- a/apps/dashboard/src/lib/orpc/routers/onboarding.ts
+++ b/apps/dashboard/src/lib/orpc/routers/onboarding.ts
@@ -1,3 +1,4 @@
+import { retrieveBrand } from "@notra/ai/utils/context-dev";
 import { db } from "@notra/db/drizzle";
 import {
   brandSettings,
@@ -14,12 +15,14 @@ import {
   SELF_SERVE_AGENT_ERROR_MESSAGES,
 } from "@/constants/onboarding-agent";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
+import { pickCompanyLogoUrl } from "@/lib/onboarding/company-logo";
 import {
   getOnboardingAgentState,
   startSelfServeOnboardingAgent,
 } from "@/lib/onboarding-agent";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import { organizationIdSchema } from "@/schemas/auth/organization";
+import { companyLogoInputSchema } from "@/schemas/onboarding/company-logo";
 import {
   dismissSuggestionInputSchema,
   listSuggestionsInputSchema,
@@ -31,6 +34,25 @@ const onboardingInputSchema = z.object({
 });
 
 export const onboardingRouter = {
+  companyLogo: authorizedProcedure
+    .input(companyLogoInputSchema)
+    .handler(async ({ context, input }) => {
+      const { success: withinLimit } = await ratelimit.companyLogo.limit(
+        context.user.id
+      );
+      if (!withinLimit) {
+        throw new ORPCError("TOO_MANY_REQUESTS", {
+          message: "Too many logo lookups. Please try again shortly.",
+        });
+      }
+
+      try {
+        const response = await retrieveBrand(input.domain);
+        return { url: pickCompanyLogoUrl(response.brand?.logos) };
+      } catch {
+        return { url: null };
+      }
+    }),
   get: authorizedProcedure
     .input(onboardingInputSchema)
     .handler(async ({ context, input }) => {

--- a/apps/dashboard/src/lib/orpc/routers/upload.ts
+++ b/apps/dashboard/src/lib/orpc/routers/upload.ts
@@ -3,8 +3,13 @@ import { db } from "@notra/db/drizzle";
 import { members } from "@notra/db/schema";
 import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
+import {
+  COMPANY_LOGO_FETCH_TIMEOUT_MS,
+  COMPANY_LOGO_SOURCE_HOSTS,
+} from "@/constants/company-logo";
 import { SVG_MIME_TYPE } from "@/constants/upload";
 import { authorizedProcedure } from "@/lib/orpc/base";
+import { getFileExtension } from "@/lib/upload/mime";
 import { getR2Config } from "@/lib/upload/r2";
 import { SvgSanitizationError, sanitizeSvg } from "@/lib/upload/sanitize-svg";
 import {
@@ -15,8 +20,10 @@ import {
 import {
   deleteChatUploadSchema,
   recordChatAttachmentSchema,
+  uploadLogoFromUrlSchema,
   uploadSchema,
   uploadSvgSchema,
+  validateUpload,
 } from "@/schemas/upload";
 import { badRequest, forbidden, unauthorized } from "../utils/errors";
 
@@ -51,6 +58,74 @@ export const uploadRouter = {
         mediaType: input.mediaType,
         size: input.size,
       });
+    }),
+  logoFromUrl: authorizedProcedure
+    .input(uploadLogoFromUrlSchema)
+    .handler(async ({ context, input }) => {
+      const orgId = context.session?.activeOrganizationId;
+
+      if (!orgId) {
+        throw unauthorized("Active organization required for logo upload");
+      }
+
+      const membership = await db.query.members.findFirst({
+        where: and(
+          eq(members.userId, context.user.id),
+          eq(members.organizationId, orgId)
+        ),
+        columns: { id: true },
+      });
+
+      if (!membership) {
+        throw forbidden("You do not have access to this organization");
+      }
+
+      const sourceUrl = new URL(input.sourceUrl);
+      const isAllowedSource =
+        sourceUrl.protocol === "https:" &&
+        COMPANY_LOGO_SOURCE_HOSTS.some((host) => host === sourceUrl.hostname);
+
+      if (!isAllowedSource) {
+        throw badRequest("Logo source is not allowed");
+      }
+
+      const response = await fetch(sourceUrl, {
+        signal: AbortSignal.timeout(COMPANY_LOGO_FETCH_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        throw badRequest("Could not fetch the logo image");
+      }
+
+      const fileType =
+        response.headers.get("content-type")?.split(";")[0]?.trim() ?? "";
+      const body = Buffer.from(await response.arrayBuffer());
+
+      validateUpload({
+        type: "logo",
+        fileType,
+        fileSize: body.byteLength,
+      });
+
+      const id = nanoid();
+      const key = `organization/${orgId}/logo/${id}.${getFileExtension(fileType)}`;
+      const { client: r2Client, bucketName, publicUrl } = getR2Config();
+
+      await r2Client.send(
+        new PutObjectCommand({
+          Bucket: bucketName,
+          Key: key,
+          Body: body,
+          ContentType: fileType,
+        })
+      );
+
+      const baseUrl = publicUrl.replace(TRAILING_SLASH_REGEX, "");
+
+      return {
+        key,
+        publicUrl: `${baseUrl}/${key}`,
+      };
     }),
   uploadSvg: authorizedProcedure
     .input(uploadSvgSchema)

--- a/apps/dashboard/src/schemas/onboarding/company-logo.ts
+++ b/apps/dashboard/src/schemas/onboarding/company-logo.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const companyLogoInputSchema = z.object({
+  domain: z.string().trim().min(1).max(255),
+});

--- a/apps/dashboard/src/schemas/upload.ts
+++ b/apps/dashboard/src/schemas/upload.ts
@@ -133,7 +133,7 @@ export const uploadSvgSchema = z.discriminatedUnion("type", [
 export type UploadSvgInput = z.infer<typeof uploadSvgSchema>;
 
 export const uploadLogoFromUrlSchema = z.object({
-  sourceUrl: z.string().url().max(2048),
+  sourceUrl: z.url().max(2048),
 });
 
 const maxSizeByType = {

--- a/apps/dashboard/src/schemas/upload.ts
+++ b/apps/dashboard/src/schemas/upload.ts
@@ -132,6 +132,10 @@ export const uploadSvgSchema = z.discriminatedUnion("type", [
 
 export type UploadSvgInput = z.infer<typeof uploadSvgSchema>;
 
+export const uploadLogoFromUrlSchema = z.object({
+  sourceUrl: z.string().url().max(2048),
+});
+
 const maxSizeByType = {
   avatar: MAX_AVATAR_FILE_SIZE,
   brand_asset: MAX_BRAND_ASSET_FILE_SIZE,

--- a/apps/dashboard/src/types/onboarding.ts
+++ b/apps/dashboard/src/types/onboarding.ts
@@ -18,12 +18,20 @@ export interface OnboardingExistingOrg {
   heardAboutNotraOther: string | null;
   heardAboutNotraSource: string | null;
   id: string;
+  logo: string | null;
   slug: string;
   name: string;
 }
 
 export interface WorkspaceFormProps {
   existingOrg?: OnboardingExistingOrg;
+}
+
+export interface OrgLogoFieldProps {
+  disabled?: boolean;
+  isLoading?: boolean;
+  onSelect: (file: File) => void;
+  previewUrl: string | null;
 }
 
 export interface OnboardingWorkspaceFormValues {
@@ -36,6 +44,8 @@ export interface OnboardingWorkspaceFormValues {
 
 export interface SubmitWorkspaceFormArgs {
   existingOrg?: OnboardingExistingOrg;
+  logoFile: File | null;
+  logoSourceUrl: string | null;
   value: OnboardingWorkspaceFormValues;
 }
 

--- a/apps/dashboard/src/utils/ratelimit.ts
+++ b/apps/dashboard/src/utils/ratelimit.ts
@@ -65,6 +65,12 @@ export const ratelimit = {
     prefix: "ratelimit:onboarding-brand-analysis",
     limiter: Ratelimit.slidingWindow(2, "10m"),
   }),
+  companyLogo: new Ratelimit({
+    redis,
+    analytics: true,
+    prefix: "ratelimit:company-logo",
+    limiter: Ratelimit.slidingWindow(20, "1m"),
+  }),
   onboardingAgent: new Ratelimit({
     redis,
     analytics: true,


### PR DESCRIPTION
## Summary

Redesigns the `/onboarding/workspace` step to match the new sign up design (Paper: LANDING PAGE 2 / ONBOARDING · WORKSPACE artboard) and adds a workspace logo during onboarding.

![Onboarding workspace design](https://github.com/usenotra/notra/blob/pr-assets/onboarding-redesign/onboarding-workspace.png?raw=true)

## Changes

**Layout and form**
- New split layout for the workspace step reusing `AuthBrandPanel` (logo top left, form centered, violet dither panel right), same `h-screen` shell as the auth pages
- Form restyled to the design scale: 44px inputs with 12px radius, centered header via `AuthFormHeader`, `CtaButton` submit, progress dots
- Copy cleanup: "Set up your workspace", labels are Name / Slug / Website (no "org" wording), website validates on submit instead of on change

**Workspace logo**
- Logo tile inline next to the Name input; manual upload with client side validation (raster types, 5MB), instant preview, skeleton while loading, dashed border only when empty
- Typing a website debounces via TanStack Pacer (`useDebouncedValue`, 500ms) and looks up the company logo server side through the existing brand data wrapper in `@notra/ai` (new `onboarding.companyLogo` procedure, rate limited, misses return null)
- On submit the fetched logo is downloaded server side (`upload.logoFromUrl`: https only, host allowlist, timeout, size/mime validation), stored in R2 under the org logo key, and set via `organization.update`; manual files use the existing presigned flow
- Logo failures never block onboarding; the generated avatar stays as fallback

**Refactor**
- The duplicated paid history redirect loop in the three onboarding pages is extracted into `lib/onboarding/billing-gate.ts` (behavior unchanged)

## Testing

- Typecheck and Biome pass
- Brand lookup verified against the live API (github.com, vercel.com)
- Flow exercised in dev: logo appears after debounce while typing a domain, manual upload overrides, submit sets the workspace logo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the /onboarding/workspace step and adds workspace logo capture to improve first‑run branding. Previously we collected name/slug/website only; now we also auto‑fetch a logo from the website and allow manual upload. Logo failures never block onboarding; avatar fallback remains.

- Split layout via a dedicated `layout.tsx` using `AuthBrandPanel`; form restyled with `AuthFormHeader` and `CtaButton`. Copy uses “Workspace”. Website validates on submit.
- Inline logo picker (`OrgLogoField`) beside Name with preview and client-side validation; manual preview now uses a data URL. Debounced (500ms) domain input calls `onboarding.companyLogo` (ORPC) which wraps `@notra/ai` brand retrieval; results cached (5m) and rate-limited.
- On submit: manual logos upload via existing `uploadFile`; fetched logos persist via new `upload.logoFromUrl` (HTTPS only, host allowlist in `COMPANY_LOGO_SOURCE_HOSTS`, 10s timeout, size/MIME validation) to R2, then `organization.update` sets the logo. Fetched logos apply only if they match the submitted domain.
- Extracted the paid-history redirect into `redirectIfAnyOrganizationHasPaidHistory` and reused across onboarding pages (behavior unchanged).

**Review focus**
- `workspace-form.tsx`: debounced website handling, logo selection/preview (data URL), domain-match guard for fetched logos, submit flow.
- New utilities/components: `OrgLogoField`, `validateLogoFile`, `extractDomain`, constants in `constants/company-logo.ts`, `useCompanyLogo` hook.
- Server: `onboarding.companyLogo` selection logic and rate limit; `upload.logoFromUrl` validations; `submit-workspace-form.ts` logo application.

**Rollout**
- No data migrations. Ensure R2 is configured and `@notra/ai` access is available. If your logo source host differs, add it to `COMPANY_LOGO_SOURCE_HOSTS`.

<sup>Written for commit 9d2215f46bfb3f0946c85eb3bbf70469678a3168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

