### PR TITLE
feat(dashboard): improve workspace navigation and empty states

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,8 @@ NEXT_PUBLIC_C15T_BACKEND_URL=https://development-notra.inth.app
 
 # Autumn Billing
 AUTUMN_SECRET_KEY=
-ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false
+# Skip Autumn credit/plan checks in `next dev`. Set to false to test billing locally.
+ALLOW_UNMETERED_AI_IN_DEVELOPMENT=true
 
 # Workflows
 NEXT_PUBLIC_APP_URL=

--- a/apps/api/src/lib/chat/run.ts
+++ b/apps/api/src/lib/chat/run.ts
@@ -1,5 +1,8 @@
 import type { z } from "@hono/zod-openapi";
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import {
@@ -43,7 +46,7 @@ export async function runChatMessage({
   requestId,
 }: RunChatMessageArgs): Promise<Response> {
   let useMarkup = false;
-  if (autumn) {
+  if (autumn && !allowUnmeteredAiInDevelopment) {
     let checkData: CheckResponse | null = null;
     try {
       checkData = await autumn.check({

--- a/apps/api/src/utils/agent-credits.ts
+++ b/apps/api/src/utils/agent-credits.ts
@@ -1,4 +1,7 @@
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import type { CheckResponse } from "autumn-js";
@@ -10,7 +13,7 @@ export type AgentCreditCheck =
 export async function checkAgentAiCredits(
   organizationId: string
 ): Promise<AgentCreditCheck> {
-  if (!autumn) {
+  if (!autumn || allowUnmeteredAiInDevelopment) {
     return { allowed: true, useMarkup: false };
   }
   let checkData: CheckResponse | null = null;

--- a/apps/dashboard/src/app/(dashboard)/[slug]/(overview)/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/(overview)/page-client.tsx
@@ -2,14 +2,18 @@
 
 import type { ContentType } from "@notra/ai/schemas/content";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import Link from "next/link";
 import { useId } from "react";
+import { Button } from "@/components/button";
 import { ContentCard } from "@/components/content/content-card";
 import { ContentSkeletonCard } from "@/components/content/content-skeleton-card";
 import { LazyCreateContentDialog } from "@/components/content/lazy-create-content-dialog";
 import { ContentActivityCard } from "@/components/dashboard/content-activity-card";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { EMPTY_STATE_CARD_COUNT } from "@/constants/empty-state";
 import { authClient } from "@/lib/auth/client";
 import { useActiveGenerations } from "@/lib/hooks/use-active-generations";
 import { useTodayPosts } from "@/lib/hooks/use-posts";
@@ -113,8 +117,19 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
     return (
       <EmptyState
-        className="p-6"
+        action={
+          <Button render={<Link href={`/${organizationSlug}/content`} />}>
+            View content
+          </Button>
+        }
         description="You have no new posts today. Create one now or review your existing drafts on the content page."
+        preview={
+          <EmptyStateCardsPreview
+            columns={3}
+            count={EMPTY_STATE_CARD_COUNT.content}
+            variant="content"
+          />
+        }
         title="No content created today"
       />
     );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/events/page-client.tsx
@@ -36,8 +36,13 @@ import { TriggerRowActions } from "@/components/automation/triggers/trigger-row-
 import { TriggerStatusBadge } from "@/components/automation/triggers/trigger-status-badge";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import {
+  EMPTY_STATE_TABLE_COLUMNS,
+  EMPTY_STATE_TABLE_ROWS,
+} from "@/constants/empty-state";
 import { useCreateFromSuggestion } from "@/lib/hooks/use-onboarding";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
@@ -238,10 +243,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             open={createOpen}
             organizationId={organizationId ?? ""}
             trigger={
-              <Button className="gap-1.5">
-                <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                Create Trigger
-                <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+              <Button className="w-fit gap-2">
+                <span className="inline-flex items-center gap-1.5">
+                  <HugeiconsIcon className="size-4" icon={Add01Icon} />
+                  Create Trigger
+                </span>
+                <Kbd className="hidden sm:inline-flex">C</Kbd>
               </Button>
             }
           />
@@ -281,6 +288,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
               />
             }
             description="Create your first event trigger to react to GitHub activity."
+            preview={
+              <EmptyStateTablePreview
+                columns={EMPTY_STATE_TABLE_COLUMNS.events}
+                rows={EMPTY_STATE_TABLE_ROWS}
+              />
+            }
             title="No event triggers yet"
           />
         )}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
@@ -62,8 +62,13 @@ import { SourcesCell } from "@/components/automation/sources-cell";
 import { TriggerStatusBadge } from "@/components/automation/triggers/trigger-status-badge";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import {
+  EMPTY_STATE_TABLE_COLUMNS,
+  EMPTY_STATE_TABLE_ROWS,
+} from "@/constants/empty-state";
 import { useCreateFromSuggestion } from "@/lib/hooks/use-onboarding";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
@@ -422,10 +427,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
             open={createOpen}
             organizationId={organizationId ?? ""}
             trigger={
-              <Button className="gap-1.5">
-                <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                Create Schedule
-                <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+              <Button className="w-fit gap-2">
+                <span className="inline-flex items-center gap-1.5">
+                  <HugeiconsIcon className="size-4" icon={Add01Icon} />
+                  Create Schedule
+                </span>
+                <Kbd className="hidden sm:inline-flex">C</Kbd>
               </Button>
             }
           />
@@ -472,6 +479,12 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
               />
             }
             description="Create your first schedule to automate recurring content."
+            preview={
+              <EmptyStateTablePreview
+                columns={EMPTY_STATE_TABLE_COLUMNS.schedule}
+                rows={EMPTY_STATE_TABLE_ROWS}
+              />
+            }
             title="No schedules yet"
           />
         )}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-header.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-header.tsx
@@ -27,7 +27,7 @@ export function BrandIdentityHeader({
       onClick: onAddIdentity,
     },
     references: {
-      label: "Create Reference",
+      label: "Add Reference",
       onClick: onAddReference,
     },
     sitemap: {
@@ -43,13 +43,13 @@ export function BrandIdentityHeader({
         <h1 className="font-bold text-3xl tracking-tight">
           {BRAND_TAB_HEADERS[activeTab].title}
         </h1>
-        <p className="text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           {BRAND_TAB_HEADERS[activeTab].description}
         </p>
       </div>
       {activeTab === "guidelines" ? (
         <Button
-          className="gap-1.5"
+          className="w-fit gap-1.5 px-3"
           disabled={isRefreshingGuidelines}
           onClick={onRefreshGuidelines}
         >
@@ -62,7 +62,7 @@ export function BrandIdentityHeader({
         </Button>
       ) : null}
       {action ? (
-        <Button className="gap-1.5" onClick={action.onClick}>
+        <Button className="w-fit gap-1.5 px-3" onClick={action.onClick}>
           <HugeiconsIcon className="size-4" icon={Add01Icon} />
           {action.label}
           <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/guidelines-panel.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/guidelines-panel.tsx
@@ -8,6 +8,7 @@ import { useEffect } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateGuidelinesPreview } from "@/components/empty-state-preview";
 import { GUIDELINES_SKELETON_KEYS } from "@/constants/brand-guideline-ui";
 import {
   useBrandGuidelines,
@@ -84,11 +85,7 @@ export function GuidelinesPanel({
     return (
       <EmptyState
         action={
-          <Button
-            disabled={isRefreshBusy}
-            onClick={refresh.refreshGuidelines}
-            size="sm"
-          >
+          <Button disabled={isRefreshBusy} onClick={refresh.refreshGuidelines}>
             {isRefreshBusy ? (
               <Loader2Icon className="size-4 animate-spin" />
             ) : (
@@ -98,6 +95,7 @@ export function GuidelinesPanel({
           </Button>
         }
         description="Brand guidelines have not been generated yet. Generate them to pull logos, colors, typography, and landing page screenshots from your website."
+        preview={<EmptyStateGuidelinesPreview />}
         title="No guidelines yet"
       />
     );
@@ -179,7 +177,6 @@ export function GuidelinesPanel({
             <Button
               disabled={isRefreshBusy}
               onClick={refresh.refreshGuidelines}
-              size="sm"
             >
               {isRefreshBusy ? (
                 <Loader2Icon className="size-4 animate-spin" />
@@ -190,6 +187,7 @@ export function GuidelinesPanel({
             </Button>
           }
           description="No brand assets were detected for this identity yet. Refresh to pull the latest logos, colors, and screenshots."
+          preview={<EmptyStateGuidelinesPreview />}
           title="Guidelines are empty"
         />
       )}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/references-list.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/references-list.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
+import { EMPTY_STATE_CARD_COUNT } from "@/constants/empty-state";
 import { QUERY_KEYS } from "@/utils/query-keys";
 import {
   useDeleteReference,
@@ -104,12 +109,20 @@ export function ReferencesList({
   return (
     <div className="space-y-4">
       {references.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-6 text-center">
-          <p className="text-muted-foreground text-sm">
-            No references yet. Add a tweet to help the AI match your writing
-            style.
-          </p>
-        </div>
+        <EmptyState
+          actionIcon={<HugeiconsIcon className="size-4" icon={Add01Icon} />}
+          actionLabel="Add Reference"
+          description="Add a tweet or writing sample so the AI can match your style."
+          onActionClick={() => onDialogOpenChange(true)}
+          preview={
+            <EmptyStateCardsPreview
+              columns={2}
+              count={EMPTY_STATE_CARD_COUNT.reference}
+              variant="reference"
+            />
+          }
+          title="No references yet"
+        />
       ) : (
         <div className="columns-1 gap-4 space-y-4 sm:columns-2">
           {references.map((ref) => (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-list.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/sitemap-list.tsx
@@ -21,6 +21,11 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateTablePreview } from "@/components/empty-state-preview";
+import {
+  EMPTY_STATE_TABLE_COLUMNS,
+  EMPTY_STATE_TABLE_ROWS,
+} from "@/constants/empty-state";
 import { useDeleteSitemap, useSitemaps } from "@/lib/hooks/use-brand-sitemaps";
 import { getSafeHttpUrl } from "@/lib/sitemap/sitemap-url";
 import type { SitemapListProps } from "@/types/hooks/brand-sitemaps";
@@ -104,6 +109,12 @@ export function SitemapList({
           actionLabel="Add Sitemap"
           description="Add a sitemap to track indexed pages and monitor site health for AI discovery."
           onActionClick={() => onDialogOpenChange(true)}
+          preview={
+            <EmptyStateTablePreview
+              columns={EMPTY_STATE_TABLE_COLUMNS.sitemap}
+              rows={EMPTY_STATE_TABLE_ROWS}
+            />
+          }
           title="No sitemaps yet"
         />
       ) : (

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/voice-selector.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/voice-selector.tsx
@@ -101,7 +101,7 @@ export function VoiceSelector({
 
           return (
             <button
-              className={`group flex min-w-40 shrink-0 cursor-pointer gap-2 rounded-lg border px-4 py-3 text-left transition-colors ${
+              className={`group flex min-w-40 shrink-0 cursor-pointer items-center gap-2.5 rounded-lg border py-2.5 pr-2 pl-3 text-left transition-colors ${
                 isActive
                   ? "border-primary bg-primary/5"
                   : "border-border hover:border-primary/40"
@@ -111,7 +111,7 @@ export function VoiceSelector({
               type="button"
             >
               <Avatar
-                className="size-8 rounded-full after:rounded-full"
+                className="size-8 shrink-0 rounded-full after:rounded-full"
                 size="sm"
               >
                 <AvatarImage src={getBrandFaviconUrl(voice.websiteUrl)} />
@@ -120,118 +120,113 @@ export function VoiceSelector({
                 </AvatarFallback>
               </Avatar>
               <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  {hasTooltipInfo ? (
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <span className="block cursor-help truncate font-medium text-sm leading-tight">
-                            {truncateText(voice.name, IDENTITY_NAME_MAX_LENGTH)}
-                          </span>
-                        }
-                      />
-                      <TooltipContent className="max-w-64 space-y-1">
-                        {voice.toneProfile && (
-                          <p>Tone Profile: {voice.toneProfile}</p>
-                        )}
-                        {voice.language && <p>Language: {voice.language}</p>}
-                        {voice.isDefault && (
-                          <p>
-                            Default brand identity used when no specific
-                            identity is selected.
-                          </p>
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <span className="block truncate font-medium text-sm leading-tight">
-                      {truncateText(voice.name, IDENTITY_NAME_MAX_LENGTH)}
-                    </span>
-                  )}
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      className={`ml-auto flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md hover:bg-accent ${
-                        isActive
-                          ? "opacity-100"
-                          : "opacity-0 group-hover:opacity-100"
-                      }`}
-                      disabled={isDeleting || isSettingDefault || isReanalyzing}
-                      nativeButton={false}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (!isActive) {
-                          onSelect(voice.id);
-                        }
-                      }}
-                      render={<span />}
-                    >
-                      <HugeiconsIcon
-                        className="size-3.5 text-muted-foreground"
-                        icon={MoreVerticalIcon}
-                      />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-64">
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onSelect(voice.id);
-                          setIdentityName(voice.name);
-                          setEditDialogOpen(true);
-                        }}
-                      >
-                        <HugeiconsIcon className="size-4" icon={Edit02Icon} />
-                        Edit identity name
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={!voice.websiteUrl?.trim() || isReanalyzing}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onSelect(voice.id);
-                          if (voice.websiteUrl) {
-                            onReanalyze(voice.websiteUrl);
-                          }
-                        }}
-                      >
-                        <HugeiconsIcon
-                          className="size-4"
-                          icon={Refresh01Icon}
-                        />
-                        Re-analyze
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        disabled={voice.isDefault}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onSelect(voice.id);
-                          onSetDefault();
-                        }}
-                      >
-                        <HugeiconsIcon className="size-4" icon={StarIcon} />
-                        {voice.isDefault
-                          ? "Already default identity"
-                          : "Set as default identity"}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={voice.isDefault}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onRequestDelete(voice.id);
-                        }}
-                        variant="destructive"
-                      >
-                        <HugeiconsIcon className="size-4" icon={Delete02Icon} />
-                        Delete identity
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-                {voice.websiteUrl && (
-                  <p className="truncate text-muted-foreground text-xs italic">
+                {hasTooltipInfo ? (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <span className="block cursor-help truncate font-medium text-sm leading-5">
+                          {truncateText(voice.name, IDENTITY_NAME_MAX_LENGTH)}
+                        </span>
+                      }
+                    />
+                    <TooltipContent className="max-w-64 space-y-1">
+                      {voice.toneProfile && (
+                        <p>Tone Profile: {voice.toneProfile}</p>
+                      )}
+                      {voice.language && <p>Language: {voice.language}</p>}
+                      {voice.isDefault && (
+                        <p>
+                          Default brand identity used when no specific identity
+                          is selected.
+                        </p>
+                      )}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <span className="block truncate font-medium text-sm leading-5">
+                    {truncateText(voice.name, IDENTITY_NAME_MAX_LENGTH)}
+                  </span>
+                )}
+                {voice.websiteUrl ? (
+                  <p className="truncate text-muted-foreground text-xs leading-4">
                     {getWebsiteDisplayText(voice.websiteUrl)}
                   </p>
-                )}
+                ) : null}
               </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  className={`flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md hover:bg-accent ${
+                    isActive
+                      ? "opacity-100"
+                      : "opacity-0 group-hover:opacity-100"
+                  }`}
+                  disabled={isDeleting || isSettingDefault || isReanalyzing}
+                  nativeButton={false}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!isActive) {
+                      onSelect(voice.id);
+                    }
+                  }}
+                  render={<span />}
+                >
+                  <HugeiconsIcon
+                    className="size-3.5 text-muted-foreground"
+                    icon={MoreVerticalIcon}
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect(voice.id);
+                      setIdentityName(voice.name);
+                      setEditDialogOpen(true);
+                    }}
+                  >
+                    <HugeiconsIcon className="size-4" icon={Edit02Icon} />
+                    Edit identity name
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={!voice.websiteUrl?.trim() || isReanalyzing}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect(voice.id);
+                      if (voice.websiteUrl) {
+                        onReanalyze(voice.websiteUrl);
+                      }
+                    }}
+                  >
+                    <HugeiconsIcon className="size-4" icon={Refresh01Icon} />
+                    Re-analyze
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    disabled={voice.isDefault}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect(voice.id);
+                      onSetDefault();
+                    }}
+                  >
+                    <HugeiconsIcon className="size-4" icon={StarIcon} />
+                    {voice.isDefault
+                      ? "Already default identity"
+                      : "Set as default identity"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={voice.isDefault}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRequestDelete(voice.id);
+                    }}
+                    variant="destructive"
+                  >
+                    <HugeiconsIcon className="size-4" icon={Delete02Icon} />
+                    Delete identity
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </button>
           );
         })}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/page-client.tsx
@@ -88,11 +88,13 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   );
   const [activeVoiceId, setActiveVoiceId] = useQueryState(
     "voice",
-    parseAsString
+    parseAsString.withOptions({ history: "replace" })
   );
   const [activeTab, setActiveTab] = useQueryState(
     "view",
-    parseAsStringLiteral(BRAND_IDENTITY_TAB_VALUES).withDefault("identity")
+    parseAsStringLiteral(BRAND_IDENTITY_TAB_VALUES)
+      .withDefault("identity")
+      .withOptions({ history: "replace" })
   );
   const [newIdentityParam, setNewIdentityParam] = useQueryState("new");
   const isAddIdentityOpen =

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -74,7 +74,7 @@ import { renderTextWithIntegrationReferences } from "@/components/chat/integrati
 import { SlackRelayFooterNotice } from "@/components/chat/slack-relay-footer-notice";
 import {
   UserMessageActions,
-  UserMessageEditor,
+  UserMessageTextBubble,
 } from "@/components/chat/user-message-actions";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { MAX_VISIBLE_CHAT_IMAGES } from "@/constants/chat-images";
@@ -2307,60 +2307,40 @@ function StandaloneChatPageClient({
                             from={message.role}
                           >
                             {isUser ? (
-                              <m.div
-                                className={cn(
-                                  "ml-auto overflow-hidden",
-                                  isEditing
-                                    ? "w-full"
-                                    : "flex w-fit max-w-full flex-col items-end gap-2"
+                              <div className="ml-auto flex w-full max-w-full flex-col items-end gap-2">
+                                {userImageParts.length > 0 && (
+                                  <UserImageGrid>
+                                    {userImageParts.map((part, index) =>
+                                      renderPart(part, message.id, index)
+                                    )}
+                                  </UserImageGrid>
                                 )}
-                                layout
-                                transition={{
-                                  duration: 0.25,
-                                  ease: [0.22, 1, 0.36, 1],
-                                }}
-                              >
-                                {isEditing ? (
-                                  <UserMessageEditor
+                                {(isEditing ||
+                                  userContentParts.length > 0 ||
+                                  userFileParts.length > 0) && (
+                                  <UserMessageTextBubble
                                     initialText={toDisplayText(
                                       getUserMessageText(message)
                                     )}
+                                    isEditing={isEditing}
                                     onCancel={handleCancelEditMessage}
                                     onSubmit={(text) =>
                                       handleEditMessage(message.id, text)
                                     }
-                                  />
-                                ) : (
-                                  <>
-                                    {userImageParts.length > 0 && (
-                                      <UserImageGrid>
-                                        {userImageParts.map((part, index) =>
+                                  >
+                                    {userContentParts.map((part, index) =>
+                                      renderPart(part, message.id, index)
+                                    )}
+                                    {userFileParts.length > 0 && (
+                                      <div className="flex max-w-full flex-wrap justify-end gap-2">
+                                        {userFileParts.map((part, index) =>
                                           renderPart(part, message.id, index)
                                         )}
-                                      </UserImageGrid>
+                                      </div>
                                     )}
-                                    {(userContentParts.length > 0 ||
-                                      userFileParts.length > 0) && (
-                                      <MessageContent>
-                                        {userContentParts.map((part, index) =>
-                                          renderPart(part, message.id, index)
-                                        )}
-                                        {userFileParts.length > 0 && (
-                                          <div className="flex max-w-full flex-wrap justify-end gap-2">
-                                            {userFileParts.map((part, index) =>
-                                              renderPart(
-                                                part,
-                                                message.id,
-                                                index
-                                              )
-                                            )}
-                                          </div>
-                                        )}
-                                      </MessageContent>
-                                    )}
-                                  </>
+                                  </UserMessageTextBubble>
                                 )}
-                              </m.div>
+                              </div>
                             ) : (
                               <MessageContent>
                                 {message.parts.map((part, index) =>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/collection/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/collection/[id]/page-client.tsx
@@ -10,7 +10,9 @@ import { ContentSkeletonCard } from "@/components/content/content-skeleton-card"
 import { GroupContentTypes } from "@/components/content/group/group-content-types";
 import { RenameCollectionDialog } from "@/components/content/group/rename-collection-dialog";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
+import { EMPTY_STATE_CARD_COUNT } from "@/constants/empty-state";
 import { useCollection } from "@/lib/hooks/use-collections";
 import type { CollectionDetailPageClientProps } from "@/types/content/collection";
 import { formatLongDate, getMarkdownPreview } from "@/utils/content-preview";
@@ -140,6 +142,13 @@ export default function PageClient({
         {!hasContent && (
           <EmptyState
             description="This collection has no posts."
+            preview={
+              <EmptyStateCardsPreview
+                columns={3}
+                count={EMPTY_STATE_CARD_COUNT.content}
+                variant="content"
+              />
+            }
             title="Nothing here yet"
           />
         )}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/page-client.tsx
@@ -20,12 +20,18 @@ import {
 import { cn } from "@notra/ui/lib/utils";
 import { useRouter } from "next/navigation";
 import { parseAsInteger, useQueryState } from "nuqs";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { CreateContentButton } from "@/components/content/create-content-button";
 import { CreateContentDialog } from "@/components/content/create-content-dialog";
 import { GroupContentTypes } from "@/components/content/group/group-content-types";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import {
+  EMPTY_STATE_TABLE_COLUMNS,
+  EMPTY_STATE_TABLE_ROWS,
+} from "@/constants/empty-state";
 import { useCollections } from "@/lib/hooks/use-collections";
 import type { ContentListPageClientProps } from "@/types/content/collection";
 import { formatRelativeDate, getPageNumbers } from "@/utils/content-preview";
@@ -58,6 +64,7 @@ export default function PageClient({
     [data?.collections]
   );
   const totalPages = data?.pagination.totalPages ?? 1;
+  const [createOpen, setCreateOpen] = useState(false);
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
@@ -69,15 +76,29 @@ export default function PageClient({
               Every batch of generated content, organized into collections.
             </p>
           </div>
-          <CreateContentDialog organizationId={organizationId} />
+          <CreateContentButton
+            disabled={!organizationId}
+            onClick={() => setCreateOpen(true)}
+          />
         </div>
 
         {isPending && <GroupsPageSkeleton />}
 
         {!isPending && collections.length === 0 && (
           <EmptyState
-            className="p-8"
+            action={
+              <CreateContentButton
+                disabled={!organizationId}
+                onClick={() => setCreateOpen(true)}
+              />
+            }
             description="Generate your first piece of content to get started."
+            preview={
+              <EmptyStateTablePreview
+                columns={EMPTY_STATE_TABLE_COLUMNS.content}
+                rows={EMPTY_STATE_TABLE_ROWS}
+              />
+            }
             title="No content yet"
           />
         )}
@@ -175,6 +196,12 @@ export default function PageClient({
           </Pagination>
         )}
       </div>
+      <CreateContentDialog
+        hideTrigger
+        onOpenChange={setCreateOpen}
+        open={createOpen}
+        organizationId={organizationId}
+      />
     </PageContainer>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/github/page-client.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { ConnectGitHubDialog } from "@/components/integrations/github/connect-github-dialog";
 import { GitHubAccountCard } from "@/components/integrations/github/github-account-card";
 import { SelectRepositoriesDialog } from "@/components/integrations/github/select-repositories-dialog";
@@ -339,7 +340,14 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 
   let githubAppContent = (
     <EmptyState
+      action={
+        <Button onClick={handleOpenConnect} variant="outline">
+          <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
+          Connect GitHub
+        </Button>
+      }
       description="Install the Notra GitHub App to get started."
+      preview={<EmptyStateCardsPreview count={2} variant="integration" />}
       title="No GitHub account connected"
     />
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/granola/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/granola/page-client.tsx
@@ -25,6 +25,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { DeleteIntegrationDialog } from "@/components/delete-integration-dialog";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { AddGranolaIntegrationDialog } from "@/components/integrations/add-granola-integration-dialog";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -254,6 +255,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 </Button>
               }
               description="Connect Granola to start pulling meeting notes and summaries."
+              preview={
+                <EmptyStateCardsPreview count={2} variant="integration" />
+              }
               title="No integrations yet"
             />
           ) : null}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/linear/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/linear/page-client.tsx
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { DeleteIntegrationDialog } from "@/components/delete-integration-dialog";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { AddLinearIntegrationDialog } from "@/components/integrations/add-linear-integration-dialog";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -287,6 +288,9 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 </Button>
               }
               description="Connect Linear to start syncing issues and updates."
+              preview={
+                <EmptyStateCardsPreview count={2} variant="integration" />
+              }
               title="No integrations yet"
             />
           ) : null}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/mcp/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/mcp/page-client.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { AddMcpServerDialog } from "@/components/integrations/add-mcp-server-dialog";
 import { McpServerCard } from "@/components/integrations/mcp-server-card";
 import { PageContainer } from "@/components/layout/container";
@@ -154,6 +155,13 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
                 </Button>
               }
               description="Connect a custom MCP server to extend Notra with tools and data from your own systems."
+              preview={
+                <EmptyStateCardsPreview
+                  columns={3}
+                  count={3}
+                  variant="integration"
+                />
+              }
               title="No custom servers yet"
             />
           ) : null}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/integrations/slack/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/integrations/slack/page-client.tsx
@@ -40,6 +40,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { DeleteIntegrationDialog } from "@/components/delete-integration-dialog";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { AddSlackIntegrationDialog } from "@/components/integrations/add-slack-integration-dialog";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -653,6 +654,9 @@ export default function PageClient({
                 </Button>
               }
               description="Install the Notra agent in your Slack workspace to chat and approve content from Slack threads."
+              preview={
+                <EmptyStateCardsPreview count={2} variant="integration" />
+              }
               title="No workspace connected"
             />
           ) : null}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/page-client.tsx
@@ -2,14 +2,18 @@
 
 import type { ContentType } from "@notra/ai/schemas/content";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import Link from "next/link";
 import { useId } from "react";
+import { Button } from "@/components/button";
 import { ContentCard } from "@/components/content/content-card";
 import { ContentSkeletonCard } from "@/components/content/content-skeleton-card";
 import { CreateContentDialog } from "@/components/content/create-content-dialog";
 import { ContentActivityCard } from "@/components/dashboard/content-activity-card";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { EMPTY_STATE_CARD_COUNT } from "@/constants/empty-state";
 import { authClient } from "@/lib/auth/client";
 import { useActiveGenerations } from "@/lib/hooks/use-active-generations";
 import { useTodayPosts } from "@/lib/hooks/use-posts";
@@ -98,8 +102,19 @@ export default function PageClient({
 
     return (
       <EmptyState
-        className="p-6"
+        action={
+          <Button render={<Link href={`/${organizationSlug}/content`} />}>
+            View content
+          </Button>
+        }
         description="You have no new posts today. Create one now or review your existing drafts on the content page."
+        preview={
+          <EmptyStateCardsPreview
+            columns={3}
+            count={EMPTY_STATE_CARD_COUNT.content}
+            variant="content"
+          />
+        }
         title="No content created today"
       />
     );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/[name]/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft01Icon, Delete02Icon } from "@hugeicons/core-free-icons";
+import { ArrowLeft02Icon, Delete02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ResponsiveAlertDialog,
@@ -13,7 +13,11 @@ import {
   ResponsiveAlertDialogTitle,
 } from "@notra/ui/components/shared/responsive-alert-dialog";
 import { Badge } from "@notra/ui/components/ui/badge";
-import { Field, FieldLabel } from "@notra/ui/components/ui/field";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "@notra/ui/components/ui/field";
 import { Input } from "@notra/ui/components/ui/input";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import {
@@ -30,6 +34,7 @@ import {
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { useEffect, useRef, useState } from "react";
@@ -38,17 +43,12 @@ import { Button } from "@/components/button";
 import { DiffView } from "@/components/content/diff-view";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { SKILL_EDITOR_VIEWS } from "@/constants/skills";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import { updateSkillSchema } from "@/schemas/skills";
+import type { SkillDetailPageClientProps } from "@/types/skills/page";
 
-const VIEW_OPTIONS = ["edit", "diff"] as const;
-
-interface PageClientProps {
-  slug: string;
-  name: string;
-}
-
-export default function PageClient({ slug, name }: PageClientProps) {
+export default function PageClient({ slug, name }: SkillDetailPageClientProps) {
   const { activeOrganization } = useOrganizationsContext();
   const organizationId = activeOrganization?.id;
   const queryClient = useQueryClient();
@@ -56,7 +56,7 @@ export default function PageClient({ slug, name }: PageClientProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [view, setView] = useQueryState(
     "view",
-    parseAsStringLiteral(VIEW_OPTIONS).withDefault("edit")
+    parseAsStringLiteral(SKILL_EDITOR_VIEWS).withDefault("edit")
   );
 
   const [original, setOriginal] = useState<{
@@ -227,123 +227,141 @@ export default function PageClient({ slug, name }: PageClientProps) {
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-6 px-4 lg:px-6">
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-1">
-            <div className="flex items-center gap-3">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        onClick={() => router.push(`/${slug}/skills`)}
-                        size="icon"
-                        variant="ghost"
-                      />
-                    }
-                  >
-                    <HugeiconsIcon className="size-4" icon={ArrowLeft01Icon} />
-                  </TooltipTrigger>
-                  <TooltipContent>All skills</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <h1 className="font-bold font-mono text-3xl tracking-tight">
+      <div className="w-full space-y-8 px-4 lg:px-6">
+        <div className="space-y-4">
+          <Link
+            className="inline-flex items-center gap-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground"
+            href={`/${slug}/skills`}
+          >
+            <HugeiconsIcon className="size-4" icon={ArrowLeft02Icon} />
+            Skills
+          </Link>
+
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex min-w-0 items-center gap-2.5">
+              <h1 className="truncate font-bold font-mono text-2xl tracking-tight">
                 {name}
               </h1>
-              {skill?.isSystem && (
+              {skill?.isSystem ? (
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger
-                      render={<Badge variant="secondary">System</Badge>}
+                      render={
+                        <Badge
+                          className="whitespace-nowrap"
+                          variant="secondary"
+                        >
+                          System
+                        </Badge>
+                      }
                     />
                     <TooltipContent>
                       System skills cannot be renamed or deleted.
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
-              )}
+              ) : null}
             </div>
+            {skill && !skill.isSystem ? (
+              <Button
+                className="w-fit gap-1.5 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                disabled={saveMutation.isPending || deleteMutation.isPending}
+                onClick={() => setDeleteOpen(true)}
+                variant="outline"
+              >
+                <HugeiconsIcon className="size-4" icon={Delete02Icon} />
+                Delete
+              </Button>
+            ) : null}
           </div>
-          {skill && !skill.isSystem && (
-            <Button
-              className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
-              disabled={saveMutation.isPending || deleteMutation.isPending}
-              onClick={() => setDeleteOpen(true)}
-              variant="outline"
-            >
-              <HugeiconsIcon className="size-4" icon={Delete02Icon} />
-              Delete
-            </Button>
-          )}
         </div>
 
-        {organizationId && isPending && (
-          <div className="space-y-4">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-20 w-full" />
-            <Skeleton className="h-96 w-full" />
+        {organizationId && isPending ? (
+          <div className="space-y-8">
+            <div className="max-w-2xl space-y-5">
+              <Skeleton className="h-10 w-full max-w-md" />
+              <Skeleton className="h-20 w-full" />
+            </div>
+            <Skeleton className="h-[28rem] w-full rounded-xl" />
           </div>
-        )}
-        {!(organizationId && isPending) && skill && (
-          <div className="space-y-4">
-            <Field>
-              <FieldLabel>Name</FieldLabel>
-              <Input
-                disabled={skill.isSystem || saveMutation.isPending}
-                onChange={(e) => setNameInput(e.target.value)}
-                readOnly={skill.isSystem}
-                value={nameInput}
-              />
-              {!skill.isSystem && (
-                <p className="text-muted-foreground text-xs">
-                  Lowercase letters, digits, and hyphens. Renaming may affect
-                  references to this skill by name.
-                </p>
-              )}
-            </Field>
-            <Field>
-              <FieldLabel>
-                Description<span className="-ml-1 text-destructive">*</span>
-              </FieldLabel>
-              <Textarea
-                className="max-h-[5rem] min-h-[4rem] overflow-y-auto"
-                disabled={saveMutation.isPending}
-                onChange={(e) => setDescription(e.target.value)}
-                value={description}
-              />
-            </Field>
-            <Field>
-              <FieldLabel>
-                Content<span className="-ml-1 text-destructive">*</span>
-              </FieldLabel>
+        ) : null}
+
+        {!(organizationId && isPending) && skill ? (
+          <div className="space-y-8">
+            <div className="max-w-2xl space-y-5">
+              <Field>
+                <FieldLabel>Name</FieldLabel>
+                <Input
+                  className="max-w-md font-mono"
+                  disabled={skill.isSystem || saveMutation.isPending}
+                  onChange={(e) => setNameInput(e.target.value)}
+                  readOnly={skill.isSystem}
+                  value={nameInput}
+                />
+                {skill.isSystem ? (
+                  <FieldDescription>
+                    System skills keep a fixed name.
+                  </FieldDescription>
+                ) : (
+                  <FieldDescription>
+                    Lowercase letters, digits, and hyphens. Renaming may affect
+                    references to this skill by name.
+                  </FieldDescription>
+                )}
+              </Field>
+              <Field>
+                <FieldLabel>
+                  Description
+                  <span className="text-destructive">*</span>
+                </FieldLabel>
+                <Textarea
+                  className="max-h-32 min-h-20 resize-none overflow-y-auto leading-relaxed"
+                  disabled={saveMutation.isPending}
+                  onChange={(e) => setDescription(e.target.value)}
+                  value={description}
+                />
+              </Field>
+            </div>
+
+            <Field className="gap-3">
               <Tabs
+                className="gap-3"
                 onValueChange={(v) =>
-                  setView(v as (typeof VIEW_OPTIONS)[number])
+                  setView(v as (typeof SKILL_EDITOR_VIEWS)[number])
                 }
                 value={view}
               >
-                <TabsList variant="line">
-                  <TabsTrigger value="edit">Edit</TabsTrigger>
-                  <TabsTrigger value="diff">Diff</TabsTrigger>
-                </TabsList>
-                <TabsContent className="mt-2" value="edit">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <FieldLabel>
+                    Content
+                    <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <TabsList variant="line">
+                    <TabsTrigger value="edit">Edit</TabsTrigger>
+                    <TabsTrigger value="diff">Diff</TabsTrigger>
+                  </TabsList>
+                </div>
+                <TabsContent value="edit">
                   <Textarea
-                    className="max-h-[20rem] min-h-[16rem] overflow-y-auto font-mono text-sm"
+                    className="max-h-[min(70vh,40rem)] min-h-48 resize-none overflow-y-auto font-mono text-sm leading-relaxed"
                     disabled={saveMutation.isPending}
                     onChange={(e) => setContent(e.target.value)}
+                    spellCheck={false}
                     value={content}
                   />
                 </TabsContent>
-                <TabsContent className="mt-2" value="diff">
-                  <DiffView
-                    currentMarkdown={content}
-                    originalMarkdown={original?.content ?? ""}
-                  />
+                <TabsContent value="diff">
+                  <div className="min-h-48 overflow-auto rounded-lg border border-border/80 bg-muted/20">
+                    <DiffView
+                      currentMarkdown={content}
+                      originalMarkdown={original?.content ?? ""}
+                    />
+                  </div>
                 </TabsContent>
               </Tabs>
             </Field>
           </div>
-        )}
+        ) : null}
       </div>
 
       <ResponsiveAlertDialog onOpenChange={setDeleteOpen} open={deleteOpen}>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/skills/page-client.tsx
@@ -22,7 +22,6 @@ import { Input } from "@notra/ui/components/ui/input";
 import {
   InputGroup,
   InputGroupAddon,
-  InputGroupButton,
   InputGroupInput,
 } from "@notra/ui/components/ui/input-group";
 import { Kbd } from "@notra/ui/components/ui/kbd";
@@ -35,8 +34,11 @@ import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
+import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { EMPTY_STATE_CARD_COUNT } from "@/constants/empty-state";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import { parseSkillFrontmatter } from "@/lib/skills/parse-frontmatter";
 import { createSkillSchema } from "@/schemas/skills";
@@ -164,16 +166,34 @@ export default function PageClient({ slug }: PageClientProps) {
               Reusable instructions your agents load when generating content.
             </p>
           </div>
-          <Button className="gap-1.5" onClick={() => setDialogOpen(true)}>
-            <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
-            Create Skill
-            <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+          <Button className="w-fit gap-2" onClick={() => setDialogOpen(true)}>
+            <span className="inline-flex items-center gap-1.5">
+              <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
+              Create Skill
+            </span>
+            <Kbd className="hidden sm:inline-flex">C</Kbd>
           </Button>
         </div>
 
         {isLoadingSkills && <SkillsPageSkeleton />}
         {!isLoadingSkills && skills.length === 0 && (
-          <p className="text-muted-foreground">No skills yet.</p>
+          <EmptyState
+            action={
+              <Button onClick={() => setDialogOpen(true)} variant="outline">
+                <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
+                Create Skill
+              </Button>
+            }
+            description="Add a skill to capture writing knowledge the AI can reuse."
+            preview={
+              <EmptyStateCardsPreview
+                columns={3}
+                count={EMPTY_STATE_CARD_COUNT.skill}
+                variant="skill"
+              />
+            }
+            title="No skills yet"
+          />
         )}
         {!isLoadingSkills && skills.length > 0 && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -245,8 +265,9 @@ export default function PageClient({ slug }: PageClientProps) {
                   placeholder="https://skills.sh/..."
                   value={quickstartUrl}
                 />
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
+                <InputGroupAddon align="inline-end" className="pr-1">
+                  <Button
+                    className="h-7 px-2.5"
                     disabled={
                       !quickstartUrl.trim() ||
                       !!quickstartError ||
@@ -254,13 +275,13 @@ export default function PageClient({ slug }: PageClientProps) {
                       createMutation.isPending
                     }
                     onClick={() => importMutation.mutate()}
-                    variant="default"
+                    size="sm"
                   >
                     {importMutation.isPending ? (
                       <Loader2Icon className="size-3.5 animate-spin" />
                     ) : null}
                     {importMutation.isPending ? "Importing" : "Import"}
-                  </InputGroupButton>
+                  </Button>
                 </InputGroupAddon>
               </InputGroup>
               <p

--- a/apps/dashboard/src/components/analytics/analytics-shell.tsx
+++ b/apps/dashboard/src/components/analytics/analytics-shell.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import type { ReactNode } from "react";
 import { AnalyticsPageSkeleton } from "@/app/(dashboard)/[slug]/analytics/skeleton";
 import { AccountFilter } from "@/components/analytics/account-filter";
@@ -9,6 +8,7 @@ import { AnalyticsNav } from "@/components/analytics/analytics-nav";
 import { ConnectAccountsButtons } from "@/components/analytics/connect-accounts-buttons";
 import { SummaryStats } from "@/components/analytics/summary-stats";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateAnalyticsPreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
 import { rangeHintLabel } from "@/lib/analytics/date-range";
 import { useAnalyticsRange } from "@/lib/hooks/use-analytics-range";
@@ -67,15 +67,9 @@ export function AnalyticsShell({ children }: { children: ReactNode }) {
             </p>
           </header>
           <EmptyState
-            action={
-              <Link
-                className="text-primary text-sm underline underline-offset-4"
-                href={`/${organizationSlug}/settings/general`}
-              >
-                Connect an account
-              </Link>
-            }
+            action={<ConnectAccountsButtons organizationId={organizationId} />}
             description="Connect an X or LinkedIn account to start tracking followers, impressions, and engagement."
+            preview={<EmptyStateAnalyticsPreview />}
             title="No connected accounts"
           />
         </div>

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -118,7 +118,8 @@ const ChatInput = ({
     remainingChatCredits !== null &&
     remainingChatCredits > 0 &&
     remainingChatCredits <= 10;
-  const isUsageBlocked = checkResult ? checkResult.allowed === false : false;
+  const isUsageBlocked =
+    process.env.NODE_ENV !== "development" && checkResult?.allowed === false;
   const usageLimitError =
     externalError ??
     internalError ??
@@ -272,7 +273,7 @@ const ChatInput = ({
       </CardHeader>
       <CardContent className="p-0">
         <div
-          className="overflow-hidden rounded-[14px] border border-border bg-background shadow-sm"
+          className="overflow-hidden rounded-[14px] border border-border bg-background shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:shadow-none"
           tabIndex={-1}
         >
           <div className="p-0.5">

--- a/apps/dashboard/src/components/chat/chat-context-connect-suggestions.tsx
+++ b/apps/dashboard/src/components/chat/chat-context-connect-suggestions.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { CpuIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { CommandGroup, CommandItem } from "@notra/ui/components/ui/command";
+import { Github } from "@notra/ui/components/ui/svgs/github";
+import { Linear } from "@notra/ui/components/ui/svgs/linear";
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+import { CHAT_CONTEXT_SUGGESTED_INTEGRATIONS } from "@/constants/chat-context";
+import { buildOrganizationIntegrationConnectPath } from "@/lib/integrations/deeplink";
+import type {
+  ChatContextConnectSuggestionsProps,
+  ChatContextSuggestedIntegrationId,
+} from "@/types/components/chat-input";
+
+const SUGGESTION_ICONS: Record<ChatContextSuggestedIntegrationId, ReactNode> = {
+  github: <Github className="size-4 shrink-0" />,
+  linear: <Linear className="size-4 shrink-0" />,
+  mcp: <HugeiconsIcon className="size-4 shrink-0" icon={CpuIcon} />,
+};
+
+export function ChatContextConnectSuggestions({
+  organizationSlug,
+  onSelect,
+}: ChatContextConnectSuggestionsProps) {
+  const router = useRouter();
+
+  return (
+    <CommandGroup heading="Suggested">
+      {CHAT_CONTEXT_SUGGESTED_INTEGRATIONS.map((integration) => {
+        const href = buildOrganizationIntegrationConnectPath(
+          organizationSlug,
+          integration.href
+        );
+        return (
+          <CommandItem
+            key={integration.id}
+            keywords={[...integration.keywords]}
+            onSelect={() => {
+              onSelect();
+              router.push(href);
+            }}
+            value={integration.id}
+          >
+            {SUGGESTION_ICONS[integration.id]}
+            <span className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate text-sm">{integration.name}</span>
+              <span className="truncate text-muted-foreground text-xs">
+                {integration.description}
+              </span>
+            </span>
+            <span
+              className="ml-auto text-muted-foreground text-xs"
+              data-slot="command-shortcut"
+            >
+              Connect
+            </span>
+          </CommandItem>
+        );
+      })}
+    </CommandGroup>
+  );
+}

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -101,6 +101,7 @@ import type {
 } from "@/types/components/chat-input";
 import type { GitHubRepository } from "@/types/integrations";
 import { AttachmentPreviewDialog } from "./attachment-preview";
+import { ChatContextConnectSuggestions } from "./chat-context-connect-suggestions";
 import type { QueuedMessage } from "./chat-queue";
 import {
   buildFragmentFromReferencedText,
@@ -716,7 +717,8 @@ export function ChatInputAdvanced({
     remainingChatCredits !== null &&
     remainingChatCredits > 0 &&
     remainingChatCredits <= 10;
-  const isUsageBlocked = checkResult ? checkResult.allowed === false : false;
+  const isUsageBlocked =
+    process.env.NODE_ENV !== "development" && checkResult?.allowed === false;
   const usageLimitError =
     externalError ??
     internalError ??
@@ -1736,7 +1738,7 @@ export function ChatInputAdvanced({
         </CardHeader>
         <CardContent className="p-0">
           <div
-            className={`rounded-[14px] border border-border bg-background shadow-sm ${connectedTop ? "rounded-t-none border-t-0" : ""}`}
+            className={`rounded-[14px] border border-border bg-background shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:shadow-none ${connectedTop ? "rounded-t-none border-t-0" : ""}`}
             tabIndex={-1}
           >
             <section
@@ -2131,8 +2133,16 @@ export function ChatInputAdvanced({
                           <CommandInput placeholder="Search tools and context..." />
                           <CommandList>
                             <CommandEmpty>
-                              No matching tools or context found.
+                              {contextOptions.length === 0
+                                ? "No matching integrations."
+                                : "No matching tools or context found."}
                             </CommandEmpty>
+                            {contextOptions.length === 0 && organizationSlug ? (
+                              <ChatContextConnectSuggestions
+                                onSelect={() => setIsContextPickerOpen(false)}
+                                organizationSlug={organizationSlug}
+                              />
+                            ) : null}
                             {integrationContextOptions.length > 0 && (
                               <CommandGroup heading="Context">
                                 {integrationContextOptions.map((option) => {

--- a/apps/dashboard/src/components/chat/chat-queue.tsx
+++ b/apps/dashboard/src/components/chat/chat-queue.tsx
@@ -36,7 +36,7 @@ export function ChatQueue({ messages, onEdit, onRemove }: ChatQueueProps) {
         <motion.div
           animate={{ height: "auto", opacity: 1, y: 0 }}
           aria-label="Queued messages"
-          className="overflow-hidden rounded-t-[14px] border border-border border-b-0 bg-background px-1.5 pt-1.5 pb-1 shadow-sm"
+          className="overflow-hidden rounded-t-[14px] border border-border border-b-0 bg-background px-1.5 pt-1.5 pb-1 shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:shadow-none"
           exit={{ height: 0, opacity: 0, y: 12 }}
           initial={{ height: 0, opacity: 0, y: 12 }}
           transition={containerTransition}

--- a/apps/dashboard/src/components/chat/user-message-actions.tsx
+++ b/apps/dashboard/src/components/chat/user-message-actions.tsx
@@ -24,9 +24,14 @@ import {
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
 import { cn } from "@notra/ui/lib/utils";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/button";
 import { AVAILABLE_MODELS, ModelIcon } from "@/components/chat/chat-input";
+import type {
+  UserMessageEditorProps,
+  UserMessageTextBubbleProps,
+} from "@/types/components/chat-page";
 
 interface UserMessageActionsProps {
   messageText: string;
@@ -72,9 +77,10 @@ export function UserMessageActions({
   return (
     <div
       className={cn(
-        "mt-0.5 ml-auto flex items-center gap-1 text-muted-foreground opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100 data-[force-visible=true]:opacity-100",
-        isEditing &&
-          "pointer-events-none line-through opacity-40 focus-within:opacity-40 group-hover:opacity-40"
+        "mt-0.5 ml-auto flex items-center gap-1 text-muted-foreground transition-[opacity,height,margin] duration-200 ease-out",
+        isEditing
+          ? "pointer-events-none mt-0 h-0 overflow-hidden opacity-0"
+          : "opacity-0 focus-within:opacity-100 group-hover:opacity-100 data-[force-visible=true]:opacity-100"
       )}
       data-force-visible={retryOpen || undefined}
     >
@@ -204,19 +210,27 @@ export function UserMessageActions({
   );
 }
 
-interface UserMessageEditorProps {
-  initialText: string;
-  onCancel: () => void;
-  onSubmit: (text: string) => void;
-}
+const USER_MESSAGE_BUBBLE_CLASS =
+  "ml-auto flex min-w-0 flex-col gap-2 overflow-hidden rounded-lg bg-secondary px-4 py-3 text-foreground text-sm";
 
-export function UserMessageEditor({
+const USER_MESSAGE_EDIT_TRANSITION = {
+  duration: 0.22,
+  ease: [0.22, 1, 0.36, 1] as const,
+};
+
+const USER_MESSAGE_FADE_TRANSITION = {
+  duration: 0.14,
+  ease: [0.22, 1, 0.36, 1] as const,
+};
+
+function UserMessageEditor({
   initialText,
   onCancel,
   onSubmit,
 }: UserMessageEditorProps) {
   const [value, setValue] = useState(initialText);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const reduceMotion = useReducedMotion();
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure when value changes (scrollHeight is read from the DOM).
   useEffect(() => {
@@ -252,7 +266,7 @@ export function UserMessageEditor({
   };
 
   return (
-    <div className="ml-auto flex w-full flex-col gap-2 rounded-lg bg-secondary px-4 py-3">
+    <div className="flex flex-col gap-2">
       <textarea
         className="wrap-break-word max-h-80 min-h-6 w-full resize-none bg-transparent text-foreground text-sm leading-6 outline-none placeholder:text-muted-foreground"
         onChange={(e) => setValue(e.target.value)}
@@ -272,7 +286,12 @@ export function UserMessageEditor({
         rows={1}
         value={value}
       />
-      <div className="flex items-center justify-end gap-2">
+      <m.div
+        animate={{ opacity: 1, y: 0 }}
+        className="flex items-center justify-end gap-2"
+        initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+        transition={USER_MESSAGE_FADE_TRANSITION}
+      >
         <Button onClick={onCancel} size="sm" type="button" variant="ghost">
           Cancel
         </Button>
@@ -284,7 +303,57 @@ export function UserMessageEditor({
         >
           Send
         </Button>
-      </div>
+      </m.div>
     </div>
+  );
+}
+
+export function UserMessageTextBubble({
+  children,
+  isEditing,
+  initialText,
+  onCancel,
+  onSubmit,
+}: UserMessageTextBubbleProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <m.div
+      className={cn(
+        USER_MESSAGE_BUBBLE_CLASS,
+        isEditing ? "w-full" : "is-user:dark w-fit max-w-full"
+      )}
+      layout={!reduceMotion}
+      transition={USER_MESSAGE_EDIT_TRANSITION}
+    >
+      <AnimatePresence initial={false} mode="popLayout">
+        {isEditing ? (
+          <m.div
+            animate={{ opacity: 1 }}
+            exit={reduceMotion ? undefined : { opacity: 0 }}
+            initial={reduceMotion ? false : { opacity: 0 }}
+            key="edit"
+            transition={USER_MESSAGE_FADE_TRANSITION}
+          >
+            <UserMessageEditor
+              initialText={initialText}
+              onCancel={onCancel}
+              onSubmit={onSubmit}
+            />
+          </m.div>
+        ) : (
+          <m.div
+            animate={{ opacity: 1 }}
+            className="flex min-w-0 flex-col gap-2 overflow-hidden"
+            exit={reduceMotion ? undefined : { opacity: 0 }}
+            initial={reduceMotion ? false : { opacity: 0 }}
+            key="view"
+            transition={USER_MESSAGE_FADE_TRANSITION}
+          >
+            {children}
+          </m.div>
+        )}
+      </AnimatePresence>
+    </m.div>
   );
 }

--- a/apps/dashboard/src/components/content/create-content-button.tsx
+++ b/apps/dashboard/src/components/content/create-content-button.tsx
@@ -10,10 +10,12 @@ type CreateContentButtonProps = Omit<ComponentProps<typeof Button>, "children">;
 
 export function CreateContentButton(props: CreateContentButtonProps) {
   return (
-    <Button className="gap-1.5" {...props}>
-      <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
-      Create Content
-      <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
+    <Button className="w-fit gap-2" {...props}>
+      <span className="inline-flex items-center gap-1.5">
+        <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
+        Create Content
+      </span>
+      <Kbd className="hidden sm:inline-flex">C</Kbd>
     </Button>
   );
 }

--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -101,11 +101,11 @@ export function DashboardSidebar({
     >
       <LazyMotion features={domAnimation}>
         <SidebarHeader>
-          <div className="flex items-center gap-2 px-2 pt-1">
-            <div className="flex size-7 shrink-0 items-center justify-center rounded-lg dark:bg-[#F6F3F1]">
-              <Notra className="size-7 dark:size-5" />
+          <div className="flex h-8 items-center gap-2 px-2">
+            <div className="flex size-7 shrink-0 items-center justify-center rounded-lg transition-[width,height] duration-(--sidebar-duration) ease-(--sidebar-ease) group-data-[collapsible=icon]:size-6 group-data-[collapsible=icon]:rounded-md motion-reduce:transition-none dark:bg-[#F6F3F1]">
+              <Notra className="size-7 group-data-[collapsible=icon]:size-6 dark:size-5 dark:group-data-[collapsible=icon]:size-5" />
             </div>
-            <span className="truncate font-semibold text-base transition-opacity duration-100 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[state=expanded]:delay-200">
+            <span className="min-w-0 truncate font-semibold text-base transition-opacity duration-200 ease-(--sidebar-ease) group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-75 group-data-[state=expanded]:delay-150 motion-reduce:transition-none motion-reduce:delay-0">
               Notra
             </span>
           </div>

--- a/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/brand-topbar-identity-selector.tsx
@@ -99,7 +99,7 @@ export function BrandTopbarIdentitySelector({ slug }: { slug: string }) {
   function handleSelectVoice(voiceId: string) {
     writeStoredBrandIdentityId(organizationId, voiceId);
     notifyStoredBrandIdentityChange();
-    router.push(`${brandBasePath}?voice=${voiceId}${viewSuffix}`);
+    router.replace(`${brandBasePath}?voice=${voiceId}${viewSuffix}`);
   }
 
   if (voices.length === 0 || !activeVoice) {

--- a/apps/dashboard/src/components/dashboard/content-activity-card.tsx
+++ b/apps/dashboard/src/components/dashboard/content-activity-card.tsx
@@ -45,7 +45,7 @@ export const ContentActivityCard = () => {
   }) as { data?: ContentPublishingMetricsData; isPending: boolean };
 
   if (isPending) {
-    return <Skeleton className="h-40 w-full max-w-[53rem] rounded-lg" />;
+    return <Skeleton className="h-40 w-full rounded-lg" />;
   }
 
   return (

--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SidebarInset, SidebarProvider } from "@notra/ui/components/ui/sidebar";
+import { cn } from "@notra/ui/lib/utils";
 import { toast } from "sonner";
 import { SubscriptionGate } from "@/components/billing/subscription-gate";
 import { DashboardSidebar } from "@/components/dashboard/app-sidebar";
@@ -71,10 +72,18 @@ export function DashboardShell({
         defaultOpen={initialSidebarOpen}
       >
         <DashboardSidebar
-          className="md:top-(--eve-banner-height) md:h-[calc(100svh-var(--eve-banner-height))]"
+          className={cn(
+            "md:top-(--eve-banner-height) md:h-[calc(100svh-var(--eve-banner-height))]",
+            visible && "md:pt-0!"
+          )}
           variant="inset"
         />
-        <SidebarInset className="min-h-0 min-w-0 overflow-hidden">
+        <SidebarInset
+          className={cn(
+            "min-h-0 min-w-0 overflow-hidden",
+            visible && "md:mt-0! md:rounded-t-none! md:border-t-0!"
+          )}
+        >
           <SiteHeader />
           <div className="@container/main scrollbar-stable flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden overscroll-contain">
             <SubscriptionGate>{children}</SubscriptionGate>

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -107,7 +107,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
               !isGuidelinesView
             }
             render={
-              <Link href={companyInfoHref}>
+              <Link href={companyInfoHref} replace>
                 <HugeiconsIcon icon={CorporateIcon} />
                 <span>Company Info</span>
               </Link>
@@ -119,7 +119,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
           <SidebarMenuButton
             isActive={isGuidelinesView}
             render={
-              <Link href={guidelinesHref}>
+              <Link href={guidelinesHref} replace>
                 <HugeiconsIcon icon={PaintBoardIcon} />
                 <span>Brand Guidelines</span>
               </Link>
@@ -131,7 +131,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
           <SidebarMenuButton
             isActive={isReferencesView}
             render={
-              <Link href={referencesHref}>
+              <Link href={referencesHref} replace>
                 <HugeiconsIcon icon={Comment01Icon} />
                 <span>References</span>
                 {referenceCount > 0 ? (
@@ -148,7 +148,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
           <SidebarMenuButton
             isActive={isSitemapView}
             render={
-              <Link href={sitemapHref}>
+              <Link href={sitemapHref} replace>
                 <HugeiconsIcon icon={GlobalIcon} />
                 <span>Sitemap</span>
                 {sitemapCount > 0 ? (

--- a/apps/dashboard/src/components/dashboard/onboarding-agent-banner.tsx
+++ b/apps/dashboard/src/components/dashboard/onboarding-agent-banner.tsx
@@ -53,9 +53,12 @@ export function OnboardingAgentBanner({
   };
 
   return (
-    <div className="relative isolate flex h-(--eve-banner-height) w-full shrink-0 items-center justify-center overflow-hidden">
+    <div
+      className="relative isolate flex h-(--eve-banner-height) w-full shrink-0 items-center justify-center overflow-hidden"
+      style={{ backgroundColor: colors.colorBack }}
+    >
       <Dithering
-        className="-z-10 absolute inset-0 h-full w-full"
+        className="-z-10 -inset-px absolute size-[calc(100%+2px)] min-h-full min-w-full"
         colorBack={colors.colorBack}
         colorFront={colors.colorFront}
         scale={EVE_BANNER_DITHER_SCALE}

--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -9,6 +9,7 @@ import {
   Settings01Icon,
   SparklesIcon,
   Sun03Icon,
+  Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
@@ -22,6 +23,7 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
@@ -127,12 +129,10 @@ function OverflowAwareText({
 }
 
 function OrgSelectorTrigger({
-  isCollapsed,
   isSwitching,
   activeOrganization,
   planBadge,
 }: {
-  isCollapsed: boolean;
   isSwitching: boolean;
   activeOrganization: Organization | null;
   planBadge: "pro" | "basic" | null;
@@ -141,20 +141,12 @@ function OrgSelectorTrigger({
     <DropdownMenuTrigger
       render={
         <SidebarMenuButton
-          className={cn(
-            "cursor-pointer data-popup-open:bg-sidebar-accent/90 data-popup-open:text-sidebar-accent-foreground data-popup-open:ring-1 data-popup-open:ring-sidebar-border/70",
-            isCollapsed ? "min-w-0 justify-center" : ""
-          )}
+          className="min-w-0 cursor-pointer data-popup-open:bg-sidebar-accent/90 data-popup-open:text-sidebar-accent-foreground data-popup-open:ring-1 data-popup-open:ring-sidebar-border/70 group-data-[collapsible=icon]:justify-center"
           disabled={isSwitching}
           size="lg"
           tooltip={`Organization | ${activeOrganization?.name}`}
         >
-          <Avatar
-            className={cn(
-              "size-8 rounded-lg after:rounded-lg",
-              isCollapsed ? "size-6" : ""
-            )}
-          >
+          <Avatar className="size-8 rounded-lg transition-[width,height] duration-(--sidebar-duration) ease-(--sidebar-ease) after:rounded-lg group-data-[collapsible=icon]:size-6 motion-reduce:transition-none">
             <AvatarImage
               className="rounded-lg"
               src={activeOrganization?.logo || undefined}
@@ -163,27 +155,26 @@ function OrgSelectorTrigger({
               {activeOrganization?.name.charAt(0)}
             </AvatarFallback>
           </Avatar>
-          {isCollapsed ? null : (
-            <>
-              <div className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm leading-tight">
-                <OverflowAwareText
-                  className="font-medium text-sm"
-                  text={activeOrganization?.name}
-                />
-                {planBadge === "pro" ? (
-                  <Badge className="shrink-0 bg-purple-500/15 px-1.5 py-0 font-semibold text-[10px] text-purple-600 hover:bg-purple-500/15 dark:text-purple-400">
-                    PRO
-                  </Badge>
-                ) : null}
-                {planBadge === "basic" ? (
-                  <Badge className="shrink-0 bg-blue-500/15 px-1.5 py-0 font-semibold text-[10px] text-blue-600 hover:bg-blue-500/15 dark:text-blue-400">
-                    BASIC
-                  </Badge>
-                ) : null}
-              </div>
-              <HugeiconsIcon className="ml-auto" icon={ArrowUp01Icon} />
-            </>
-          )}
+          <div className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm leading-tight transition-opacity duration-200 ease-(--sidebar-ease) group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-75 group-data-[state=expanded]:delay-150 motion-reduce:transition-none motion-reduce:delay-0">
+            <OverflowAwareText
+              className="font-medium text-sm"
+              text={activeOrganization?.name}
+            />
+            {planBadge === "pro" ? (
+              <Badge className="shrink-0 bg-purple-500/15 px-1.5 py-0 font-semibold text-[10px] text-purple-600 hover:bg-purple-500/15 dark:text-purple-400">
+                PRO
+              </Badge>
+            ) : null}
+            {planBadge === "basic" ? (
+              <Badge className="shrink-0 bg-blue-500/15 px-1.5 py-0 font-semibold text-[10px] text-blue-600 hover:bg-blue-500/15 dark:text-blue-400">
+                BASIC
+              </Badge>
+            ) : null}
+          </div>
+          <HugeiconsIcon
+            className="ml-auto transition-opacity duration-200 ease-(--sidebar-ease) group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-75 group-data-[state=expanded]:delay-150 motion-reduce:transition-none motion-reduce:delay-0"
+            icon={ArrowUp01Icon}
+          />
         </SidebarMenuButton>
       }
     />
@@ -206,6 +197,8 @@ function OrgSelectorSkeleton({ isCollapsed }: { isCollapsed: boolean }) {
   );
 }
 
+const ORG_MENU_ITEM_CLASS = "cursor-pointer py-1.5";
+
 export function OrganizationOptionsList({
   organizations,
   selectedOrganizationId,
@@ -223,42 +216,47 @@ export function OrganizationOptionsList({
 
   return (
     <DropdownMenuGroup>
+      <DropdownMenuLabel>Organizations</DropdownMenuLabel>
       {organizations.map((org) => {
         const isSelected = selectedOrganizationId === org.id;
         return (
-          <div className="flex items-center gap-1" key={org.id}>
-            <DropdownMenuItem
-              className={cn(
-                "min-w-0 flex-1 cursor-pointer gap-2",
-                isSelected && "bg-accent text-accent-foreground"
-              )}
-              disabled={disabled}
-              onClick={() => onSelect(org.id)}
-            >
-              <Avatar className="size-6 rounded-lg after:rounded-lg">
-                <AvatarImage src={org.logo || undefined} />
-                <AvatarFallback className="rounded-lg">
-                  {org.name.slice(0, 2)}
-                </AvatarFallback>
-              </Avatar>
-              <OverflowAwareText
-                className="text-sm"
-                text={org.name}
-                thresholdMultiplier={1.75}
+          <DropdownMenuItem
+            aria-current={isSelected ? "true" : undefined}
+            className={ORG_MENU_ITEM_CLASS}
+            disabled={disabled}
+            key={org.id}
+            onClick={() => onSelect(org.id)}
+          >
+            <Avatar className="size-5 rounded-md after:rounded-md">
+              <AvatarImage src={org.logo || undefined} />
+              <AvatarFallback className="rounded-md text-[10px]">
+                {org.name.slice(0, 2)}
+              </AvatarFallback>
+            </Avatar>
+            <OverflowAwareText
+              className="text-sm"
+              text={org.name}
+              thresholdMultiplier={1.75}
+            />
+            {isSelected ? (
+              <HugeiconsIcon
+                className="ml-auto size-4 text-muted-foreground"
+                icon={Tick02Icon}
               />
-            </DropdownMenuItem>
-            {isSelected && onCreate ? (
-              <DropdownMenuItem
-                aria-label="Create organization"
-                className="size-7 shrink-0 cursor-pointer justify-center p-0 text-muted-foreground data-highlighted:text-foreground"
-                onClick={onCreate}
-              >
-                <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
-              </DropdownMenuItem>
             ) : null}
-          </div>
+          </DropdownMenuItem>
         );
       })}
+      {onCreate ? (
+        <DropdownMenuItem
+          className={cn(ORG_MENU_ITEM_CLASS, "text-muted-foreground")}
+          disabled={disabled}
+          onClick={onCreate}
+        >
+          <HugeiconsIcon icon={PlusSignIcon} />
+          New organization
+        </DropdownMenuItem>
+      ) : null}
     </DropdownMenuGroup>
   );
 }
@@ -392,7 +390,6 @@ export function OrgSelector() {
           {shouldShowTrigger ? (
             <OrgSelectorTrigger
               activeOrganization={activeOrganization}
-              isCollapsed={isCollapsed}
               isSwitching={isNavigating}
               planBadge={planBadge}
             />
@@ -401,9 +398,9 @@ export function OrgSelector() {
           )}
           <DropdownMenuContent
             align="start"
-            className="w-72 rounded-lg"
+            className="w-64"
             side={dropdownSide}
-            sideOffset={4}
+            sideOffset={6}
           >
             <OrganizationOptionsList
               disabled={isNavigating}
@@ -415,9 +412,9 @@ export function OrgSelector() {
 
             <DropdownMenuSeparator />
 
-            <CreditBalanceMenuItem />
+            <CreditBalanceMenuItem className={ORG_MENU_ITEM_CLASS} />
             <DropdownMenuItem
-              className="cursor-pointer"
+              className={ORG_MENU_ITEM_CLASS}
               onClick={() => openFeedback()}
             >
               <HugeiconsIcon icon={Message01Icon} />
@@ -425,33 +422,32 @@ export function OrgSelector() {
               <Kbd className="ml-auto">F</Kbd>
             </DropdownMenuItem>
             <DropdownMenuItem
-              className="cursor-pointer"
+              className={ORG_MENU_ITEM_CLASS}
               onClick={triggerScheduleDemo}
             >
               <HugeiconsIcon icon={Calendar03Icon} />
               Schedule a Demo
               <Kbd className="ml-auto">S</Kbd>
             </DropdownMenuItem>
-
             {hasActivePaidPlan ? null : (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  className="cursor-pointer bg-primary/10 text-primary data-highlighted:bg-primary/15 data-highlighted:text-primary [&_svg]:text-primary"
-                  onClick={() =>
-                    router.push(`/${activeOrganization?.slug}/settings/billing`)
-                  }
-                >
-                  <HugeiconsIcon icon={SparklesIcon} />
-                  Upgrade to Pro
-                </DropdownMenuItem>
-              </>
+              <DropdownMenuItem
+                className={cn(
+                  ORG_MENU_ITEM_CLASS,
+                  "text-primary focus:text-primary [&_svg]:text-primary"
+                )}
+                onClick={() =>
+                  router.push(`/${activeOrganization?.slug}/settings/billing`)
+                }
+              >
+                <HugeiconsIcon icon={SparklesIcon} />
+                Upgrade to Pro
+              </DropdownMenuItem>
             )}
 
             <DropdownMenuSeparator />
 
             <DropdownMenuItem
-              className="cursor-pointer"
+              className={ORG_MENU_ITEM_CLASS}
               onClick={() =>
                 router.push(`/${activeOrganization?.slug}/settings/account`)
               }
@@ -460,7 +456,10 @@ export function OrgSelector() {
               Settings
             </DropdownMenuItem>
 
-            <DropdownMenuItem className="cursor-pointer" onClick={toggleTheme}>
+            <DropdownMenuItem
+              className={ORG_MENU_ITEM_CLASS}
+              onClick={toggleTheme}
+            >
               <HugeiconsIcon icon={isDark ? Sun03Icon : Moon02Icon} />
               {isDark ? "Light Mode" : "Dark Mode"}
               <Kbd className="ml-auto">D</Kbd>

--- a/apps/dashboard/src/components/empty-state-preview.tsx
+++ b/apps/dashboard/src/components/empty-state-preview.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { Card, CardHeader } from "@notra/ui/components/ui/card";
+import { useId } from "react";
+import {
+  EMPTY_STATE_CARD_COUNT,
+  EMPTY_STATE_CARD_KEYS,
+  EMPTY_STATE_CHART_BARS,
+  EMPTY_STATE_GUIDELINE_ASSET_KEYS,
+  EMPTY_STATE_GUIDELINE_COLOR_KEYS,
+  EMPTY_STATE_ROW_KEYS,
+  EMPTY_STATE_SKILL_CARD_LAYOUTS,
+  EMPTY_STATE_STAT_KEYS,
+} from "@/constants/empty-state";
+import { cn } from "@/lib/utils";
+import type {
+  EmptyStateCardsPreviewProps,
+  EmptyStateCardsPreviewVariant,
+  EmptyStateTablePreviewProps,
+} from "@/types/components/empty-state";
+
+const ROW_SCALE = [1, 0.74, 0.9, 0.62, 0.84, 0.7] as const;
+
+function GhostBar({
+  className,
+  width,
+}: {
+  className?: string;
+  width?: number | string;
+}) {
+  return (
+    <div
+      className={cn("h-3.5 rounded-md bg-muted-foreground/20", className)}
+      style={width === undefined ? undefined : { width }}
+    />
+  );
+}
+
+function scaledWidth(base: number, row: number, column: number) {
+  const scale = ROW_SCALE[row % ROW_SCALE.length] ?? 1;
+  const columnNudge = 1 - (column % 3) * 0.08;
+  return Math.max(28, Math.round(base * scale * columnNudge));
+}
+
+export function EmptyStateTablePreview({
+  columns,
+  rows = 6,
+}: EmptyStateTablePreviewProps) {
+  const id = useId();
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/80 border-b-border/40 bg-muted/80 shadow-2xs">
+      <div className="flex items-center gap-4 border-border/60 border-b bg-muted/80 px-4 py-2.5">
+        {columns.map((width, index) => (
+          <GhostBar
+            className="h-3"
+            key={`${id}-header-${index}-${width}`}
+            width={Math.round(width * 0.7)}
+          />
+        ))}
+      </div>
+      {EMPTY_STATE_ROW_KEYS.slice(0, rows).map((rowKey, row) => (
+        <div
+          className="flex items-center gap-4 border-border/60 border-b bg-background px-4 py-3 last:border-b-0"
+          key={`${id}-${rowKey}`}
+        >
+          {columns.map((width, column) => (
+            <GhostBar
+              className="h-4"
+              key={`${id}-${rowKey}-${column}-${width}`}
+              width={scaledWidth(width, row, column)}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ContentCardGhost() {
+  return (
+    <div className="flex h-[8.75rem] flex-col rounded-lg border border-border/80 bg-muted/80 p-2">
+      <div className="px-2 py-1.5">
+        <GhostBar className="h-4" width="68%" />
+      </div>
+      <div className="flex-1 space-y-2 rounded-md bg-background/70 px-3 py-2.5">
+        <GhostBar className="h-3 w-full" />
+        <GhostBar className="h-3 w-5/6" />
+        <GhostBar className="h-3 w-2/3" />
+      </div>
+      <div className="flex gap-2 px-2 py-2">
+        <GhostBar className="h-5 w-12 rounded-full" />
+        <GhostBar className="h-5 w-16 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
+function SkillCardGhost({ index }: { index: number }) {
+  const layout =
+    EMPTY_STATE_SKILL_CARD_LAYOUTS[
+      index % EMPTY_STATE_SKILL_CARD_LAYOUTS.length
+    ];
+
+  if (!layout) {
+    return null;
+  }
+
+  return (
+    <Card className="h-full min-h-[9.5rem] gap-3">
+      <CardHeader>
+        <GhostBar className="h-5 rounded-md" width={layout.title} />
+        <div className="space-y-2 pt-1">
+          {layout.lines.map((line) => (
+            <GhostBar className="h-3.5" key={line.key} width={line.width} />
+          ))}
+        </div>
+        <GhostBar className="mt-2 h-3" width={layout.date} />
+      </CardHeader>
+    </Card>
+  );
+}
+
+function ReferenceCardGhost() {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border/80 bg-card p-4">
+      <div className="flex items-center gap-3">
+        <div className="size-8 shrink-0 rounded-full bg-muted-foreground/20" />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <GhostBar className="h-3.5 w-28" />
+          <GhostBar className="h-3 w-16" />
+        </div>
+      </div>
+      <GhostBar className="h-3.5 w-full" />
+      <GhostBar className="h-3.5 w-5/6" />
+      <GhostBar className="h-3.5 w-2/3" />
+    </div>
+  );
+}
+
+function RunCardGhost() {
+  return (
+    <div className="space-y-4 rounded-xl border border-border p-4">
+      <div className="flex items-center gap-2">
+        <GhostBar className="h-5 w-16 rounded-full" />
+        <GhostBar className="h-5 w-20 rounded-full" />
+        <GhostBar className="ml-auto h-3 w-16" />
+      </div>
+      <div className="space-y-2">
+        <GhostBar className="h-4 w-3/4" />
+        <GhostBar className="h-3 w-full" />
+        <GhostBar className="h-3 w-2/3" />
+      </div>
+    </div>
+  );
+}
+
+function IntegrationCardGhost() {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border/80 bg-card p-4">
+      <div className="size-10 shrink-0 rounded-lg bg-muted-foreground/20" />
+      <div className="min-w-0 flex-1 space-y-2">
+        <GhostBar className="h-4 w-36" />
+        <GhostBar className="h-3 w-52" />
+      </div>
+      <GhostBar className="h-6 w-16 rounded-full" />
+    </div>
+  );
+}
+
+function AnalyticsChartGhost({ bars }: { bars: readonly number[] }) {
+  return (
+    <div className="rounded-2xl border border-border/80 bg-card p-4">
+      <GhostBar className="h-4 w-24" />
+      <GhostBar className="mt-2 h-3 w-40" />
+      <div className="mt-5 flex h-32 items-end gap-1.5">
+        {bars.map((height) => (
+          <div
+            className="flex-1 rounded-sm bg-muted-foreground/20"
+            key={`bar-${height}`}
+            style={{ height }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function EmptyStateAnalyticsPreview() {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {EMPTY_STATE_STAT_KEYS.map((key) => (
+          <div
+            className="flex flex-col justify-center gap-2 rounded-xl border border-border/80 bg-card p-4"
+            key={key}
+          >
+            <GhostBar className="h-3 w-20" />
+            <GhostBar className="h-7 w-16" />
+            <GhostBar className="h-3 w-28" />
+          </div>
+        ))}
+      </div>
+      <div className="grid gap-3 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <AnalyticsChartGhost bars={EMPTY_STATE_CHART_BARS} />
+        </div>
+        <AnalyticsChartGhost bars={EMPTY_STATE_CHART_BARS.slice(3, 11)} />
+      </div>
+    </div>
+  );
+}
+
+export function EmptyStateGuidelinesPreview() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-3">
+        {EMPTY_STATE_GUIDELINE_ASSET_KEYS.map((key) => (
+          <div
+            className="overflow-hidden rounded-xl border border-border/80 bg-card"
+            key={key}
+          >
+            <div className="flex h-28 items-center justify-center bg-muted/50">
+              <div className="size-12 rounded-lg bg-muted-foreground/20" />
+            </div>
+            <div className="space-y-2 p-3">
+              <GhostBar className="h-3.5 w-24" />
+              <GhostBar className="h-3 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {EMPTY_STATE_GUIDELINE_COLOR_KEYS.map((key) => (
+          <div
+            className="flex items-center gap-3 rounded-xl border border-border/80 bg-card p-3"
+            key={key}
+          >
+            <div className="size-9 shrink-0 rounded-lg bg-muted-foreground/20" />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <GhostBar className="h-3.5 w-24" />
+              <GhostBar className="h-3 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function getCardGridClass(
+  variant: EmptyStateCardsPreviewVariant,
+  columns?: 2 | 3
+) {
+  if (columns === 2) {
+    return "grid-cols-1 sm:grid-cols-2";
+  }
+  if (columns === 3) {
+    return "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3";
+  }
+  if (variant === "run" || variant === "integration") {
+    return "grid-cols-1";
+  }
+  if (variant === "reference") {
+    return "grid-cols-1 sm:grid-cols-2";
+  }
+  return "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3";
+}
+
+export function EmptyStateCardsPreview({
+  variant = "content",
+  count,
+  columns,
+}: EmptyStateCardsPreviewProps) {
+  const id = useId();
+  const resolvedCount = count ?? EMPTY_STATE_CARD_COUNT[variant];
+
+  return (
+    <div
+      className={cn(
+        "grid",
+        variant === "skill" ? "gap-4" : "gap-3",
+        getCardGridClass(variant, columns)
+      )}
+    >
+      {EMPTY_STATE_CARD_KEYS.slice(0, resolvedCount).map((cardKey, index) => {
+        if (variant === "skill") {
+          return <SkillCardGhost index={index} key={`${id}-${cardKey}`} />;
+        }
+        if (variant === "reference") {
+          return <ReferenceCardGhost key={`${id}-${cardKey}`} />;
+        }
+        if (variant === "run") {
+          return <RunCardGhost key={`${id}-${cardKey}`} />;
+        }
+        if (variant === "integration") {
+          return <IntegrationCardGhost key={`${id}-${cardKey}`} />;
+        }
+        return <ContentCardGhost key={`${id}-${cardKey}`} />;
+      })}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/empty-state.tsx
+++ b/apps/dashboard/src/components/empty-state.tsx
@@ -1,16 +1,6 @@
-import type React from "react";
 import { Button } from "@/components/button";
 import { cn } from "@/lib/utils";
-
-interface EmptyStateProps extends React.ComponentProps<"div"> {
-  title: string;
-  description: string;
-  action?: React.ReactNode;
-  actionLabel?: string;
-  actionVariant?: React.ComponentProps<typeof Button>["variant"];
-  onActionClick?: React.ComponentProps<"button">["onClick"];
-  actionIcon?: React.ReactNode;
-}
+import type { EmptyStateProps } from "@/types/components/empty-state";
 
 function EmptyState({
   title,
@@ -20,14 +10,19 @@ function EmptyState({
   actionVariant = "default",
   onActionClick,
   actionIcon,
+  preview,
   className,
   ...props
 }: EmptyStateProps) {
   const renderedAction =
     action ??
     (actionLabel ? (
-      <Button onClick={onActionClick} size="sm" variant={actionVariant}>
-        {actionIcon ? <span className="mr-2">{actionIcon}</span> : null}
+      <Button
+        className="w-fit gap-1.5 px-3"
+        onClick={onActionClick}
+        variant={actionVariant}
+      >
+        {actionIcon}
         {actionLabel}
       </Button>
     ) : null);
@@ -35,16 +30,41 @@ function EmptyState({
   return (
     <div
       className={cn(
-        "rounded-2xl border border-dashed p-12 text-center",
+        "relative flex min-h-72 w-full flex-col items-center overflow-hidden text-center",
+        preview
+          ? "rounded-2xl"
+          : "justify-center rounded-2xl border border-dashed bg-muted/15 px-6 py-16",
         className
       )}
       {...props}
     >
-      <h3 className="font-semibold text-lg">{title}</h3>
-      <p className="mt-1 text-muted-foreground text-sm">{description}</p>
-      {renderedAction ? (
-        <div className="mt-4 flex justify-center">{renderedAction}</div>
+      {preview ? (
+        <div
+          aria-hidden
+          className="pointer-events-none w-full shrink-0 select-none px-3 pt-3 sm:px-4 sm:pt-4"
+        >
+          <div className="opacity-[0.38] [mask-image:linear-gradient(to_bottom,black_0%,transparent_100%)]">
+            {preview}
+          </div>
+        </div>
       ) : null}
+
+      <div
+        className={cn(
+          "relative z-10 flex w-full max-w-md flex-col items-center",
+          preview && "-mt-4 px-6 pt-2 pb-10"
+        )}
+      >
+        <h3 className="text-balance font-semibold text-lg">{title}</h3>
+        <p className="mt-1.5 text-pretty text-muted-foreground text-sm leading-relaxed">
+          {description}
+        </p>
+        {renderedAction ? (
+          <div className="relative z-10 mt-5 flex flex-wrap items-center justify-center gap-2 [&_a]:inline-flex [&_a]:items-center [&_a]:justify-center [&_button]:h-8 [&_button]:w-fit [&_button]:gap-1.5 [&_button]:px-3 [&_button]:text-sm">
+            {renderedAction}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/components/iris/iris-running-state.tsx
+++ b/apps/dashboard/src/components/iris/iris-running-state.tsx
@@ -13,10 +13,12 @@ import { Loader2Icon } from "lucide-react";
 import { useId } from "react";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { EmptyStateCardsPreview } from "@/components/empty-state-preview";
 import { IrisReadinessList } from "@/components/iris/iris-readiness-list";
 import { IrisRunCard } from "@/components/iris/iris-run-card";
 import { IrisSignalsList } from "@/components/iris/iris-signals-list";
 import { IrisStatsRow } from "@/components/iris/iris-stats";
+import { EMPTY_STATE_CARD_COUNT } from "@/constants/empty-state";
 import { cn } from "@/lib/utils";
 import type { IrisRunningStateProps } from "@/types/iris";
 
@@ -137,6 +139,12 @@ export function IrisRunningState({
           {!(runsState.isPending || runsState.isError) && runs.length === 0 ? (
             <EmptyState
               description="Iris is watching your sources. The first report shows up here as soon as something is worth announcing."
+              preview={
+                <EmptyStateCardsPreview
+                  count={EMPTY_STATE_CARD_COUNT.run}
+                  variant="run"
+                />
+              }
               title="No runs yet"
             />
           ) : null}

--- a/apps/dashboard/src/constants/chat-context.ts
+++ b/apps/dashboard/src/constants/chat-context.ts
@@ -1,0 +1,26 @@
+import type { ChatContextSuggestedIntegration } from "@/types/components/chat-input";
+
+export const CHAT_CONTEXT_SUGGESTED_INTEGRATIONS: readonly ChatContextSuggestedIntegration[] =
+  [
+    {
+      id: "github",
+      name: "GitHub",
+      description: "Add repositories as context",
+      href: "github",
+      keywords: ["github", "repo", "repository", "context"],
+    },
+    {
+      id: "linear",
+      name: "Linear",
+      description: "Add teams as context",
+      href: "linear",
+      keywords: ["linear", "issues", "team", "context"],
+    },
+    {
+      id: "mcp",
+      name: "MCP",
+      description: "Connect custom tools",
+      href: "mcp",
+      keywords: ["mcp", "tools", "server", "custom"],
+    },
+  ];

--- a/apps/dashboard/src/constants/empty-state.ts
+++ b/apps/dashboard/src/constants/empty-state.ts
@@ -1,0 +1,88 @@
+import type { EmptyStateSkillCardLayout } from "@/types/components/empty-state";
+
+export const EMPTY_STATE_TABLE_COLUMNS = {
+  content: [192, 80, 96],
+  schedule: [140, 120, 88, 72, 80, 56, 88],
+  events: [80, 132, 88, 72, 80, 56, 88],
+  sitemap: [220, 72, 96],
+} as const;
+
+export const EMPTY_STATE_TABLE_ROWS = 6;
+
+export const EMPTY_STATE_CARD_COUNT = {
+  content: 3,
+  skill: 3,
+  reference: 4,
+  run: 2,
+  integration: 3,
+} as const;
+
+export const EMPTY_STATE_ROW_KEYS = [
+  "row-a",
+  "row-b",
+  "row-c",
+  "row-d",
+  "row-e",
+  "row-f",
+  "row-g",
+  "row-h",
+] as const;
+
+export const EMPTY_STATE_CARD_KEYS = [
+  "card-a",
+  "card-b",
+  "card-c",
+  "card-d",
+] as const;
+
+export const EMPTY_STATE_STAT_KEYS = [
+  "stat-a",
+  "stat-b",
+  "stat-c",
+  "stat-d",
+] as const;
+
+export const EMPTY_STATE_CHART_BARS = [
+  28, 44, 36, 52, 40, 48, 32, 56, 42, 38, 50, 34,
+] as const;
+
+export const EMPTY_STATE_GUIDELINE_ASSET_KEYS = [
+  "asset-a",
+  "asset-b",
+  "asset-c",
+] as const;
+
+export const EMPTY_STATE_GUIDELINE_COLOR_KEYS = [
+  "color-a",
+  "color-b",
+  "color-c",
+] as const;
+
+export const EMPTY_STATE_SKILL_CARD_LAYOUTS = [
+  {
+    title: 108,
+    date: 92,
+    lines: [
+      { key: "a1", width: "100%" },
+      { key: "a2", width: "84%" },
+      { key: "a3", width: "56%" },
+    ],
+  },
+  {
+    title: 148,
+    date: 104,
+    lines: [
+      { key: "b1", width: "94%" },
+      { key: "b2", width: "70%" },
+    ],
+  },
+  {
+    title: 96,
+    date: 88,
+    lines: [
+      { key: "c1", width: "100%" },
+      { key: "c2", width: "88%" },
+      { key: "c3", width: "42%" },
+    ],
+  },
+] as const satisfies readonly EmptyStateSkillCardLayout[];

--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -32,17 +32,17 @@ export const NAV_CATEGORY_LABELS: Record<
 
 export const NAV_MAIN_ITEMS: NavMainItem[] = [
   {
+    link: "",
+    icon: Home01Icon,
+    label: "Home",
+    category: "none",
+  },
+  {
     link: "/chat",
     icon: Message01Icon,
     label: "Chat",
     category: "none",
     badge: "Beta",
-  },
-  {
-    link: "",
-    icon: Home01Icon,
-    label: "Home",
-    category: "none",
   },
   {
     link: CONTENT_NAV_LINK,

--- a/apps/dashboard/src/constants/skills.ts
+++ b/apps/dashboard/src/constants/skills.ts
@@ -1,0 +1,1 @@
+export const SKILL_EDITOR_VIEWS = ["edit", "diff"] as const;

--- a/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
+++ b/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
@@ -1,4 +1,7 @@
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { ACTIVE_PAID_PLAN_IDS, FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import type { CheckResponse } from "autumn-js";
@@ -7,7 +10,7 @@ import type { WorkflowAiCreditGateResult } from "@/types/billing/workflow-ai-cre
 export async function checkWorkflowAiCredits(
   organizationId: string
 ): Promise<WorkflowAiCreditGateResult> {
-  if (!autumn) {
+  if (!autumn || allowUnmeteredAiInDevelopment) {
     return { allowed: true, reserved: false, useMarkup: false };
   }
 

--- a/apps/dashboard/src/types/components/chat-input.ts
+++ b/apps/dashboard/src/types/components/chat-input.ts
@@ -52,3 +52,18 @@ export interface ChatContextOption {
 export interface ChatContextOptionContentProps {
   option: ChatContextOption;
 }
+
+export type ChatContextSuggestedIntegrationId = "github" | "linear" | "mcp";
+
+export interface ChatContextSuggestedIntegration {
+  id: ChatContextSuggestedIntegrationId;
+  name: string;
+  description: string;
+  href: string;
+  keywords: readonly string[];
+}
+
+export interface ChatContextConnectSuggestionsProps {
+  organizationSlug: string;
+  onSelect: () => void;
+}

--- a/apps/dashboard/src/types/components/chat-page.ts
+++ b/apps/dashboard/src/types/components/chat-page.ts
@@ -9,6 +9,20 @@ export interface UserImageGridProps {
   children: ReactNode;
 }
 
+export interface UserMessageEditorProps {
+  initialText: string;
+  onCancel: () => void;
+  onSubmit: (text: string) => void;
+}
+
+export interface UserMessageTextBubbleProps {
+  children: ReactNode;
+  isEditing: boolean;
+  initialText: string;
+  onCancel: () => void;
+  onSubmit: (text: string) => void;
+}
+
 export type CreateToolContentType =
   | "blog_post"
   | "changelog"

--- a/apps/dashboard/src/types/components/empty-state.ts
+++ b/apps/dashboard/src/types/components/empty-state.ts
@@ -1,0 +1,37 @@
+import type { Button as UiButton } from "@notra/ui/components/ui/button";
+import type { ComponentProps, ReactNode } from "react";
+
+export interface EmptyStateProps extends ComponentProps<"div"> {
+  title: string;
+  description: string;
+  action?: ReactNode;
+  actionLabel?: string;
+  actionVariant?: ComponentProps<typeof UiButton>["variant"];
+  onActionClick?: ComponentProps<"button">["onClick"];
+  actionIcon?: ReactNode;
+  preview?: ReactNode;
+}
+
+export interface EmptyStateTablePreviewProps {
+  columns: readonly number[];
+  rows?: number;
+}
+
+export type EmptyStateCardsPreviewVariant =
+  | "content"
+  | "skill"
+  | "reference"
+  | "run"
+  | "integration";
+
+export interface EmptyStateCardsPreviewProps {
+  variant?: EmptyStateCardsPreviewVariant;
+  count?: number;
+  columns?: 2 | 3;
+}
+
+export interface EmptyStateSkillCardLayout {
+  title: number;
+  date: number;
+  lines: readonly { key: string; width: string }[];
+}

--- a/apps/dashboard/src/types/skills/page.ts
+++ b/apps/dashboard/src/types/skills/page.ts
@@ -1,0 +1,4 @@
+export interface SkillDetailPageClientProps {
+  slug: string;
+  name: string;
+}

--- a/apps/dashboard/src/utils/nav.ts
+++ b/apps/dashboard/src/utils/nav.ts
@@ -21,12 +21,8 @@ export function resolveMainNavGroups(analyticsVisible: boolean): {
   if (!contentItem) {
     return { rootItems: NAV_ITEMS_BY_CATEGORY.none, workspaceItems: [] };
   }
-  const [firstItem, ...restItems] = NAV_ITEMS_BY_CATEGORY.none;
-  if (!firstItem) {
-    return { rootItems: [contentItem], workspaceItems: [] };
-  }
   return {
-    rootItems: [firstItem, contentItem, ...restItems],
+    rootItems: [...NAV_ITEMS_BY_CATEGORY.none, contentItem],
     workspaceItems: [],
   };
 }

--- a/bun.lock
+++ b/bun.lock
@@ -191,7 +191,7 @@
         "cmdk": "^1.1.1",
         "cnfast": "^0.0.6",
         "date-fns": "^4.1.0",
-        "dompurify": "3.4.12",
+        "dompurify": "3.4.13",
         "drizzle-orm": "^0.45.2",
         "echarts": "^6.1.0",
         "effect": "4.0.0-beta.93",

--- a/packages/ai/src/billing/autumn.ts
+++ b/packages/ai/src/billing/autumn.ts
@@ -6,6 +6,9 @@ export const autumn = AUTUMN_SECRET_KEY
   ? new Autumn({ secretKey: AUTUMN_SECRET_KEY })
   : null;
 
+// Local `next dev` skips Autumn plan/credit gates so AI features work without
+// billing. Set ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false to test billing. Production
+// never uses this bypass.
 export const allowUnmeteredAiInDevelopment =
   process.env.NODE_ENV === "development" &&
-  process.env.ALLOW_UNMETERED_AI_IN_DEVELOPMENT === "true";
+  process.env.ALLOW_UNMETERED_AI_IN_DEVELOPMENT !== "false";

--- a/packages/ui/src/components/kibo-ui/contribution-graph/index.tsx
+++ b/packages/ui/src/components/kibo-ui/contribution-graph/index.tsx
@@ -296,7 +296,7 @@ export const ContributionGraph = ({
       }}
     >
       <div
-        className={cn("flex w-max max-w-full flex-col gap-2", className)}
+        className={cn("flex w-full flex-col gap-2", className)}
         style={{ fontSize, ...style }}
         {...props}
       />
@@ -383,10 +383,10 @@ export const ContributionGraphCalendar = ({
       {...props}
     >
       <svg
-        className="block overflow-visible"
-        height={height}
+        className="block h-auto w-full overflow-visible"
+        preserveAspectRatio="xMinYMid meet"
+        style={{ aspectRatio: `${width} / ${height}`, minWidth: width }}
         viewBox={`0 0 ${width} ${height}`}
-        width={width}
       >
         <title>Contribution Graph</title>
         {!hideMonthLabels && (
@@ -428,7 +428,7 @@ export const ContributionGraphFooter = ({
 }: ContributionGraphFooterProps) => (
   <div
     className={cn(
-      "flex flex-wrap gap-1 whitespace-nowrap sm:gap-x-4",
+      "flex w-full flex-wrap items-center justify-between gap-1 whitespace-nowrap sm:gap-x-4",
       className
     )}
     {...props}

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -35,6 +35,10 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_DURATION = "320ms";
+const SIDEBAR_EASE = "cubic-bezier(0.22, 1, 0.36, 1)";
+const SIDEBAR_WIDTH_TRANSITION =
+	"duration-(--sidebar-duration) ease-(--sidebar-ease) motion-reduce:duration-0";
 
 type SidebarContextProps = {
 	state: "expanded" | "collapsed";
@@ -158,6 +162,8 @@ function SidebarProvider({
 					{
 						"--sidebar-width": SIDEBAR_WIDTH,
 						"--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+						"--sidebar-duration": SIDEBAR_DURATION,
+						"--sidebar-ease": SIDEBAR_EASE,
 						...style,
 					} as React.CSSProperties
 				}
@@ -235,7 +241,7 @@ function Sidebar({
 			{/* This is what handles the sidebar gap on desktop */}
 			<div
 				className={cn(
-					"relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+					`relative w-(--sidebar-width) bg-transparent transition-[width] ${SIDEBAR_WIDTH_TRANSITION}`,
 					"group-data-[collapsible=offExamples]:w-0",
 					"group-data-[side=right]:rotate-180",
 					variant === "floating" || variant === "inset"
@@ -246,7 +252,7 @@ function Sidebar({
 			/>
 			<div
 				className={cn(
-					"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+					`fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] ${SIDEBAR_WIDTH_TRANSITION} md:flex`,
 					side === "left"
 						? "left-0 group-data-[collapsible=offExamples]:left-[calc(var(--sidebar-width)*-1)]"
 						: "right-0 group-data-[collapsible=offExamples]:right-[calc(var(--sidebar-width)*-1)]",
@@ -326,7 +332,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 	return (
 		<main
 			className={cn(
-				"relative flex w-full flex-1 flex-col bg-background transition-[margin] duration-200 ease-linear md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-xs md:peer-data-[variant=inset]:border",
+				`relative flex w-full flex-1 flex-col bg-background transition-[margin] ${SIDEBAR_WIDTH_TRANSITION} md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-[0_1px_2px_rgba(0,0,0,0.04)] md:peer-data-[variant=inset]:dark:shadow-none md:peer-data-[variant=inset]:border`,
 				className,
 			)}
 			data-slot="sidebar-inset"
@@ -358,7 +364,7 @@ function SidebarHeader({
 
 	return (
 		<div
-			className={cn("flex flex-col gap-2 p-2", className)}
+			className={cn("flex flex-col gap-2 overflow-x-hidden p-2", className)}
 			data-sidebar="header"
 			data-slot="sidebar-header"
 			onWheel={(event) => {
@@ -379,7 +385,7 @@ function SidebarFooter({
 
 	return (
 		<div
-			className={cn("flex flex-col gap-2 p-2", className)}
+			className={cn("flex flex-col gap-2 overflow-x-hidden p-2", className)}
 			data-sidebar="footer"
 			data-slot="sidebar-footer"
 			onWheel={(event) => {
@@ -447,7 +453,7 @@ function SidebarGroupLabel({
 		props: mergeProps<"div">(
 			{
 				className: cn(
-					"flex h-8 shrink-0 items-center rounded-md px-2 font-medium text-sidebar-foreground/70 text-xs outline-hidden ring-sidebar-ring transition-[margin,opacity] [transition-duration:200ms,100ms] ease-linear focus-visible:ring-2 group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0 group-data-[state=expanded]:[transition-delay:0ms,200ms] [&>svg]:size-4 [&>svg]:shrink-0",
+					"flex h-8 shrink-0 items-center overflow-hidden whitespace-nowrap rounded-md px-2 font-medium text-sidebar-foreground/70 text-xs outline-hidden ring-sidebar-ring transition-[margin,opacity] [transition-duration:280ms,200ms] ease-(--sidebar-ease) group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:[transition-delay:80ms,60ms] group-data-[state=expanded]:[transition-delay:0ms,140ms] motion-reduce:transition-none focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
 					className,
 				),
 			},
@@ -522,7 +528,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-	"peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-inset active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-sidebar-accent data-active:font-medium data-active:text-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! group-data-[collapsible=icon]:[&>span]:opacity-0 group-data-[state=expanded]:[&>span]:delay-200 [&>span]:transition-opacity [&>span]:duration-100 [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
+	"peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] duration-(--sidebar-duration) ease-(--sidebar-ease) motion-reduce:duration-0 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-inset active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-sidebar-accent data-active:font-medium data-active:text-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-1.5! group-data-[collapsible=icon]:[&>span]:opacity-0 group-data-[collapsible=icon]:[&>span]:delay-75 group-data-[state=expanded]:[&>span]:delay-150 [&>span]:transition-opacity [&>span]:duration-200 [&>span]:ease-(--sidebar-ease) [&>span]:motion-reduce:delay-0 [&>span]:motion-reduce:transition-none [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0 group-data-[collapsible=icon]:[&_svg]:size-5",
 	{
 		variants: {
 			variant: {
@@ -601,7 +607,9 @@ function SidebarMenuButton({
 				align="center"
 				hidden={state !== "collapsed" || isMobile}
 				side="right"
+				sideOffset={8}
 				{...tooltip}
+				showArrow={false}
 			/>
 		</Tooltip>
 	);

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -35,13 +35,16 @@ function TooltipContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
+  showArrow = true,
   children,
   ...props
 }: TooltipPrimitive.Popup.Props &
   Pick<
     TooltipPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & {
+    showArrow?: boolean;
+  }) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -60,7 +63,9 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] border-r border-b bg-background fill-background z-50 data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          {showArrow ? (
+            <TooltipPrimitive.Arrow className="z-50 size-2.5 fill-background" />
+          ) : null}
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
Improve dashboard navigation, empty states, chat context suggestions, and local AI billing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes dashboard navigation and empty states, and skips Autumn plan/credit checks in local development to unblock chat and workflows. Previously, dev enforced billing gates and could block usage; now dev bypasses checks by default, while production behavior is unchanged.

- Development billing gate: Introduces `allowUnmeteredAiInDevelopment` in `@notra/ai` and updates API/chat/workflow gates to skip Autumn checks in dev. Chat usage blocking now only applies outside development. To test billing locally, set `ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false` in `.env`.  
- Navigation: Moves Home before Chat in the sidebar and simplifies root grouping. Brand identity links and selectors use history replace to avoid back-button stacking. Sidebar width transitions are smoother.  
- Empty states: `EmptyState` supports a `preview` slot. Adds `EmptyState*Preview` components (cards, tables, analytics, guidelines) and wires them into Content, Collections, Brand (Guidelines, References, Sitemap), Integrations (GitHub/Linear/Slack/MCP), Analytics, and Iris. Copy and button polish throughout.  
- Chat UX: Adds `ChatContextConnectSuggestions` to suggest connecting GitHub/Linear/MCP based on context. Refactors user message bubble/actions and adjusts subtle shadows and queued message styling.  
- Skills: Editor polish and navigation tweaks (URLs, fields, views).  
- UI polish: More responsive contribution graph; optional tooltip arrow; minor layout, skeleton, and button refinements; copy tweaks across brand identity header and actions.  
- Dependency: Bumps `dompurify` to 3.4.13.

**Rollout notes**
- Local development: Add `ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false` to validate Autumn plan/credit behavior locally. No production changes required.

<sup>Written for commit 8d4569bff272b0d071e885a68f534ee1c355512d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

