### PR TITLE
fix(geo): smooth provider and model reveals

### DIFF
--- a/apps/dashboard/src/components/geo/geo-engine-picker.tsx
+++ b/apps/dashboard/src/components/geo/geo-engine-picker.tsx
@@ -68,6 +68,9 @@ function GeoModelRow({
   id,
   model,
   onCheckedChange,
+  revealIndex,
+  revealTotal,
+  revealed,
   showZdrState,
 }: {
   approved: boolean;
@@ -76,21 +79,44 @@ function GeoModelRow({
   id: string;
   model: GeoModelCatalogEntry;
   onCheckedChange: (checked: boolean) => void;
+  revealIndex?: number;
+  revealTotal?: number;
+  revealed?: boolean;
   showZdrState: boolean;
 }) {
   const reduceMotion = useReducedMotion();
+  const hasRevealAnimation = revealed !== undefined;
+  const staggerDelay = revealed
+    ? (revealIndex ?? 0) * 0.045
+    : ((revealTotal ?? 1) - (revealIndex ?? 0) - 1) * 0.035;
+  const revealAnimation = revealed
+    ? { filter: "blur(0px)", opacity: 1, y: 0 }
+    : { filter: "blur(5px)", opacity: 0, y: -5 };
 
   return (
     <motion.li
+      animate={hasRevealAnimation ? revealAnimation : undefined}
       className="flex items-center justify-between gap-3 py-1.5 ps-10 pe-3"
+      initial={false}
       layout={reduceMotion ? false : "position"}
       layoutId={reduceMotion ? undefined : `geo-model-${id}`}
-      transition={{
-        layout: {
-          duration: 0.24,
-          ease: [0.77, 0, 0.175, 1],
-        },
-      }}
+      transition={
+        reduceMotion
+          ? { duration: 0 }
+          : {
+              delay: hasRevealAnimation ? staggerDelay : 0,
+              filter: { duration: 0.18 },
+              layout: {
+                duration: 0.24,
+                ease: [0.77, 0, 0.175, 1],
+              },
+              opacity: { duration: 0.16 },
+              y: {
+                duration: 0.2,
+                ease: [0.23, 1, 0.32, 1],
+              },
+            }
+      }
     >
       <Label
         className="flex min-w-0 flex-1 items-center gap-2 font-normal"
@@ -128,6 +154,7 @@ export function GeoEnginePicker({
   labeled = true,
 }: GeoEnginePickerProps) {
   const id = useId();
+  const reduceMotion = useReducedMotion();
   const { activeOrganization } = useOrganizationsContext();
   const [expanded, setExpanded] = useState<Set<string>>(() =>
     partiallySelectedProviders(catalog, selected)
@@ -246,10 +273,13 @@ export function GeoEnginePicker({
     }
   };
 
-  const visibleProviders = catalog.providers.filter(
-    (provider) => provider.featured || showMore
+  const hiddenProviders = catalog.providers.filter(
+    (provider) => !provider.featured
   );
-  const hiddenCount = catalog.providers.length - visibleProviders.length;
+  const hiddenProviderIndex = new Map(
+    hiddenProviders.map((provider, index) => [provider.id, index])
+  );
+  const hiddenCount = hiddenProviders.length;
   const billingHref = activeOrganization
     ? `/${activeOrganization.slug}/settings/billing#${ZDR_ADDON_ANCHOR}`
     : null;
@@ -267,7 +297,12 @@ export function GeoEnginePicker({
       ) : null}
 
       <ul className="overflow-hidden rounded-xl border bg-card">
-        {visibleProviders.map((provider) => {
+        {catalog.providers.map((provider) => {
+          const isVisible = provider.featured || showMore;
+          const revealIndex = hiddenProviderIndex.get(provider.id) ?? 0;
+          const staggerDelay = showMore
+            ? revealIndex * 0.045
+            : (hiddenCount - revealIndex - 1) * 0.035;
           const models = geoModelsForProvider(catalog, provider.id);
           const isExpanded = expanded.has(provider.id);
           const allModelsShown = showAllModels.has(provider.id);
@@ -296,9 +331,44 @@ export function GeoEnginePicker({
           const providerLocked = allOn && selectedCount === selected.length;
           const checkboxId = `${id}-${provider.id}`;
           return (
-            <li
-              className="relative border-border/60 border-b last:border-b-0"
+            <motion.li
+              animate={
+                isVisible
+                  ? {
+                      filter: "blur(0px)",
+                      height: "auto",
+                      opacity: 1,
+                      y: 0,
+                    }
+                  : {
+                      filter: "blur(5px)",
+                      height: 0,
+                      opacity: 0,
+                      y: -5,
+                    }
+              }
+              aria-hidden={!isVisible}
+              className="relative overflow-hidden border-border/60 border-b last:border-b-0"
+              inert={isVisible ? undefined : true}
+              initial={false}
               key={provider.id}
+              transition={
+                reduceMotion
+                  ? { duration: 0 }
+                  : {
+                      delay: provider.featured ? 0 : staggerDelay,
+                      filter: { duration: 0.18 },
+                      height: {
+                        duration: 0.24,
+                        ease: [0.23, 1, 0.32, 1],
+                      },
+                      opacity: { duration: 0.16 },
+                      y: {
+                        duration: 0.2,
+                        ease: [0.23, 1, 0.32, 1],
+                      },
+                    }
+              }
             >
               <div
                 className={cn(
@@ -387,7 +457,7 @@ export function GeoEnginePicker({
                         <li
                           aria-hidden={!allModelsShown}
                           className={cn(
-                            "grid transition-[grid-template-rows] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+                            "grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
                             allModelsShown
                               ? "grid-rows-[1fr]"
                               : "grid-rows-[0fr]"
@@ -397,15 +467,8 @@ export function GeoEnginePicker({
                             className="min-h-0 overflow-hidden"
                             inert={allModelsShown ? undefined : true}
                           >
-                            <ul
-                              className={cn(
-                                "motion-reduce:translate-none transition-[opacity,translate] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:duration-150",
-                                allModelsShown
-                                  ? "translate-y-0 opacity-100"
-                                  : "-translate-y-1 opacity-0"
-                              )}
-                            >
-                              {additionalModels.map((model) => {
+                            <ul>
+                              {additionalModels.map((model, modelIndex) => {
                                 const checked = selected.includes(model.id);
                                 const modelId = `${id}-${model.id}`;
                                 return (
@@ -421,6 +484,9 @@ export function GeoEnginePicker({
                                     onCheckedChange={(next) =>
                                       toggleModel(model, next)
                                     }
+                                    revealed={allModelsShown}
+                                    revealIndex={modelIndex}
+                                    revealTotal={additionalModels.length}
                                     showZdrState={zdrActive}
                                   />
                                 );
@@ -447,7 +513,7 @@ export function GeoEnginePicker({
                   </div>
                 </div>
               </div>
-            </li>
+            </motion.li>
           );
         })}
         {catalog.providers.some((provider) => !provider.featured) ? (


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths provider and model reveals in the Geo Engine Picker to remove flicker and layout jumps. Previously hidden providers/models snapped open/closed; now they animate in/out with reduced-motion-aware transitions and remain non-interactive when hidden.

- Always render providers and animate visibility (opacity/blur/translate/height) to prevent list reflow.
- Schedule per-item delays for both show and hide using index-based staggering.
- Pass `revealed`, `revealIndex`, and `revealTotal` to `GeoModelRow` to animate additional model rows individually.
- Keep hidden items non-interactive with `aria-hidden` and `inert`.
- Honor reduced motion by disabling animation timings.
- Lengthen additional-models expand transition to 300ms.

<sup>Written for commit 15aaae27014c63e88bec7c60e3b6b859a599c9df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

