### PR TITLE
fix(dashboard): credits modal closes itself when opened

### DIFF
--- a/apps/dashboard/src/components/billing/credit-balance-button.tsx
+++ b/apps/dashboard/src/components/billing/credit-balance-button.tsx
@@ -4,13 +4,14 @@ import { Wallet01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { DropdownMenuItem } from "@notra/ui/components/ui/dropdown-menu";
 import { cn } from "@notra/ui/lib/utils";
-import { useState } from "react";
-import { CreditTopupModal } from "@/components/billing/credit-topup-modal";
 import { useCreditBalance } from "@/lib/hooks/use-credit-balance";
+import type { CreditBalanceMenuItemProps } from "@/types/billing/credits";
 import { formatDollars } from "@/utils/format";
 
-export function CreditBalanceMenuItem({ className }: { className?: string }) {
-  const [open, setOpen] = useState(false);
+export function CreditBalanceMenuItem({
+  className,
+  onOpenTopup,
+}: CreditBalanceMenuItemProps) {
   const { isLoading, hasActiveSubscription, balance } = useCreditBalance();
 
   if (isLoading || !hasActiveSubscription) {
@@ -18,20 +19,17 @@ export function CreditBalanceMenuItem({ className }: { className?: string }) {
   }
 
   return (
-    <>
-      <DropdownMenuItem
-        className={cn("cursor-pointer", className)}
-        onClick={() => setOpen(true)}
-      >
-        <HugeiconsIcon icon={Wallet01Icon} />
-        Credits
-        {balance !== null ? (
-          <span className="ml-auto text-muted-foreground tabular-nums">
-            {formatDollars(balance)}
-          </span>
-        ) : null}
-      </DropdownMenuItem>
-      <CreditTopupModal onOpenChange={setOpen} open={open} />
-    </>
+    <DropdownMenuItem
+      className={cn("cursor-pointer", className)}
+      onClick={onOpenTopup}
+    >
+      <HugeiconsIcon icon={Wallet01Icon} />
+      Credits
+      {balance !== null ? (
+        <span className="ml-auto text-muted-foreground tabular-nums">
+          {formatDollars(balance)}
+        </span>
+      ) : null}
+    </DropdownMenuItem>
   );
 }

--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -42,6 +42,7 @@ import { useTheme } from "next-themes";
 import { useEffect, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { CreditBalanceMenuItem } from "@/components/billing/credit-balance-button";
+import { CreditTopupModal } from "@/components/billing/credit-topup-modal";
 import { useFeedback } from "@/components/dashboard/feedback-context";
 import { authClient } from "@/lib/auth/client";
 import { cn, errorMessageOr } from "@/lib/utils";
@@ -292,6 +293,7 @@ export function OrgSelector() {
   const [isPending, startTransition] = useTransition();
   const [isSwitching, setIsSwitching] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isTopupModalOpen, setIsTopupModalOpen] = useState(false);
   const isNavigating = isSwitching || isPending;
 
   const activeSubscription = customer?.subscriptions.find(
@@ -420,7 +422,9 @@ export function OrgSelector() {
 
             <DropdownMenuSeparator />
 
-            <CreditBalanceMenuItem />
+            <CreditBalanceMenuItem
+              onOpenTopup={() => setIsTopupModalOpen(true)}
+            />
             <DropdownMenuItem
               className="cursor-pointer"
               onClick={() => openFeedback()}
@@ -476,6 +480,11 @@ export function OrgSelector() {
         <CreateOrgModal
           onOpenChange={setIsCreateModalOpen}
           open={isCreateModalOpen}
+        />
+
+        <CreditTopupModal
+          onOpenChange={setIsTopupModalOpen}
+          open={isTopupModalOpen}
         />
       </SidebarMenuItem>
     </SidebarMenu>

--- a/apps/dashboard/src/types/billing/credits.ts
+++ b/apps/dashboard/src/types/billing/credits.ts
@@ -9,6 +9,11 @@ export const CREDIT_RANGE_LABELS: Record<CreditRangeOption, string> = {
   "90d": "90 days",
 };
 
+export interface CreditBalanceMenuItemProps {
+  className?: string;
+  onOpenTopup: () => void;
+}
+
 export type ListEventsRow = NonNullable<
   Awaited<ReturnType<IAutumnClient["listEvents"]>>["list"]
 >[number];


### PR DESCRIPTION
The credit top-up modal was rendered inside the org-selector dropdown's content, alongside its own open state. Clicking the Credits item closes the dropdown, which unmounts the dropdown content — taking the modal and its state with it, so the modal flashes open and immediately disappears.

Fix: the modal and its open state now live in OrgSelector (which stays mounted), rendered outside the DropdownMenu; the menu item just receives an onOpenTopup callback. Props interface moved to types/billing/credits.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the credit top‑up modal closing immediately after opening from the org selector. Previously the modal was inside the dropdown and unmounted when the menu closed; now `OrgSelector` owns the modal state and renders `CreditTopupModal` outside the dropdown, and the menu item triggers an `onOpenTopup` callback.

- If you render `CreditBalanceMenuItem` elsewhere, pass `onOpenTopup` to open the top‑up modal.
- `CreditBalanceMenuItem` no longer manages open state or renders the modal; `CreditBalanceMenuItemProps` is defined in `apps/dashboard/src/types/billing/credits.ts`.

<sup>Written for commit 12f0e85876d4197d860de3031b6b91fa13eceb50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

