### PR TITLE
fix(dashboard): improve chat credit warning

### DIFF
--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Alert02Icon,
   ArrowUp02Icon,
   AtIcon,
   StopIcon,
@@ -9,6 +10,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FEATURES } from "@notra/ai/billing/features";
 import type { ContextItem } from "@notra/ai/types/chat";
+import { Button } from "@notra/ui/components/ui/button";
 import {
   Command,
   CommandEmpty,
@@ -279,7 +281,8 @@ const ChatInput = ({
     contextPickerDisabledReason = "Context is unavailable right now.";
   }
   const hasContextChips = context.length > 0 || Boolean(selection);
-  const showComposerNudge = hasContextChips || shouldShowLowCredits;
+  const showComposerNudge =
+    hasContextChips || shouldShowLowCredits || Boolean(usageLimitError);
   let sendTooltip = "Enter to send. Shift+Enter for a new line.";
   if (showStop) {
     sendTooltip = "Stop generating";
@@ -294,8 +297,22 @@ const ChatInput = ({
       nudge={
         showComposerNudge ? (
           <Composer.Nudge
+            action={
+              usageLimitError && organizationSlug ? (
+                <Button
+                  nativeButton={false}
+                  render={
+                    <Link href={`/${organizationSlug}/settings/billing`} />
+                  }
+                  size="xs"
+                  variant="outline"
+                >
+                  Upgrade
+                </Button>
+              ) : null
+            }
             title={
-              shouldShowLowCredits && !hasContextChips
+              shouldShowLowCredits && !hasContextChips && !usageLimitError
                 ? `${remainingChatCredits} chat messages left`
                 : undefined
             }
@@ -315,23 +332,19 @@ const ChatInput = ({
                 ) : null}
               </>
             ) : null}
+            {usageLimitError ? (
+              <span className="flex min-w-0 items-center gap-1.5 text-sm">
+                <HugeiconsIcon
+                  className="size-4 shrink-0 text-amber-600 dark:text-amber-500"
+                  icon={Alert02Icon}
+                />
+                <span className="truncate">{usageLimitError}</span>
+              </span>
+            ) : null}
           </Composer.Nudge>
         ) : null
       }
     >
-      {usageLimitError ? (
-        <div className="mx-2 mt-2 mb-1 flex w-fit max-w-full flex-wrap items-center gap-1 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-xs">
-          <span>{usageLimitError}</span>
-          {organizationSlug ? (
-            <Link
-              className="font-medium underline underline-offset-2"
-              href={`/${organizationSlug}/settings/billing`}
-            >
-              Upgrade
-            </Link>
-          ) : null}
-        </div>
-      ) : null}
       <div className="flex min-w-0 items-end gap-1 p-1.5">
         <Tooltip>
           <TooltipTrigger

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -2,6 +2,7 @@
 
 import {
   AiBrain01Icon,
+  Alert02Icon,
   ArrowDown01Icon,
   ArrowUp02Icon,
   AtIcon,
@@ -18,6 +19,7 @@ import type {
   ChatInputHandle,
   ContextItem,
 } from "@notra/ai/types/chat";
+import { Button } from "@notra/ui/components/ui/button";
 import {
   Command,
   CommandEmpty,
@@ -1493,7 +1495,10 @@ export function ChatInputAdvanced({
   const hasAttachmentChips =
     attachments.length > 0 || pendingUploads.length > 0;
   const showComposerNudge =
-    hasContextChips || hasAttachmentChips || shouldShowLowCredits;
+    hasContextChips ||
+    hasAttachmentChips ||
+    shouldShowLowCredits ||
+    Boolean(usageLimitError);
 
   return (
     <>
@@ -1612,10 +1617,25 @@ export function ChatInputAdvanced({
           nudge={
             showComposerNudge ? (
               <Composer.Nudge
+                action={
+                  usageLimitError && organizationSlug ? (
+                    <Button
+                      nativeButton={false}
+                      render={
+                        <Link href={`/${organizationSlug}/settings/billing`} />
+                      }
+                      size="xs"
+                      variant="outline"
+                    >
+                      Upgrade
+                    </Button>
+                  ) : null
+                }
                 title={
                   shouldShowLowCredits &&
                   !hasContextChips &&
-                  !hasAttachmentChips
+                  !hasAttachmentChips &&
+                  !usageLimitError
                     ? `${remainingChatCredits} chat messages left`
                     : undefined
                 }
@@ -1690,6 +1710,15 @@ export function ChatInputAdvanced({
                     ) : null}
                   </>
                 ) : null}
+                {usageLimitError ? (
+                  <span className="flex min-w-0 items-center gap-1.5 text-sm">
+                    <HugeiconsIcon
+                      className="size-4 shrink-0 text-amber-600 dark:text-amber-500"
+                      icon={Alert02Icon}
+                    />
+                    <span className="truncate">{usageLimitError}</span>
+                  </span>
+                ) : null}
               </Composer.Nudge>
             ) : null
           }
@@ -1703,19 +1732,6 @@ export function ChatInputAdvanced({
               ref={fileInputRef}
               type="file"
             />
-            {usageLimitError && (
-              <div className="mx-2 mt-2 mb-1 flex w-fit max-w-full flex-wrap items-center gap-1 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-xs">
-                <span>{usageLimitError}</span>
-                {organizationSlug && (
-                  <Link
-                    className="font-medium underline underline-offset-2"
-                    href={`/${organizationSlug}/settings/billing`}
-                  >
-                    Upgrade
-                  </Link>
-                )}
-              </div>
-            )}
             <div className="relative flex min-w-0 flex-col rounded-t-[13px] bg-background">
               <div className="flex w-full min-w-0 items-center rounded-t-[12px]">
                 <div className="relative flex min-w-0 flex-1 cursor-text transition-colors [--lh:1lh]">


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
after:
<img width="675" height="153" alt="Screenshot 2026-08-25 at 14 09 26" src="https://github.com/user-attachments/assets/70ebe3c2-cc55-42cd-96d3-7008ef983c94" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates chat credit warnings into the composer nudge and adds an Upgrade action. Previously, usage limit errors showed in a separate red banner; now they appear inline with the nudge and suppress the “X messages left” title when present.

**Bug Fixes**
- Shows usage limit errors inside the composer nudge with an amber icon.
- Adds an Upgrade button linking to the organization billing page when available.
- Removes the destructive banner below the input.
- Ensures the nudge appears when a usage limit error is present.
- Hides the remaining-credits title when an error message is shown.
- Applies to both ChatInput and ChatInputAdvanced.

<sup>Written for commit d887d9bc00c7046ecb836357f2c824c5fe4d82b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

