### PR TITLE
chore: re-enable turbopack filesystem cache for dev

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -8,7 +8,6 @@ const nextConfig: NextConfig = {
     "/*": ["./src/lib/ai/skills/**/*", "../../packages/ai/src/skills/**/*"],
   },
   experimental: {
-    turbopackFileSystemCacheForDev: false,
     optimizePackageImports: ["@hugeicons/core-free-icons", "lucide-react"],
     staleTimes: {
       dynamic: 30,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -17,9 +17,6 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname, "../.."),
   },
-  experimental: {
-    turbopackFileSystemCacheForDev: false,
-  },
   transpilePackages: ["@notra/ui", "@notra/email", "@notra/kiwi"],
   serverExternalPackages: ["@remotion/bundler", "@remotion/renderer"],
   rewrites: async () => {


### PR DESCRIPTION
### Description
Re-enables the Turbopack filesystem cache for `next dev` by removing the `experimental.turbopackFileSystemCacheForDev: false` override from the web and dashboard Next.js configs.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables Turbopack filesystem cache for `next dev` in `apps/web` and `apps/dashboard` by removing the `experimental.turbopackFileSystemCacheForDev: false` override. Previously `next dev` did not persist Turbopack state between runs; now it caches to disk to speed restarts, with minor added disk usage and a small risk of stale artifacts.

**Review notes**
- Dev-only change; `next build` and production are unaffected.
- The diff only removes the override in `apps/web/next.config.ts` and `apps/dashboard/next.config.ts`.
- If you hit stale behavior, clear caches: `rm -rf apps/web/.next apps/dashboard/.next`.

<sup>Written for commit d3de39c2c28f7f9a07bc4732975c81b5cdc98352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

