### PR TITLE
feat(geo): add Search Console property picker

### DIFF
--- a/apps/dashboard/src/components/geo/prompts-table.tsx
+++ b/apps/dashboard/src/components/geo/prompts-table.tsx
@@ -157,6 +157,7 @@ export function PromptsTable({
         ),
         sortable: true,
         width: "1fr",
+        minWidth: "10rem",
         cell: (row) => (
           <Tooltip>
             <TooltipTrigger

--- a/apps/dashboard/src/components/geo/search-console-card.tsx
+++ b/apps/dashboard/src/components/geo/search-console-card.tsx
@@ -2,6 +2,14 @@
 
 import { Cancel01Icon, MoreHorizontalIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogTrigger,
+} from "@notra/ui/components/shared/responsive-dialog";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { Card } from "@notra/ui/components/ui/card";
 import {
@@ -118,59 +126,94 @@ function ConnectAction({
 
 function SelectSiteState({
   organizationId,
+  callbackPath,
   status,
 }: SearchConsoleSelectSiteStateProps) {
   const id = useId();
   const [siteUrl, setSiteUrl] = useState("");
   const selectSite = useGscSelectSite(organizationId);
 
-  if (status.sites.length === 0) {
-    return (
-      <p className="text-muted-foreground px-4 py-3 text-sm">
-        {status.lastError ??
-          "No Search Console properties found for this Google account. Add a property in Search Console, then reconnect."}
-      </p>
-    );
-  }
-
   return (
-    <div className="space-y-2 px-4 py-3">
-      <Label htmlFor={`${id}-site`}>Choose the property to analyze</Label>
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <Select
-          onValueChange={(value) => setSiteUrl(value ?? "")}
-          value={siteUrl}
+    <ResponsiveDialog defaultOpen>
+      <div className="flex flex-col items-start gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-muted-foreground text-sm">
+          {status.lastError ??
+            "Choose which Search Console property Notra should analyze."}
+        </p>
+        <ResponsiveDialogTrigger
+          className="shrink-0"
+          render={<Button size="sm" variant="outline" />}
         >
-          <SelectTrigger className="w-full sm:max-w-md" id={`${id}-site`}>
-            <SelectValue placeholder="Select a property">
-              {(value: string | null) =>
-                value ? formatGscSiteUrl(value) : "Select a property"
-              }
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent align="start" alignItemWithTrigger={false}>
-            {status.sites.map((site) => (
-              <SelectItem key={site.siteUrl} value={site.siteUrl}>
-                {formatGscSiteUrl(site.siteUrl)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button
-          aria-busy={selectSite.isPending}
-          className={cn(
-            "shrink-0",
-            selectSite.isPending && "disabled:opacity-100"
-          )}
-          disabled={siteUrl.length === 0 || selectSite.isPending}
-          onClick={() => selectSite.mutate({ siteUrl })}
-          size="sm"
-        >
-          {selectSite.isPending ? <StatusSpinner /> : null}
-          {selectSite.isPending ? "Checking…" : "Use property"}
-        </Button>
+          Choose property
+        </ResponsiveDialogTrigger>
       </div>
-    </div>
+      <ResponsiveDialogContent className="sm:max-w-md">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>
+            Choose a Search Console property
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Select the domain whose search queries Notra should use for prompt
+            suggestions.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        {status.sites.length > 0 ? (
+          <div className="space-y-4 px-4 md:px-0">
+            <div className="space-y-2">
+              <Label htmlFor={`${id}-site`}>Property</Label>
+              <Select
+                onValueChange={(value) => setSiteUrl(value ?? "")}
+                value={siteUrl}
+              >
+                <SelectTrigger className="w-full" id={`${id}-site`}>
+                  <SelectValue placeholder="Select a property">
+                    {(value: string | null) =>
+                      value ? formatGscSiteUrl(value) : "Select a property"
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent align="start" alignItemWithTrigger={false}>
+                  {status.sites.map((site) => (
+                    <SelectItem key={site.siteUrl} value={site.siteUrl}>
+                      {formatGscSiteUrl(site.siteUrl)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              aria-busy={selectSite.isPending}
+              className={cn(
+                "w-full",
+                selectSite.isPending && "disabled:opacity-100"
+              )}
+              disabled={siteUrl.length === 0 || selectSite.isPending}
+              onClick={() => selectSite.mutate({ siteUrl })}
+            >
+              {selectSite.isPending ? <StatusSpinner /> : null}
+              {selectSite.isPending ? "Connecting…" : "Connect property"}
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4 px-4 md:px-0">
+            <p className="text-muted-foreground text-sm">
+              {status.lastError ??
+                "No properties were found for this Google account. Add or verify a property in Search Console, then reconnect."}
+            </p>
+            <Button
+              className="w-full"
+              nativeButton={false}
+              render={
+                <a href={buildAuthorizeUrl(organizationId, callbackPath)}>
+                  Reconnect Google
+                </a>
+              }
+              variant="outline"
+            />
+          </div>
+        )}
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
 }
 
@@ -200,7 +243,7 @@ function ConnectedState({
   const busy = sync.isPending || clearSite.isPending || disconnect.isPending;
 
   return (
-    <div className="flex items-start gap-3 px-4 py-3">
+    <div className="flex items-center gap-3 px-4 py-3">
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex flex-wrap items-center gap-2">
           <p className="truncate text-sm leading-snug font-medium">
@@ -304,7 +347,13 @@ export function SearchConsoleCard({
   } else if (status.siteUrl) {
     body = <ConnectedState organizationId={organizationId} status={status} />;
   } else {
-    body = <SelectSiteState organizationId={organizationId} status={status} />;
+    body = (
+      <SelectSiteState
+        callbackPath={callbackPath}
+        organizationId={organizationId}
+        status={status}
+      />
+    );
   }
 
   return (

--- a/apps/dashboard/src/types/components/geo.ts
+++ b/apps/dashboard/src/types/components/geo.ts
@@ -45,6 +45,7 @@ export interface SearchConsoleConnectActionProps {
 
 export interface SearchConsoleSelectSiteStateProps {
   organizationId: string;
+  callbackPath: string;
   status: GeoSearchConsoleStatus;
 }
 


### PR DESCRIPTION
### Description
Adds a dedicated Google Search Console property picker after connecting an account and when changing properties later.

The picker:
- Opens automatically when no property is selected
- Supports switching properties after setup
- Provides a reconnect path when no properties are available
- Improves the connected-state alignment
- Prevents the Prompts table from collapsing below a usable minimum width

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Search Console property picker that opens automatically when no property is selected and supports switching properties later.

- Moves property selection into a modal dialog instead of inline content.
- Adds a reconnect path when the account has no properties.
- Prevents the Prompts table from collapsing below a minimum width.
- Centers the connected-state layout vertically.

<sup>Written for commit ebeb93d4ca125a41756da5f152b3d997262cb000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

