### PR TITLE
feat(geo): improve Search Console property selection

### DIFF
--- a/apps/dashboard/src/components/geo/search-console-card.tsx
+++ b/apps/dashboard/src/components/geo/search-console-card.tsx
@@ -30,15 +30,19 @@ import { Google } from "@notra/ui/components/ui/svgs/google";
 import { type ReactNode, useId, useState } from "react";
 
 import { Button } from "@/components/button";
+import { ProjectLogo } from "@/components/geo/project-logo";
 import { StatusSpinner } from "@/components/geo/status-spinner";
+import { useGeoProjectScope } from "@/components/providers/geo-project-provider";
 import { GSC_OAUTH_AUTHORIZE_PATH } from "@/constants/google-search-console";
+import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import {
   useGscCardDismissal,
-  useGscClearSite,
   useGscDisconnect,
   useGscSelectSite,
+  useGscSites,
   useGscStatus,
   useGscSync,
+  useGeoProjects,
 } from "@/lib/hooks/use-geo";
 import { useGscConnectionToast } from "@/lib/hooks/use-gsc-connection-toast";
 import { cn } from "@/lib/utils";
@@ -47,11 +51,16 @@ import type {
   SearchConsoleConnectActionProps,
   SearchConsoleConnectedStateProps,
   SearchConsoleHeaderRowProps,
+  SearchConsolePropertyPickerProps,
   SearchConsoleSelectSiteStateProps,
 } from "@/types/components/geo";
 import type { GeoSearchConsoleStatus } from "@/types/google-search-console";
 import { formatRelative } from "@/utils/format-relative";
