### PR TITLE
fix(console): sign out returns to console login

### DIFF
--- a/apps/console/src/lib/auth/user-actions.ts
+++ b/apps/console/src/lib/auth/user-actions.ts
@@ -3,5 +3,6 @@
 import { signOut } from "@workos-inc/authkit-nextjs";
 
 export async function signOutAction(options?: { returnTo?: string }) {
-  await signOut(options);
+  const appUrl = process.env.CONSOLE_APP_URL ?? "http://localhost:3003";
+  await signOut({ returnTo: options?.returnTo ?? `${appUrl}/login` });
 }

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import "@notra/ui/cta-button.css";
 
 @source "../../../../packages/ui/src/**/*.{ts,tsx}";
 


### PR DESCRIPTION
Console sign-out passed no returnTo, so WorkOS fell back to the environment's default logout URI (usenotra.com). The action now defaults to `${CONSOLE_APP_URL}/login`; the logout-URI allowlists (prod + dev) already include it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Console sign-out returns users to the Console login page. Previously we passed no returnTo and WorkOS used the environment’s default logout URI; we now default to `${CONSOLE_APP_URL}/login` (or `http://localhost:3003/login` if unset) when `returnTo` is not provided, and import `@notra/ui/cta-button.css` so the login button renders with shared styles.

- Set `CONSOLE_APP_URL` in all non-local environments to avoid redirecting to localhost.
- No changes needed to WorkOS logout-URI allowlists; `${CONSOLE_APP_URL}/login` is already allowed.

<sup>Written for commit 604503a512f7ffe8ad18a7bc67645526b55e3df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

