### PR TITLE
feat(geo): polish visibility overview

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
@@ -141,7 +141,7 @@ export function GeoTabs({
           </TabSection>
         </InstrumentGrid>
         <TabSection active={revealActive} order={4}>
-          <ModelUsageCard isScanning={isScanning} usage={modelUsage} />
+          <ModelUsageCard usage={modelUsage} />
         </TabSection>
       </TabsContent>
 

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -266,11 +266,13 @@ export function SiteHeader() {
               <HugeiconsIcon icon={ArrowRight01Icon} />
             </BreadcrumbSeparator>,
             <BreadcrumbItem
-              className={cn(!isLast && "hover:underline")}
+              className={cn(isLast && "min-w-0", !isLast && "hover:underline")}
               key={`${id}-geo-item-${segment}`}
             >
               {isLast ? (
-                <BreadcrumbPage>{label}</BreadcrumbPage>
+                <BreadcrumbPage className="block truncate">
+                  {label}
+                </BreadcrumbPage>
               ) : (
                 <BreadcrumbLink render={<Link href={href}>{label}</Link>} />
               )}
@@ -281,8 +283,10 @@ export function SiteHeader() {
           <BreadcrumbSeparator key={`${id}-geo-tab-sep`}>
             <HugeiconsIcon icon={ArrowRight01Icon} />
           </BreadcrumbSeparator>,
-          <BreadcrumbItem key={`${id}-geo-tab`}>
-            <BreadcrumbPage>{geoTabLabel}</BreadcrumbPage>
+          <BreadcrumbItem className="min-w-0" key={`${id}-geo-tab`}>
+            <BreadcrumbPage className="block truncate">
+              {geoTabLabel}
+            </BreadcrumbPage>
           </BreadcrumbItem>,
         ];
 
@@ -310,8 +314,8 @@ export function SiteHeader() {
 
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 bg-muted transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-      <div className="grid h-full w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-4 md:grid-cols-[minmax(8rem,1fr)_minmax(2rem,20rem)_minmax(2.5rem,1fr)] lg:gap-2">
-        <div className="flex h-full min-w-0 items-center gap-2 overflow-hidden">
+      <div className="flex h-full w-full min-w-0 items-center gap-2 px-4">
+        <div className="flex h-full min-w-0 flex-1 items-center gap-2 overflow-hidden">
           <SidebarToggle className="-mx-1.5" />
           <Breadcrumb className="min-w-0">
             <BreadcrumbList className="min-w-0 flex-nowrap gap-2">
@@ -321,7 +325,7 @@ export function SiteHeader() {
         </div>
         <button
           aria-label="Search"
-          className="@container/search hidden h-8 w-full cursor-pointer items-center @[8rem]/search:justify-start justify-center gap-2 rounded-lg border bg-background/60 @[8rem]/search:px-3 px-2 text-muted-foreground text-sm transition-colors hover:bg-muted/60 md:flex"
+          className="@container/search hidden h-8 w-full max-w-48 shrink-0 cursor-pointer items-center @[8rem]/search:justify-start justify-center gap-2 rounded-lg border bg-background/60 @[8rem]/search:px-3 px-2 text-muted-foreground text-sm transition-colors hover:bg-muted/60 md:flex lg:max-w-64 xl:max-w-80"
           onClick={() => setCommandPaletteOpen(true)}
           type="button"
         >
@@ -334,7 +338,7 @@ export function SiteHeader() {
             <Kbd>K</Kbd>
           </KbdGroup>
         </button>
-        <div className="flex h-full min-w-0 items-center justify-end gap-2">
+        <div className="flex h-full min-w-0 shrink-0 items-center justify-end gap-2">
           <button
             aria-hidden
             className="hidden"

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -314,8 +314,8 @@ export function SiteHeader() {
 
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 bg-muted transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-      <div className="flex h-full w-full min-w-0 items-center gap-2 px-4">
-        <div className="flex h-full min-w-0 flex-1 items-center gap-2 overflow-hidden">
+      <div className="grid h-full w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-4 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
+        <div className="flex h-full min-w-0 items-center gap-2 overflow-hidden">
           <SidebarToggle className="-mx-1.5" />
           <Breadcrumb className="min-w-0">
             <BreadcrumbList className="min-w-0 flex-nowrap gap-2">
@@ -325,7 +325,7 @@ export function SiteHeader() {
         </div>
         <button
           aria-label="Search"
-          className="@container/search hidden h-8 w-full max-w-48 shrink-0 cursor-pointer items-center @[8rem]/search:justify-start justify-center gap-2 rounded-lg border bg-background/60 @[8rem]/search:px-3 px-2 text-muted-foreground text-sm transition-colors hover:bg-muted/60 md:flex lg:max-w-64 xl:max-w-80"
+          className="@container/search hidden h-8 w-48 cursor-pointer items-center @[8rem]/search:justify-start justify-center gap-2 rounded-lg border bg-background/60 @[8rem]/search:px-3 px-2 text-muted-foreground text-sm transition-colors hover:bg-muted/60 md:flex lg:w-64 xl:w-80"
           onClick={() => setCommandPaletteOpen(true)}
           type="button"
         >
@@ -338,7 +338,7 @@ export function SiteHeader() {
             <Kbd>K</Kbd>
           </KbdGroup>
         </button>
-        <div className="flex h-full min-w-0 shrink-0 items-center justify-end gap-2">
+        <div className="flex h-full min-w-0 items-center justify-end gap-2">
           <button
             aria-hidden
             className="hidden"

--- a/apps/dashboard/src/components/empty-state-preview.tsx
+++ b/apps/dashboard/src/components/empty-state-preview.tsx
@@ -201,6 +201,69 @@ function AnalyticsChartGhost({ bars }: { bars: readonly number[] }) {
   );
 }
 
+export function EmptyStateTrendPreview() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-full w-full text-muted-foreground"
+      fill="none"
+      preserveAspectRatio="none"
+      viewBox="0 0 1200 320"
+    >
+      <g
+        className="text-border"
+        stroke="currentColor"
+        strokeDasharray="3 3"
+        strokeWidth="1"
+      >
+        <path d="M48 32H1176" />
+        <path d="M48 96H1176" />
+        <path d="M48 160H1176" />
+        <path d="M48 224H1176" />
+        <path d="M48 288H1176" />
+      </g>
+      <path
+        d="M48 237C100 224 134 188 189 196C244 204 277 173 330 181C383 189 418 139 471 151C524 163 559 128 612 137C665 146 700 97 753 112C806 127 841 91 894 102C947 113 982 69 1035 83C1088 97 1123 61 1176 72V288H48Z"
+        fill="currentColor"
+        fillOpacity="0.16"
+        stroke="none"
+      />
+      <path
+        d="M48 237C100 224 134 188 189 196C244 204 277 173 330 181C383 189 418 139 471 151C524 163 559 128 612 137C665 146 700 97 753 112C806 127 841 91 894 102C947 113 982 69 1035 83C1088 97 1123 61 1176 72"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      <path
+        d="M48 273C101 266 135 240 189 247C243 254 277 224 330 232C383 240 418 204 471 215C524 226 559 195 612 202C665 209 700 175 753 184C806 193 841 160 894 171C947 182 982 147 1035 157C1088 167 1123 137 1176 145"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeOpacity="0.58"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      <path
+        d="M48 257C101 248 135 258 189 238C243 218 277 227 330 207C383 187 418 202 471 178C524 154 559 173 612 151C665 129 700 148 753 128C806 108 841 123 894 103C947 83 982 101 1035 81C1088 61 1123 76 1176 55"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeOpacity="0.34"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      <path
+        className="text-border"
+        d="M48 257L1176 91"
+        stroke="currentColor"
+        strokeDasharray="5 5"
+        strokeLinecap="round"
+        strokeWidth="2"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
 export function EmptyStateAnalyticsPreview() {
   return (
     <div className="space-y-3">

--- a/apps/dashboard/src/components/geo/engine-rate-table.tsx
+++ b/apps/dashboard/src/components/geo/engine-rate-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { EngineFamilySheet } from "@/components/geo/engine-family-sheet";
 import { EngineIcon } from "@/components/geo/engine-icon";
 import { GeoBar } from "@/components/geo/geo-bar";
@@ -9,6 +10,7 @@ import {
   InstrumentSection,
 } from "@/components/instrument/instrument-module";
 import { Table, type TableColumn } from "@/components/motion/table";
+import { EMPTY_STATE_TABLE_COLUMNS } from "@/constants/empty-state";
 import {
   GEO_EMPTY_PROMPT_RESULTS,
   GEO_EMPTY_TIMESERIES,
@@ -132,6 +134,14 @@ export function EngineRateTable({
             isScanning,
             "Run a scan to see engine mention rates"
           )}
+          preview={
+            <div className="px-6 pt-2">
+              <EmptyStateTablePreview
+                columns={EMPTY_STATE_TABLE_COLUMNS.engines}
+                rows={3}
+              />
+            </div>
+          }
           seed="Mention rate by engine"
         />
       ) : (

--- a/apps/dashboard/src/components/geo/mention-trend-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { EmptyStateTrendPreview } from "@/components/empty-state-preview";
 import { EChartsAreaChart } from "@/components/evilcharts/charts/echarts-area-chart";
 import { engineIconHtml } from "@/components/geo/engine-icon";
 import { MentionTrendAgentsPicker } from "@/components/geo/mention-trend-agents";
@@ -161,6 +162,7 @@ export function MentionTrendCard({
           busy={isScanning}
           className="h-80"
           message={emptyMessage}
+          preview={<EmptyStateTrendPreview />}
           seed="Mention trend"
         />
       ) : (

--- a/apps/dashboard/src/components/geo/model-usage-card.tsx
+++ b/apps/dashboard/src/components/geo/model-usage-card.tsx
@@ -16,7 +16,6 @@ import { formatMetric } from "@/utils/analytics-charts";
 import { modelUsageSeriesColors } from "@/utils/chart-colors";
 import { formatUsageShare } from "@/utils/geo-charts";
 import { buildModelUsageChart } from "@/utils/geo-model-usage";
-import { geoScanEmptyMessage } from "@/utils/geo-scan";
 
 function ModelUsageLegend({
   series,
@@ -63,10 +62,7 @@ function ModelUsageLegend({
   );
 }
 
-export function ModelUsageCard({
-  usage,
-  isScanning = false,
-}: ModelUsageCardProps) {
+export function ModelUsageCard({ usage }: ModelUsageCardProps) {
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const chart = useMemo(
     () =>
@@ -100,12 +96,8 @@ export function ModelUsageCard({
     >
       {chart.rows.length === 0 ? (
         <InstrumentEmpty
-          busy={isScanning}
           className={GEO_MODEL_USAGE_CHART_HEIGHT_CLASS}
-          message={geoScanEmptyMessage(
-            isScanning,
-            "Run a scan to capture model usage share"
-          )}
+          message="Model usage data is currently unavailable"
           seed="Where AI usage actually happens"
         />
       ) : (

--- a/apps/dashboard/src/components/geo/share-of-voice-table.tsx
+++ b/apps/dashboard/src/components/geo/share-of-voice-table.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useMemo } from "react";
+import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { CompetitorLogo } from "@/components/geo/competitor-logo";
 import { GeoBar } from "@/components/geo/geo-bar";
 import { InstrumentEmpty } from "@/components/instrument/instrument-module";
 import { Table, type TableColumn } from "@/components/motion/table";
 import { CHART_OTHER_SLICE_LABEL } from "@/constants/charts";
+import { EMPTY_STATE_TABLE_COLUMNS } from "@/constants/empty-state";
 import { TABLE_ROW_HEIGHT } from "@/constants/table";
 import { findCompetitorDomain } from "@/lib/geo/domain";
 import type { ShareOfVoiceRow, ShareOfVoiceTableProps } from "@/types/geo";
@@ -109,7 +111,18 @@ export function ShareOfVoiceTable({
       <InstrumentEmpty
         busy={isScanning}
         className="h-full"
-        message={geoScanEmptyMessage(isScanning, "No competitor data yet")}
+        message={geoScanEmptyMessage(
+          isScanning,
+          "Run a scan to see your share of voice"
+        )}
+        preview={
+          <div className="px-4 pt-2">
+            <EmptyStateTablePreview
+              columns={EMPTY_STATE_TABLE_COLUMNS.shareOfVoice}
+              rows={4}
+            />
+          </div>
+        }
         seed="Share of voice"
       />
     );

--- a/apps/dashboard/src/components/instrument/instrument-module.tsx
+++ b/apps/dashboard/src/components/instrument/instrument-module.tsx
@@ -145,17 +145,33 @@ export function InstrumentEmpty({
   className,
   busy = false,
   action,
+  preview,
 }: InstrumentEmptyProps) {
   return (
     <div
       aria-busy={busy}
       aria-live={busy ? "polite" : undefined}
       className={cn(
-        "flex h-full min-h-56 flex-col items-center justify-center gap-3 text-center",
+        "relative flex h-full min-h-56 flex-col items-center justify-center gap-3 text-center",
+        preview && "overflow-hidden",
         className
       )}
     >
-      <div className="flex items-center justify-center gap-2">
+      {preview ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 select-none opacity-40 [mask-image:linear-gradient(to_bottom,transparent_0%,black_24%,black_70%,transparent_100%)]"
+        >
+          {preview}
+        </div>
+      ) : null}
+      <div
+        className={cn(
+          "relative z-10 flex items-center justify-center gap-2",
+          preview &&
+            "rounded-full bg-background/85 px-3 py-1.5 shadow-xs backdrop-blur-[2px]"
+        )}
+      >
         {busy ? (
           <span
             aria-hidden="true"
@@ -186,7 +202,7 @@ export function InstrumentEmpty({
         ) : null}
         <p className="text-muted-foreground text-sm capitalize">{message}</p>
       </div>
-      {action && !busy ? action : null}
+      {action && !busy ? <div className="relative z-10">{action}</div> : null}
     </div>
   );
 }

--- a/apps/dashboard/src/constants/empty-state.ts
+++ b/apps/dashboard/src/constants/empty-state.ts
@@ -7,6 +7,8 @@ export const EMPTY_STATE_TABLE_COLUMNS = {
   sitemap: [220, 72, 96],
   prompts: [240, 72, 56],
   competitors: [160, 120, 72, 88],
+  engines: [160, 180, 100, 120],
+  shareOfVoice: [180, 240, 80],
   traffic: [128, 96, 72, 80, 88],
   write: [220, 72, 88],
   gaps: [220, 72, 96, 88],

--- a/apps/dashboard/src/lib/auth/password-actions.ts
+++ b/apps/dashboard/src/lib/auth/password-actions.ts
@@ -34,6 +34,14 @@ const DEFAULT_POST_LOGIN_PATH = "/callback";
 const RATE_LIMITED_MESSAGE = "Too many attempts. Please try again shortly.";
 
 async function isRateLimited(limiter: Ratelimit, email: string) {
+  if (
+    process.env.NODE_ENV !== "production" &&
+    (!process.env.UPSTASH_REDIS_REST_URL ||
+      !process.env.UPSTASH_REDIS_REST_TOKEN)
+  ) {
+    return false;
+  }
+
   const headersList = await headers();
   const ip = getClientIpFromHeaders(headersList);
   const { success } = await limiter.limit(`${ip}:${email.toLowerCase()}`);
@@ -61,7 +69,17 @@ const tryWorkOSAuth = <T>(run: () => Promise<T>) =>
 const completeAuthentication = Effect.fn("auth.password.completeSession")(
   function* (response: AuthenticationResponse, returnTo?: string | null) {
     yield* Effect.tryPromise({
-      try: () => saveSession(response, getAppUrl()),
+      try: () =>
+        saveSession(
+          {
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            user: response.user,
+            impersonator: response.impersonator,
+            authenticationMethod: response.authenticationMethod,
+          },
+          getAppUrl()
+        ),
       catch: (cause) =>
         new UserSyncError({ message: "Failed to persist session", cause }),
     });

--- a/apps/dashboard/src/lib/geo/mappers.ts
+++ b/apps/dashboard/src/lib/geo/mappers.ts
@@ -1,9 +1,7 @@
 import type { GeoTrafficLogRow } from "@notra/analytics/types/tinybird-endpoints";
-import { normalizeModelId } from "@/lib/geo/model-usage";
 import type {
   GeoCompetitor,
   GeoCompetitorRow,
-  GeoEngineCoverage,
   GeoModelCatalog,
   GeoModelUsageRow,
   GeoProject,
@@ -115,36 +113,20 @@ export function toNullableNumber(value: number | bigint | null): number | null {
   return Number(value);
 }
 
-export function buildCoverageByModel(
-  rows: { engine: string; mentions: number | bigint; checks: number | bigint }[]
-): Map<string, GeoEngineCoverage> {
-  const coverage = new Map<string, GeoEngineCoverage>();
-  for (const row of rows) {
-    const model = normalizeModelId(row.engine);
-    const entry = coverage.get(model) ?? { mentions: 0, checks: 0 };
-    entry.mentions += Number(row.mentions);
-    entry.checks += Number(row.checks);
-    coverage.set(model, entry);
-  }
-  return coverage;
-}
-
 export function toModelUsageRow(
   model: string,
   rank: number | bigint,
   share: number,
-  rawTokens: number | bigint | null,
-  coverage: GeoEngineCoverage | undefined
+  rawTokens: number | bigint | null
 ): GeoModelUsageRow {
-  const checks = coverage?.checks ?? 0;
   return {
     model,
     label: formatModelLabel(model),
     rank: Number(rank),
     share,
     rawTokens: rawTokens === null ? null : Number(rawTokens),
-    scanned: checks > 0,
-    mentionRate: checks > 0 ? (coverage?.mentions ?? 0) / checks : null,
-    checks,
+    scanned: false,
+    mentionRate: null,
+    checks: 0,
   };
 }

--- a/apps/dashboard/src/lib/geo/model-usage.ts
+++ b/apps/dashboard/src/lib/geo/model-usage.ts
@@ -1,5 +1,4 @@
 import { cachedExternalFetch } from "@notra/analytics/cache/query-cache";
-import { ingestModelUsageShare } from "@notra/analytics/tinybird/client";
 import type { ModelUsageShareRow } from "@notra/analytics/tinybird/datasources";
 import { Effect } from "effect";
 import {
@@ -18,7 +17,6 @@ import {
   openRouterModelsResponseSchema,
   openRouterRankingsChartSchema,
 } from "@/schemas/geo";
-import type { GeoModelUsageSnapshot } from "@/types/geo";
 import { GROUNDED_SUFFIX_PATTERN } from "@/utils/geo-presence";
 
 const VARIANT_SUFFIX = /:[a-z0-9-]+$/;
@@ -29,7 +27,7 @@ interface WeeklyTotal {
   tokens: number;
 }
 
-export function normalizeModelId(value: string): string {
+function normalizeModelId(value: string): string {
   return value
     .toLowerCase()
     .replace(GROUNDED_SUFFIX_PATTERN, "")
@@ -127,7 +125,7 @@ function buildRows(
   return rows;
 }
 
-export const captureModelUsageShare = Effect.fn("geo.captureModelUsageShare")(
+export const loadModelUsageRows = Effect.fn("geo.modelUsage.loadRows")(
   function* () {
     const payload = yield* Effect.tryPromise({
       try: () =>
@@ -166,24 +164,6 @@ export const captureModelUsageShare = Effect.fn("geo.captureModelUsageShare")(
 
     const slugs = yield* fetchSlugMap();
     const rows = buildRows(weeks, slugs);
-
-    if (rows.length === 0) {
-      const skipped: GeoModelUsageSnapshot = { status: "skipped" };
-      return skipped;
-    }
-
-    yield* Effect.tryPromise({
-      try: () => ingestModelUsageShare(rows),
-      catch: (cause) =>
-        new GeoScanError({ message: "Failed to ingest model usage", cause }),
-    });
-
-    const lastPoint = parsed.data.data.data.at(-1);
-    const captured: GeoModelUsageSnapshot = {
-      status: "captured",
-      models: rows.length,
-      capturedAt: lastPoint?.x,
-    };
-    return captured;
+    return rows;
   }
 );

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -7,6 +7,8 @@ import {
   queryGeoTrafficOverview,
   queryGeoTrafficPages,
   queryGeoTrafficTimeseries,
+  queryModelUsageLatest,
+  queryModelUsageTrend,
 } from "@notra/analytics/tinybird/client";
 import { db } from "@notra/db/drizzle";
 import {
@@ -636,10 +638,49 @@ export const loadGeoModelUsage = Effect.fn("geo.modelUsage")(function* (
 ) {
   yield* resolveGeoScope(input);
   const resolvedLimit = limit ?? GEO_MODEL_USAGE_DEFAULT_LIMIT;
-  const rows =
-    (yield* loadModelUsageRows().pipe(
-      geoSkip("model usage source unavailable")
-    )) ?? [];
+  const liveRows = yield* loadModelUsageRows().pipe(
+    geoSkip("model usage source unavailable")
+  );
+
+  if (!liveRows || liveRows.length === 0) {
+    const [usage, trend] = yield* Effect.all(
+      [
+        geoQuery("model usage fallback query failed", () =>
+          queryModelUsageLatest({
+            source: GEO_MODEL_USAGE_SOURCE,
+            limit: resolvedLimit,
+          })
+        ),
+        geoQuery("model usage trend fallback query failed", () =>
+          queryModelUsageTrend({
+            source: GEO_MODEL_USAGE_SOURCE,
+            weeks: GEO_MODEL_USAGE_TREND_WEEKS,
+          })
+        ),
+      ],
+      { concurrency: "unbounded" }
+    );
+    const rows = usage?.data ?? [];
+
+    const fallback: GeoModelUsageResponse = {
+      configured: isTinybirdConfigured(),
+      source: GEO_MODEL_USAGE_SOURCE,
+      attribution: GEO_MODEL_USAGE_ATTRIBUTION,
+      capturedAt: rows[0]?.captured_at ?? null,
+      models: rows.map((row) =>
+        toModelUsageRow(row.model, row.rank, Number(row.share), row.raw_tokens)
+      ),
+      points: (trend?.data ?? []).map((row) => ({
+        week: String(row.week).slice(0, 10),
+        model: row.model,
+        share: Number(row.avg_share),
+        tokens: row.peak_tokens === null ? null : Number(row.peak_tokens),
+      })),
+    };
+    return fallback;
+  }
+
+  const rows = liveRows;
   const capturedAt = rows.reduce<string | null>(
     (latest, row) =>
       latest === null || row.captured_at > latest ? row.captured_at : latest,

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -7,8 +7,6 @@ import {
   queryGeoTrafficOverview,
   queryGeoTrafficPages,
   queryGeoTrafficTimeseries,
-  queryModelUsageLatest,
-  queryModelUsageTrend,
 } from "@notra/analytics/tinybird/client";
 import { db } from "@notra/db/drizzle";
 import {
@@ -54,7 +52,6 @@ import {
   GeoSettingsMissingError,
 } from "@/lib/geo/errors";
 import {
-  buildCoverageByModel,
   toGeoCompetitor,
   toGeoSettings,
   toGeoTrafficLogEntry,
@@ -63,6 +60,7 @@ import {
   toTrackedPrompt,
 } from "@/lib/geo/mappers";
 import { loadGeoModelCatalog } from "@/lib/geo/model-catalog";
+import { loadModelUsageRows } from "@/lib/geo/model-usage";
 import {
   ensureGeoProject,
   geoCheckScope,
@@ -633,55 +631,51 @@ export const loadGeoCompetitorDetail = Effect.fn("geo.competitorDetail")(
 
 export const loadGeoModelUsage = Effect.fn("geo.modelUsage")(function* (
   input: GeoScopeInput,
-  window: GeoWindowInput,
+  _window: GeoWindowInput,
   limit: number | undefined
 ) {
-  const scope = yield* resolveGeoScope(input);
+  yield* resolveGeoScope(input);
   const resolvedLimit = limit ?? GEO_MODEL_USAGE_DEFAULT_LIMIT;
-  const [usage, trend, overview] = yield* Effect.all(
-    [
-      geoQuery("model usage query failed", () =>
-        queryModelUsageLatest({
-          source: GEO_MODEL_USAGE_SOURCE,
-          limit: resolvedLimit,
-        })
-      ),
-      geoQuery("model usage trend query failed", () =>
-        queryModelUsageTrend({
-          source: GEO_MODEL_USAGE_SOURCE,
-          weeks: GEO_MODEL_USAGE_TREND_WEEKS,
-        })
-      ),
-      geoDb("overview query failed", () =>
-        queryGeoCheckOverview(geoCheckScope(scope), toGeoCheckWindow(window))
-      ).pipe(geoSkip("overview query failed")),
-    ],
-    { concurrency: "unbounded" }
+  const rows =
+    (yield* loadModelUsageRows().pipe(
+      geoSkip("model usage source unavailable")
+    )) ?? [];
+  const capturedAt = rows.reduce<string | null>(
+    (latest, row) =>
+      latest === null || row.captured_at > latest ? row.captured_at : latest,
+    null
   );
-
-  const coverage = buildCoverageByModel(overview ?? []);
-  const rows = usage?.data ?? [];
+  const latestRows = rows
+    .filter((row) => row.captured_at === capturedAt)
+    .sort((left, right) => Number(left.rank) - Number(right.rank))
+    .slice(0, resolvedLimit);
+  const featuredModels = new Set(latestRows.map((row) => row.model));
+  const visibleWeeks = new Set(
+    [...new Set(rows.map((row) => row.captured_at))]
+      .sort()
+      .slice(-GEO_MODEL_USAGE_TREND_WEEKS)
+  );
+  const points = rows.reduce<GeoModelUsageResponse["points"]>((result, row) => {
+    if (visibleWeeks.has(row.captured_at) && featuredModels.has(row.model)) {
+      result.push({
+        week: row.captured_at.slice(0, 10),
+        model: row.model,
+        share: Number(row.share),
+        tokens: row.raw_tokens === null ? null : Number(row.raw_tokens),
+      });
+    }
+    return result;
+  }, []);
 
   const response: GeoModelUsageResponse = {
-    configured: isTinybirdConfigured(),
+    configured: rows.length > 0,
     source: GEO_MODEL_USAGE_SOURCE,
     attribution: GEO_MODEL_USAGE_ATTRIBUTION,
-    capturedAt: rows[0]?.captured_at ?? null,
-    models: rows.map((row) =>
-      toModelUsageRow(
-        row.model,
-        row.rank,
-        Number(row.share),
-        row.raw_tokens,
-        coverage.get(row.model)
-      )
+    capturedAt,
+    models: latestRows.map((row) =>
+      toModelUsageRow(row.model, row.rank, Number(row.share), row.raw_tokens)
     ),
-    points: (trend?.data ?? []).map((row) => ({
-      week: String(row.week).slice(0, 10),
-      model: row.model,
-      share: Number(row.avg_share),
-      tokens: row.peak_tokens === null ? null : Number(row.peak_tokens),
-    })),
+    points,
   };
   return response;
 });

--- a/apps/dashboard/src/lib/geo/scan.ts
+++ b/apps/dashboard/src/lib/geo/scan.ts
@@ -39,7 +39,6 @@ import {
 import { GeoScanError } from "@/lib/geo/errors";
 import { toGeoSettings } from "@/lib/geo/mappers";
 import { loadGeoModelCatalog } from "@/lib/geo/model-catalog";
-import { captureModelUsageShare } from "@/lib/geo/model-usage";
 import { buildGeoPrompts, customPromptScanId } from "@/lib/geo/prompts";
 import { markGeoScanFinished, withGeoScanRun } from "@/lib/geo/scan-status";
 import {
@@ -634,8 +633,6 @@ export const runGeoScan = Effect.fn("geo.runScan")(function* (
     checks += result.checks ?? 0;
     mentions += result.mentions ?? 0;
   }
-
-  yield* captureModelUsageShare().pipe(geoSkip("model usage snapshot failed"));
 
   const completed: GeoScanResult = {
     status: "completed",

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -140,11 +140,6 @@ export interface GeoSettingsRow {
   updatedAt: Date;
 }
 
-export interface GeoEngineCoverage {
-  mentions: number;
-  checks: number;
-}
-
 export interface GeoOverviewEngine {
   engine: string;
   checks: number;
@@ -600,12 +595,6 @@ export interface ModelUsageChart {
   incompleteTail: boolean;
 }
 
-export interface GeoModelUsageSnapshot {
-  status: "captured" | "skipped";
-  models?: number;
-  capturedAt?: string;
-}
-
 export interface GeoJudgeResult {
   mentioned: boolean;
   position: number | null;
@@ -938,7 +927,6 @@ export interface GeoLanguageShareResponse {
 
 export interface ModelUsageCardProps {
   usage: GeoModelUsageResponse | undefined;
-  isScanning?: boolean;
 }
 
 export interface ModelUsageLegendProps {

--- a/apps/dashboard/src/types/instrument.ts
+++ b/apps/dashboard/src/types/instrument.ts
@@ -30,4 +30,5 @@ export interface InstrumentEmptyProps {
   className?: string;
   busy?: boolean;
   action?: ReactNode;
+  preview?: ReactNode;
 }


### PR DESCRIPTION
### Description
Polishes the GEO visibility overview with more representative empty-state previews for Mention Trend, Mention Rate by Engine, and Share of Voice. It also makes OpenRouter model-usage data independent of GEO scans and fixes the dashboard header layout so breadcrumbs, search, and account controls remain aligned across viewport and sidebar states.

### Screenshot/Recording (if applicable)
<img width="908" height="956" alt="image" src="https://github.com/user-attachments/assets/5c44cb21-a4a2-4239-9315-1b051d06b9ee" />


<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches model usage from scan-time ingestion to on-demand loading; if live OpenRouter data isn’t available, we fall back to the existing Tinybird source. Also polishes the GEO visibility overview with inline empty-state previews and centers the header.

- New Features
  - Adds inline empty-state previews via `InstrumentEmpty`, including `EmptyStateTrendPreview` and table mocks.
  - Shows table previews for Engines and Share of Voice using `EMPTY_STATE_TABLE_COLUMNS`.
  - Truncates breadcrumb labels and geo tab titles; centers the topbar search across breakpoints.
  - Updates the model-usage empty message to “Model usage data is currently unavailable.”

- Refactors
  - Computes latest models and trend from loaded rows only; stops ingesting model usage during scans.
  - Sets model-usage defaults (scanned=false, mentionRate=null, checks=0).
  - Removes `isScanning` from `ModelUsageCard` props; update call sites.
  - Skips rate limiting outside production when `UPSTASH_REDIS_REST_URL` or `UPSTASH_REDIS_REST_TOKEN` are unset, and saves sessions with explicit fields only.

<sup>Written for commit 2c4a69884a3c484e604f3ea55eeb139fe4daa4fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



