### PR TITLE
fix(dashboard): use APP_URL for Google Search Console OAuth redirect

### DIFF
--- a/apps/dashboard/src/app/api/integrations/google-search-console/authorize/route.ts
+++ b/apps/dashboard/src/app/api/integrations/google-search-console/authorize/route.ts
@@ -7,12 +7,12 @@ import { redis } from "@notra/ai/utils/redis";
 import { ORPCError } from "@orpc/server";
 import { type NextRequest, NextResponse } from "next/server";
 import {
-  GSC_OAUTH_CALLBACK_PATH,
   GSC_OAUTH_STATE_KEY_PREFIX,
   GSC_OAUTH_STATE_TTL_SECONDS,
 } from "@/constants/google-search-console";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { gscOAuthErrorParam } from "@/lib/integrations/google-search-console/oauth-errors";
+import { getGscRedirectUri } from "@/lib/integrations/google-search-console/redirect-uri";
 import { gscAuthorizeQuerySchema } from "@/schemas/google-search-console";
 import type { GscOAuthState } from "@/types/google-search-console";
 import { ratelimit } from "@/utils/ratelimit";
@@ -21,8 +21,7 @@ import { ratelimit } from "@/utils/ratelimit";
 // a random, short-lived CSRF state nonce in Redis.
 // react-doctor-disable-next-line nextjs-no-side-effect-in-get-handler
 export async function GET(request: NextRequest) {
-  const baseUrl =
-    process.env.APP_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+  const baseUrl = process.env.APP_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
 
   try {
     const { searchParams } = new URL(request.url);
@@ -83,10 +82,7 @@ export async function GET(request: NextRequest) {
 
     const authUrl = new URL(GSC_OAUTH_AUTHORIZE_URL);
     authUrl.searchParams.set("client_id", credentials.clientId);
-    authUrl.searchParams.set(
-      "redirect_uri",
-      `${baseUrl}${GSC_OAUTH_CALLBACK_PATH}`
-    );
+    authUrl.searchParams.set("redirect_uri", getGscRedirectUri(baseUrl));
     authUrl.searchParams.set("response_type", "code");
     authUrl.searchParams.set("scope", GSC_OAUTH_SCOPES.join(" "));
     authUrl.searchParams.set("access_type", "offline");

--- a/apps/dashboard/src/app/api/integrations/google-search-console/authorize/route.ts
+++ b/apps/dashboard/src/app/api/integrations/google-search-console/authorize/route.ts
@@ -22,7 +22,7 @@ import { ratelimit } from "@/utils/ratelimit";
 // react-doctor-disable-next-line nextjs-no-side-effect-in-get-handler
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+    process.env.APP_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
 
   try {
     const { searchParams } = new URL(request.url);

--- a/apps/dashboard/src/app/api/integrations/google-search-console/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/google-search-console/callback/route.ts
@@ -20,7 +20,7 @@ import type { GscOAuthState } from "@/types/google-search-console";
 
 export async function GET(request: NextRequest) {
   const baseUrl =
-    process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+    process.env.APP_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
 
   let restoreOAuthState: (() => Promise<void>) | null = null;
   let callbackPath = "/";

--- a/apps/dashboard/src/app/api/integrations/google-search-console/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/google-search-console/callback/route.ts
@@ -16,11 +16,11 @@ import {
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { getServerSession } from "@/lib/auth/session";
 import { gscOAuthErrorParam } from "@/lib/integrations/google-search-console/oauth-errors";
+import { getGscRedirectUri } from "@/lib/integrations/google-search-console/redirect-uri";
 import type { GscOAuthState } from "@/types/google-search-console";
 
 export async function GET(request: NextRequest) {
-  const baseUrl =
-    process.env.APP_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
+  const baseUrl = process.env.APP_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "";
 
   let restoreOAuthState: (() => Promise<void>) | null = null;
   let callbackPath = "/";
@@ -135,7 +135,7 @@ export async function GET(request: NextRequest) {
     try {
       tokens = await exchangeGscAuthorizationCode({
         code,
-        redirectUri: `${baseUrl}${GSC_OAUTH_CALLBACK_PATH}`,
+        redirectUri: getGscRedirectUri(baseUrl),
       });
     } catch (exchangeError) {
       console.error(

--- a/apps/dashboard/src/lib/geo-ingest/snippet.ts
+++ b/apps/dashboard/src/lib/geo-ingest/snippet.ts
@@ -5,9 +5,7 @@ const FALLBACK_APP_URL = "https://app.usenotra.com";
 
 export function buildGeoAppUrl(): string {
   const base =
-    process.env.NEXT_PUBLIC_APP_URL ??
-    process.env.APP_URL ??
-    FALLBACK_APP_URL;
+    process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL ?? FALLBACK_APP_URL;
   return new URL("/", base).origin;
 }
 

--- a/apps/dashboard/src/lib/geo-ingest/snippet.ts
+++ b/apps/dashboard/src/lib/geo-ingest/snippet.ts
@@ -6,7 +6,7 @@ const FALLBACK_APP_URL = "https://app.usenotra.com";
 export function buildGeoAppUrl(): string {
   const base =
     process.env.NEXT_PUBLIC_APP_URL ??
-    process.env.BETTER_AUTH_URL ??
+    process.env.APP_URL ??
     FALLBACK_APP_URL;
   return new URL("/", base).origin;
 }

--- a/apps/dashboard/src/lib/integrations/google-search-console/redirect-uri.ts
+++ b/apps/dashboard/src/lib/integrations/google-search-console/redirect-uri.ts
@@ -1,0 +1,4 @@
+import { GSC_OAUTH_CALLBACK_PATH } from "@/constants/google-search-console";
+
+export const getGscRedirectUri = (baseUrl: string): string =>
+  new URL(GSC_OAUTH_CALLBACK_PATH, baseUrl).toString();


### PR DESCRIPTION
## Summary
- A user hit `Error 400: redirect_uri_mismatch` connecting Google Search Console.
- The GSC authorize/callback routes were the only OAuth routes still reading `BETTER_AUTH_URL` (Better Auth leftover). That var no longer exists in prod, so the base URL fell through to `NEXT_PUBLIC_SITE_URL` (marketing origin) and Google received a redirect_uri on the wrong host.
- Switch both routes to `APP_URL ?? NEXT_PUBLIC_SITE_URL`, matching the Linear and Slack authorize routes. Same swap in `geo-ingest/snippet.ts`, which had the same stale fallback.

## Google Cloud config
The OAuth client behind `GOOGLE_SEARCH_CONSOLE_CLIENT_ID` needs this authorized redirect URI (assuming `APP_URL=https://app.usenotra.com`):

```
https://app.usenotra.com/api/integrations/google-search-console/callback
```

## Test plan
- [ ] Deploy, then retry Connect on the Search Console card and confirm the Google consent screen loads.
- [ ] Complete the flow and confirm the integration shows as connected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google Search Console OAuth failing with `redirect_uri_mismatch` by switching the OAuth base URL from the stale `BETTER_AUTH_URL` fallback to `APP_URL`.

- `BETTER_AUTH_URL` no longer exists in prod; the old fallback resolved to the marketing host, so Google received a redirect_uri on the wrong domain.
- The authorize, callback, and geo-ingest routes now prefer `APP_URL`, matching the Linear and Slack integrations.
- A shared helper builds the redirect URI with `new URL()`, so a trailing slash on `APP_URL` no longer creates a malformed double-slash path.
- The Google Cloud OAuth client needs `https://app.usenotra.com/api/integrations/google-search-console/callback` added as an authorized redirect URI.

<sup>Written for commit ebb978e58e71766b62a17bc05373a98e466bdbd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

