### PR TITLE
fix(chat): remove duplicate model checkmark

### DIFF
--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -1995,12 +1995,6 @@ export function ChatInputAdvanced({
                                 {m.pricing}
                               </span>
                             </div>
-                            {model === m.id ? (
-                              <HugeiconsIcon
-                                className="ml-auto size-3.5 text-primary"
-                                icon={Tick02Icon}
-                              />
-                            ) : null}
                           </CommandItem>
                         ))}
                       </CommandGroup>


### PR DESCRIPTION
### Description
Removes the manually rendered model selector checkmark so selected models display only the shared CommandItem checkmark.

AI disclosure: This change was implemented with Amp.

### Screenshot/Recording (if applicable)
Not included; this removes a duplicate icon while preserving the existing shared checkmark.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the manual checkmark in the chat model selector so the selected model shows only the shared `CommandItem` checkmark. This eliminates the double-checkmark visual bug without changing selection logic or behavior.

<sup>Written for commit c800ed8a350c677b089ce72ed88fb05109f8dd19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

