### PR TITLE
feat(geo): add ZDR checkout from settings

### DIFF
--- a/apps/dashboard/src/components/geo/geo-engine-picker.tsx
+++ b/apps/dashboard/src/components/geo/geo-engine-picker.tsx
@@ -20,9 +20,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
+import { useCustomer } from "autumn-js/react";
 import { motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import { useId, useState } from "react";
+import { toast } from "sonner";
+import { ZdrConsentDialog } from "@/components/billing/zdr-consent-dialog";
 import { EngineIcon } from "@/components/geo/engine-icon";
 import {
   hasProviderWordmark,
@@ -30,7 +33,7 @@ import {
 } from "@/components/geo/provider-wordmark";
 import { Checkbox } from "@/components/motion/checkbox";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
-import { ZDR_ADDON_ANCHOR } from "@/constants/billing";
+import { ZDR_ADDON_ADD_SUCCESS, ZDR_ADDON_ANCHOR } from "@/constants/billing";
 import { GEO_PICKER_VISIBLE_MODELS } from "@/constants/geo-model-catalog";
 import { cn } from "@/lib/utils";
 import type {
@@ -38,6 +41,10 @@ import type {
   GeoModelCatalog,
   GeoModelCatalogEntry,
 } from "@/types/geo";
+import {
+  findActivePlanSubscription,
+  zdrAddonPlanId,
+} from "@/utils/billing-plans";
 import {
   applyGeoZdrEngineFallback,
   sortKnownEngines,
@@ -156,6 +163,9 @@ export function GeoEnginePicker({
   const id = useId();
   const reduceMotion = useReducedMotion();
   const { activeOrganization } = useOrganizationsContext();
+  const { attach, data: customer, refetch } = useCustomer();
+  const [addonLoading, setAddonLoading] = useState(false);
+  const [consentOpen, setConsentOpen] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(() =>
     partiallySelectedProviders(catalog, selected)
   );
@@ -271,6 +281,43 @@ export function GeoEnginePicker({
         })
       );
     }
+  };
+
+  const handleAddZdr = async () => {
+    const activeSubscription = findActivePlanSubscription(
+      customer?.subscriptions
+    );
+    const addonPlanId = zdrAddonPlanId(activeSubscription?.planId);
+    if (!addonPlanId) {
+      toast.error("Choose a plan before adding zero data retention.");
+      return;
+    }
+
+    setAddonLoading(true);
+    const successUrl = activeOrganization?.slug
+      ? `${window.location.origin}/${activeOrganization.slug}/geo/settings`
+      : undefined;
+    try {
+      const result = await attach({
+        planId: addonPlanId,
+        redirectMode: "if_required",
+        successUrl,
+      });
+      if (result.paymentUrl) {
+        window.location.assign(result.paymentUrl);
+        return;
+      }
+      await refetch();
+      handleZdrChange(true);
+      toast.success(ZDR_ADDON_ADD_SUCCESS);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not add zero data retention. Please try again."
+      );
+    }
+    setAddonLoading(false);
   };
 
   const hiddenProviders = catalog.providers.filter(
@@ -584,17 +631,14 @@ export function GeoEnginePicker({
             />
           ) : (
             <Tooltip>
-              <TooltipTrigger
-                aria-disabled="true"
-                className="inline-flex cursor-not-allowed"
-                type="button"
-              >
+              <TooltipTrigger render={<span className="inline-flex" />}>
                 <Switch
-                  aria-hidden="true"
+                  aria-label="Add zero data retention"
                   checked={false}
-                  disabled
+                  className="cursor-pointer disabled:cursor-not-allowed"
+                  disabled={disabled || planLoading || addonLoading}
                   id={`${id}-zdr`}
-                  tabIndex={-1}
+                  onCheckedChange={() => setConsentOpen(true)}
                 />
               </TooltipTrigger>
               <TooltipContent side="top">
@@ -606,6 +650,12 @@ export function GeoEnginePicker({
           )}
         </div>
       </div>
+
+      <ZdrConsentDialog
+        onConfirm={handleAddZdr}
+        onOpenChange={setConsentOpen}
+        open={consentOpen}
+      />
 
       <AlertDialog
         onOpenChange={(open) => {

--- a/apps/dashboard/src/components/geo/geo-engine-picker.tsx
+++ b/apps/dashboard/src/components/geo/geo-engine-picker.tsx
@@ -23,7 +23,7 @@ import {
 import { useCustomer } from "autumn-js/react";
 import { motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
-import { useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ZdrConsentDialog } from "@/components/billing/zdr-consent-dialog";
 import { EngineIcon } from "@/components/geo/engine-icon";
@@ -33,7 +33,11 @@ import {
 } from "@/components/geo/provider-wordmark";
 import { Checkbox } from "@/components/motion/checkbox";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
-import { ZDR_ADDON_ADD_SUCCESS, ZDR_ADDON_ANCHOR } from "@/constants/billing";
+import {
+  ZDR_ADDON_ADD_SUCCESS,
+  ZDR_ADDON_ANCHOR,
+  ZDR_CHECKOUT_SUCCESS_PARAM,
+} from "@/constants/billing";
 import { GEO_PICKER_VISIBLE_MODELS } from "@/constants/geo-model-catalog";
 import { cn } from "@/lib/utils";
 import type {
@@ -166,6 +170,7 @@ export function GeoEnginePicker({
   const { attach, data: customer, refetch } = useCustomer();
   const [addonLoading, setAddonLoading] = useState(false);
   const [consentOpen, setConsentOpen] = useState(false);
+  const checkoutReturnHandled = useRef(false);
   const [expanded, setExpanded] = useState<Set<string>>(() =>
     partiallySelectedProviders(catalog, selected)
   );
@@ -271,17 +276,36 @@ export function GeoEnginePicker({
     setPendingApproval(null);
   };
 
-  const handleZdrChange = (next: boolean) => {
-    onEnforceZdrChange(next);
-    if (next) {
-      onChange(
-        applyGeoZdrEngineFallback(catalog, selected, {
-          enforceZdr: true,
-          nonZdrApprovedEngines: nonZdrApproved,
-        })
-      );
+  const handleZdrChange = useCallback(
+    (next: boolean) => {
+      onEnforceZdrChange(next);
+      if (next) {
+        onChange(
+          applyGeoZdrEngineFallback(catalog, selected, {
+            enforceZdr: true,
+            nonZdrApprovedEngines: nonZdrApproved,
+          })
+        );
+      }
+    },
+    [catalog, nonZdrApproved, onChange, onEnforceZdrChange, selected]
+  );
+
+  useEffect(() => {
+    if (checkoutReturnHandled.current || !canEnforceZdr) {
+      return;
     }
-  };
+
+    const returnUrl = new URL(window.location.href);
+    if (returnUrl.searchParams.get(ZDR_CHECKOUT_SUCCESS_PARAM) !== "true") {
+      return;
+    }
+
+    checkoutReturnHandled.current = true;
+    handleZdrChange(true);
+    returnUrl.searchParams.delete(ZDR_CHECKOUT_SUCCESS_PARAM);
+    window.history.replaceState(null, "", returnUrl);
+  }, [canEnforceZdr, handleZdrChange]);
 
   const handleAddZdr = async () => {
     const activeSubscription = findActivePlanSubscription(
@@ -295,13 +319,14 @@ export function GeoEnginePicker({
 
     setAddonLoading(true);
     const successUrl = activeOrganization?.slug
-      ? `${window.location.origin}/${activeOrganization.slug}/geo/settings`
+      ? new URL(window.location.href)
       : undefined;
+    successUrl?.searchParams.set(ZDR_CHECKOUT_SUCCESS_PARAM, "true");
     try {
       const result = await attach({
         planId: addonPlanId,
         redirectMode: "if_required",
-        successUrl,
+        successUrl: successUrl?.toString(),
       });
       if (result.paymentUrl) {
         window.location.assign(result.paymentUrl);

--- a/apps/dashboard/src/constants/billing.ts
+++ b/apps/dashboard/src/constants/billing.ts
@@ -57,6 +57,7 @@ export const ZDR_ADDON_BY_TIER: Record<string, string> = {
 export const ZDR_ADDON_PREFIX = "zdr_";
 export const ANNUAL_ADDON_SUFFIX = "_annual";
 export const ZDR_ADDON_ANCHOR = "zdr";
+export const ZDR_CHECKOUT_SUCCESS_PARAM = "zdrCheckout";
 export const PLANS_ANCHOR = "plans";
 export const ZDR_ADDON_TITLE = "Zero data retention";
 export const ZDR_ADDON_DESCRIPTION =


### PR DESCRIPTION
### Description
Makes the locked "Enforce ZDR" switch in GEO Settings actionable.

Clicking the switch now opens the existing ZDR consent dialog. After confirmation, the app selects the correct monthly or annual ZDR add-on for the organization's active plan and starts the Autumn checkout flow. Successful checkouts return to GEO Settings, refresh the customer's entitlements, and enable ZDR.

The existing Billing link remains available as a fallback.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
