### PR TITLE
feat(geo): stop storing human visits at ingest

### DIFF
--- a/apps/dashboard/src/constants/geo.ts
+++ b/apps/dashboard/src/constants/geo.ts
@@ -22,6 +22,7 @@ import type {
   GeoTimeseriesPoint,
   GeoTrafficLogPurposeOption,
   GeoTrafficLogVisitorOption,
+  GeoVisitorType,
 } from "@/types/geo";
 
 export const GEO_MAX_ENGINES = 64;
@@ -505,7 +506,6 @@ export const GEO_BROWSER_UA_PATTERNS: readonly string[] = [
 export const GEO_VISITOR_TYPE_LABELS: Record<string, string> = {
   crawler: "AI crawler",
   ai_referral: "AI referral",
-  human: "Human",
   unknown: "Unknown",
 };
 
@@ -538,8 +538,9 @@ export const GEO_TRAFFIC_LOG_VISITOR_OPTIONS: readonly GeoTrafficLogVisitorOptio
   [
     { value: "crawler", label: "AI crawler" },
     { value: "ai_referral", label: "AI referral" },
-    { value: "human", label: "Human" },
   ];
+
+export const GEO_UNTRACKED_VISITOR_TYPES: readonly GeoVisitorType[] = ["human"];
 
 export const GEO_TRAFFIC_LOG_PURPOSE_OPTIONS: readonly GeoTrafficLogPurposeOption[] =
   [
@@ -608,7 +609,7 @@ export const GEO_EMPTY_TIMESERIES: readonly GeoTimeseriesPoint[] = [];
 export const GEO_EMPTY_PROMPT_RESULTS: readonly GeoPromptResult[] = [];
 export const GEO_EMPTY_TRAFFIC_RESPONSE: AiTrafficResponse = {
   configured: false,
-  totals: { crawler: 0, aiReferral: 0, human: 0 },
+  totals: { crawler: 0, aiReferral: 0 },
   sources: [],
   points: [],
 };

--- a/apps/dashboard/src/lib/geo-ingest/pipeline.ts
+++ b/apps/dashboard/src/lib/geo-ingest/pipeline.ts
@@ -19,6 +19,7 @@ import { resolveJourneyId } from "@/lib/geo-ingest/journey";
 import { verifyGeoIngestToken } from "@/lib/geo-ingest/token";
 import { geoRequestPayloadSchema } from "@/schemas/geo";
 import type { GeoIngestIdentity } from "@/types/geo";
+import { isTrackedGeoVisitorType } from "@/utils/ai-traffic";
 import { ratelimit } from "@/utils/ratelimit";
 
 const authenticate = Effect.fn("geoIngest.authenticate")(function* (
@@ -92,6 +93,9 @@ const buildEvent = Effect.fn("geoIngest.buildEvent")(function* (
     accept: payload.accept,
     signals: payload.signals,
   });
+  if (!isTrackedGeoVisitorType(classification.visitorType)) {
+    return null;
+  }
   const capturedAt = toCapturedDate(payload.timestamp);
   const journey = resolveJourneyId({
     url,
@@ -129,5 +133,8 @@ export const runGeoIngest = Effect.fn("geoIngest.run")(function* (
   yield* enforceRateLimit(identity.organizationId);
   const payload = yield* readPayload(request);
   const event = yield* buildEvent(identity, payload);
+  if (!event) {
+    return;
+  }
   yield* ingestEvent(event);
 });

--- a/apps/dashboard/src/lib/geo-ingest/pipeline.ts
+++ b/apps/dashboard/src/lib/geo-ingest/pipeline.ts
@@ -130,11 +130,11 @@ export const runGeoIngest = Effect.fn("geoIngest.run")(function* (
   request: NextRequest
 ) {
   const identity = yield* authenticate(request);
-  yield* enforceRateLimit(identity.organizationId);
   const payload = yield* readPayload(request);
   const event = yield* buildEvent(identity, payload);
   if (!event) {
     return;
   }
+  yield* enforceRateLimit(identity.organizationId);
   yield* ingestEvent(event);
 });

--- a/apps/dashboard/src/schemas/geo.ts
+++ b/apps/dashboard/src/schemas/geo.ts
@@ -281,7 +281,7 @@ export const aiTrafficInputSchema = geoOrganizationInputSchema.extend({
 
 export const geoTrafficLogInputSchema = geoOrganizationInputSchema.extend({
   limit: number().int().min(1).max(MAX_AI_TRAFFIC_LOG_LIMIT).optional(),
-  visitorTypes: array(enumType(["crawler", "ai_referral", "human"]))
+  visitorTypes: array(enumType(["crawler", "ai_referral"]))
     .max(MAX_GEO_TRAFFIC_LOG_FILTER_VALUES)
     .optional(),
   categories: array(

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -633,7 +633,7 @@ export interface GeoTrafficLogEntry {
   wantsMarkdown: boolean;
 }
 
-export type GeoTrafficLogVisitorFilter = "crawler" | "ai_referral" | "human";
+export type GeoTrafficLogVisitorFilter = "crawler" | "ai_referral";
 
 export type GeoTrafficLogPurposeFilter =
   | "training-crawler"
@@ -741,7 +741,6 @@ export interface JourneyDetailDialogProps {
 export interface GeoTrafficTotals {
   crawler: number;
   aiReferral: number;
-  human: number;
 }
 
 export interface AiTrafficResponse {

--- a/apps/dashboard/src/utils/ai-traffic.test.ts
+++ b/apps/dashboard/src/utils/ai-traffic.test.ts
@@ -6,6 +6,7 @@ import {
   buildTrafficTrendRows,
   formatTrafficDelta,
   hasTrafficSourceSeries,
+  isTrackedGeoVisitorType,
   isTrafficPagePending,
   trafficDeltaTone,
   trafficSourceKey,
@@ -79,6 +80,15 @@ describe("buildTrafficTrendRows", () => {
     assert.equal(rows.length, 1);
     assert.equal(rows[0]?.crawler, 3);
     assert.equal(rows[0]?.aiReferral, 0);
+  });
+});
+
+describe("isTrackedGeoVisitorType", () => {
+  test("drops humans and keeps AI visitors", () => {
+    assert.equal(isTrackedGeoVisitorType("human"), false);
+    assert.equal(isTrackedGeoVisitorType("crawler"), true);
+    assert.equal(isTrackedGeoVisitorType("ai_referral"), true);
+    assert.equal(isTrackedGeoVisitorType("unknown"), true);
   });
 });
 

--- a/apps/dashboard/src/utils/ai-traffic.ts
+++ b/apps/dashboard/src/utils/ai-traffic.ts
@@ -5,6 +5,7 @@ import {
   GEO_JOURNEY_EXPLICIT_PREFIX,
   GEO_TRAFFIC_TREND_CRAWLER_KEY,
   GEO_TRAFFIC_TREND_REFERRAL_KEY,
+  GEO_UNTRACKED_VISITOR_TYPES,
 } from "@/constants/geo";
 import type {
   GeoTrafficLogFilters,
@@ -29,6 +30,10 @@ export function toGeoVisitorType(value: string): GeoVisitorType {
   return VISITOR_TYPES.find((type) => type === value) ?? "unknown";
 }
 
+export function isTrackedGeoVisitorType(value: GeoVisitorType): boolean {
+  return !GEO_UNTRACKED_VISITOR_TYPES.includes(value);
+}
+
 export function formatGeoSource(
   source: string,
   visitorType: GeoVisitorType
@@ -42,14 +47,12 @@ export function formatGeoSource(
 export function toGeoTrafficTotals(
   sources: readonly GeoTrafficSource[]
 ): GeoTrafficTotals {
-  const totals: GeoTrafficTotals = { crawler: 0, aiReferral: 0, human: 0 };
+  const totals: GeoTrafficTotals = { crawler: 0, aiReferral: 0 };
   for (const source of sources) {
     if (source.visitorType === "crawler") {
       totals.crawler += source.visits;
     } else if (source.visitorType === "ai_referral") {
       totals.aiReferral += source.visits;
-    } else if (source.visitorType === "human") {
-      totals.human += source.visits;
     }
   }
   return totals;

--- a/packages/analytics/src/tinybird/datasources.ts
+++ b/packages/analytics/src/tinybird/datasources.ts
@@ -225,7 +225,7 @@ export const aiTrafficEvents = defineDatasource("ai_traffic_events", {
 
 export const geoTrafficEvents = defineDatasource("geo_traffic_events", {
   description:
-    "Append-only log of every request captured by the geo SDK, classified into AI crawlers, AI assistant referrals and humans",
+    "Append-only log of AI requests captured by the geo SDK, classified into AI crawlers and AI assistant referrals; human requests are dropped at ingest",
   schema: {
     organization_id: t.string(),
     project_id: t.string().lowCardinality(),

--- a/packages/geo/README.md
+++ b/packages/geo/README.md
@@ -3,7 +3,8 @@
 Request capture SDK for AI traffic attribution. It captures every page request your
 site serves and sends a neutral request envelope to Notra. All classification, crawler
 versus AI referral versus human, happens server side at ingest, so a stale local table
-never costs you traffic. The core tracker ships no signature table. Only the optional
+never costs you traffic. Requests classified as human are discarded at ingest and never
+stored. The core tracker ships no signature table. Only the optional
 Next.js `tagLinks` path bundles the matcher, because it has to decide at the edge which
 responses to rewrite for AI agents.
 


### PR DESCRIPTION
## Summary
- Drop requests classified as `human` in the GEO ingest pipeline before they are written to `geo_traffic_events`, so the daily rollups stop accruing human rows too. Existing human rows are left in place, nothing is deleted.
- Remove "Human" from the AI logs visitor filter (option, filter type, Zod schema, labels) and drop `totals.human` from traffic totals.
- Update the `geo_traffic_events` description and the `@usenotra/geo` README to say human requests are discarded at ingest (description only, no schema change).

## Notes
- `unknown` visitors are still stored since they are the "maybe an agent" bucket.
- The SDK still sends every request; classification stays server side, so no package publish is needed.

## Test plan
- [x] `tsc --noEmit` for dashboard and analytics
- [x] `bun test apps/dashboard/src/utils/ai-traffic.test.ts` (adds a case for `isTrackedGeoVisitorType`)
- [ ] Hit `/api/geo/ingest` with a browser UA and confirm no row lands in `geo_traffic_events`