### PR TITLE
fix(kiwi): convert SVG primitives to vector geometry

### DIFF
--- a/packages/kiwi/src/constants/dom-to-scene.ts
+++ b/packages/kiwi/src/constants/dom-to-scene.ts
@@ -35,3 +35,5 @@ export const IGNORED_TAGS = new Set([
   "head",
 ]);
 export const MAX_LAYER_NAME_LENGTH = 80;
+export const SVG_GEOMETRY_SELECTOR =
+  "path, circle, ellipse, rect, line, polyline, polygon";

--- a/packages/kiwi/src/converters/dom-to-scene.ts
+++ b/packages/kiwi/src/converters/dom-to-scene.ts
@@ -658,6 +658,13 @@ function extractLayout(node: Node): LayoutNode | null {
     const shapes: SvgShape[] = [];
     const geomEls = svg.querySelectorAll(SVG_GEOMETRY_SELECTOR);
     for (const geomEl of geomEls) {
+      if (!(geomEl instanceof SVGGraphicsElement)) {
+        continue;
+      }
+      const ctm = geomEl.getScreenCTM();
+      if (!ctm) {
+        continue;
+      }
       const subpaths = svgPrimitiveToSubpaths(geomEl.tagName.toLowerCase(), {
         d: geomEl.getAttribute("d"),
         cx: geomEl.getAttribute("cx"),
@@ -678,13 +685,6 @@ function extractLayout(node: Node): LayoutNode | null {
       if (subpaths.length === 0) {
         continue;
       }
-      if (!(geomEl instanceof SVGGraphicsElement)) {
-        continue;
-      }
-      const ctm = geomEl.getScreenCTM();
-      if (!ctm) {
-        continue;
-      }
       const geomStyle = getComputedStyle(geomEl);
       const geomFill = geomEl.getAttribute("fill");
       const geomStroke = geomEl.getAttribute("stroke");
@@ -694,9 +694,9 @@ function extractLayout(node: Node): LayoutNode | null {
         fallbackColor
       );
       const strokeDasharray =
-        parseSvgDasharray(pathEl.getAttribute("stroke-dasharray")) ??
+        parseSvgDasharray(geomEl.getAttribute("stroke-dasharray")) ??
         parseSvgDasharray(svg.getAttribute("stroke-dasharray")) ??
-        parseSvgDasharray(pathStyle.getPropertyValue("stroke-dasharray"));
+        parseSvgDasharray(geomStyle.getPropertyValue("stroke-dasharray"));
       const fill = svgPaintValue(
         geomFill,
         svgFill ?? (stroke || geomStroke || svgStroke ? null : geomStyle.fill),
@@ -731,12 +731,14 @@ function extractLayout(node: Node): LayoutNode | null {
           geomEl.getAttribute("stroke-linejoin") ??
           svg.getAttribute("stroke-linejoin") ??
           geomStyle.strokeLinejoin,
+        strokeDasharray:
+          strokeDasharray?.map((dash) => dash * strokeScale) ?? null,
         strokeWidth:
           parsePx(
             geomEl.getAttribute("stroke-width") ??
               svg.getAttribute("stroke-width") ??
               geomStyle.strokeWidth
-          ) * (Math.hypot(ctm.a, ctm.b) || 1),
+          ) * strokeScale,
       });
     }
 

--- a/packages/kiwi/src/converters/dom-to-scene.ts
+++ b/packages/kiwi/src/converters/dom-to-scene.ts
@@ -10,6 +10,7 @@ import {
   LAYER_WORD_SPLIT_RE,
   MAX_LAYER_NAME_LENGTH,
   RGB_RE,
+  SVG_GEOMETRY_SELECTOR,
   TEXT_ALIGN_MAP,
   WEIGHT_TO_STYLE,
   WHITESPACE_GLOBAL_RE,
@@ -27,7 +28,7 @@ import type {
 } from "../types/dom-to-scene";
 import type { Guid, Transform } from "../types/scene";
 import type { PathSubpath } from "../types/svg-path";
-import { parseSvgPath } from "../utils/svg-path";
+import { svgPrimitiveToSubpaths } from "../utils/svg-primitive";
 import { TextLayoutCache } from "../utils/text-layout";
 
 export type { BuildSceneFromElementOptions } from "../types/dom-to-scene";
@@ -627,39 +628,54 @@ function extractLayout(node: Node): LayoutNode | null {
     const fallbackColor = style.color;
 
     const shapes: SvgShape[] = [];
-    const pathEls = svg.querySelectorAll("path");
-    for (const pathEl of pathEls) {
-      const d = pathEl.getAttribute("d");
-      if (!d) {
-        continue;
-      }
-      const ctm = pathEl.getScreenCTM();
-      if (!ctm) {
-        continue;
-      }
-      const subpaths = parseSvgPath(d);
+    const geomEls = svg.querySelectorAll(SVG_GEOMETRY_SELECTOR);
+    for (const geomEl of geomEls) {
+      const subpaths = svgPrimitiveToSubpaths(geomEl.tagName.toLowerCase(), {
+        d: geomEl.getAttribute("d"),
+        cx: geomEl.getAttribute("cx"),
+        cy: geomEl.getAttribute("cy"),
+        r: geomEl.getAttribute("r"),
+        rx: geomEl.getAttribute("rx"),
+        ry: geomEl.getAttribute("ry"),
+        x: geomEl.getAttribute("x"),
+        y: geomEl.getAttribute("y"),
+        width: geomEl.getAttribute("width"),
+        height: geomEl.getAttribute("height"),
+        x1: geomEl.getAttribute("x1"),
+        y1: geomEl.getAttribute("y1"),
+        x2: geomEl.getAttribute("x2"),
+        y2: geomEl.getAttribute("y2"),
+        points: geomEl.getAttribute("points"),
+      });
       if (subpaths.length === 0) {
         continue;
       }
-      const pathStyle = getComputedStyle(pathEl);
-      const pathFill = pathEl.getAttribute("fill");
-      const pathStroke = pathEl.getAttribute("stroke");
+      if (!(geomEl instanceof SVGGraphicsElement)) {
+        continue;
+      }
+      const ctm = geomEl.getScreenCTM();
+      if (!ctm) {
+        continue;
+      }
+      const geomStyle = getComputedStyle(geomEl);
+      const geomFill = geomEl.getAttribute("fill");
+      const geomStroke = geomEl.getAttribute("stroke");
       const stroke = svgPaintValue(
-        pathStroke,
-        svgStroke ?? pathStyle.stroke,
+        geomStroke,
+        svgStroke ?? geomStyle.stroke,
         fallbackColor
       );
       const fill = svgPaintValue(
-        pathFill,
-        svgFill ?? (stroke || pathStroke || svgStroke ? null : pathStyle.fill),
+        geomFill,
+        svgFill ?? (stroke || geomStroke || svgStroke ? null : geomStyle.fill),
         fallbackColor
       );
       if (!fill && !stroke) {
         continue;
       }
       const fillRule: "nonzero" | "evenodd" =
-        pathEl.getAttribute("fill-rule") === "evenodd" ||
-        pathEl.getAttribute("clip-rule") === "evenodd"
+        geomEl.getAttribute("fill-rule") === "evenodd" ||
+        geomEl.getAttribute("clip-rule") === "evenodd"
           ? "evenodd"
           : "nonzero";
       const transformed: PathSubpath[] = subpaths.map((sub) => ({
@@ -675,18 +691,18 @@ function extractLayout(node: Node): LayoutNode | null {
         fillRule,
         stroke,
         strokeLineCap:
-          pathEl.getAttribute("stroke-linecap") ??
+          geomEl.getAttribute("stroke-linecap") ??
           svg.getAttribute("stroke-linecap") ??
-          pathStyle.strokeLinecap,
+          geomStyle.strokeLinecap,
         strokeLineJoin:
-          pathEl.getAttribute("stroke-linejoin") ??
+          geomEl.getAttribute("stroke-linejoin") ??
           svg.getAttribute("stroke-linejoin") ??
-          pathStyle.strokeLinejoin,
+          geomStyle.strokeLinejoin,
         strokeWidth:
           parsePx(
-            pathEl.getAttribute("stroke-width") ??
+            geomEl.getAttribute("stroke-width") ??
               svg.getAttribute("stroke-width") ??
-              pathStyle.strokeWidth
+              geomStyle.strokeWidth
           ) * (Math.hypot(ctm.a, ctm.b) || 1),
       });
     }

--- a/packages/kiwi/src/types/svg-primitive.ts
+++ b/packages/kiwi/src/types/svg-primitive.ts
@@ -1,0 +1,17 @@
+export interface SvgPrimitiveAttrs {
+  d?: string | null;
+  cx?: string | null;
+  cy?: string | null;
+  r?: string | null;
+  rx?: string | null;
+  ry?: string | null;
+  x?: string | null;
+  y?: string | null;
+  width?: string | null;
+  height?: string | null;
+  x1?: string | null;
+  y1?: string | null;
+  x2?: string | null;
+  y2?: string | null;
+  points?: string | null;
+}

--- a/packages/kiwi/src/utils/svg-primitive.test.ts
+++ b/packages/kiwi/src/utils/svg-primitive.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { PathSubpath } from "../types/svg-path";
+import { svgPrimitiveToSubpaths } from "./svg-primitive";
+
+function bounds(subpaths: PathSubpath[]) {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (const sub of subpaths) {
+    for (const p of sub.points) {
+      if (p.x < minX) {
+        minX = p.x;
+      }
+      if (p.y < minY) {
+        minY = p.y;
+      }
+      if (p.x > maxX) {
+        maxX = p.x;
+      }
+      if (p.y > maxY) {
+        maxY = p.y;
+      }
+    }
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+describe("svgPrimitiveToSubpaths", () => {
+  test("circle is a closed loop around its bbox", () => {
+    const subpaths = svgPrimitiveToSubpaths("circle", {
+      cx: "10",
+      cy: "10",
+      r: "10",
+    });
+    assert.equal(subpaths.length, 1);
+    const sub = subpaths[0];
+    assert.equal(sub?.closed, true);
+    assert.ok((sub?.points.length ?? 0) >= 4);
+    const box = bounds(subpaths);
+    assert.ok(Math.abs(box.minX - 0) < 0.5);
+    assert.ok(Math.abs(box.maxX - 20) < 0.5);
+    assert.ok(Math.abs(box.minY - 0) < 0.5);
+    assert.ok(Math.abs(box.maxY - 20) < 0.5);
+  });
+
+  test("ellipse is a closed loop around its bbox", () => {
+    const subpaths = svgPrimitiveToSubpaths("ellipse", {
+      cx: "8",
+      cy: "4",
+      rx: "8",
+      ry: "4",
+    });
+    assert.equal(subpaths.length, 1);
+    const sub = subpaths[0];
+    assert.equal(sub?.closed, true);
+    assert.ok((sub?.points.length ?? 0) >= 4);
+    const box = bounds(subpaths);
+    assert.ok(Math.abs(box.minX - 0) < 0.5);
+    assert.ok(Math.abs(box.maxX - 16) < 0.5);
+    assert.ok(Math.abs(box.minY - 0) < 0.5);
+    assert.ok(Math.abs(box.maxY - 8) < 0.5);
+  });
+
+  test("rect is a closed box at its corners", () => {
+    const subpaths = svgPrimitiveToSubpaths("rect", {
+      x: "1",
+      y: "2",
+      width: "10",
+      height: "8",
+    });
+    assert.equal(subpaths.length, 1);
+    const sub = subpaths[0];
+    assert.equal(sub?.closed, true);
+    assert.deepEqual(sub?.points, [
+      { x: 1, y: 2 },
+      { x: 11, y: 2 },
+      { x: 11, y: 10 },
+      { x: 1, y: 10 },
+    ]);
+  });
+
+  test("line is an open two-point path", () => {
+    const subpaths = svgPrimitiveToSubpaths("line", {
+      x1: "0",
+      y1: "0",
+      x2: "5",
+      y2: "10",
+    });
+    assert.equal(subpaths.length, 1);
+    const sub = subpaths[0];
+    assert.equal(sub?.closed, false);
+    assert.deepEqual(sub?.points, [
+      { x: 0, y: 0 },
+      { x: 5, y: 10 },
+    ]);
+  });
+
+  test("polyline is an open path through its points", () => {
+    const subpaths = svgPrimitiveToSubpaths("polyline", {
+      points: "0,0 4,0 4,3",
+    });
+    assert.equal(subpaths.length, 1);
+    const sub = subpaths[0];
+    assert.equal(sub?.closed, false);
+    assert.deepEqual(sub?.points, [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+      { x: 4, y: 3 },
+    ]);
+  });
+
+  test("polygon is a closed path through its points", () => {
+    const subpaths = svgPrimitiveToSubpaths("polygon", {
+      points: "0 0 6 0 3 4",
+    });
+    assert.equal(subpaths.length, 1);
+    const sub = subpaths[0];
+    assert.equal(sub?.closed, true);
+    assert.deepEqual(sub?.points, [
+      { x: 0, y: 0 },
+      { x: 6, y: 0 },
+      { x: 3, y: 4 },
+    ]);
+  });
+});

--- a/packages/kiwi/src/utils/svg-primitive.ts
+++ b/packages/kiwi/src/utils/svg-primitive.ts
@@ -1,0 +1,163 @@
+import type { PathSubpath } from "../types/svg-path";
+import type { SvgPrimitiveAttrs } from "../types/svg-primitive";
+import { parseSvgPath } from "./svg-path";
+
+const NUM_RE = /-?\d*\.?\d+(?:[eE][+-]?\d+)?/g;
+
+function attrNumber(value: string | null | undefined, fallback = 0): number {
+  if (value == null || value === "") {
+    return fallback;
+  }
+  const n = Number.parseFloat(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function parsePoints(
+  points: string | null | undefined
+): Array<{ x: number; y: number }> {
+  if (!points) {
+    return [];
+  }
+  const nums: number[] = [];
+  let m: RegExpExecArray | null = NUM_RE.exec(points);
+  while (m) {
+    nums.push(Number.parseFloat(m[0]));
+    m = NUM_RE.exec(points);
+  }
+  NUM_RE.lastIndex = 0;
+  const out: Array<{ x: number; y: number }> = [];
+  for (let i = 0; i + 1 < nums.length; i += 2) {
+    const x = nums[i];
+    const y = nums[i + 1];
+    if (x === undefined || y === undefined) {
+      continue;
+    }
+    out.push({ x, y });
+  }
+  return out;
+}
+
+function circlePath(attrs: SvgPrimitiveAttrs): string | null {
+  const r = attrNumber(attrs.r);
+  if (r <= 0) {
+    return null;
+  }
+  const cx = attrNumber(attrs.cx);
+  const cy = attrNumber(attrs.cy);
+  return `M${cx - r} ${cy}A${r} ${r} 0 1 0 ${cx + r} ${cy}A${r} ${r} 0 1 0 ${cx - r} ${cy}Z`;
+}
+
+function ellipsePath(attrs: SvgPrimitiveAttrs): string | null {
+  const hasRx = attrs.rx != null && attrs.rx !== "";
+  const hasRy = attrs.ry != null && attrs.ry !== "";
+  if (!(hasRx || hasRy)) {
+    return null;
+  }
+  const rx = hasRx ? attrNumber(attrs.rx) : attrNumber(attrs.ry);
+  const ry = hasRy ? attrNumber(attrs.ry) : attrNumber(attrs.rx);
+  if (rx <= 0 || ry <= 0) {
+    return null;
+  }
+  const cx = attrNumber(attrs.cx);
+  const cy = attrNumber(attrs.cy);
+  return `M${cx - rx} ${cy}A${rx} ${ry} 0 1 0 ${cx + rx} ${cy}A${rx} ${ry} 0 1 0 ${cx - rx} ${cy}Z`;
+}
+
+function rectPath(attrs: SvgPrimitiveAttrs): string | null {
+  const width = attrNumber(attrs.width);
+  const height = attrNumber(attrs.height);
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  const x = attrNumber(attrs.x);
+  const y = attrNumber(attrs.y);
+  const hasRx = attrs.rx != null && attrs.rx !== "";
+  const hasRy = attrs.ry != null && attrs.ry !== "";
+  let rx = 0;
+  let ry = 0;
+  if (hasRx || hasRy) {
+    rx = Math.min(
+      Math.abs(hasRx ? attrNumber(attrs.rx) : attrNumber(attrs.ry)),
+      width / 2
+    );
+    ry = Math.min(
+      Math.abs(hasRy ? attrNumber(attrs.ry) : attrNumber(attrs.rx)),
+      height / 2
+    );
+  }
+  if (rx === 0 || ry === 0) {
+    return `M${x} ${y}H${x + width}V${y + height}H${x}Z`;
+  }
+  return `M${x + rx} ${y}H${x + width - rx}A${rx} ${ry} 0 0 1 ${x + width} ${y + ry}V${y + height - ry}A${rx} ${ry} 0 0 1 ${x + width - rx} ${y + height}H${x + rx}A${rx} ${ry} 0 0 1 ${x} ${y + height - ry}V${y + ry}A${rx} ${ry} 0 0 1 ${x + rx} ${y}Z`;
+}
+
+function linePath(attrs: SvgPrimitiveAttrs): string | null {
+  const x1 = attrNumber(attrs.x1);
+  const y1 = attrNumber(attrs.y1);
+  const x2 = attrNumber(attrs.x2);
+  const y2 = attrNumber(attrs.y2);
+  if (x1 === x2 && y1 === y2) {
+    return null;
+  }
+  return `M${x1} ${y1}L${x2} ${y2}`;
+}
+
+function polyPath(attrs: SvgPrimitiveAttrs, closed: boolean): string | null {
+  const pts = parsePoints(attrs.points);
+  if (pts.length < 2) {
+    return null;
+  }
+  const first = pts[0];
+  if (!first) {
+    return null;
+  }
+  let d = `M${first.x} ${first.y}`;
+  for (let i = 1; i < pts.length; i += 1) {
+    const p = pts[i];
+    if (!p) {
+      continue;
+    }
+    d += `L${p.x} ${p.y}`;
+  }
+  if (closed) {
+    d += "Z";
+  }
+  return d;
+}
+
+export function svgPrimitiveToPathData(
+  tag: string,
+  attrs: SvgPrimitiveAttrs
+): string | null {
+  switch (tag) {
+    case "path": {
+      const d = attrs.d?.trim();
+      return d ? d : null;
+    }
+    case "circle":
+      return circlePath(attrs);
+    case "ellipse":
+      return ellipsePath(attrs);
+    case "rect":
+      return rectPath(attrs);
+    case "line":
+      return linePath(attrs);
+    case "polyline":
+      return polyPath(attrs, false);
+    case "polygon":
+      return polyPath(attrs, true);
+    default:
+      return null;
+  }
+}
+
+export function svgPrimitiveToSubpaths(
+  tag: string,
+  attrs: SvgPrimitiveAttrs
+): PathSubpath[] {
+  const d = svgPrimitiveToPathData(tag, attrs);
+  if (!d) {
+    return [];
+  }
+  return parseSvgPath(d);
+}


### PR DESCRIPTION
### Description
Kiwi only imported SVG `path` elements, so logos and icons built from `circle`, `rect`, `line`, `polyline`, `polygon`, and `ellipse` pasted into Figma incomplete. Primitive geometry is now converted to path data during DOM extraction, then reused by the existing vector-network pipeline, including fill/stroke inheritance.

### Screenshot/Recording (if applicable)


https://github.com/user-attachments/assets/45eed0ae-551d-4838-876b-7e9a1148037f



<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did


</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Imports SVG primitives by converting them to path geometry during DOM extraction, so pasted SVGs with `circle`, `ellipse`, `rect`, `line`, `polyline`, and `polygon` import completely. Previously only `path` was imported; now primitives convert to path data and reuse the existing vector pipeline with inherited fill and stroke.

- Collects geometry with `SVG_GEOMETRY_SELECTOR` and converts each element via `svgPrimitiveToSubpaths`.
- Conversion: `circle`/`ellipse` via arc commands; `rect` supports `rx`/`ry`; `line` becomes a two-point open path; `polyline` is open; `polygon` is closed; invalid or zero-size primitives are ignored.
- Styling/transforms: reads computed style; preserves fill/stroke inheritance and fill-rule; carries linecap/linejoin; scales stroke width by the element CTM; restores stroke-dasharray parsing (element → SVG → computed style) and scales dash segments by the CTM.
- Adds `SvgPrimitiveAttrs` and `svgPrimitiveToPathData`; tests cover each primitive for closure, bbox, and points. No API or data model changes.

<sup>Written for commit 35c3254c6b4c17d9fcbdf6c717f6dc1e2e770617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

