### PR TITLE
fix(auth): false 'social sign-in failed' error on redirect

### DIFF
--- a/apps/dashboard/src/components/auth/login-form.tsx
+++ b/apps/dashboard/src/components/auth/login-form.tsx
@@ -19,6 +19,7 @@ import {
   setLastUsedLoginMethod,
 } from "@/lib/auth/last-login-method";
 import { signInWithPasswordAction } from "@/lib/auth/password-actions";
+import { isNextRedirectError } from "@/lib/auth/redirect-error";
 import { startSocialSignInAction } from "@/lib/auth/social-actions";
 import { errorMessageOr } from "@/lib/utils";
 import { loginSchema } from "@/schemas/auth/credentials";
@@ -81,11 +82,16 @@ export function LoginForm({
     authInFlightRef.current = true;
     flushSync(() => setAuthMethod(provider));
     setLastUsedLoginMethod(provider);
-    startSocialSignInAction({ provider, returnTo: callbackURL }).catch(() => {
-      authInFlightRef.current = false;
-      setAuthMethod(null);
-      setFormError("Social sign-in failed. Please try again.");
-    });
+    startSocialSignInAction({ provider, returnTo: callbackURL }).catch(
+      (error) => {
+        if (isNextRedirectError(error)) {
+          return;
+        }
+        authInFlightRef.current = false;
+        setAuthMethod(null);
+        setFormError("Social sign-in failed. Please try again.");
+      }
+    );
   }
 
   const form = useForm({

--- a/apps/dashboard/src/components/auth/signup-form.tsx
+++ b/apps/dashboard/src/components/auth/signup-form.tsx
@@ -17,6 +17,7 @@ import { EmailVerificationForm } from "@/components/auth/email-verification-form
 import { SignupCreditsBanner } from "@/components/auth/signup-credits-banner";
 import { setLastUsedLoginMethod } from "@/lib/auth/last-login-method";
 import { signUpWithPasswordAction } from "@/lib/auth/password-actions";
+import { isNextRedirectError } from "@/lib/auth/redirect-error";
 import { startSocialSignInAction } from "@/lib/auth/social-actions";
 import { errorMessageOr } from "@/lib/utils";
 import { signupSchema } from "@/schemas/auth/credentials";
@@ -106,7 +107,10 @@ export function SignupForm({
     startSocialSignInAction({
       provider,
       returnTo: buildCallbackUrl(provider),
-    }).catch(() => {
+    }).catch((error) => {
+      if (isNextRedirectError(error)) {
+        return;
+      }
       authInFlightRef.current = false;
       setAuthMethod(null);
       setFormError("Social sign-up failed. Please try again.");

--- a/apps/dashboard/src/components/settings/connected-accounts-section.tsx
+++ b/apps/dashboard/src/components/settings/connected-accounts-section.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { authClient } from "@/lib/auth/client";
+import { isNextRedirectError } from "@/lib/auth/redirect-error";
 import { startSocialSignInAction } from "@/lib/auth/social-actions";
 import { errorMessageOr } from "@/lib/utils";
 import type { ConnectedAccountsSectionProps } from "@/types/settings/account";
@@ -30,7 +31,10 @@ export function ConnectedAccountsSection({
     startSocialSignInAction({
       provider,
       returnTo: window.location.pathname,
-    }).catch(() => {
+    }).catch((error) => {
+      if (isNextRedirectError(error)) {
+        return;
+      }
       setLoadingProvider(null);
       toast.error("Could not start the connection. Please try again.");
     });

--- a/apps/dashboard/src/lib/auth/client.ts
+++ b/apps/dashboard/src/lib/auth/client.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { isNextRedirectError } from "@/lib/auth/redirect-error";
 import {
   deleteUserAction,
   listAccountsAction,
@@ -76,16 +77,6 @@ function useSessionInvalidation() {
   return () => {
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.AUTH.session });
   };
-}
-
-function isNextRedirectError(error: unknown) {
-  return (
-    error !== null &&
-    typeof error === "object" &&
-    "digest" in error &&
-    typeof error.digest === "string" &&
-    error.digest.startsWith("NEXT_REDIRECT")
-  );
 }
 
 async function signOut(options?: SignOutOptions) {

--- a/apps/dashboard/src/lib/auth/redirect-error.ts
+++ b/apps/dashboard/src/lib/auth/redirect-error.ts
@@ -1,0 +1,9 @@
+export function isNextRedirectError(error: unknown) {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "digest" in error &&
+    typeof error.digest === "string" &&
+    error.digest.startsWith("NEXT_REDIRECT")
+  );
+}

--- a/apps/dashboard/src/lib/integrations/github/install.ts
+++ b/apps/dashboard/src/lib/integrations/github/install.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { Effect } from "effect";
+import { isNextRedirectError } from "@/lib/auth/redirect-error";
 import { startSocialSignInAction } from "@/lib/auth/social-actions";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import {
@@ -15,6 +16,10 @@ function authorizeGitHub(callbackURL: string) {
       await startSocialSignInAction({
         provider: "github",
         returnTo: callbackURL,
+      }).catch((error) => {
+        if (!isNextRedirectError(error)) {
+          throw error;
+        }
       });
       return true;
     },


### PR DESCRIPTION
When the social sign-in server action redirects to the external WorkOS authorization URL, Next surfaces the redirect as a rejected promise on the client. The catch handlers in the login/signup forms, connected-accounts section, and GitHub install flow treated that rejection as a failure and flashed "Social sign-in failed" even though the flow succeeded.

Extracts the existing `isNextRedirectError` digest check into `lib/auth/redirect-error.ts` and guards all four social-start call sites (plus the signOut facade now imports it from there). Redirect rejections are ignored; real failures still surface the error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false “Social sign-in failed” toasts when starting social auth. Previously, the redirect to the WorkOS authorization URL surfaced as a rejected promise from Next and our catch handlers showed an error; now we detect Next redirect rejections and ignore them while still surfacing real failures.

- Adds `isNextRedirectError` in `apps/dashboard/src/lib/auth/redirect-error.ts` and removes the duplicate implementation from `auth/client`.
- Guards redirect rejections in login, signup, connected accounts, and the GitHub install flow so UI does not show failure on successful redirect.
- Identification logic: ignore errors whose `error.digest` starts with `NEXT_REDIRECT`.

<sup>Written for commit 10d3dc724b13fb871159185aa78362cff3ec481e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

