### PR TITLE
fix(web): stabilize mobile landing experience

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -157,22 +157,19 @@ export default function LandingPage() {
         </p>
         <LogoMarquee />
         <FounderQuote />
-        <section className="content-defer" id="features">
+        <section id="features">
           <FeaturesSection />
         </section>
-        <section className="content-defer" id="testimonials">
+        <section id="testimonials">
           <TestimonialsSection />
         </section>
-        <div className="content-defer">
+        <div>
           <LandingPricingSection />
         </div>
-        <section className="content-defer" id="faq">
+        <section id="faq">
           <FaqSection />
         </section>
-        <section
-          className="px-6 pt-27.5 pb-27.5 content-defer lg:px-20"
-          id="cta"
-        >
+        <section className="px-6 pt-27.5 pb-27.5 lg:px-20" id="cta">
           <CtaBanner />
         </section>
       </main>

--- a/apps/web/src/components/footer-section.tsx
+++ b/apps/web/src/components/footer-section.tsx
@@ -49,7 +49,7 @@ export default function FooterSection() {
     <footer className="relative isolate overflow-hidden rounded-t-3xl bg-[linear-gradient(in_oklab_180deg,oklab(80.3%_0.045_-0.074/15%)_0%,oklab(71.8%_0.066_-0.109/50%)_100%)] pt-6 shadow-[0_0.0625rem_0.125rem_#28282814,0_0_0_0.0625rem_#ececec] dark:bg-[#141019] dark:bg-none dark:shadow-none">
       <div className="-z-10 pointer-events-none absolute inset-0 overflow-hidden">
         <DeferredDithering
-          className="absolute top-[8.8125rem] left-[-5.40625rem] h-[66.125rem] w-[calc(100%+10.8125rem)] min-w-[100.8125rem]"
+          className="absolute top-[8.8125rem] left-0 h-[calc(100%-8.8125rem)] w-full sm:left-[-5.40625rem] sm:h-[66.125rem] sm:w-[calc(100%+10.8125rem)] sm:min-w-[100.8125rem]"
           colorBack={FOOTER_DITHERING.colorBack}
           colorFront={FOOTER_DITHERING.colorFront}
           scale={FOOTER_DITHERING.scale}
@@ -60,7 +60,7 @@ export default function FooterSection() {
         />
       </div>
 
-      <div className="-z-10 pointer-events-none absolute inset-x-0 bottom-0 flex justify-center overflow-hidden">
+      <div className="-z-10 pointer-events-none absolute inset-x-0 bottom-0 hidden justify-center overflow-hidden sm:flex">
         <Image
           alt=""
           aria-hidden="true"
@@ -71,7 +71,7 @@ export default function FooterSection() {
         />
       </div>
 
-      <div className="relative mx-auto flex w-full max-w-[87rem] flex-col px-6 pb-64 md:px-8 md:pb-[30rem]">
+      <div className="relative mx-auto flex w-full max-w-[87rem] flex-col px-6 pb-8 sm:pb-64 md:px-8 md:pb-[30rem]">
         <div className="flex flex-col gap-12 py-7 lg:flex-row lg:items-start lg:justify-between lg:gap-24">
           <div className="flex w-full max-w-[18.5rem] flex-col gap-7">
             <div className="flex flex-col gap-2.5">

--- a/apps/web/src/components/landing/cta-banner.tsx
+++ b/apps/web/src/components/landing/cta-banner.tsx
@@ -35,9 +35,9 @@ export function CtaBanner() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-7">
+        <div className="grid w-full grid-cols-2 items-center gap-4 sm:flex sm:w-auto sm:gap-7">
           <CtaButton
-            className="text-lg"
+            className="w-full min-w-0 px-3 text-lg sm:w-auto sm:px-6"
             nativeButton={false}
             render={<TrackedSignupLink source={CTA_BANNER_SIGNUP_SOURCE} />}
             variant="primary"
@@ -45,7 +45,7 @@ export function CtaBanner() {
             {CTA_BANNER_PRIMARY_LABEL}
           </CtaButton>
           <CtaButton
-            className="text-lg"
+            className="w-full min-w-0 px-3 text-lg sm:w-auto sm:px-6"
             nativeButton={false}
             render={<Link href={CTA_BANNER_CONTACT_HREF} />}
             variant="light"

--- a/apps/web/src/components/landing/features-card-publish.tsx
+++ b/apps/web/src/components/landing/features-card-publish.tsx
@@ -108,7 +108,7 @@ function ViewDocs() {
 export function FeaturesCardPublish() {
   return (
     <div aria-hidden className="pointer-events-none absolute inset-0">
-      <div className="absolute top-21.5 left-51 grid h-88 w-164.5 gap-4 overflow-clip rounded-2xl bg-white p-4 [box-shadow:#1E1E1E1A_0rem_0.125rem_1.25rem,#1717171A_0rem_0rem_0rem_0.0625rem]">
+      <div className="absolute top-42 left-51 grid h-88 w-164.5 gap-4 overflow-clip rounded-2xl bg-white p-4 [box-shadow:#1E1E1E1A_0rem_0.125rem_1.25rem,#1717171A_0rem_0rem_0rem_0.0625rem] lg:top-21.5">
         <div>
           <div className="flex flex-col gap-2">
             <div className="font-medium font-sans text-[#171717] text-[1.125rem] leading-[133.333%]">
@@ -215,10 +215,10 @@ export function FeaturesCardPublish() {
           </svg>
         </div>
       </div>
-      <div className="-left-65.75 absolute top-31.5 flex w-110.25 flex-col gap-4 rounded-2xl border border-[#1717171A] bg-white p-4 [box-shadow:#1717170D_0rem_0.1875rem_0.9375rem_-0.125rem]">
+      <div className="-left-65.75 absolute top-51.5 flex w-110.25 flex-col gap-4 rounded-2xl border border-[#1717171A] bg-white p-4 [box-shadow:#1717170D_0rem_0.1875rem_0.9375rem_-0.125rem] lg:top-31.5">
         <div className="flex grow basis-[0%] flex-col gap-4">
           <div className="flex items-center justify-end self-stretch">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white [box-shadow:#0000000D_0rem_0rem_0rem_0.0625rem,#0000001A_0rem_0.25rem_0.625rem,#0000001A_0rem_0.0625rem_0.125rem_-0.0625rem]">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white [box-shadow:#0000000A_0rem_0.125rem_0.375rem,#0000000D_0rem_0rem_0rem_0.0625rem]">
               <svg
                 className="size-5 shrink-0 overflow-clip"
                 fill="none"
@@ -269,10 +269,10 @@ export function FeaturesCardPublish() {
           </div>
         </div>
       </div>
-      <div className="-left-42 absolute top-78 flex w-86.5 flex-col items-end justify-center gap-4 rounded-2xl border border-[#1717171A] bg-white p-4 [box-shadow:#1717170D_0rem_0.1875rem_0.9375rem_-0.125rem]">
+      <div className="-left-42 absolute top-98 flex w-86.5 flex-col items-end justify-center gap-4 rounded-2xl border border-[#1717171A] bg-white p-4 [box-shadow:#1717170D_0rem_0.1875rem_0.9375rem_-0.125rem] lg:top-78">
         <div className="flex grow basis-[0%] flex-col gap-4 self-stretch">
           <div className="flex items-start justify-end self-stretch">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white [box-shadow:#0000000D_0rem_0rem_0rem_0.0625rem,#0000001A_0rem_0.25rem_0.625rem,#0000001A_0rem_0.0625rem_0.125rem_-0.0625rem]">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white [box-shadow:#0000000A_0rem_0.125rem_0.375rem,#0000000D_0rem_0rem_0rem_0.0625rem]">
               <svg
                 className="size-5 shrink-0 overflow-clip"
                 fill="none"

--- a/apps/web/src/components/landing/features-section.tsx
+++ b/apps/web/src/components/landing/features-section.tsx
@@ -90,7 +90,7 @@ export function FeaturesSection() {
             <FeaturesCardAssets />
           </FeaturesCard>
           <FeaturesCard
-            containerClassName="h-98.25 w-full lg:w-110.25"
+            containerClassName="h-120 w-full lg:h-98.25 lg:w-110.25"
             copy={FEATURES_PUBLISH_COPY}
             shaderClassName="-top-4.5 -left-px"
             shaderColorFront="#FFEA0040"

--- a/apps/web/src/components/landing/hero-collage-content-panel.tsx
+++ b/apps/web/src/components/landing/hero-collage-content-panel.tsx
@@ -16,7 +16,7 @@ const HEADER_CLASS = "text-muted-foreground text-xs uppercase tracking-wider";
 
 export function HeroCollageContentPanel() {
   return (
-    <div className="relative z-10 h-[51.4375rem] w-[28.125rem] shrink-0 overflow-hidden rounded-3xl border border-black/5 bg-background py-5 pr-12 pl-8 transition-transform duration-300 ease-out dark:border-white/10 lg:[transform:perspective(87.5rem)_rotateY(-8deg)] lg:motion-safe:hover:[transform:perspective(87.5rem)_rotateY(-3deg)_scale(1.03)]">
+    <div className="-translate-x-28 relative z-10 h-[51.4375rem] w-[28.125rem] shrink-0 overflow-hidden rounded-3xl border border-black/5 bg-background py-5 pr-12 pl-8 transition-transform duration-300 ease-out dark:border-white/10 lg:[transform:perspective(87.5rem)_rotateY(-8deg)] lg:motion-safe:hover:[transform:perspective(87.5rem)_rotateY(-3deg)_scale(1.03)]">
       <div className="mb-6 space-y-1">
         <h3 className="font-bold font-sans text-[1.375rem] text-foreground leading-[1.2] tracking-[-0.0375rem]">
           {HERO_COLLAGE_CONTENT.heading}
@@ -26,9 +26,9 @@ export function HeroCollageContentPanel() {
         </p>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-border/80 border-b-border/40 bg-muted/80 shadow-2xs">
+      <div className="overflow-hidden rounded-lg border border-transparent bg-transparent shadow-none lg:border-border/80 lg:border-b-border/40 lg:bg-muted/80 lg:shadow-2xs">
         <Table>
-          <TableHeader>
+          <TableHeader className="bg-transparent lg:bg-muted/80">
             <TableRow>
               <TableHead className={`${HEADER_CLASS} w-[14.5rem]`}>
                 {HERO_COLLAGE_CONTENT.nameHeader}

--- a/apps/web/src/components/landing/hero-collage-events-panel.tsx
+++ b/apps/web/src/components/landing/hero-collage-events-panel.tsx
@@ -16,7 +16,7 @@ import {
 
 export function HeroCollageEventsPanel() {
   return (
-    <div className="relative z-10 h-[52rem] w-[28.125rem] shrink-0 overflow-hidden rounded-3xl border border-black/5 bg-background py-5 pr-8 pl-12 transition-transform duration-300 ease-out dark:border-white/10 lg:[transform:perspective(87.5rem)_rotateY(8deg)] lg:motion-safe:hover:[transform:perspective(87.5rem)_rotateY(3deg)_scale(1.03)]">
+    <div className="relative z-10 h-[52rem] w-[28.125rem] shrink-0 translate-x-28 overflow-hidden rounded-3xl border border-black/5 bg-background py-5 pr-8 pl-12 transition-transform duration-300 ease-out dark:border-white/10 lg:[transform:perspective(87.5rem)_rotateY(8deg)] lg:motion-safe:hover:[transform:perspective(87.5rem)_rotateY(3deg)_scale(1.03)]">
       <div className="mb-6 space-y-1">
         <h3 className="font-bold font-sans text-[1.375rem] text-foreground leading-[1.2] tracking-[-0.0375rem]">
           {HERO_COLLAGE_EVENTS.heading}
@@ -35,9 +35,9 @@ export function HeroCollageEventsPanel() {
         </span>
       </div>
 
-      <div className="mt-4 overflow-hidden rounded-lg border border-border/80 border-b-border/40 bg-muted/80 shadow-2xs">
+      <div className="mt-4 overflow-hidden rounded-lg border border-transparent bg-transparent shadow-none lg:border-border/80 lg:border-b-border/40 lg:bg-muted/80 lg:shadow-2xs">
         <Table>
-          <TableHeader>
+          <TableHeader className="bg-transparent lg:bg-muted/80">
             <TableRow>
               <TableHead>{HERO_COLLAGE_EVENTS.typeHeader}</TableHead>
               <TableHead>{HERO_COLLAGE_EVENTS.eventsHeader}</TableHead>

--- a/apps/web/src/components/landing/hero-collage-profile-panel.tsx
+++ b/apps/web/src/components/landing/hero-collage-profile-panel.tsx
@@ -1,17 +1,35 @@
-import { ArrowDown01Icon, UnfoldMoreIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+"use client";
+
 import { Input } from "@notra/ui/components/ui/input";
 import { Label } from "@notra/ui/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@notra/ui/components/ui/select";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
-import { HERO_COLLAGE_PROFILE } from "@/constants/landing/hero-collage";
+import { useState } from "react";
+import {
+  HERO_COLLAGE_LANGUAGE_OPTIONS,
+  HERO_COLLAGE_PROFILE,
+  HERO_COLLAGE_TONE_OPTIONS,
+} from "@/constants/landing/hero-collage";
 
 function FieldValue({ value }: { value: string }) {
   return <Input defaultValue={value} />;
 }
 
 export function HeroCollageProfilePanel() {
+  const [isCustomTone, setIsCustomTone] = useState(false);
+  const [toneProfile, setToneProfile] = useState(
+    HERO_COLLAGE_PROFILE.toneProfileValue
+  );
+  const [language, setLanguage] = useState(HERO_COLLAGE_PROFILE.languageValue);
+
   return (
-    <div className="-mx-26 relative z-20 w-[30rem] shrink-0 self-center rounded-3xl border border-black/5 bg-background px-12 py-5 shadow-[0_0.125rem_4.4375rem_rgba(0,0,0,0.1)] transition-transform duration-300 ease-out lg:motion-safe:hover:scale-[1.02] dark:border-white/10">
+    <div className="-mx-26 relative z-20 w-[30rem] shrink-0 self-center rounded-3xl border border-black/5 bg-background px-12 py-5 shadow-none transition-transform duration-300 ease-out lg:shadow-[0_0.125rem_4.4375rem_rgba(0,0,0,0.1)] lg:motion-safe:hover:scale-[1.02] dark:border-white/10">
       <div className="mb-6 space-y-1">
         <h3 className="font-bold font-sans text-[1.375rem] text-foreground leading-[1.2] tracking-[-0.046875rem]">
           {HERO_COLLAGE_PROFILE.heading}
@@ -62,64 +80,141 @@ export function HeroCollageProfilePanel() {
 
         <TitleCard heading={HERO_COLLAGE_PROFILE.sectionTone}>
           <div className="space-y-4">
-            <div className="space-y-3">
-              <div className="flex items-center gap-2">
-                <span className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                  <svg
-                    aria-hidden="true"
-                    className="size-3"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={3}
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M5 13l4 4L19 7"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
+            <div aria-label="Tone mode" className="space-y-3" role="radiogroup">
+              <label className="flex w-fit cursor-pointer items-center gap-2 text-left">
+                <input
+                  checked={!isCustomTone}
+                  className="sr-only"
+                  name="hero-tone-mode"
+                  onChange={() => setIsCustomTone(false)}
+                  type="radio"
+                  value="profile"
+                />
+                <span
+                  className={
+                    isCustomTone
+                      ? "size-5 rounded-full border-2 border-muted-foreground/30"
+                      : "flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                  }
+                >
+                  {isCustomTone ? null : (
+                    <svg
+                      aria-hidden="true"
+                      className="size-3"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={3}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M5 13l4 4L19 7"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
                 </span>
                 <span className="text-sm">
                   {HERO_COLLAGE_PROFILE.toneProfileLabel}
                 </span>
-              </div>
-              <div className="flex h-8 w-fit items-center justify-between gap-1.5 whitespace-nowrap rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm">
-                {HERO_COLLAGE_PROFILE.toneProfileValue}
-                <HugeiconsIcon
-                  className="size-4 text-muted-foreground"
-                  icon={UnfoldMoreIcon}
-                />
-              </div>
-            </div>
+              </label>
+              <Select
+                disabled={isCustomTone}
+                onValueChange={(value) => {
+                  if (value) {
+                    setToneProfile(value);
+                  }
+                }}
+                value={toneProfile}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent
+                  align="start"
+                  alignItemWithTrigger={false}
+                  className="min-w-30"
+                >
+                  {HERO_COLLAGE_TONE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
 
-            <div className="space-y-3 pt-4">
-              <div className="flex items-center gap-2">
-                <span className="size-5 rounded-full border-2 border-muted-foreground/30" />
+              <label className="flex w-fit cursor-pointer items-center gap-2 pt-4 text-left">
+                <input
+                  checked={isCustomTone}
+                  className="sr-only"
+                  name="hero-tone-mode"
+                  onChange={() => setIsCustomTone(true)}
+                  type="radio"
+                  value="custom"
+                />
+                <span
+                  className={
+                    isCustomTone
+                      ? "flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                      : "size-5 rounded-full border-2 border-muted-foreground/30"
+                  }
+                >
+                  {isCustomTone ? (
+                    <svg
+                      aria-hidden="true"
+                      className="size-3"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={3}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M5 13l4 4L19 7"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  ) : null}
+                </span>
                 <span className="text-sm">
                   {HERO_COLLAGE_PROFILE.customToneLabel}
                 </span>
-              </div>
+              </label>
               <Input
-                className="opacity-50"
+                className="transition-[color,background-color,border-color,box-shadow,opacity] duration-200 ease-out motion-reduce:transition-none"
+                disabled={!isCustomTone}
                 placeholder={HERO_COLLAGE_PROFILE.customTonePlaceholder}
               />
             </div>
 
             <div className="space-y-2 pt-4">
               <Label>{HERO_COLLAGE_PROFILE.languageLabel}</Label>
-              <div className="flex h-8 items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent px-3 text-sm">
-                <span className="flex items-center gap-2">
-                  <span className="text-base leading-none">
-                    {HERO_COLLAGE_PROFILE.languageFlag}
-                  </span>
-                  {HERO_COLLAGE_PROFILE.languageValue}
-                </span>
-                <HugeiconsIcon
-                  className="size-4 text-muted-foreground"
-                  icon={ArrowDown01Icon}
-                />
-              </div>
+              <Select
+                onValueChange={(value) => {
+                  if (value) {
+                    setLanguage(value);
+                  }
+                }}
+                value={language}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent
+                  align="start"
+                  alignItemWithTrigger={false}
+                  className="min-w-0"
+                >
+                  {HERO_COLLAGE_LANGUAGE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      <span className="text-base leading-none">
+                        {option.flag}
+                      </span>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2 pt-4">

--- a/apps/web/src/components/landing/hero-collage.tsx
+++ b/apps/web/src/components/landing/hero-collage.tsx
@@ -5,7 +5,7 @@ import { HeroCollageProfilePanel } from "@/components/landing/hero-collage-profi
 export function HeroCollage() {
   return (
     <div className="@container w-full lg:w-[73.25rem]">
-      <div className="relative h-[135cqw] w-full overflow-hidden lg:h-auto lg:overflow-visible">
+      <div className="relative h-[calc(62.5rem*min(1,calc(100cqw/34rem)))] w-full overflow-hidden lg:h-auto lg:overflow-visible">
         <div className="absolute top-0 left-[calc(50cqw-36.625rem*min(1,calc(100cqw/34rem)))] w-[73.25rem] origin-top-left [transform:scale(min(1,calc(100cqw/34rem)))] lg:left-0 lg:[transform:scale(min(1,calc(100cqw/73.25rem)))]">
           <div className="relative flex items-end justify-center">
             <HeroCollageContentPanel />

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -6,41 +6,69 @@ import { HeroDither } from "@/components/landing/hero-dither";
 import { TrackedSignupLink } from "@/components/tracked-signup-link";
 import {
   HERO_BOOK_A_CALL_HREF,
+  HERO_HEADLINE_MOBILE_BREAK_INDEX,
   HERO_HEADLINE_SEGMENTS,
   HERO_SIGNUP_SOURCE,
   HERO_SUBHEAD,
 } from "@/constants/landing/hero";
 
 const CTA_BUTTON_CLASSNAME =
-  "h-auto rounded-[2.5625rem] px-6 py-3 font-display font-medium text-[1.125rem] leading-[1.14] tracking-[-0.015em]";
+  "h-auto rounded-[2.5625rem] px-4 py-2.5 font-display font-medium text-base leading-[1.14] tracking-[-0.015em] sm:px-6 sm:py-3 sm:text-[1.125rem]";
 
 export function HeroSection() {
   return (
-    <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
+    <section className="w-full px-2 pt-2 antialiased [font-synthesis:none] sm:px-6 sm:pt-6">
       <div className="relative isolate overflow-clip rounded-3xl bg-[#C8B2EE40] lg:h-[59.9375rem] dark:bg-[#2a2140]">
         <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
-          <HeroDither className="-top-1.25 -left-10.75 absolute h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />
+          <HeroDither className="-top-1.25 -left-10.75 absolute hidden h-[calc(100%+1.25rem)] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000] lg:block lg:h-[66.125rem]" />
         </div>
 
         <div className="relative flex h-full w-full flex-col items-center">
-          <div className="flex flex-col items-center gap-8 px-6 pt-28 pb-2 sm:gap-10 sm:pt-24 lg:pt-[7.5rem]">
+          <div className="flex flex-col items-center gap-8 px-6 pt-20 pb-2 sm:gap-10 sm:pt-24 lg:pt-[7.5rem]">
             <div className="flex flex-col items-center gap-7">
-              <h1 className="max-w-[56.875rem] text-center font-display font-medium text-[#1E1E1E] text-[2.5rem] leading-[1.08] tracking-[-0.015em] sm:font-semibold sm:text-[3.25rem] lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
-                {HERO_HEADLINE_SEGMENTS.map((segment) => (
-                  <span
-                    className={cn(segment.accent && "text-primary")}
-                    key={segment.text}
-                  >
-                    {segment.text}
-                  </span>
-                ))}
+              <h1 className="max-w-[20.5rem] text-center font-display font-medium text-[#1E1E1E] text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] tracking-[-0.015em] sm:max-w-[56.875rem] sm:font-semibold sm:text-[3.25rem] lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
+                <span className="block whitespace-nowrap sm:hidden">
+                  {HERO_HEADLINE_SEGMENTS.slice(
+                    0,
+                    HERO_HEADLINE_MOBILE_BREAK_INDEX
+                  ).map((segment) => (
+                    <span
+                      className={cn(segment.accent && "text-primary")}
+                      key={segment.text}
+                    >
+                      {segment.text}
+                    </span>
+                  ))}
+                </span>
+                <span className="block whitespace-nowrap sm:hidden">
+                  {HERO_HEADLINE_SEGMENTS.slice(
+                    HERO_HEADLINE_MOBILE_BREAK_INDEX
+                  ).map((segment) => (
+                    <span
+                      className={cn(segment.accent && "text-primary")}
+                      key={segment.text}
+                    >
+                      {segment.text}
+                    </span>
+                  ))}
+                </span>
+                <span className="hidden sm:inline">
+                  {HERO_HEADLINE_SEGMENTS.map((segment) => (
+                    <span
+                      className={cn(segment.accent && "text-primary")}
+                      key={segment.text}
+                    >
+                      {segment.text}
+                    </span>
+                  ))}
+                </span>
               </h1>
               <p className="max-w-[42.875rem] text-center font-medium font-sans text-[#1E1E1EBF] text-[1.0625rem] leading-[1.14] tracking-[-0.005em] sm:text-[1.25rem] dark:text-white/70">
                 {HERO_SUBHEAD}
               </p>
             </div>
 
-            <div className="flex flex-col items-center gap-7 sm:flex-row">
+            <div className="flex flex-row items-center gap-3 sm:gap-7">
               <CtaButton
                 className={CTA_BUTTON_CLASSNAME}
                 nativeButton={false}

--- a/apps/web/src/components/landing/pricing-section.tsx
+++ b/apps/web/src/components/landing/pricing-section.tsx
@@ -4,13 +4,7 @@ import { ArrowRight02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CtaButton } from "@notra/ui/components/shared/cta-button";
 import { cn } from "@notra/ui/lib/utils";
-import {
-  AnimatePresence,
-  domMax,
-  LazyMotion,
-  m,
-  useReducedMotion,
-} from "motion/react";
+import { AnimatePresence, domMax, LazyMotion, m } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
@@ -39,8 +33,6 @@ function PricingBillingToggle({
   value,
   onValueChange,
 }: PricingBillingToggleProps) {
-  const shouldReduceMotion = useReducedMotion();
-
   return (
     <div className="flex items-center justify-center gap-2 rounded-full bg-[linear-gradient(180deg,#FFFFFF,#F2F2F2)] p-1.75 shadow-[0_0.0625rem_0.125rem_#28282814,0_0_0_0.0625rem_#ECECEC] dark:bg-none dark:bg-white/[0.06] dark:shadow-[0_0_0_0.0625rem] dark:shadow-white/10">
       {PRICING_BILLING_OPTIONS.map((option) => {
@@ -50,31 +42,16 @@ function PricingBillingToggle({
           <button
             aria-pressed={isActive}
             className={cn(
-              "relative flex h-8 cursor-pointer items-center justify-center rounded-full px-3.5 py-1.75 font-sans text-base leading-6 tracking-[-0.01em]",
-              isActive ? "text-white" : "text-[#1E1E1E] dark:text-white"
+              "relative flex h-8 cursor-pointer touch-manipulation items-center justify-center rounded-full px-3.5 py-1.75 font-sans text-base leading-6 tracking-[-0.01em] focus-visible:ring-[0.1875rem] focus-visible:ring-ring/50",
+              isActive
+                ? "cta-gradient-primary text-white shadow-[0_0.0625rem_0.125rem_#28282814,0_0_0_0.0625rem_#1E1E1E40]"
+                : "text-[#1E1E1E] dark:text-white"
             )}
             key={option.value}
             onClick={() => onValueChange(option.value)}
             type="button"
           >
-            {isActive ? (
-              <m.span
-                className="cta-gradient-primary absolute inset-0 rounded-full"
-                layoutId="pricing-billing-thumb"
-                style={{
-                  boxShadow:
-                    "0 0.0625rem 0.125rem #28282814, 0 0 0 0.0625rem #1E1E1E40",
-                }}
-                transition={
-                  shouldReduceMotion
-                    ? { duration: 0 }
-                    : { type: "spring", stiffness: 500, damping: 40 }
-                }
-              />
-            ) : null}
-            <span className="relative z-10 transition-colors duration-200">
-              {option.label}
-            </span>
+            {option.label}
           </button>
         );
       })}
@@ -313,7 +290,7 @@ export function LandingPricingSection({
   return (
     <LazyMotion features={domMax}>
       <section
-        className="flex w-full flex-col items-center gap-13.5 px-6 py-24"
+        className="flex w-full flex-col items-center gap-13.5 px-6 pt-12 pb-24 sm:py-24"
         id="pricing"
       >
         {showHeader ? (

--- a/apps/web/src/components/landing/testimonials-section.tsx
+++ b/apps/web/src/components/landing/testimonials-section.tsx
@@ -69,7 +69,7 @@ function TestimonialCard({
 
 export function TestimonialsSection() {
   return (
-    <section className="flex w-full flex-col items-center gap-10 px-6 pt-24 pb-27.5 sm:px-12 lg:gap-13.5 lg:px-20 lg:pt-70">
+    <section className="flex w-full flex-col items-center gap-10 px-6 pt-24 pb-12 sm:px-12 sm:pb-27.5 lg:gap-13.5 lg:px-20 lg:pt-70">
       <div className="flex flex-col items-center gap-4">
         <h2 className="text-center font-display font-medium text-[2rem]/tight text-black tracking-[-0.02em] sm:text-4xl/tight lg:text-[3.0625rem]/14 dark:text-foreground">
           Shipping, without the <span className="text-primary">busywork</span>.

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -384,14 +384,15 @@ export function Navbar({ variant }: NavbarProps = {}) {
     "text-[#1E1E1EA6] hover:text-[#1E1E1E] dark:text-neutral-400 dark:hover:text-white";
   let positionClass = "w-full sticky top-4";
   if (isLanding) {
-    positionClass = "fixed inset-x-4 sm:inset-x-6";
+    positionClass =
+      "fixed inset-x-4 [--navbar-top:1.5rem] sm:inset-x-6 sm:[--navbar-top:2.5rem]";
   } else if (isStatic) {
     positionClass = "w-full";
   }
   const shellAnimate = isLanding
     ? {
         maxWidth: chrome ? "64rem" : "80.9375rem",
-        top: chrome ? "1rem" : "2.5rem",
+        top: chrome ? "1rem" : "var(--navbar-top)",
       }
     : { maxWidth: chrome ? "64rem" : "80rem" };
   const rowHeightClass = isLandingTop ? "h-11 lg:h-[2.4375rem]" : "h-16";
@@ -669,7 +670,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
           {isOpen && (
             <m.div
               animate={{ opacity: 1, y: 0 }}
-              className={`absolute top-[calc(100%+0.5rem)] z-40 rounded-2xl bg-white p-3 shadow-[0_0.125rem_2.0625rem_#1E1E1E1A,0_0.0625rem_0.125rem_#28282814] ring-1 ring-[#1E1E1E14] lg:hidden dark:bg-neutral-950 dark:shadow-black/50 dark:ring-white/10 ${isLandingTop ? "inset-x-6" : "inset-x-4"}`}
+              className={`absolute top-[calc(100%+0.5rem)] z-40 max-h-[calc(100dvh-6.5rem)] overflow-y-auto overscroll-contain rounded-2xl bg-white p-3 pb-[max(1.75rem,env(safe-area-inset-bottom))] shadow-[0_0.125rem_2.0625rem_#1E1E1E1A,0_0.0625rem_0.125rem_#28282814] ring-1 ring-[#1E1E1E14] lg:hidden dark:bg-neutral-950 dark:shadow-black/50 dark:ring-white/10 ${isLandingTop ? "inset-x-6" : "inset-x-4"}`}
               exit={{ opacity: 0, y: -6 }}
               id="mobile-navigation"
               initial={{ opacity: 0, y: -6 }}

--- a/apps/web/src/constants/landing/hero-collage.ts
+++ b/apps/web/src/constants/landing/hero-collage.ts
@@ -110,6 +110,20 @@ export const HERO_COLLAGE_PROFILE = {
     "Add any specific instructions for AI-generated content",
 };
 
+export const HERO_COLLAGE_TONE_OPTIONS = [
+  { label: "Professional", value: "Professional" },
+  { label: "Friendly", value: "Friendly" },
+  { label: "Casual", value: "Casual" },
+  { label: "Bold", value: "Bold" },
+];
+
+export const HERO_COLLAGE_LANGUAGE_OPTIONS = [
+  { flag: "🇺🇸", label: "English", value: "English" },
+  { flag: "🇩🇪", label: "German", value: "German" },
+  { flag: "🇪🇸", label: "Spanish", value: "Spanish" },
+  { flag: "🇫🇷", label: "French", value: "French" },
+];
+
 export const HERO_COLLAGE_EVENTS = {
   heading: "Events",
   subhead:

--- a/apps/web/src/constants/landing/hero.ts
+++ b/apps/web/src/constants/landing/hero.ts
@@ -8,6 +8,8 @@ export const HERO_HEADLINE_SEGMENTS: HeroHeadlineSegment[] = [
   { text: "." },
 ];
 
+export const HERO_HEADLINE_MOBILE_BREAK_INDEX = 2;
+
 export const HERO_SUBHEAD =
   "Notra turns your team's real GitHub and Linear activity into changelogs, launch posts, and social updates. In your voice, not ChatGPT's.";
 

--- a/apps/web/src/lib/dithering/use-dither-visibility.ts
+++ b/apps/web/src/lib/dithering/use-dither-visibility.ts
@@ -15,7 +15,6 @@ export function useDitherVisibility(): DitherVisibilityState {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isIdle, setIsIdle] = useState(false);
   const [isInView, setIsInView] = useState(false);
-  const [hasEntered, setHasEntered] = useState(false);
   const prefersReducedMotion = useSyncExternalStore(
     subscribeToReducedMotion,
     getReducedMotionSnapshot,
@@ -43,9 +42,6 @@ export function useDitherVisibility(): DitherVisibilityState {
       (entries) => {
         const visible = entries.some((entry) => entry.isIntersecting);
         setIsInView(visible);
-        if (visible) {
-          setHasEntered(true);
-        }
       },
       { rootMargin: VIEWPORT_MARGIN }
     );
@@ -55,7 +51,8 @@ export function useDitherVisibility(): DitherVisibilityState {
 
   return {
     containerRef,
-    shouldRender: isIdle && hasEntered,
+    // Unmount offscreen canvases so their WebGL contexts and GPU memory are released.
+    shouldRender: isIdle && isInView,
     isAnimating: isInView && !prefersReducedMotion,
   };
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -10,11 +10,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@utility content-defer {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 40rem;
-}
-
 :root {
   --background: hsl(0 0% 100%);
   --foreground: hsl(0 0% 9%);


### PR DESCRIPTION
### Description
Fixes the Safari scrolling crash by unmounting offscreen WebGL dither canvases.

Also improves the mobile landing page layout and interactions across the hero, navigation, feature cards, pricing toggle, CTA, and footer. The profile preview now includes working tone and language controls.

### Screenshot/Recording (if applicable)
https://t-03gr46r46e5oqfudhwbd1hx15-p21059.onamp.dev/

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Safari scrolling crash on the mobile landing page by unmounting offscreen WebGL dither canvases. Improves mobile layout and interactions across the hero, navigation, feature cards, pricing toggle, CTA, and footer.

**Key changes**
- Dither canvases now unmount when offscreen instead of staying mounted, releasing WebGL contexts and GPU memory.
- Removed the `content-defer` utility (`content-visibility: auto`).
- Hero collage profile panel now has working tone and language `Select` controls.
- Pricing toggle replaces the animated layout thumb with a static gradient.
- Mobile nav menu scrolls within the viewport and respects safe-area insets.
- Hero headline wraps to two lines on small screens; section spacing and CTA buttons adjust responsively.

<sup>Written for commit 9bedfe4959d2312226419f2919c121ed68fb2a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

