### PR TITLE
fix(onboarding): stabilize referral field layout

### DIFF
--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -299,7 +299,7 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
           }}
         >
           {(field) => (
-            <div className="space-y-5">
+            <div>
               <div className="grid gap-2">
                 <Label htmlFor="heard-about-notra">
                   Where did you hear about Notra?{" "}
@@ -363,7 +363,7 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
                     }}
                   >
                     {(otherField) => (
-                      <div className="grid gap-2">
+                      <div className="grid gap-2 pt-5">
                         <Label htmlFor="heard-about-notra-other">
                           Tell us where
                         </Label>

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -19,7 +19,6 @@ import { useState } from "react";
 import { toast } from "sonner";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
-import { Button } from "@/components/button";
 import { OrgLogoField } from "@/components/onboarding/org-logo-field";
 import { OnboardingProgress } from "@/components/onboarding/progress";
 import { COMPANY_LOGO_DEBOUNCE_MS } from "@/constants/company-logo";
@@ -300,33 +299,16 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
           }}
         >
           {(field) => (
-            <>
+            <div className="space-y-5">
               <div className="grid gap-2">
-                <div className="flex items-center justify-between gap-3">
-                  <Label htmlFor="heard-about-notra">
-                    Where did you hear about Notra?{" "}
-                    {field.state.value !== "other" ? (
-                      <span className="text-muted-foreground text-xs">
-                        (optional)
-                      </span>
-                    ) : null}
-                  </Label>
-                  {field.state.value && !isAttributionLocked ? (
-                    <Button
-                      className="h-auto px-0 text-muted-foreground"
-                      disabled={isSubmitting}
-                      onClick={() => {
-                        field.handleChange("");
-                        form.setFieldValue("heardAboutNotraOther", "");
-                      }}
-                      size="sm"
-                      type="button"
-                      variant="ghost"
-                    >
-                      Clear
-                    </Button>
+                <Label htmlFor="heard-about-notra">
+                  Where did you hear about Notra?{" "}
+                  {field.state.value !== "other" ? (
+                    <span className="text-muted-foreground text-xs">
+                      (optional)
+                    </span>
                   ) : null}
-                </div>
+                </Label>
                 <Select
                   onValueChange={(value) => {
                     if (!isHeardAboutNotraSource(value)) {
@@ -367,45 +349,54 @@ export function WorkspaceForm({ existingOrg }: WorkspaceFormProps) {
                 ) : null}
               </div>
 
-              {field.state.value === "other" ? (
-                <form.Field
-                  name="heardAboutNotraOther"
-                  validators={{
-                    onChange:
-                      onboardingWorkspaceFormFieldsSchema.shape
-                        .heardAboutNotraOther,
-                  }}
-                >
-                  {(otherField) => (
-                    <div className="grid gap-2">
-                      <Label htmlFor="heard-about-notra-other">
-                        Tell us where{" "}
-                        <span className="text-destructive">*</span>
-                      </Label>
-                      <Textarea
-                        aria-invalid={otherField.state.meta.errors.length > 0}
-                        disabled={isSubmitting || isAttributionLocked}
-                        id="heard-about-notra-other"
-                        onBlur={otherField.handleBlur}
-                        onChange={(e) =>
-                          otherField.handleChange(e.target.value)
-                        }
-                        placeholder="Podcast, community, friend, etc."
-                        rows={3}
-                        value={otherField.state.value}
-                      />
-                      {otherField.state.meta.errors.length > 0 ? (
-                        <p className="text-destructive text-sm">
-                          {getValidationMessage(
-                            otherField.state.meta.errors[0]
-                          )}
-                        </p>
-                      ) : null}
-                    </div>
-                  )}
-                </form.Field>
-              ) : null}
-            </>
+              <div
+                aria-hidden={field.state.value !== "other"}
+                className={`grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none ${field.state.value === "other" ? "grid-rows-[1fr] opacity-100" : "pointer-events-none grid-rows-[0fr] opacity-0"}`}
+              >
+                <div className="min-h-0 overflow-hidden">
+                  <form.Field
+                    name="heardAboutNotraOther"
+                    validators={{
+                      onChange:
+                        onboardingWorkspaceFormFieldsSchema.shape
+                          .heardAboutNotraOther,
+                    }}
+                  >
+                    {(otherField) => (
+                      <div className="grid gap-2">
+                        <Label htmlFor="heard-about-notra-other">
+                          Tell us where
+                        </Label>
+                        <Textarea
+                          aria-invalid={otherField.state.meta.errors.length > 0}
+                          className="resize-none focus-visible:ring-inset"
+                          disabled={
+                            isSubmitting ||
+                            isAttributionLocked ||
+                            field.state.value !== "other"
+                          }
+                          id="heard-about-notra-other"
+                          onBlur={otherField.handleBlur}
+                          onChange={(e) =>
+                            otherField.handleChange(e.target.value)
+                          }
+                          placeholder="Podcast, community, friend, etc."
+                          rows={3}
+                          value={otherField.state.value}
+                        />
+                        {otherField.state.meta.errors.length > 0 ? (
+                          <p className="text-destructive text-sm">
+                            {getValidationMessage(
+                              otherField.state.meta.errors[0]
+                            )}
+                          </p>
+                        ) : null}
+                      </div>
+                    )}
+                  </form.Field>
+                </div>
+              </div>
+            </div>
           )}
         </form.Field>
 


### PR DESCRIPTION
### Description
Fixes the onboarding referral UI shift, removes the Clear button, smoothly reveals the “Tell us where” field, and improves its automatic textarea sizing and focus border.

### Screenshot/Recording (if applicable)
before:
https://streamable.com/jpfodp

after:
https://streamable.com/7v89to

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the onboarding referral field and removes the Clear button. Previously the “Tell us where” textarea mounted/unmounted and caused layout jumps; now it stays mounted, collapses hidden spacing to 0, and reveals smoothly only when “other” is selected.

- Replaces conditional render with a grid transition and aria-hidden; disables the textarea unless “other” is selected.
- Removes the Clear action; users change the select to update or clear the answer.
- Tweaks textarea UX: prevents manual resize and uses an inset focus ring; validation stays required when “other” is selected, and the visual asterisk is removed.

<sup>Written for commit 24f35d850270d35f5a0d14fae3f60ea94b909b4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

