### PR TITLE
fix(dashboard): log underlying cause of webhook sync failures

### DIFF
--- a/apps/dashboard/src/app/api/webhooks/workos/route.ts
+++ b/apps/dashboard/src/app/api/webhooks/workos/route.ts
@@ -51,7 +51,14 @@ export async function POST(request: NextRequest) {
       Effect.as(true),
       Effect.catch((error) =>
         Effect.logWarning("Webhook membership sync failed").pipe(
-          Effect.annotateLogs({ event: event.event, error: error.message }),
+          Effect.annotateLogs({
+            event: event.event,
+            error: error.message,
+            cause:
+              error.cause instanceof Error
+                ? error.cause.message
+                : String(error.cause),
+          }),
           Effect.as(false)
         )
       )


### PR DESCRIPTION
Investigating the WorkOS 'webhook events failed to deliver' warning showed the endpoint is healthy — the failed attempts all happened in the pre-deploy window (webhook registered and migration events fired before WORKOS_WEBHOOK_SECRET and the cutover deploy landed), and every event was redelivered successfully on retry.

What the investigation did surface: the failure log only carried the wrapper message ('Failed to resolve local ids') and dropped the underlying cause, which made diagnosis needlessly slow. The sync-failure warning now includes the cause message alongside the event type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs the underlying cause of WorkOS webhook membership sync failures to speed up diagnosis. Previously the warning log captured only the event and the top-level error message; now it also records the cause message when present. No functional change to webhook handling or delivery.

- Annotates logs with `event`, `error`, and `cause` fields; extracts `cause.message` for `Error` instances and stringifies non-Error causes.
- No config or migration changes; safe to deploy.

<sup>Written for commit a4c75640f9d87ffb043aed41076651910b657ce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

