### PR TITLE
fix(dashboard): align sidebar back button

### DIFF
--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -109,10 +109,13 @@ export function DashboardSidebar({
               Notra
             </span>
           </div>
+        </SidebarHeader>
+        <SidebarContent>
           <AnimatePresence initial={false} mode="popLayout">
             {isSubpage && (
               <m.div
                 animate="animate"
+                className="p-2"
                 exit="exit"
                 initial="initial"
                 key="back-button"
@@ -132,8 +135,6 @@ export function DashboardSidebar({
               </m.div>
             )}
           </AnimatePresence>
-        </SidebarHeader>
-        <SidebarContent>
           <AnimatePresence initial={false} mode="popLayout">
             {isSettingsRoute && (
               <m.div

--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -115,7 +115,7 @@ export function DashboardSidebar({
             {isSubpage && (
               <m.div
                 animate="animate"
-                className="p-2"
+                className="sticky top-0 z-10 bg-sidebar p-2"
                 exit="exit"
                 initial="initial"
                 key="back-button"


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns and keeps visible the dashboard sidebar back button by rendering it in sidebar content with sticky positioning and padding. Previously it lived in the header, which caused misalignment and allowed it to scroll out of view.

- Moves the back button from `SidebarHeader` into `SidebarContent` and sets `className="sticky top-0 z-10 bg-sidebar p-2"` on its `m.div`.
- Verify alignment with navigation items and visibility while scrolling on subpages (`isSubpage`) and the settings route (`isSettingsRoute`).
- Confirm `AnimatePresence` transitions still behave as before and header layout remains unchanged.

<sup>Written for commit c864160cf228ea24ecfe14a18c5599bb92afe638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

