### PR TITLE
fix(dashboard): prevent Studio mode redirect loop

### DIFF
--- a/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
@@ -55,7 +55,7 @@ export function NavModeSwitch({
                 )}
                 key={option.id}
                 onClick={() => onModeChange(option.id)}
-                prefetch
+                prefetch={option.id === "geo"}
               >
                 <HugeiconsIcon className="size-3.5" icon={option.icon} />
                 {option.label}
@@ -77,6 +77,7 @@ export function NavModeSwitch({
                     projectId
                   )}
                   onClick={() => onModeChange(option.id)}
+                  prefetch={option.id === "geo"}
                 >
                   <HugeiconsIcon icon={option.icon} />
                   <SidebarLabel>{option.label}</SidebarLabel>

--- a/apps/dashboard/src/utils/cookies.ts
+++ b/apps/dashboard/src/utils/cookies.ts
@@ -21,7 +21,11 @@ async function setClientCookie(
     (window.location.protocol === "https:" ||
       process.env.NODE_ENV === "production");
 
-  if (typeof window !== "undefined" && "cookieStore" in window) {
+  if (
+    typeof document === "undefined" &&
+    typeof window !== "undefined" &&
+    "cookieStore" in window
+  ) {
     const cookieOptions: CookieInit = {
       name,
       value,
@@ -38,7 +42,7 @@ async function setClientCookie(
 
   if (typeof document !== "undefined") {
     const secureFlag = isSecure ? "; Secure" : "";
-    // biome-ignore lint/suspicious/noDocumentCookie: Fallback for browsers without Cookie Store API support
+    // biome-ignore lint/suspicious/noDocumentCookie: Navigation must see the updated cookie synchronously
     document.cookie = `${name}=${value}; max-age=${maxAge}; path=/; SameSite=Lax${secureFlag}`;
   }
 }


### PR DESCRIPTION
### Description
Fixes a race condition where switching organizations and then selecting Studio could redirect the user back to GEO.

- Writes the sidebar mode cookie synchronously before navigation.
- Prevents Studio from being prefetched with a stale GEO cookie.
- Keeps the selected organization and mode consistent across navigation.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where switching organizations and then selecting Studio could redirect back to GEO. The sidebar mode cookie is now written synchronously before navigation, and Studio is no longer prefetched with a stale cookie.

<sup>Written for commit 110a2523b026db81e62f971ff9486b24a42cccc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

