### PR TITLE
fix(dashboard): billing shows wrong org after workos cutover

### DIFF
--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -346,9 +346,14 @@ export function OrgSelector() {
 
       await setLastVisitedOrganization(org.slug);
       queryClient.invalidateQueries({ refetchType: "none" });
-      await queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.AUTH.activeOrganization,
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.AUTH.activeOrganization,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.AUTH.session,
+        }),
+      ]);
 
       setIsSwitching(false);
       startTransition(() => {

--- a/apps/dashboard/src/components/providers/organization-provider.tsx
+++ b/apps/dashboard/src/components/providers/organization-provider.tsx
@@ -174,6 +174,9 @@ export function OrganizationsProvider({
           queryClient.invalidateQueries({
             queryKey: QUERY_KEYS.AUTH.activeOrganization,
           });
+          queryClient.invalidateQueries({
+            queryKey: QUERY_KEYS.AUTH.session,
+          });
         }
       })
       .catch((error) => {
@@ -221,6 +224,9 @@ export function OrganizationsProvider({
               queryClient.invalidateQueries({ refetchType: "none" });
               queryClient.invalidateQueries({
                 queryKey: QUERY_KEYS.AUTH.activeOrganization,
+              });
+              queryClient.invalidateQueries({
+                queryKey: QUERY_KEYS.AUTH.session,
               });
             }
           })


### PR DESCRIPTION
After the WorkOS migration the active organization is cookie-derived, and `/api/session` falls back to the most recently created membership when the cookie is absent (true for every user right after cutover). The organization provider syncs the cookie to the URL org via setActive, but it only invalidated queries with `refetchType: "none"` — the session query was never refetched, so the Autumn billing provider kept identifying as the fallback org indefinitely. Symptoms: sidebar shows "trial ended, choose a plan" while viewing a pro org, and the credits modal closes itself when the Autumn provider finally remounts mid-interaction.

Fix: actively refetch the session query after every active-org change (path sync, auto-select, and the org switcher). The Autumn provider then re-keys to the correct org right after page load instead of at some arbitrary later moment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refetches the session whenever the active organization changes so billing tracks the viewed org. Previously, after the WorkOS cutover, the session stayed on a fallback org until a later remount; now it updates immediately, fixing incorrect “trial ended” banners and the credits modal closing mid-interaction.

**Changes**
- In `OrganizationsProvider`, also invalidates `QUERY_KEYS.AUTH.session` alongside `QUERY_KEYS.AUTH.activeOrganization` on path sync and auto-select.
- In `OrgSelector`, invalidates both `activeOrganization` and `session` queries in parallel when switching orgs.

**Rollout**
- No migrations. Adds a single extra session refetch per org change.

<sup>Written for commit fbc5efadf6cdbf86b7c90501bc57dc7e399ea4c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

