### PR TITLE
fix(dashboard): hide signup credits banner behind boolean

### DIFF
--- a/apps/dashboard/src/components/auth/signup-form.tsx
+++ b/apps/dashboard/src/components/auth/signup-form.tsx
@@ -21,6 +21,7 @@ import { useQueryStates } from "nuqs";
 import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { SignupCreditsBanner } from "@/components/auth/signup-credits-banner";
+import { SHOW_SIGNUP_CREDITS_BANNER } from "@/constants/signup-credits";
 import {
   signUpWithPasswordAction,
   verifyEmailCodeAction,
@@ -205,7 +206,7 @@ export function SignupForm({
     <div className="flex w-full flex-col gap-5">
       <AuthFormHeader description={description} title={title} />
 
-      <SignupCreditsBanner />
+      {SHOW_SIGNUP_CREDITS_BANNER && <SignupCreditsBanner />}
 
       <div className="grid gap-4">
         <AuthSocialButtons

--- a/apps/dashboard/src/constants/signup-credits.ts
+++ b/apps/dashboard/src/constants/signup-credits.ts
@@ -1,3 +1,5 @@
 export const SIGNUP_CREDITS_GRANT_CENTS = 500;
 
 export const SIGNUP_CREDITS_BALANCE_PREFIX = "signup-credits";
+
+export const SHOW_SIGNUP_CREDITS_BANNER = false;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the signup credits banner behind a boolean and disable it by default. Previously the banner always rendered on the signup form; now it renders only when `SHOW_SIGNUP_CREDITS_BANNER` is true.

- Add `SHOW_SIGNUP_CREDITS_BANNER` (default `false`) in `apps/dashboard/src/constants/signup-credits.ts`.
- Conditionally render `<SignupCreditsBanner />` in `apps/dashboard/src/components/auth/signup-form.tsx` using the new flag.
- To re-enable, set `SHOW_SIGNUP_CREDITS_BANNER` to `true` and deploy.

<sup>Written for commit aac64d3c77499b7679d7ed9d32d978ee9de96521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

