### PR TITLE
fix(dashboard): prevent chat sidebar overlap

### DIFF
--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -230,7 +230,7 @@ export const SIDEBAR_MODE_EXIT_RIGHT_CLASS = `pointer-events-none z-0 translate-
 /** Indicator that slides between the two tabs of the mode switch. */
 export const SIDEBAR_MODE_PILL_CLASS = `pointer-events-none absolute inset-y-0 left-0 w-1/2 rounded-md bg-background ring-1 ring-border transition-[translate] will-change-[translate] duration-[320ms] ${SIDEBAR_MODE_SWOOSH_IN} motion-reduce:transition-none`;
 
-export const SIDEBAR_MODE_PANEL_CLASS = `flex w-full flex-col ${SIDEBAR_MODE_FADE_CLASS}`;
+export const SIDEBAR_MODE_PANEL_CLASS = `flex min-h-0 w-full flex-col ${SIDEBAR_MODE_FADE_CLASS}`;
 
 /** Collapses the primary-action row when the active mode has no action to offer. */
 export const SIDEBAR_MODE_SLOT_CLASS = `grid transition-[grid-template-rows,opacity] duration-[320ms] ${SIDEBAR_MODE_SWOOSH_IN} motion-reduce:transition-none`;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat sidebar overlap by adding `min-h-0` to the sidebar mode panel so the flex child can shrink below its content height.

<sup>Written for commit 03dd3e16c15ec1bc0a9481d3860f50d3c9967481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

