### PR TITLE
fix(auth): keep testimonial carousel timer running

### DIFF
--- a/apps/dashboard/src/components/auth/testimonial-carousel.tsx
+++ b/apps/dashboard/src/components/auth/testimonial-carousel.tsx
@@ -12,19 +12,11 @@ import {
 export function TestimonialCarousel() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [progress, setProgress] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isFocused, setIsFocused] = useState(false);
   const shouldReduceMotion = useReducedMotion();
   const testimonial = AUTH_TESTIMONIALS[activeIndex];
-  const isPaused = isHovered || isFocused;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: activeIndex intentionally restarts testimonial progress.
   useEffect(() => {
     if (shouldReduceMotion) {
-      return;
-    }
-
-    if (isPaused) {
       return;
     }
 
@@ -39,83 +31,70 @@ export function TestimonialCarousel() {
 
       if (nextProgress >= 100) {
         setProgress(0);
-        setActiveIndex(
-          (currentIndex) => (currentIndex + 1) % AUTH_TESTIMONIALS.length
-        );
+        setActiveIndex((activeIndex + 1) % AUTH_TESTIMONIALS.length);
       } else {
         setProgress(nextProgress);
       }
     }, 50);
 
     return () => window.clearInterval(interval);
-  }, [activeIndex, shouldReduceMotion, isPaused]);
+  }, [activeIndex, shouldReduceMotion]);
 
   if (!testimonial) {
     return null;
   }
 
   return (
-    // biome-ignore lint/a11y/noNoninteractiveElementInteractions: hover and focus only pause the carousel timer, this is not an interactive control
-    // biome-ignore lint/a11y/noStaticElementInteractions: hover and focus only pause the carousel timer, this is not an interactive control
-    <div
-      onBlur={() => {
-        setIsFocused(false);
-        setProgress(0);
-      }}
-      onFocus={() => setIsFocused(true)}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => {
-        setIsHovered(false);
-        setProgress(0);
-      }}
+    <section
+      aria-label="Customer testimonials"
+      aria-roledescription="carousel"
+      className="flex w-full max-w-xl flex-col gap-5"
     >
-      <section
-        aria-label="Customer testimonials"
-        aria-roledescription="carousel"
-        className="flex w-full max-w-xl flex-col gap-5"
-      >
-        <div aria-live={isPaused || shouldReduceMotion ? "polite" : "off"}>
-          <figure
-            aria-label={`Testimonial ${activeIndex + 1} of ${AUTH_TESTIMONIALS.length}`}
-            aria-roledescription="slide"
-            className="fade-in-0 slide-in-from-bottom-2 flex min-h-[15rem] animate-in flex-col justify-between gap-5 rounded-3xl bg-white/10 p-7 shadow-[0_0_0_0.0625rem_rgba(255,255,255,0.2)] duration-500 motion-reduce:animate-none"
-            key={activeIndex}
-          >
-            <blockquote className="text-base text-white leading-relaxed">
-              "{testimonial.quote}"
-            </blockquote>
-            <figcaption className="flex items-center gap-3">
-              <Image
-                alt={testimonial.name}
-                className="size-10 shrink-0 rounded-full object-cover"
-                height={40}
-                src={testimonial.avatarSrc}
-                width={40}
-              />
-              <div className="flex flex-col">
-                <span className="font-semibold text-sm text-white">
-                  {testimonial.name}
-                </span>
-                <span className="text-sm text-violet-100/75">
-                  {testimonial.role}
-                </span>
-              </div>
-            </figcaption>
-          </figure>
-        </div>
-        <CarouselProgress
-          activeIndex={activeIndex}
-          labels={AUTH_TESTIMONIALS.map(
-            (item) => `Show testimonial from ${item.name}`
-          )}
-          onSelect={(index) => {
-            setActiveIndex(index);
-            setProgress(0);
-          }}
-          progress={shouldReduceMotion ? 100 : progress}
-          variant="inverted"
-        />
-      </section>
-    </div>
+      <div aria-live={shouldReduceMotion ? "polite" : "off"}>
+        <figure
+          aria-label={`Testimonial ${activeIndex + 1} of ${AUTH_TESTIMONIALS.length}`}
+          aria-roledescription="slide"
+          className="fade-in-0 slide-in-from-bottom-2 flex min-h-[15rem] animate-in flex-col justify-between gap-5 rounded-3xl bg-white/10 p-7 shadow-[0_0_0_0.0625rem_rgba(255,255,255,0.2)] duration-500 motion-reduce:animate-none"
+          key={activeIndex}
+        >
+          <blockquote className="text-base text-white leading-relaxed">
+            "{testimonial.quote}"
+          </blockquote>
+          <figcaption className="flex items-center gap-3">
+            <Image
+              alt={testimonial.name}
+              className="size-10 shrink-0 rounded-full object-cover"
+              height={40}
+              src={testimonial.avatarSrc}
+              width={40}
+            />
+            <div className="flex flex-col">
+              <span className="font-semibold text-sm text-white">
+                {testimonial.name}
+              </span>
+              <span className="text-sm text-violet-100/75">
+                {testimonial.role}
+              </span>
+            </div>
+          </figcaption>
+        </figure>
+      </div>
+      <CarouselProgress
+        activeIndex={activeIndex}
+        labels={AUTH_TESTIMONIALS.map(
+          (item) => `Show testimonial from ${item.name}`
+        )}
+        onSelect={(index) => {
+          if (index === activeIndex) {
+            return;
+          }
+
+          setActiveIndex(index);
+          setProgress(0);
+        }}
+        progress={shouldReduceMotion ? 100 : progress}
+        variant="inverted"
+      />
+    </section>
   );
 }


### PR DESCRIPTION
### Description
Fixes the testimonial carousel timer resetting on hover and focus changes. The timer now runs continuously and restarts correctly when selecting a different testimonial. On the Dashboard Login page.

### Screenshot/Recording (if applicable)
before and after (amp orb portals take some time to load lol): https://streamable.com/7v89to 

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the Dashboard Login testimonial carousel from resetting its timer on hover or focus. The timer now runs continuously and restarts only when the user selects a different testimonial.

- Removes hover/focus state and pause logic; deletes related event handlers.
- Ties the progress interval to `activeIndex` only; restarts on index change.
- Guards `onSelect` to ignore re-selecting the current slide; resets progress on a new selection.
- Adjusts a11y: `aria-live` is now polite only when reduced motion is enabled; wraps content in a `section` with carousel semantics.

**QA**
- Hovering or focusing the carousel does not pause or reset progress.
- Selecting a different dot switches slides and restarts the timer; selecting the current dot does nothing.
- With reduced motion on, progress is full and announcements are polite.

<sup>Written for commit a1394e2c8a7bf68276e2ab088c4580ff1d0c0628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

