### PR TITLE
fix(dashboard): improve mobile header and sidebar

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 import { withWorkflow } from "workflow/next";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: process.env.APP_URL
+    ? [new URL(process.env.APP_URL).hostname]
+    : [],
   reactCompiler: true,
   cacheComponents: true,
   partialPrefetching: true,

--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -20,7 +20,7 @@ import {
   m,
   useReducedMotion,
 } from "motion/react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type * as React from "react";
 import { useEffect, useRef } from "react";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -61,9 +61,11 @@ export function DashboardSidebar({
 }: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { isMobile, setOpenMobile } = useSidebar();
   const { activeOrganization } = useOrganizationsContext();
   const shouldReduceMotion = useReducedMotion();
+  const navigationKey = `${pathname}?${searchParams.toString()}`;
   const pathnameSegments = pathname.split("/").filter(Boolean);
   const slug = pathnameSegments[0] ?? activeOrganization?.slug ?? "";
 
@@ -79,7 +81,7 @@ export function DashboardSidebar({
     drilldownCategory !== null;
 
   const hasVisitedMainRef = useRef(false);
-  const previousPathnameRef = useRef(pathname);
+  const previousNavigationKeyRef = useRef(navigationKey);
   useEffect(() => {
     if (!isSubpage) {
       hasVisitedMainRef.current = true;
@@ -87,11 +89,11 @@ export function DashboardSidebar({
   }, [isSubpage]);
 
   useEffect(() => {
-    if (previousPathnameRef.current !== pathname && isMobile) {
+    if (previousNavigationKeyRef.current !== navigationKey && isMobile) {
       setOpenMobile(false);
     }
-    previousPathnameRef.current = pathname;
-  }, [isMobile, pathname, setOpenMobile]);
+    previousNavigationKeyRef.current = navigationKey;
+  }, [isMobile, navigationKey, setOpenMobile]);
 
   function handleBack() {
     if (hasVisitedMainRef.current) {

--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
+  useSidebar,
 } from "@notra/ui/components/ui/sidebar";
 import { Notra } from "@notra/ui/components/ui/svgs/notra";
 import { cn } from "@notra/ui/lib/utils";
@@ -60,6 +61,7 @@ export function DashboardSidebar({
 }: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname();
   const router = useRouter();
+  const { isMobile, setOpenMobile } = useSidebar();
   const { activeOrganization } = useOrganizationsContext();
   const shouldReduceMotion = useReducedMotion();
   const pathnameSegments = pathname.split("/").filter(Boolean);
@@ -77,11 +79,19 @@ export function DashboardSidebar({
     drilldownCategory !== null;
 
   const hasVisitedMainRef = useRef(false);
+  const previousPathnameRef = useRef(pathname);
   useEffect(() => {
     if (!isSubpage) {
       hasVisitedMainRef.current = true;
     }
   }, [isSubpage]);
+
+  useEffect(() => {
+    if (previousPathnameRef.current !== pathname && isMobile) {
+      setOpenMobile(false);
+    }
+    previousPathnameRef.current = pathname;
+  }, [isMobile, pathname, setOpenMobile]);
 
   function handleBack() {
     if (hasVisitedMainRef.current) {

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -310,7 +310,7 @@ export function SiteHeader() {
 
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 bg-muted transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-      <div className="grid h-full w-full min-w-0 grid-cols-[minmax(8rem,1fr)_minmax(2rem,20rem)_minmax(2.5rem,1fr)] items-center gap-2 px-4 lg:gap-2">
+      <div className="grid h-full w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-4 md:grid-cols-[minmax(8rem,1fr)_minmax(2rem,20rem)_minmax(2.5rem,1fr)] lg:gap-2">
         <div className="flex h-full min-w-0 items-center gap-2 overflow-hidden">
           <SidebarToggle className="-mx-1.5" />
           <Breadcrumb className="min-w-0">

--- a/apps/dashboard/src/components/dashboard/sidebar-toggle.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-toggle.tsx
@@ -15,12 +15,13 @@ export function SidebarToggle({
   onClick,
   ...props
 }: ComponentProps<typeof Button>) {
-  const { open, toggleSidebar } = useSidebar();
+  const { isMobile, open, openMobile, toggleSidebar } = useSidebar();
+  const isOpen = isMobile ? openMobile : open;
 
   return (
     <Button
-      aria-expanded={open}
-      aria-label={open ? "Hide sidebar" : "Show sidebar"}
+      aria-expanded={isOpen}
+      aria-label={isOpen ? "Hide sidebar" : "Show sidebar"}
       className={cn("cursor-pointer", className)}
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
@@ -33,7 +34,7 @@ export function SidebarToggle({
       {...props}
     >
       <HugeiconsIcon
-        icon={open ? SidebarLeft01Icon : SidebarRight01Icon}
+        icon={isOpen ? SidebarLeft01Icon : SidebarRight01Icon}
         strokeWidth={1.8}
       />
     </Button>


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
before:
<img width="1474" height="230" alt="image" src="https://github.com/user-attachments/assets/a8c8896a-5eff-4fa0-af50-bad26b21a5f3" />

after:
<img width="739" height="284" alt="Screenshot 2026-08-25 at 12 40 09" src="https://github.com/user-attachments/assets/521a380e-7e94-406e-83ef-1ac601fd8a6e" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile dashboard header and sidebar so the header fits on small screens and the sidebar closes after navigation on mobile. Previously the toggle icon/aria could desync from the actual state; it now reflects the correct open state.

- Closes the sidebar on pathname or query changes only when `isMobile` to avoid desktop regressions.
- Uses the mobile open state for the toggle button so the icon and aria-expanded/label stay accurate.
- Switches the header to a compact two-column grid on small screens; restores the three-column layout from `md` and up.
- Adds allowedDevOrigins from `APP_URL` in Next config to allow the dashboard’s dev origin for workflow-related requests.

<sup>Written for commit 53dabcc60f5243a969fb4cc3377987f47537b8ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

