### PR TITLE
fix(billing): correct GEO upgrade pricing

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
@@ -193,8 +193,11 @@ function BillingPageContent() {
 
   function renderPlanCard(group: BillingPlanGroup) {
     const plan = selectPlanVariant(group, isYearly);
+    if (!plan) {
+      return null;
+    }
     const isCurrent = isPlanInGroup(group, activePlanId);
-    const addonPlan = hasZdr ? null : findZdrAddonPlan(plans, plan?.id);
+    const addonPlan = hasZdr ? null : findZdrAddonPlan(plans, plan.id);
     return (
       <PlanCard
         action={

--- a/apps/dashboard/src/app/onboarding/pricing-client.tsx
+++ b/apps/dashboard/src/app/onboarding/pricing-client.tsx
@@ -23,8 +23,6 @@ import {
   zdrAddonToggle,
 } from "@/utils/billing-plans";
 
-const noop = () => undefined;
-
 export function PricingClient({ slug }: PricingClientProps) {
   const { data: plans, isLoading: plansLoading } = useListPlans();
   const { attach, multiAttach } = useCustomer();
@@ -64,9 +62,12 @@ export function PricingClient({ slug }: PricingClientProps) {
 
   function renderPlanCard(group: BillingPlanGroup) {
     const plan = selectPlanVariant(group, isYearly);
+    if (!plan) {
+      return null;
+    }
     const featured = group.id === FEATURED_PLAN_TIER;
     const hasTrial = Boolean(
-      plan?.freeTrial && plan.customerEligibility?.trialAvailable
+      plan.freeTrial && plan.customerEligibility?.trialAvailable
     );
     let action: React.ReactNode;
     if (hasTrial) {
@@ -75,22 +76,22 @@ export function PricingClient({ slug }: PricingClientProps) {
       action = <Badge>Most popular</Badge>;
     }
     let label = hasTrial ? "Start free trial" : "Get started";
-    if (plan && loading === plan.id) {
+    if (loading === plan.id) {
       label = "Loading...";
     }
     return (
       <PlanCard
         action={action}
         addon={zdrAddonToggle(
-          findZdrAddonPlan(plans, plan?.id),
+          findZdrAddonPlan(plans, plan.id),
           includeZdr,
           setIncludeZdr
         )}
         button={{
           label,
-          disabled: loading !== null || !plan,
+          disabled: loading !== null,
           variant: featured ? "default" : "outline",
-          onClick: plan ? () => handleSelectPlan(plan.id) : noop,
+          onClick: () => handleSelectPlan(plan.id),
         }}
         description={planGroupDescription(group)}
         featured={featured}

--- a/apps/dashboard/src/components/billing/geo-upgrade-dialog.tsx
+++ b/apps/dashboard/src/components/billing/geo-upgrade-dialog.tsx
@@ -30,8 +30,6 @@ import {
   zdrAddonToggle,
 } from "@/utils/billing-plans";
 
-const noop = () => undefined;
-
 export function GeoUpgradeDialog({
   slug,
   open,
@@ -73,24 +71,27 @@ export function GeoUpgradeDialog({
 
   function renderPlanCard(group: BillingPlanGroup) {
     const plan = selectPlanVariant(group, isYearly);
+    if (!plan) {
+      return null;
+    }
     const featured = group.id === FEATURED_PLAN_TIER;
-    let label = plan ? getPricingButtonText(plan) : group.name;
-    if (plan && loading === plan.id) {
+    let label = getPricingButtonText(plan);
+    if (loading === plan.id) {
       label = "Loading...";
     }
     return (
       <PlanCard
         action={featured ? <Badge>Most popular</Badge> : undefined}
         addon={zdrAddonToggle(
-          findZdrAddonPlan(plans, plan?.id),
+          findZdrAddonPlan(plans, plan.id),
           includeZdr,
           setIncludeZdr
         )}
         button={{
           label,
-          disabled: loading !== null || !plan,
+          disabled: loading !== null,
           variant: featured ? "default" : "outline",
-          onClick: plan ? () => handleSelectPlan(plan.id) : noop,
+          onClick: () => handleSelectPlan(plan.id),
         }}
         description={planGroupDescription(group)}
         featured={featured}
@@ -106,7 +107,7 @@ export function GeoUpgradeDialog({
 
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
-      <ResponsiveDialogContent className="max-h-[90svh] overflow-y-auto sm:max-w-5xl">
+      <ResponsiveDialogContent className="flex max-h-[90svh] flex-col overflow-hidden sm:max-w-5xl">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>{GEO_UPGRADE_TITLE}</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>
@@ -129,17 +130,19 @@ export function GeoUpgradeDialog({
             </TabsList>
           </Tabs>
         </div>
-        {plansLoading ? (
-          <div className="grid gap-4 lg:grid-cols-3">
-            <Skeleton className="h-96 rounded-lg" />
-            <Skeleton className="h-96 rounded-lg" />
-            <Skeleton className="h-96 rounded-lg" />
-          </div>
-        ) : (
-          <div className="grid gap-4 lg:grid-cols-3">
-            {planGroups.map(renderPlanCard)}
-          </div>
-        )}
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-1">
+          {plansLoading ? (
+            <div className="grid gap-4 lg:grid-cols-3">
+              <Skeleton className="h-96 rounded-lg" />
+              <Skeleton className="h-96 rounded-lg" />
+              <Skeleton className="h-96 rounded-lg" />
+            </div>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-3">
+              {planGroups.map(renderPlanCard)}
+            </div>
+          )}
+        </div>
       </ResponsiveDialogContent>
     </ResponsiveDialog>
   );

--- a/apps/dashboard/src/utils/billing-plans.ts
+++ b/apps/dashboard/src/utils/billing-plans.ts
@@ -1,4 +1,4 @@
-import { FEATURES } from "@notra/ai/billing/features";
+import { ACTIVE_PAID_PLAN_IDS, FEATURES } from "@notra/ai/billing/features";
 import {
   ANNUAL_ADDON_SUFFIX,
   ANNUAL_PLAN_NAME_SUFFIX,
@@ -157,10 +157,15 @@ export function groupBillingPlans(
   const groups = new Map<string, BillingPlanGroup>();
 
   for (const plan of plans ?? []) {
-    if (plan.addOn || plan.archived || !plan.price) {
+    if (
+      plan.addOn ||
+      plan.archived ||
+      !plan.price ||
+      !ACTIVE_PAID_PLAN_IDS.has(plan.id)
+    ) {
       continue;
     }
-    const id = plan.baseVariantId ?? plan.id;
+    const id = planTierId(plan.id) ?? plan.id;
     const group = groups.get(id) ?? {
       id,
       name: planDisplayName(plan.name) ?? id,
@@ -188,9 +193,9 @@ export function selectPlanVariant(
   isYearly: boolean
 ): BillingPlan | null {
   if (isYearly) {
-    return group.annual ?? group.monthly;
+    return group.annual;
   }
-  return group.monthly ?? group.annual;
+  return group.monthly;
 }
 
 export function planGroupDescription(group: BillingPlanGroup): string {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GEO upgrade pricing by selecting the correct plan variant and filtering to active paid plans. Previously we fell back to the other variant and included inactive plans, which could show incorrect prices and add-ons.

- Filter grouped plans to `ACTIVE_PAID_PLAN_IDS` from `@notra/ai/billing/features`.
- Group variants by `planTierId` so monthly and annual plans align correctly.
- Select variants strictly (annual for yearly, monthly for monthly) with no fallback.
- Skip rendering plan cards when a required variant is missing to avoid mismatched prices.
- Use the selected plan’s id for ZDR add-on lookup and button actions.
- Make the GEO upgrade dialog body scroll inside the modal to prevent layout overflow.

<sup>Written for commit 10675e6056aef2876272cd5583f9f7c6fdf0f9b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