-import { formatGscSiteUrl } from "@/utils/gsc-site-url";
+import {
+  findMatchingGscSiteUrl,
+  formatGscSiteUrl,
+  getGscSiteDomain,
+} from "@/utils/gsc-site-url";
 
 function buildAuthorizeUrl(organizationId: string, callbackPath: string) {
   const params = new URLSearchParams({ organizationId, callbackPath });
@@ -128,15 +137,86 @@ function ConnectAction({
   );
 }
 
+function PropertyPicker({
+  organizationId,
+  sites,
+  websiteUrl,
+  onSelected,
+}: SearchConsolePropertyPickerProps) {
+  const id = useId();
+  const [selectedSiteUrl, setSelectedSiteUrl] = useState<string | null>(null);
+  const selectSite = useGscSelectSite(organizationId);
+  const siteUrl =
+    selectedSiteUrl ?? findMatchingGscSiteUrl(sites, websiteUrl) ?? "";
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor={`${id}-site`}>Property</Label>
+        <Select
+          onValueChange={(value) => setSelectedSiteUrl(value ?? "")}
+          value={siteUrl}
+        >
+          <SelectTrigger className="w-full" id={`${id}-site`}>
+            <SelectValue placeholder="Select a property">
+              {(value: string | null) => {
+                if (!value) {
+                  return "Select a property";
+                }
+                const label = formatGscSiteUrl(value);
+                return (
+                  <>
+                    <span aria-hidden="true">
+                      <ProjectLogo
+                        domain={getGscSiteDomain(value)}
+                        name={label}
+                      />
+                    </span>
+                    <span className="truncate">{label}</span>
+                  </>
+                );
+              }}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent align="start" alignItemWithTrigger={false}>
+            {sites.map((site) => {
+              const label = formatGscSiteUrl(site.siteUrl);
+              return (
+                <SelectItem key={site.siteUrl} value={site.siteUrl}>
+                  <span aria-hidden="true">
+                    <ProjectLogo
+                      domain={getGscSiteDomain(site.siteUrl)}
+                      name={label}
+                    />
+                  </span>
+                  <span>{label}</span>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+      <Button
+        aria-busy={selectSite.isPending}
+        className={cn("w-full", selectSite.isPending && "disabled:opacity-100")}
+        disabled={siteUrl.length === 0 || selectSite.isPending}
+        onClick={() =>
+          selectSite.mutate({ siteUrl }, { onSuccess: () => onSelected?.() })
+        }
+      >
+        {selectSite.isPending ? <StatusSpinner /> : null}
+        {selectSite.isPending ? "Connecting…" : "Connect property"}
+      </Button>
+    </div>
+  );
+}
+
 function SelectSiteState({
   organizationId,
   callbackPath,
   status,
+  websiteUrl,
 }: SearchConsoleSelectSiteStateProps) {
-  const id = useId();
-  const [siteUrl, setSiteUrl] = useState("");
-  const selectSite = useGscSelectSite(organizationId);
-
   return (
     <ResponsiveDialog>
       <div className="flex flex-col items-start gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
@@ -162,41 +242,12 @@ function SelectSiteState({
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
         {status.sites.length > 0 ? (
-          <div className="space-y-4 px-4 md:px-0">
-            <div className="space-y-2">
-              <Label htmlFor={`${id}-site`}>Property</Label>
-              <Select
-                onValueChange={(value) => setSiteUrl(value ?? "")}
-                value={siteUrl}
-              >
-                <SelectTrigger className="w-full" id={`${id}-site`}>
-                  <SelectValue placeholder="Select a property">
-                    {(value: string | null) =>
-                      value ? formatGscSiteUrl(value) : "Select a property"
-                    }
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent align="start" alignItemWithTrigger={false}>
-                  {status.sites.map((site) => (
-                    <SelectItem key={site.siteUrl} value={site.siteUrl}>
-                      {formatGscSiteUrl(site.siteUrl)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <Button
-              aria-busy={selectSite.isPending}
-              className={cn(
-                "w-full",
-                selectSite.isPending && "disabled:opacity-100"
-              )}
-              disabled={siteUrl.length === 0 || selectSite.isPending}
-              onClick={() => selectSite.mutate({ siteUrl })}
-            >
-              {selectSite.isPending ? <StatusSpinner /> : null}
-              {selectSite.isPending ? "Connecting…" : "Connect property"}
-            </Button>
+          <div className="px-4 md:px-0">
+            <PropertyPicker
+              organizationId={organizationId}
+              sites={status.sites}
+              websiteUrl={websiteUrl}
+            />
           </div>
         ) : (
           <div className="space-y-4 px-4 md:px-0">
@@ -239,71 +290,130 @@ function connectedMeta(status: GeoSearchConsoleStatus): string {
 
 function ConnectedState({
   organizationId,
+  callbackPath,
   status,
+  websiteUrl,
 }: SearchConsoleConnectedStateProps) {
+  const [changeOpen, setChangeOpen] = useState(false);
   const sync = useGscSync(organizationId);
-  const clearSite = useGscClearSite(organizationId);
+  const sites = useGscSites(organizationId, changeOpen);
   const disconnect = useGscDisconnect(organizationId);
-  const busy = sync.isPending || clearSite.isPending || disconnect.isPending;
+  const busy = sync.isPending || disconnect.isPending;
+
+  let changeDialogBody: ReactNode;
+  if (sites.isPending) {
+    changeDialogBody = (
+      <div className="text-muted-foreground flex items-center gap-2 px-4 py-3 text-sm md:px-0">
+        <StatusSpinner />
+        Loading properties…
+      </div>
+    );
+  } else if (sites.data?.sites.length) {
+    changeDialogBody = (
+      <div className="px-4 md:px-0">
+        <PropertyPicker
+          onSelected={() => setChangeOpen(false)}
+          organizationId={organizationId}
+          sites={sites.data.sites}
+          websiteUrl={websiteUrl}
+        />
+      </div>
+    );
+  } else {
+    changeDialogBody = (
+      <div className="space-y-4 px-4 md:px-0">
+        <p className="text-muted-foreground text-sm">
+          {sites.isError
+            ? "Search Console properties could not be loaded. Reconnect Google and try again."
+            : "No properties were found for this Google account."}
+        </p>
+        <Button
+          className="w-full"
+          nativeButton={false}
+          render={
+            <a href={buildAuthorizeUrl(organizationId, callbackPath)}>
+              Reconnect Google
+            </a>
+          }
+          variant="outline"
+        />
+      </div>
+    );
+  }
 
   return (
-    <div className="flex items-center gap-3 px-4 py-3">
-      <div className="min-w-0 flex-1 space-y-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="truncate text-sm leading-snug font-medium">
-            {formatGscSiteUrl(status.siteUrl ?? "")}
+    <>
+      <div className="flex items-center gap-3 px-4 py-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate text-sm leading-snug font-medium">
+              {formatGscSiteUrl(status.siteUrl ?? "")}
+            </p>
+            {status.weeklySyncScheduled ? (
+              <Badge className="font-normal" variant="secondary">
+                Weekly sync
+              </Badge>
+            ) : null}
+          </div>
+          <p className="text-muted-foreground text-xs leading-snug">
+            {connectedMeta(status)}
           </p>
-          {status.weeklySyncScheduled ? (
-            <Badge className="font-normal" variant="secondary">
-              Weekly sync
-            </Badge>
-          ) : null}
         </div>
-        <p className="text-muted-foreground text-xs leading-snug">
-          {connectedMeta(status)}
-        </p>
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
-        <Button
-          disabled={busy}
-          onClick={() => sync.mutate()}
-          size="sm"
-          variant="outline"
-        >
-          {sync.isPending ? <StatusSpinner /> : null}
-          {sync.isPending ? "Syncing…" : "Sync now"}
-        </Button>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button
-                aria-label="Search Console actions"
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            disabled={busy}
+            onClick={() => sync.mutate()}
+            size="sm"
+            variant="outline"
+          >
+            {sync.isPending ? <StatusSpinner /> : null}
+            {sync.isPending ? "Syncing…" : "Sync now"}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  aria-label="Search Console actions"
+                  disabled={busy}
+                  size="icon-sm"
+                  variant="ghost"
+                >
+                  <HugeiconsIcon icon={MoreHorizontalIcon} size={16} />
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end" className="w-44">
+              <DropdownMenuItem
                 disabled={busy}
-                size="icon-sm"
-                variant="ghost"
+                onClick={() => setChangeOpen(true)}
               >
-                <HugeiconsIcon icon={MoreHorizontalIcon} size={16} />
-              </Button>
-            }
-          />
-          <DropdownMenuContent align="end" className="w-44">
-            <DropdownMenuItem
-              disabled={busy}
-              onClick={() => clearSite.mutate()}
-            >
-              Change property
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              disabled={busy}
-              onClick={() => disconnect.mutate()}
-              variant="destructive"
-            >
-              Disconnect
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+                Change property
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={busy}
+                onClick={() => disconnect.mutate()}
+                variant="destructive"
+              >
+                Disconnect
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
-    </div>
+      <ResponsiveDialog onOpenChange={setChangeOpen} open={changeOpen}>
+        <ResponsiveDialogContent className="sm:max-w-md">
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>
+              Change Search Console property
+            </ResponsiveDialogTitle>
+            <ResponsiveDialogDescription>
+              Your current property stays connected until you confirm a new one.
+            </ResponsiveDialogDescription>
+          </ResponsiveDialogHeader>
+          {changeDialogBody}
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+    </>
   );
 }
 
@@ -312,9 +422,22 @@ export function SearchConsoleCard({
   callbackPath,
 }: SearchConsoleCardProps) {
   const headingId = useId();
+  const { projectId } = useGeoProjectScope();
   useGscConnectionToast();
   const { data: status, isPending } = useGscStatus(organizationId);
   const { dismiss, dismissed } = useGscCardDismissal(organizationId);
+  const { data: projectsData } = useGeoProjects(organizationId);
+  const { data: brandData } = useBrandSettings(organizationId);
+
+  const projects = projectsData?.projects ?? [];
+  const activeProject =
+    projects.find((project) => project.id === projectId) ??
+    projects.at(0) ??
+    null;
+  const websiteUrl =
+    brandData?.voices.find(
+      (voice) => voice.id === activeProject?.brandSettingsId
+    )?.websiteUrl ?? null;
 
   const connectPromo = !isPending && status !== undefined && !status.connected;
 
@@ -349,13 +472,22 @@ export function SearchConsoleCard({
       );
     }
   } else if (status.siteUrl) {
-    body = <ConnectedState organizationId={organizationId} status={status} />;
+    body = (
+      <ConnectedState
+        callbackPath={callbackPath}
+        organizationId={organizationId}
+        status={status}
+        websiteUrl={websiteUrl}
+      />
+    );
   } else {
     body = (
       <SelectSiteState
         callbackPath={callbackPath}
+        key={activeProject?.id}
         organizationId={organizationId}
         status={status}
+        websiteUrl={websiteUrl}
       />
     );
   }

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -61,6 +61,7 @@ import type {
 import type {
   GeoSearchConsoleStatus,
   GscSelectSiteInput,
+  GscSitesResponse,
   GscSyncResult,
 } from "@/types/google-search-console";
 import {
@@ -719,6 +720,16 @@ export function useGscStatus(organizationId: string) {
   });
 }
 
+export function useGscSites(organizationId: string, enabled: boolean) {
+  return useQuery<GscSitesResponse>({
+    ...dashboardOrpc.geo.searchConsoleSites.queryOptions({
+      input: { organizationId },
+    }),
+    enabled: !!organizationId && enabled,
+    meta: { errorMessage: "Failed to load Search Console properties" },
+  });
+}
+
 function useInvalidateGscQueries(organizationId: string) {
   const queryClient = useQueryClient();
   return async () => {
@@ -776,20 +787,6 @@ export function useGscSync(organizationId: string) {
     },
     onError: (error) => {
       toast.error(toErrorMessage(error, "Failed to sync Search Console"));
-    },
-  });
-}
-
-export function useGscClearSite(organizationId: string) {
-  const invalidate = useInvalidateGscQueries(organizationId);
-  return useMutation({
-    mutationFn: () =>
-      dashboardOrpc.geo.searchConsoleClearSite.call({ organizationId }),
-    onSuccess: async () => {
-      await invalidate();
-    },
-    onError: (error) => {
-      toast.error(toErrorMessage(error, "Failed to change property"));
     },
   });
 }

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -756,13 +756,30 @@ export const geoRouter = {
       }
 
       try {
-        return await syncGscSuggestions(input.organizationId);
+        return await runGscSyncOrBadRequest(input.organizationId);
       } catch (error) {
         console.error(
           "[GSC] Initial sync failed after selecting property:",
           error
         );
-        return { status: "skipped", reason: "sync_failed" };
+        try {
+          // Keep authentication changes made while refreshing the token, but
+          // restore the selection state this request replaced.
+          await updateGscIntegration(input.organizationId, {
+            siteUrl: integration.siteUrl,
+            qstashScheduleId: integration.qstashScheduleId,
+            lastError: integration.lastError,
+          });
+        } catch (rollbackError) {
+          console.error(
+            "[GSC] Failed to restore integration after initial sync:",
+            rollbackError
+          );
+        }
+        if (scheduleId && scheduleId !== integration.qstashScheduleId) {
+          await removeGscSchedule(scheduleId);
+        }
+        throw error;
       }
     }),
   searchConsoleSync: authorizedProcedure

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -136,6 +136,7 @@ import type {
 } from "@/types/geo";
 import type {
   GeoSearchConsoleStatus,
+  GscSitesResponse,
   GscSyncResult,
 } from "@/types/google-search-console";
 import { ratelimit } from "@/utils/ratelimit";
@@ -686,6 +687,29 @@ export const geoRouter = {
         sites,
       };
     }),
+  searchConsoleSites: authorizedProcedure
+    .input(geoOrganizationInputSchema)
+    .handler(async ({ context, input }): Promise<GscSitesResponse> => {
+      await assertGeoAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
+
+      const integration = await getGscIntegration(input.organizationId);
+      if (!integration) {
+        throw notFound("Google Search Console is not connected");
+      }
+
+      try {
+        return { sites: await listGscSites(integration) };
+      } catch (error) {
+        console.error("[GSC] Failed to list sites:", error);
+        throw badRequest(
+          toGscErrorMessage(error, "Failed to load Search Console properties")
+        );
+      }
+    }),
   searchConsoleSelectSite: authorizedProcedure
     .input(gscSelectSiteInputSchema)
     .handler(async ({ context, input }): Promise<GscSyncResult> => {
@@ -731,7 +755,15 @@ export const geoRouter = {
         throw notFound("Google Search Console is not connected");
       }
 
-      return await runGscSyncOrBadRequest(input.organizationId);
+      try {
+        return await syncGscSuggestions(input.organizationId);
+      } catch (error) {
+        console.error(
+          "[GSC] Initial sync failed after selecting property:",
+          error
+        );
+        return { status: "skipped", reason: "sync_failed" };
+      }
     }),
   searchConsoleSync: authorizedProcedure
     .input(geoOrganizationInputSchema)
@@ -771,27 +803,6 @@ export const geoRouter = {
       }
 
       return await runGscSyncOrBadRequest(input.organizationId);
-    }),
-  searchConsoleClearSite: authorizedProcedure
-    .input(geoOrganizationInputSchema)
-    .handler(async ({ context, input }): Promise<{ cleared: boolean }> => {
-      await assertGeoAccess({
-        headers: context.headers,
-        organizationId: input.organizationId,
-        user: context.user,
-      });
-
-      const integration = await getGscIntegration(input.organizationId);
-      if (!integration) {
-        throw notFound("Google Search Console is not connected");
-      }
-      await removeGscSchedule(integration.qstashScheduleId);
-      await updateGscIntegration(input.organizationId, {
-        siteUrl: null,
-        qstashScheduleId: null,
-        lastError: null,
-      });
-      return { cleared: true };
     }),
   searchConsoleDisconnect: authorizedProcedure
     .input(geoOrganizationInputSchema)

--- a/apps/dashboard/src/types/components/geo.ts
+++ b/apps/dashboard/src/types/components/geo.ts
@@ -47,11 +47,21 @@ export interface SearchConsoleSelectSiteStateProps {
   organizationId: string;
   callbackPath: string;
   status: GeoSearchConsoleStatus;
+  websiteUrl: string | null;
+}
+
+export interface SearchConsolePropertyPickerProps {
+  organizationId: string;
+  sites: GeoSearchConsoleStatus["sites"];
+  websiteUrl: string | null;
+  onSelected?: () => void;
 }
 
 export interface SearchConsoleConnectedStateProps {
   organizationId: string;
+  callbackPath: string;
   status: GeoSearchConsoleStatus;
+  websiteUrl: string | null;
 }
 
 export interface GeoUpgradeGateProps {

--- a/apps/dashboard/src/types/google-search-console.ts
+++ b/apps/dashboard/src/types/google-search-console.ts
@@ -23,6 +23,10 @@ export interface GeoSearchConsoleStatus {
   sites: GscSite[];
 }
 
+export interface GscSitesResponse {
+  sites: GscSite[];
+}
+
 export interface GscSelectSiteInput {
   siteUrl: string;
 }

--- a/apps/dashboard/src/utils/gsc-site-url.test.js
+++ b/apps/dashboard/src/utils/gsc-site-url.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import { findMatchingGscSiteUrl, getGscSiteDomain } from "./gsc-site-url";
+
+const site = (siteUrl) => ({ siteUrl, permissionLevel: "siteOwner" });
+
+describe("getGscSiteDomain", () => {
+  test("extracts domains from domain and URL-prefix properties", () => {
+    expect(getGscSiteDomain("sc-domain:Example.com.")).toBe("example.com");
+    expect(getGscSiteDomain("https://www.example.com/blog/")).toBe(
+      "www.example.com"
+    );
+  });
+
+  test("returns null for an invalid property", () => {
+    expect(getGscSiteDomain("not a property")).toBeNull();
+  });
+});
+
+describe("findMatchingGscSiteUrl", () => {
+  test("matches the project's domain property", () => {
+    expect(
+      findMatchingGscSiteUrl(
+        [site("sc-domain:example.com"), site("sc-domain:other.com")],
+        "https://example.com/"
+      )
+    ).toBe("sc-domain:example.com");
+  });
+
+  test("matches a parent domain property for a project subdomain", () => {
+    expect(
+      findMatchingGscSiteUrl(
+        [site("sc-domain:example.com")],
+        "https://www.example.com/"
+      )
+    ).toBe("sc-domain:example.com");
+  });
+
+  test("prefers the most specific matching domain property", () => {
+    expect(
+      findMatchingGscSiteUrl(
+        [site("sc-domain:example.com"), site("sc-domain:shop.example.com")],
+        "https://shop.example.com/"
+      )
+    ).toBe("sc-domain:shop.example.com");
+  });
+
+  test("falls back to a URL-prefix property with the same origin", () => {
+    expect(
+      findMatchingGscSiteUrl(
+        [site("http://example.com/"), site("https://example.com/")],
+        "https://example.com/"
+      )
+    ).toBe("https://example.com/");
+  });
+
+  test("prefers the most specific URL-prefix property that covers the project", () => {
+    expect(
+      findMatchingGscSiteUrl(
+        [
+          site("https://example.com/"),
+          site("https://example.com/blog/"),
+          site("https://example.com/blog/guides/"),
+        ],
+        "https://example.com/blog/guides/getting-started"
+      )
+    ).toBe("https://example.com/blog/guides/");
+  });
+
+  test("does not match a different protocol or non-covering path", () => {
+    expect(
+      findMatchingGscSiteUrl(
+        [site("http://example.com/"), site("https://example.com/docs/")],
+        "https://example.com/blog/"
+      )
+    ).toBeNull();
+  });
+
+  test("does not match a lookalike or narrower domain", () => {
+    expect(
+      findMatchingGscSiteUrl(
+        [site("sc-domain:notexample.com"), site("sc-domain:www.example.com")],
+        "https://example.com/"
+      )
+    ).toBeNull();
+  });
+
+  test("returns null without a valid project website", () => {
+    expect(
+      findMatchingGscSiteUrl([site("sc-domain:example.com")], null)
+    ).toBeNull();
+    expect(
+      findMatchingGscSiteUrl([site("sc-domain:example.com")], "not a url")
+    ).toBeNull();
+  });
+});

--- a/apps/dashboard/src/utils/gsc-site-url.test.ts
+++ b/apps/dashboard/src/utils/gsc-site-url.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { findMatchingGscSiteUrl, getGscSiteDomain } from "./gsc-site-url";
 
-const site = (siteUrl) => ({ siteUrl, permissionLevel: "siteOwner" });
+const site = (siteUrl: string) => ({ siteUrl, permissionLevel: "siteOwner" });
 
 describe("getGscSiteDomain", () => {
   test("extracts domains from domain and URL-prefix properties", () => {

--- a/apps/dashboard/src/utils/gsc-site-url.ts
+++ b/apps/dashboard/src/utils/gsc-site-url.ts
@@ -1,7 +1,92 @@
+import type { GscSite } from "@notra/ai/types/google-search-console";
+
 const SC_DOMAIN_PREFIX = "sc-domain:";
 
 export function formatGscSiteUrl(siteUrl: string): string {
   return siteUrl.startsWith(SC_DOMAIN_PREFIX)
     ? `${siteUrl.slice(SC_DOMAIN_PREFIX.length)} (domain)`
     : siteUrl;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/\.$/, "");
+}
+
+function parseUrl(siteUrl: string): URL | null {
+  try {
+    return new URL(siteUrl);
+  } catch {
+    return null;
+  }
+}
+
+export function getGscSiteDomain(siteUrl: string): string | null {
+  if (siteUrl.startsWith(SC_DOMAIN_PREFIX)) {
+    const hostname = normalizeHostname(siteUrl.slice(SC_DOMAIN_PREFIX.length));
+    return hostname || null;
+  }
+
+  const site = parseUrl(siteUrl);
+  return site ? normalizeHostname(site.hostname) : null;
+}
+
+export function findMatchingGscSiteUrl(
+  sites: GscSite[],
+  websiteUrl: string | null
+): string | null {
+  if (!websiteUrl) {
+    return null;
+  }
+
+  const website = parseUrl(websiteUrl);
+  if (!website) {
+    return null;
+  }
+
+  const websiteHostname = normalizeHostname(website.hostname);
+  let domainMatch: GscSite | null = null;
+  let domainMatchLength = -1;
+
+  for (const site of sites) {
+    if (!site.siteUrl.startsWith(SC_DOMAIN_PREFIX)) {
+      continue;
+    }
+
+    const propertyHostname = normalizeHostname(
+      site.siteUrl.slice(SC_DOMAIN_PREFIX.length)
+    );
+    const coversWebsite =
+      websiteHostname === propertyHostname ||
+      websiteHostname.endsWith(`.${propertyHostname}`);
+
+    if (coversWebsite && propertyHostname.length > domainMatchLength) {
+      domainMatch = site;
+      domainMatchLength = propertyHostname.length;
+    }
+  }
+
+  if (domainMatch) {
+    return domainMatch.siteUrl;
+  }
+
+  const websiteHref = website.href;
+  let prefixMatch: string | null = null;
+  let prefixMatchLength = -1;
+  for (const site of sites) {
+    const propertyUrl = parseUrl(site.siteUrl);
+    if (
+      !propertyUrl ||
+      propertyUrl.origin !== website.origin ||
+      !websiteHref.startsWith(propertyUrl.href)
+    ) {
+      continue;
+    }
+
+    if (propertyUrl.href.length > prefixMatchLength) {
+      prefixMatch = site.siteUrl;
+      prefixMatchLength = propertyUrl.href.length;
+    }
+  }
+
+  return prefixMatch;
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Search Console property selection: the picker now shows each property's favicon, and changing properties keeps the current one connected until you confirm a new one.

- Pre-selects the property that best matches the project's website URL, preferring domain properties and the most specific match, with unit tests for the matching logic.
- Loads properties on demand when the change dialog opens instead of relying on the cached status.
- Removes the old clear-site flow; the picker now opens in a dialog from the connected state.
- Rolls back the property selection and surfaces the error if the initial sync fails after selecting a property.

<sup>Written for commit 9f6bf09704b53744651ff97584981f83c47cb5f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

