### PR TITLE
feat(billing): allow unmetered local AI development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,8 @@ NEXT_PUBLIC_C15T_BACKEND_URL=https://development-notra.inth.app
 
 # Autumn Billing
 AUTUMN_SECRET_KEY=
-ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false
+# Skip Autumn credit/plan checks in `next dev`. Set to false to test billing locally.
+ALLOW_UNMETERED_AI_IN_DEVELOPMENT=true
 
 # Workflows
 NEXT_PUBLIC_APP_URL=

--- a/apps/api/src/lib/chat/run.ts
+++ b/apps/api/src/lib/chat/run.ts
@@ -1,5 +1,8 @@
 import type { z } from "@hono/zod-openapi";
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import {
@@ -43,7 +46,7 @@ export async function runChatMessage({
   requestId,
 }: RunChatMessageArgs): Promise<Response> {
   let useMarkup = false;
-  if (autumn) {
+  if (autumn && !allowUnmeteredAiInDevelopment) {
     let checkData: CheckResponse | null = null;
     try {
       checkData = await autumn.check({

--- a/apps/api/src/utils/agent-credits.ts
+++ b/apps/api/src/utils/agent-credits.ts
@@ -1,4 +1,7 @@
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import type { CheckResponse } from "autumn-js";
@@ -10,7 +13,7 @@ export type AgentCreditCheck =
 export async function checkAgentAiCredits(
   organizationId: string
 ): Promise<AgentCreditCheck> {
-  if (!autumn) {
+  if (!autumn || allowUnmeteredAiInDevelopment) {
     return { allowed: true, useMarkup: false };
   }
   let checkData: CheckResponse | null = null;

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -118,7 +118,8 @@ const ChatInput = ({
     remainingChatCredits !== null &&
     remainingChatCredits > 0 &&
     remainingChatCredits <= 10;
-  const isUsageBlocked = checkResult ? checkResult.allowed === false : false;
+  const isUsageBlocked =
+    process.env.NODE_ENV !== "development" && checkResult?.allowed === false;
   const usageLimitError =
     externalError ??
     internalError ??

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -716,7 +716,8 @@ export function ChatInputAdvanced({
     remainingChatCredits !== null &&
     remainingChatCredits > 0 &&
     remainingChatCredits <= 10;
-  const isUsageBlocked = checkResult ? checkResult.allowed === false : false;
+  const isUsageBlocked =
+    process.env.NODE_ENV !== "development" && checkResult?.allowed === false;
   const usageLimitError =
     externalError ??
     internalError ??

--- a/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
+++ b/apps/dashboard/src/lib/billing/workflow-ai-credits.ts
@@ -1,4 +1,7 @@
-import { autumn } from "@notra/ai/billing/autumn";
+import {
+  allowUnmeteredAiInDevelopment,
+  autumn,
+} from "@notra/ai/billing/autumn";
 import { ACTIVE_PAID_PLAN_IDS, FEATURES } from "@notra/ai/billing/features";
 import { shouldApplyMarkup } from "@notra/ai/billing/token-pricing";
 import type { CheckResponse } from "autumn-js";
@@ -7,7 +10,7 @@ import type { WorkflowAiCreditGateResult } from "@/types/billing/workflow-ai-cre
 export async function checkWorkflowAiCredits(
   organizationId: string
 ): Promise<WorkflowAiCreditGateResult> {
-  if (!autumn) {
+  if (!autumn || allowUnmeteredAiInDevelopment) {
     return { allowed: true, reserved: false, useMarkup: false };
   }
 

--- a/packages/ai/src/billing/autumn.ts
+++ b/packages/ai/src/billing/autumn.ts
@@ -6,6 +6,9 @@ export const autumn = AUTUMN_SECRET_KEY
   ? new Autumn({ secretKey: AUTUMN_SECRET_KEY })
   : null;
 
+// Local `next dev` skips Autumn plan/credit gates so AI features work without
+// billing. Set ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false to test billing. Production
+// never uses this bypass.
 export const allowUnmeteredAiInDevelopment =
   process.env.NODE_ENV === "development" &&
-  process.env.ALLOW_UNMETERED_AI_IN_DEVELOPMENT === "true";
+  process.env.ALLOW_UNMETERED_AI_IN_DEVELOPMENT !== "false";


### PR DESCRIPTION
Allow local AI development without Autumn credit and plan checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow local development of AI features without Autumn plan/credit gates. Previously, dev builds enforced Autumn checks and could block usage; now `next dev` bypasses them by default. Production behavior is unchanged.

- API and workflow gates skip when `allowUnmeteredAiInDevelopment` is true (derived from `NODE_ENV==="development"` and `ALLOW_UNMETERED_AI_IN_DEVELOPMENT !== "false"`). No markup is applied during the bypass.
- Dashboard no longer blocks usage in development (`isUsageBlocked` ignores failed checks in dev).
- `.env.example` defaults `ALLOW_UNMETERED_AI_IN_DEVELOPMENT=true` with guidance to toggle.

**Rollout and testing**
- No production changes; the bypass never runs outside development.
- To test billing gates locally, set `ALLOW_UNMETERED_AI_IN_DEVELOPMENT=false` and restart `next dev`.

<sup>Written for commit 9a314990dce4942add4cd468b63ad6476edf5026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

