### PR TITLE
fix(auth): respect explicit organization slug

### DIFF
--- a/apps/dashboard/src/lib/auth/actions.ts
+++ b/apps/dashboard/src/lib/auth/actions.ts
@@ -17,7 +17,7 @@ export async function validateOrganizationAccess(slug: string) {
     if (await isSessionBanned()) {
       redirect("/auth/banned");
     }
-    redirect("/login");
+    redirect(`/login?returnTo=${encodeURIComponent(`/${slug}`)}`);
   }
 
   const organization = await retryTransientDbError(() =>
@@ -32,12 +32,6 @@ export async function validateOrganizationAccess(slug: string) {
   );
 
   if (!organization || organization.members.length === 0) {
-    const fallbackOrganization = await getLastActiveOrganizationForUser(
-      session.user.id
-    );
-    if (fallbackOrganization && fallbackOrganization.slug !== slug) {
-      redirect(`/${fallbackOrganization.slug}`);
-    }
     notFound();
   }
 


### PR DESCRIPTION
### Description
Ensures that an explicitly requested organization slug takes precedence over the last active organization. Invalid or inaccessible slugs now return a 404 instead of redirecting to the previously active organization. The requested organization is also preserved through login via `returnTo`.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
