### PR TITLE
feat(chat): show integrations as composer context

### DIFF
--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -1105,12 +1105,12 @@ export function ChatInputAdvanced({
       range.deleteContents();
 
       const pastedContent = extractIntegrationReferences(text);
+      let nextContext = contextRef.current;
       for (const referencedItem of pastedContent.items) {
         if (
-          !contextRef.current.some((item) =>
-            contextItemsEqual(item, referencedItem)
-          )
+          !nextContext.some((item) => contextItemsEqual(item, referencedItem))
         ) {
+          nextContext = [...nextContext, referencedItem];
           onAddContext?.(referencedItem);
         }
       }
@@ -1123,8 +1123,9 @@ export function ChatInputAdvanced({
       selection?.removeAllRanges();
       selection?.addRange(after);
       editor.dispatchEvent(new Event("input", { bubbles: true }));
+      persistDraft(nextContext);
     },
-    [onAddContext]
+    [onAddContext, persistDraft]
   );
 
   const clearComposer = useCallback(() => {

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -94,6 +94,7 @@ import type { ChatContextOption } from "@/types/components/chat-input";
 import type { GitHubRepository } from "@/types/integrations";
 import {
   extractIntegrationReferences,
+  getIntegrationReferenceValue,
   getReferenceDisplay,
 } from "@/utils/integration-reference";
 import { AttachmentPreviewDialog } from "./attachment-preview";
@@ -869,16 +870,19 @@ export function ChatInputAdvanced({
     []
   );
 
-  const handleInput = useCallback(() => {
-    const editor = editorRef.current;
-    if (!editor) {
-      return;
-    }
-    setIsEmpty(readEditorText().trim().length === 0);
+  const persistDraft = useCallback(
+    (draftContext: readonly ContextItem[]) => {
+      const editor = editorRef.current;
+      if (!(editor && draftStorageKey)) {
+        return;
+      }
 
-    if (draftStorageKey) {
       try {
-        const draft = serializeEditorWithReferences(editor).trim();
+        const text = serializeEditorWithReferences(editor).trim();
+        const references = draftContext
+          .map(getIntegrationReferenceValue)
+          .join("\n");
+        const draft = [text, references].filter(Boolean).join("\n");
         if (draft) {
           window.localStorage.setItem(draftStorageKey, draft);
         } else {
@@ -887,7 +891,17 @@ export function ChatInputAdvanced({
       } catch {
         // noop
       }
+    },
+    [draftStorageKey]
+  );
+
+  const handleInput = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
     }
+    setIsEmpty(readEditorText().trim().length === 0);
+    persistDraft(contextRef.current);
 
     const sel = window.getSelection();
     if (!sel || sel.rangeCount === 0) {
@@ -937,7 +951,7 @@ export function ChatInputAdvanced({
 
     mentionAnchorRef.current = null;
     setMentionQuery(null);
-  }, [draftStorageKey, readEditorText]);
+  }, [persistDraft, readEditorText]);
 
   const restoredDraftKeyRef = useRef<string | null>(null);
 
@@ -1021,20 +1035,23 @@ export function ChatInputAdvanced({
       const selection = window.getSelection();
       selection?.removeAllRanges();
       selection?.addRange(replaceRange);
+      let nextContext = contextRef.current;
       if (
         !contextRef.current.some((item) =>
           contextItemsEqual(item, option.contextItem)
         )
       ) {
+        nextContext = [...contextRef.current, option.contextItem];
         onAddContext?.(option.contextItem);
       }
       editor.dispatchEvent(new Event("input", { bubbles: true }));
+      persistDraft(nextContext);
 
       mentionAnchorRef.current = null;
       setMentionQuery(null);
       editor.focus();
     },
-    [onAddContext]
+    [onAddContext, persistDraft]
   );
 
   const addContext = useCallback(
@@ -1044,16 +1061,22 @@ export function ChatInputAdvanced({
         return;
       }
       onAddContext?.(item);
+      persistDraft([...contextRef.current, item]);
       editorRef.current?.focus();
     },
-    [onAddContext]
+    [onAddContext, persistDraft]
   );
 
   const removeContext = useCallback(
     (item: ContextItem) => {
       onRemoveContext?.(item);
+      persistDraft(
+        contextRef.current.filter(
+          (contextItem) => !contextItemsEqual(contextItem, item)
+        )
+      );
     },
-    [onRemoveContext]
+    [onRemoveContext, persistDraft]
   );
 
   const insertTextAtRange = useCallback(

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -76,7 +76,6 @@ import {
   PASTE_TO_ATTACHMENT_THRESHOLD,
 } from "@/constants/upload";
 import { useAutumnRefreshListener } from "@/lib/hooks/use-autumn-refresh-listener";
-import { getMcpIconUrls } from "@/lib/integrations/mcp";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import {
   dragEventHasFiles,
@@ -93,19 +92,15 @@ import {
 } from "@/lib/upload/mime";
 import type { ChatContextOption } from "@/types/components/chat-input";
 import type { GitHubRepository } from "@/types/integrations";
-import { getReferenceDisplay } from "@/utils/integration-reference";
+import {
+  extractIntegrationReferences,
+  getReferenceDisplay,
+} from "@/utils/integration-reference";
 import { AttachmentPreviewDialog } from "./attachment-preview";
 import { ChatContextConnectSuggestions } from "./chat-context-connect-suggestions";
 import { ChatContextOptionContent } from "./chat-context-option-content";
 import type { QueuedMessage } from "./chat-queue";
 import {
-  buildFragmentFromReferencedText,
-  buildIntegrationReferenceElement,
-  hydrateLinearReferenceTeamNames,
-  hydrateMcpReferenceIcons,
-  INTEGRATION_REFERENCE_SELECTOR,
-  isIntegrationReferenceElement,
-  parseIntegrationReferenceElement,
   serializeEditorWithReferences,
   serializeFragmentWithReferences,
 } from "./integration-reference";
@@ -818,19 +813,6 @@ export function ChatInputAdvanced({
     () => contextOptions.filter((option) => option.kind === "mcp"),
     [contextOptions]
   );
-  const mcpIconsByIntegrationId = useMemo(
-    () =>
-      new Map(
-        mcpToolOptions.map((option) => [
-          option.contextItem.integrationId,
-          getMcpIconUrls({
-            lightUrl: option.logoLightUrl,
-            darkUrl: option.logoDarkUrl,
-          }),
-        ])
-      ),
-    [mcpToolOptions]
-  );
 
   const isInContext = useCallback(
     (item: ContextItem) =>
@@ -887,58 +869,6 @@ export function ChatInputAdvanced({
     []
   );
 
-  const syncContextFromDOM = useCallback(() => {
-    const editor = editorRef.current;
-    if (!editor) {
-      return;
-    }
-    const chips = Array.from(
-      editor.querySelectorAll<HTMLElement>(INTEGRATION_REFERENCE_SELECTOR)
-    );
-    const editorItems = chips
-      .map(parseIntegrationReferenceElement)
-      .filter((x): x is ContextItem => x !== null);
-
-    const current = contextRef.current;
-    for (const existing of current) {
-      if (!editorItems.some((e) => contextItemsEqual(e, existing))) {
-        onRemoveContext?.(existing);
-      }
-    }
-    for (const next of editorItems) {
-      if (!current.some((c) => contextItemsEqual(c, next))) {
-        onAddContext?.(next);
-      }
-    }
-  }, [onAddContext, onRemoveContext]);
-
-  const insertChipAndSpace = useCallback(
-    (chip: HTMLSpanElement, replaceRange: Range) => {
-      const editor = editorRef.current;
-      if (!editor) {
-        return;
-      }
-      replaceRange.deleteContents();
-      replaceRange.insertNode(chip);
-      const space = document.createTextNode("\u00A0");
-      const afterChip = document.createRange();
-      afterChip.setStartAfter(chip);
-      afterChip.collapse(true);
-      afterChip.insertNode(space);
-
-      const cursor = document.createRange();
-      cursor.setStartAfter(space);
-      cursor.collapse(true);
-      const sel = window.getSelection();
-      sel?.removeAllRanges();
-      sel?.addRange(cursor);
-
-      setIsEmpty(readEditorText().trim().length === 0);
-      syncContextFromDOM();
-    },
-    [readEditorText, syncContextFromDOM]
-  );
-
   const handleInput = useCallback(() => {
     const editor = editorRef.current;
     if (!editor) {
@@ -963,14 +893,12 @@ export function ChatInputAdvanced({
     if (!sel || sel.rangeCount === 0) {
       setMentionQuery(null);
       mentionAnchorRef.current = null;
-      syncContextFromDOM();
       return;
     }
     const range = sel.getRangeAt(0);
     if (!editor.contains(range.startContainer)) {
       setMentionQuery(null);
       mentionAnchorRef.current = null;
-      syncContextFromDOM();
       return;
     }
 
@@ -1001,7 +929,6 @@ export function ChatInputAdvanced({
             };
             setMentionQuery(query);
             setMentionIndex(0);
-            syncContextFromDOM();
             return;
           }
         }
@@ -1010,8 +937,7 @@ export function ChatInputAdvanced({
 
     mentionAnchorRef.current = null;
     setMentionQuery(null);
-    syncContextFromDOM();
-  }, [draftStorageKey, readEditorText, syncContextFromDOM]);
+  }, [draftStorageKey, readEditorText]);
 
   const restoredDraftKeyRef = useRef<string | null>(null);
 
@@ -1029,39 +955,17 @@ export function ChatInputAdvanced({
       if (!draft) {
         return;
       }
-      editor.append(
-        buildFragmentFromReferencedText(draft, mcpIconsByIntegrationId)
-      );
-      setIsEmpty(draft.trim().length === 0);
-      syncContextFromDOM();
+      const restoredDraft = extractIntegrationReferences(draft);
+      for (const referencedItem of restoredDraft.items) {
+        onAddContext?.(referencedItem);
+      }
+      const restoredText = restoredDraft.text.trim();
+      editor.textContent = restoredText;
+      setIsEmpty(restoredText.length === 0);
     } catch {
       // noop
     }
-  }, [
-    draftStorageKey,
-    initialValue,
-    mcpIconsByIntegrationId,
-    readEditorText,
-    syncContextFromDOM,
-  ]);
-
-  useEffect(() => {
-    const editor = editorRef.current;
-    if (!editor || enabledLinearIntegrations.length === 0) {
-      return;
-    }
-    if (hydrateLinearReferenceTeamNames(editor, enabledLinearIntegrations)) {
-      syncContextFromDOM();
-    }
-  }, [enabledLinearIntegrations, syncContextFromDOM]);
-
-  useEffect(() => {
-    const editor = editorRef.current;
-    if (!editor || mcpIconsByIntegrationId.size === 0) {
-      return;
-    }
-    hydrateMcpReferenceIcons(editor, mcpIconsByIntegrationId);
-  }, [mcpIconsByIntegrationId]);
+  }, [draftStorageKey, initialValue, onAddContext, readEditorText]);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -1113,85 +1017,43 @@ export function ChatInputAdvanced({
       replaceRange.setStart(anchor.node, anchor.offset);
       replaceRange.setEnd(cursor.startContainer, cursor.startOffset);
 
-      const chip = buildIntegrationReferenceElement(
-        option.contextItem,
-        getMcpIconUrls({
-          lightUrl: option.logoLightUrl,
-          darkUrl: option.logoDarkUrl,
-        })
-      );
-      insertChipAndSpace(chip, replaceRange);
+      replaceRange.deleteContents();
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(replaceRange);
+      if (
+        !contextRef.current.some((item) =>
+          contextItemsEqual(item, option.contextItem)
+        )
+      ) {
+        onAddContext?.(option.contextItem);
+      }
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
 
       mentionAnchorRef.current = null;
       setMentionQuery(null);
       editor.focus();
     },
-    [insertChipAndSpace]
+    [onAddContext]
   );
 
-  const insertChipAtCursor = useCallback(
+  const addContext = useCallback(
     (option: ChatContextOption) => {
-      const editor = editorRef.current;
-      if (!editor) {
-        return;
-      }
       const item = option.contextItem;
       if (contextRef.current.some((c) => contextItemsEqual(c, item))) {
         return;
       }
-      editor.focus();
-      const sel = window.getSelection();
-      let range: Range;
-      if (
-        sel &&
-        sel.rangeCount > 0 &&
-        editor.contains(sel.getRangeAt(0).startContainer)
-      ) {
-        range = sel.getRangeAt(0);
-      } else {
-        range = document.createRange();
-        range.selectNodeContents(editor);
-        range.collapse(false);
-      }
-      const chip = buildIntegrationReferenceElement(
-        item,
-        getMcpIconUrls({
-          lightUrl: option.logoLightUrl,
-          darkUrl: option.logoDarkUrl,
-        })
-      );
-      insertChipAndSpace(chip, range);
+      onAddContext?.(item);
+      editorRef.current?.focus();
     },
-    [insertChipAndSpace]
+    [onAddContext]
   );
 
-  const removeChipForItem = useCallback(
+  const removeContext = useCallback(
     (item: ContextItem) => {
-      const editor = editorRef.current;
-      if (editor) {
-        const chips = Array.from(
-          editor.querySelectorAll<HTMLElement>(INTEGRATION_REFERENCE_SELECTOR)
-        );
-        for (const chip of chips) {
-          const parsed = parseIntegrationReferenceElement(chip);
-          if (parsed && contextItemsEqual(parsed, item)) {
-            const next = chip.nextSibling;
-            chip.remove();
-            if (
-              next &&
-              next.nodeType === Node.TEXT_NODE &&
-              next.textContent === "\u00A0"
-            ) {
-              next.parentNode?.removeChild(next);
-            }
-            break;
-          }
-        }
-        setIsEmpty(readEditorText().trim().length === 0);
-      }
       onRemoveContext?.(item);
     },
-    [onRemoveContext, readEditorText]
+    [onRemoveContext]
   );
 
   const insertTextAtRange = useCallback(
@@ -1219,25 +1081,27 @@ export function ChatInputAdvanced({
 
       range.deleteContents();
 
-      const fragment = buildFragmentFromReferencedText(
-        text,
-        mcpIconsByIntegrationId
-      );
-      const lastNode = fragment.lastChild;
-      range.insertNode(fragment);
+      const pastedContent = extractIntegrationReferences(text);
+      for (const referencedItem of pastedContent.items) {
+        if (
+          !contextRef.current.some((item) =>
+            contextItemsEqual(item, referencedItem)
+          )
+        ) {
+          onAddContext?.(referencedItem);
+        }
+      }
+      const textNode = document.createTextNode(pastedContent.text);
+      range.insertNode(textNode);
 
       const after = document.createRange();
-      if (lastNode) {
-        after.setStartAfter(lastNode);
-      } else {
-        after.setStart(range.endContainer, range.endOffset);
-      }
+      after.setStartAfter(textNode);
       after.collapse(true);
       selection?.removeAllRanges();
       selection?.addRange(after);
       editor.dispatchEvent(new Event("input", { bubbles: true }));
     },
-    [mcpIconsByIntegrationId]
+    [onAddContext]
   );
 
   const clearComposer = useCallback(() => {
@@ -1591,43 +1455,6 @@ export function ChatInputAdvanced({
         editorRef.current?.dispatchEvent(new Event("input", { bubbles: true }));
         return;
       }
-
-      if (event.key === "Backspace") {
-        const sel = window.getSelection();
-        if (!sel || sel.rangeCount === 0 || !sel.getRangeAt(0).collapsed) {
-          return;
-        }
-        const range = sel.getRangeAt(0);
-        const node = range.startContainer;
-        let prev: ChildNode | null = null;
-        if (node.nodeType === Node.TEXT_NODE && range.startOffset === 0) {
-          prev = node.previousSibling;
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-          prev = (node as Element).childNodes[range.startOffset - 1] ?? null;
-        }
-        if (
-          prev &&
-          prev.nodeType === Node.TEXT_NODE &&
-          prev.textContent === "\u00A0"
-        ) {
-          prev = prev.previousSibling;
-        }
-        if (isIntegrationReferenceElement(prev)) {
-          event.preventDefault();
-          const nextOfChip = prev.nextSibling;
-          prev.remove();
-          if (
-            nextOfChip &&
-            nextOfChip.nodeType === Node.TEXT_NODE &&
-            nextOfChip.textContent === "\u00A0"
-          ) {
-            nextOfChip.parentNode?.removeChild(nextOfChip);
-          }
-          editorRef.current?.dispatchEvent(
-            new Event("input", { bubbles: true })
-          );
-        }
-      }
     },
     [
       mentionQuery,
@@ -1782,7 +1609,7 @@ export function ChatInputAdvanced({
                             isQueued
                               ? undefined
                               : () => {
-                                  removeChipForItem(item);
+                                  removeContext(item);
                                 }
                           }
                           removeLabel={`Remove ${label}`}
@@ -2107,9 +1934,9 @@ export function ChatInputAdvanced({
                                     keywords={[option.searchText]}
                                     onSelect={() => {
                                       if (inContext) {
-                                        removeChipForItem(option.contextItem);
+                                        removeContext(option.contextItem);
                                       } else {
-                                        insertChipAtCursor(option);
+                                        addContext(option);
                                       }
                                       setIsContextPickerOpen(false);
                                     }}
@@ -2134,9 +1961,9 @@ export function ChatInputAdvanced({
                                     keywords={[option.searchText]}
                                     onSelect={() => {
                                       if (inContext) {
-                                        removeChipForItem(option.contextItem);
+                                        removeContext(option.contextItem);
                                       } else {
-                                        insertChipAtCursor(option);
+                                        addContext(option);
                                       }
                                       setIsContextPickerOpen(false);
                                     }}

--- a/apps/dashboard/src/components/chat/integration-reference.tsx
+++ b/apps/dashboard/src/components/chat/integration-reference.tsx
@@ -16,9 +16,6 @@ import {
 
 const REFERENCE_ATTR = "data-integration-reference";
 
-export const INTEGRATION_REFERENCE_SELECTOR =
-  "[data-integration-reference='true']";
-
 const REFERENCE_CONTAINER_CLASS =
   "chat-integration-reference inline-flex cursor-text select-text items-center gap-[0.48em] whitespace-nowrap rounded-md border border-dashed border-foreground/30 bg-background px-[0.68em] py-[0.28em] align-middle text-[0.88em] text-foreground leading-[1.15]";
 
@@ -69,70 +66,6 @@ function getReferenceIconMarkup(kind: ReferenceKind): string {
   return kind === "linear" ? LINEAR_ICON_MARKUP : MCP_ICON_MARKUP;
 }
 
-function appendReferenceData(span: HTMLSpanElement, item: ContextItem): void {
-  if (item.type === "github-repo") {
-    span.dataset.kind = "github";
-    span.dataset.owner = item.owner;
-    span.dataset.repo = item.repo;
-    span.dataset.integrationId = item.integrationId;
-    return;
-  }
-
-  if (item.type === "mcp-server") {
-    span.dataset.kind = "mcp";
-    span.dataset.integrationId = item.integrationId;
-    span.dataset.name = item.name;
-    return;
-  }
-
-  span.dataset.kind = "linear";
-  span.dataset.integrationId = item.integrationId;
-  if (item.teamName) {
-    span.dataset.teamName = item.teamName;
-  }
-}
-
-function createReferenceIcon(
-  kind: ReferenceKind,
-  mcpIcon?: McpIconUrls
-): HTMLSpanElement {
-  const icon = document.createElement("span");
-  icon.setAttribute("aria-hidden", "true");
-  icon.className = getReferenceIconWrapperClass(kind);
-
-  const lightLogo = mcpIcon?.lightUrl ?? mcpIcon?.darkUrl;
-  const darkLogo = mcpIcon?.darkUrl ?? mcpIcon?.lightUrl;
-  if (kind === "mcp" && lightLogo && darkLogo) {
-    const lightImage = document.createElement("img");
-    lightImage.alt = "";
-    lightImage.className = "size-full rounded-sm object-contain dark:hidden";
-    lightImage.src = lightLogo;
-
-    const darkImage = document.createElement("img");
-    darkImage.alt = "";
-    darkImage.className =
-      "hidden size-full rounded-sm object-contain dark:block";
-    darkImage.src = darkLogo;
-
-    let didFallback = false;
-    const showFallbackIcon = () => {
-      if (didFallback) {
-        return;
-      }
-      didFallback = true;
-      icon.innerHTML = MCP_ICON_MARKUP;
-    };
-    lightImage.addEventListener("error", showFallbackIcon, { once: true });
-    darkImage.addEventListener("error", showFallbackIcon, { once: true });
-
-    icon.append(lightImage, darkImage);
-    return icon;
-  }
-
-  icon.innerHTML = getReferenceIconMarkup(kind);
-  return icon;
-}
-
 function ReferenceIcon({
   kind,
   mcpIcon,
@@ -162,152 +95,6 @@ function ReferenceIcon({
       dangerouslySetInnerHTML={{ __html: getReferenceIconMarkup(kind) }}
     />
   );
-}
-
-export function buildIntegrationReferenceElement(
-  item: ContextItem,
-  mcpIcon?: McpIconUrls
-): HTMLSpanElement {
-  const span = document.createElement("span");
-  span.contentEditable = "false";
-  span.className = REFERENCE_CONTAINER_CLASS;
-  span.setAttribute(REFERENCE_ATTR, "true");
-  span.dataset.value = getIntegrationReferenceValue(item);
-  appendReferenceData(span, item);
-
-  const icon = createReferenceIcon(getReferenceKind(item), mcpIcon);
-  const label = document.createElement("span");
-  label.className = REFERENCE_LABEL_CLASS;
-  label.textContent = getReferenceDisplay(item);
-
-  span.append(icon, label);
-  return span;
-}
-
-export function hydrateLinearReferenceTeamNames(
-  root: HTMLElement,
-  teams: ReadonlyArray<{ integrationId: string; teamName?: string | null }>
-): boolean {
-  let changed = false;
-  const chips = root.querySelectorAll<HTMLElement>(
-    INTEGRATION_REFERENCE_SELECTOR
-  );
-
-  for (const chip of chips) {
-    if (chip.dataset.kind !== "linear" || chip.dataset.teamName) {
-      continue;
-    }
-    const team = teams.find(
-      (candidate) => candidate.integrationId === chip.dataset.integrationId
-    );
-    if (!team?.teamName) {
-      continue;
-    }
-    chip.dataset.teamName = team.teamName;
-    const label = chip.lastElementChild;
-    if (label instanceof HTMLElement) {
-      label.textContent = getReferenceDisplay({
-        type: "linear-team",
-        integrationId: team.integrationId,
-        teamName: team.teamName,
-      });
-    }
-    changed = true;
-  }
-
-  return changed;
-}
-
-export function hydrateMcpReferenceIcons(
-  root: HTMLElement,
-  iconsByIntegrationId: ReadonlyMap<string, McpIconUrls>
-): boolean {
-  let changed = false;
-  const chips = root.querySelectorAll<HTMLElement>(
-    INTEGRATION_REFERENCE_SELECTOR
-  );
-
-  for (const chip of chips) {
-    if (chip.dataset.kind !== "mcp") {
-      continue;
-    }
-    const integrationId = chip.dataset.integrationId;
-    if (!integrationId) {
-      continue;
-    }
-    const iconUrls = iconsByIntegrationId.get(integrationId);
-    if (!(iconUrls?.lightUrl || iconUrls?.darkUrl)) {
-      continue;
-    }
-    chip.firstElementChild?.replaceWith(createReferenceIcon("mcp", iconUrls));
-    changed = true;
-  }
-
-  return changed;
-}
-
-export function buildFragmentFromReferencedText(
-  text: string,
-  mcpIconsByIntegrationId?: ReadonlyMap<string, McpIconUrls>
-): DocumentFragment {
-  const fragment = document.createDocumentFragment();
-  const segments = text.split(INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX);
-
-  for (const segment of segments) {
-    if (!segment) {
-      continue;
-    }
-
-    const referenceItem = parseReferenceValue(segment);
-    if (referenceItem) {
-      const mcpIcon =
-        referenceItem.type === "mcp-server"
-          ? mcpIconsByIntegrationId?.get(referenceItem.integrationId)
-          : undefined;
-      fragment.append(buildIntegrationReferenceElement(referenceItem, mcpIcon));
-      continue;
-    }
-
-    const lines = segment.split("\n");
-    lines.forEach((line, index) => {
-      if (line) {
-        fragment.append(document.createTextNode(line));
-      }
-      if (index < lines.length - 1) {
-        fragment.append(document.createElement("br"));
-      }
-    });
-  }
-
-  return fragment;
-}
-
-export function parseIntegrationReferenceElement(
-  el: HTMLElement
-): ContextItem | null {
-  const kind = el.dataset.kind;
-  if (kind === "github") {
-    const { owner, repo, integrationId } = el.dataset;
-    if (!(owner && repo && integrationId)) {
-      return null;
-    }
-    return { type: "github-repo", owner, repo, integrationId };
-  }
-  if (kind === "linear") {
-    const { integrationId, teamName } = el.dataset;
-    if (!integrationId) {
-      return null;
-    }
-    return { type: "linear-team", integrationId, teamName };
-  }
-  if (kind === "mcp") {
-    const { integrationId, name } = el.dataset;
-    if (!(integrationId && name)) {
-      return null;
-    }
-    return { type: "mcp-server", integrationId, name };
-  }
-  return null;
 }
 
 export function renderTextWithIntegrationReferences(
@@ -356,12 +143,6 @@ export function renderTextWithIntegrationReferences(
   });
 
   return nodes;
-}
-
-export function isIntegrationReferenceElement(
-  node: ChildNode | Node | null | undefined
-): node is HTMLElement {
-  return node instanceof HTMLElement && node.hasAttribute(REFERENCE_ATTR);
 }
 
 export function serializeEditorWithReferences(editor: HTMLElement): string {

--- a/apps/dashboard/src/utils/integration-reference.ts
+++ b/apps/dashboard/src/utils/integration-reference.ts
@@ -1,6 +1,7 @@
 import type { ContextItem } from "@notra/ai/types/chat";
 import {
   GITHUB_REFERENCE_VALUE_PATTERN,
+  INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX,
   LINEAR_REFERENCE_VALUE_PATTERN,
   MCP_REFERENCE_VALUE_PATTERN,
 } from "@/constants/integration-reference";
@@ -60,4 +61,20 @@ export function parseReferenceValue(value: string): ContextItem | null {
   }
 
   return null;
+}
+
+export function extractIntegrationReferences(value: string) {
+  const items: ContextItem[] = [];
+  const textSegments: string[] = [];
+
+  for (const segment of value.split(INTEGRATION_REFERENCE_TOKEN_SPLIT_REGEX)) {
+    const item = parseReferenceValue(segment);
+    if (item) {
+      items.push(item);
+    } else {
+      textSegments.push(segment);
+    }
+  }
+
+  return { items, text: textSegments.join("") };
 }


### PR DESCRIPTION
### Description


### Screenshot/Recording (if applicable)
before:
<img width="748" height="172" alt="Screenshot 2026-08-25 at 11 44 26" src="https://github.com/user-attachments/assets/adf8a58b-a568-45e3-ae94-6dfa9b3f403d" />

after:
<img width="722" height="238" alt="Screenshot 2026-08-25 at 11 30 56" src="https://github.com/user-attachments/assets/23d49656-5ab0-438f-bf02-f5e22cb96084" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows selected integrations as composer context instead of inline chips, and persists them across drafts and pastes. Previously chips rendered inside the editor; now the editor stays plain text and integrations live in the context list.

- Refactors
  - Extracts integration references from pasted or restored text via `extractIntegrationReferences`, adds them to context, and inserts only plain text into the editor.
  - Saves drafts as plain text plus reference tokens and restores both; context is persisted on paste and on add/remove.
  - Manages context only through `onAddContext`/`onRemoveContext`; no DOM chips are inserted or synced.
  - Removes chip hydration (Linear team names, MCP icons) and chip-specific Backspace handling.

<sup>Written for commit 4b97e1f00166ed35e09b1d266590a0470058b52c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



