### PR TITLE
feat(geo): integrate Search Console suggestions table

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
@@ -15,7 +15,6 @@ import { GeoRangePicker } from "@/components/geo/geo-range-picker";
 import { PromptAddDialog } from "@/components/geo/prompt-add-dialog";
 import { PromptSuggestions } from "@/components/geo/prompt-suggestions";
 import { PromptsTable } from "@/components/geo/prompts-table";
-import { SearchConsoleCard } from "@/components/geo/search-console-card";
 import { PageContainer } from "@/components/layout/container";
 import {
   GeoProjectProvider,
@@ -134,14 +133,6 @@ function GeoPromptsPageContent({ organizationSlug }: PageClientProps) {
             </Button>
           </div>
         </header>
-        <PromptSuggestions organizationId={organizationId} />
-        <SearchConsoleCard
-          callbackPath={withGeoProject(
-            `/${organizationSlug}/geo/prompts`,
-            projectId
-          )}
-          organizationId={organizationId}
-        />
         <PromptsTable
           isScanning={isScanning}
           organizationId={organizationId}
@@ -149,6 +140,13 @@ function GeoPromptsPageContent({ organizationSlug }: PageClientProps) {
           results={promptResults?.results ?? []}
         />
         <ConversationsCard organizationId={organizationId} />
+        <PromptSuggestions
+          callbackPath={withGeoProject(
+            `/${organizationSlug}/geo/prompts`,
+            projectId
+          )}
+          organizationId={organizationId}
+        />
       </div>
       <PromptAddDialog
         onOpenChange={setAddOpen}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/skeleton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/skeleton.tsx
@@ -28,8 +28,6 @@ export function GeoPromptsSkeleton() {
             <Kbd className="ml-1 hidden sm:inline-flex">P</Kbd>
           </Button>
         </header>
-        <Skeleton className="h-18 w-full rounded-xl" />
-        <Skeleton className="h-18 w-full rounded-xl" />
         <div className="space-y-3">
           <Skeleton className="h-9 w-full rounded-md sm:max-w-72" />
           <GeoTableSkeleton rows={PROMPT_ROW_COUNT} />
@@ -46,6 +44,20 @@ export function GeoPromptsSkeleton() {
           </div>
           <GeoTableSkeleton rows={2} />
         </div>
+        <GeoTableSkeleton
+          rows={3}
+          toolbar={
+            <div className="flex h-16 items-center gap-3 px-4">
+              <Skeleton className="size-4 shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-40 rounded-md" />
+                <Skeleton className="h-3 w-56 max-w-full rounded-md" />
+              </div>
+              <Skeleton className="h-8 w-20 rounded-lg" />
+              <Skeleton className="h-8 w-24 rounded-lg" />
+            </div>
+          }
+        />
       </div>
     </PageContainer>
   );

--- a/apps/dashboard/src/components/geo/prompt-suggestions.tsx
+++ b/apps/dashboard/src/components/geo/prompt-suggestions.tsx
@@ -47,28 +47,24 @@ function bestPosition(suggestion: GeoPromptSuggestion): number | null {
 }
 
 function SuggestionRowActions({
-  checking,
+  accepting,
+  disabled,
+  onAccept,
   organizationId,
   suggestion,
 }: SuggestionRowActionsProps) {
-  const accept = useGeoSuggestionAccept(organizationId);
   const dismiss = useGeoSuggestionDismiss(organizationId);
-  const busy = checking || accept.isPending || dismiss.isPending;
+  const busy = disabled || dismiss.isPending;
 
   return (
     <div className="flex items-center justify-end gap-1">
-      <Button
-        disabled={busy}
-        onClick={() => accept.mutate({ suggestionId: suggestion.id })}
-        size="sm"
-        variant="outline"
-      >
-        {accept.isPending ? (
+      <Button disabled={busy} onClick={onAccept} size="sm" variant="outline">
+        {accepting ? (
           <StatusSpinner />
         ) : (
           <HugeiconsIcon icon={PlusSignIcon} size={14} />
         )}
-        {accept.isPending ? "Adding…" : "Track"}
+        {accepting ? "Adding…" : "Track"}
       </Button>
       <Button
         aria-label={`Dismiss ${suggestion.prompt}`}
@@ -92,9 +88,14 @@ export function PromptSuggestions({
     useGscStatus(organizationId);
   const { dismiss, dismissed } = useGscCardDismissal(organizationId);
   const checking = useGscAnalyzing(organizationId);
+  const accept = useGeoSuggestionAccept(organizationId);
   const acceptAll = useGeoSuggestionsAcceptAll(organizationId);
   const suggestions = data?.suggestions ?? [];
   const hasSuggestions = suggestions.length > 0;
+  const acceptingSuggestionId = accept.isPending
+    ? accept.variables?.suggestionId
+    : undefined;
+  const trackingDisabled = accept.isPending || acceptAll.isPending;
   const connectPromo =
     !isSearchConsolePending &&
     searchConsoleStatus !== undefined &&
@@ -188,7 +189,9 @@ export function PromptSuggestions({
       width: "8.5rem",
       cell: (row) => (
         <SuggestionRowActions
-          checking={checking}
+          accepting={acceptingSuggestionId === row.id}
+          disabled={checking || trackingDisabled}
+          onAccept={() => accept.mutate({ suggestionId: row.id })}
           organizationId={organizationId}
           suggestion={row}
         />
@@ -203,7 +206,7 @@ export function PromptSuggestions({
   const trackAllAction =
     !checking && suggestions.length > 1 ? (
       <Button
-        disabled={acceptAll.isPending}
+        disabled={trackingDisabled}
         onClick={() => acceptAll.mutate()}
         size="sm"
         variant="outline"

--- a/apps/dashboard/src/components/geo/prompt-suggestions.tsx
+++ b/apps/dashboard/src/components/geo/prompt-suggestions.tsx
@@ -49,16 +49,19 @@ function bestPosition(suggestion: GeoPromptSuggestion): number | null {
 function SuggestionRowActions({
   accepting,
   disabled,
+  dismissing,
   onAccept,
-  organizationId,
+  onDismiss,
   suggestion,
 }: SuggestionRowActionsProps) {
-  const dismiss = useGeoSuggestionDismiss(organizationId);
-  const busy = disabled || dismiss.isPending;
-
   return (
     <div className="flex items-center justify-end gap-1">
-      <Button disabled={busy} onClick={onAccept} size="sm" variant="outline">
+      <Button
+        disabled={disabled}
+        onClick={onAccept}
+        size="sm"
+        variant="outline"
+      >
         {accepting ? (
           <StatusSpinner />
         ) : (
@@ -68,12 +71,16 @@ function SuggestionRowActions({
       </Button>
       <Button
         aria-label={`Dismiss ${suggestion.prompt}`}
-        disabled={busy}
-        onClick={() => dismiss.mutate({ suggestionId: suggestion.id })}
+        disabled={disabled}
+        onClick={onDismiss}
         size="icon-sm"
         variant="ghost"
       >
-        <HugeiconsIcon icon={Cancel01Icon} size={16} />
+        {dismissing ? (
+          <StatusSpinner />
+        ) : (
+          <HugeiconsIcon icon={Cancel01Icon} size={16} />
+        )}
       </Button>
     </div>
   );
@@ -86,16 +93,22 @@ export function PromptSuggestions({
   const { data } = useGeoSuggestions(organizationId);
   const { data: searchConsoleStatus, isPending: isSearchConsolePending } =
     useGscStatus(organizationId);
-  const { dismiss, dismissed } = useGscCardDismissal(organizationId);
+  const { dismiss: dismissCard, dismissed } =
+    useGscCardDismissal(organizationId);
   const checking = useGscAnalyzing(organizationId);
   const accept = useGeoSuggestionAccept(organizationId);
   const acceptAll = useGeoSuggestionsAcceptAll(organizationId);
+  const dismissSuggestion = useGeoSuggestionDismiss(organizationId);
   const suggestions = data?.suggestions ?? [];
   const hasSuggestions = suggestions.length > 0;
   const acceptingSuggestionId = accept.isPending
     ? accept.variables?.suggestionId
     : undefined;
-  const trackingDisabled = accept.isPending || acceptAll.isPending;
+  const dismissingSuggestionId = dismissSuggestion.isPending
+    ? dismissSuggestion.variables?.suggestionId
+    : undefined;
+  const actionsDisabled =
+    accept.isPending || acceptAll.isPending || dismissSuggestion.isPending;
   const connectPromo =
     !isSearchConsolePending &&
     searchConsoleStatus !== undefined &&
@@ -190,9 +203,10 @@ export function PromptSuggestions({
       cell: (row) => (
         <SuggestionRowActions
           accepting={acceptingSuggestionId === row.id}
-          disabled={checking || trackingDisabled}
+          disabled={checking || actionsDisabled}
+          dismissing={dismissingSuggestionId === row.id}
           onAccept={() => accept.mutate({ suggestionId: row.id })}
-          organizationId={organizationId}
+          onDismiss={() => dismissSuggestion.mutate({ suggestionId: row.id })}
           suggestion={row}
         />
       ),
@@ -206,7 +220,7 @@ export function PromptSuggestions({
   const trackAllAction =
     !checking && suggestions.length > 1 ? (
       <Button
-        disabled={trackingDisabled}
+        disabled={actionsDisabled}
         onClick={() => acceptAll.mutate()}
         size="sm"
         variant="outline"
@@ -225,7 +239,7 @@ export function PromptSuggestions({
       action={trackAllAction}
       callbackPath={callbackPath}
       isPending={isSearchConsolePending}
-      onDismiss={connectPromo ? dismiss : undefined}
+      onDismiss={connectPromo ? dismissCard : undefined}
       organizationId={organizationId}
       status={searchConsoleStatus}
     />

--- a/apps/dashboard/src/components/geo/prompt-suggestions.tsx
+++ b/apps/dashboard/src/components/geo/prompt-suggestions.tsx
@@ -176,8 +176,13 @@ export function PromptSuggestions({
 
     trackAllQueued.current = true;
     setIsTrackAllQueued(true);
-    await Promise.allSettled([...pendingSuggestionRequests.current.values()]);
     try {
+      const pendingResults = await Promise.allSettled([
+        ...pendingSuggestionRequests.current.values(),
+      ]);
+      if (pendingResults.some((result) => result.status === "rejected")) {
+        return;
+      }
       await acceptAll.mutateAsync();
     } catch {
       // The mutation hook reports the error.

--- a/apps/dashboard/src/components/geo/prompt-suggestions.tsx
+++ b/apps/dashboard/src/components/geo/prompt-suggestions.tsx
@@ -2,6 +2,7 @@
 
 import { Cancel01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useRef, useState } from "react";
 
 import { Button } from "@/components/button";
 import { SearchConsoleToolbar } from "@/components/geo/search-console-card";
@@ -99,16 +100,18 @@ export function PromptSuggestions({
   const accept = useGeoSuggestionAccept(organizationId);
   const acceptAll = useGeoSuggestionsAcceptAll(organizationId);
   const dismissSuggestion = useGeoSuggestionDismiss(organizationId);
+  const [acceptingSuggestionIds, setAcceptingSuggestionIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [dismissingSuggestionIds, setDismissingSuggestionIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [isTrackAllQueued, setIsTrackAllQueued] = useState(false);
+  const pendingSuggestionRequests = useRef(new Map<string, Promise<unknown>>());
+  const trackAllQueued = useRef(false);
   const suggestions = data?.suggestions ?? [];
   const hasSuggestions = suggestions.length > 0;
-  const acceptingSuggestionId = accept.isPending
-    ? accept.variables?.suggestionId
-    : undefined;
-  const dismissingSuggestionId = dismissSuggestion.isPending
-    ? dismissSuggestion.variables?.suggestionId
-    : undefined;
-  const actionsDisabled =
-    accept.isPending || acceptAll.isPending || dismissSuggestion.isPending;
+  const trackAllPending = isTrackAllQueued || acceptAll.isPending;
   const connectPromo =
     !isSearchConsolePending &&
     searchConsoleStatus !== undefined &&
@@ -117,6 +120,72 @@ export function PromptSuggestions({
     dismissed &&
     (isSearchConsolePending || !searchConsoleStatus || connectPromo)
   );
+
+  const acceptSuggestion = (suggestionId: string) => {
+    if (
+      pendingSuggestionRequests.current.has(suggestionId) ||
+      trackAllQueued.current ||
+      acceptAll.isPending
+    ) {
+      return;
+    }
+
+    const request = accept.mutateAsync({ suggestionId });
+    pendingSuggestionRequests.current.set(suggestionId, request);
+    setAcceptingSuggestionIds((current) => new Set(current).add(suggestionId));
+    void request
+      .catch(() => undefined)
+      .finally(() => {
+        pendingSuggestionRequests.current.delete(suggestionId);
+        setAcceptingSuggestionIds((current) => {
+          const next = new Set(current);
+          next.delete(suggestionId);
+          return next;
+        });
+      });
+  };
+
+  const dismissPromptSuggestion = (suggestionId: string) => {
+    if (
+      pendingSuggestionRequests.current.has(suggestionId) ||
+      trackAllQueued.current ||
+      acceptAll.isPending
+    ) {
+      return;
+    }
+
+    const request = dismissSuggestion.mutateAsync({ suggestionId });
+    pendingSuggestionRequests.current.set(suggestionId, request);
+    setDismissingSuggestionIds((current) => new Set(current).add(suggestionId));
+    void request
+      .catch(() => undefined)
+      .finally(() => {
+        pendingSuggestionRequests.current.delete(suggestionId);
+        setDismissingSuggestionIds((current) => {
+          const next = new Set(current);
+          next.delete(suggestionId);
+          return next;
+        });
+      });
+  };
+
+  const acceptAllSuggestions = async () => {
+    if (trackAllQueued.current || acceptAll.isPending) {
+      return;
+    }
+
+    trackAllQueued.current = true;
+    setIsTrackAllQueued(true);
+    await Promise.allSettled([...pendingSuggestionRequests.current.values()]);
+    try {
+      await acceptAll.mutateAsync();
+    } catch {
+      // The mutation hook reports the error.
+    } finally {
+      trackAllQueued.current = false;
+      setIsTrackAllQueued(false);
+    }
+  };
 
   const columns: TableColumn<GeoPromptSuggestion>[] = [
     {
@@ -200,16 +269,20 @@ export function PromptSuggestions({
       header: "",
       minWidth: "8.5rem",
       width: "8.5rem",
-      cell: (row) => (
-        <SuggestionRowActions
-          accepting={acceptingSuggestionId === row.id}
-          disabled={checking || actionsDisabled}
-          dismissing={dismissingSuggestionId === row.id}
-          onAccept={() => accept.mutate({ suggestionId: row.id })}
-          onDismiss={() => dismissSuggestion.mutate({ suggestionId: row.id })}
-          suggestion={row}
-        />
-      ),
+      cell: (row) => {
+        const accepting = acceptingSuggestionIds.has(row.id);
+        const dismissing = dismissingSuggestionIds.has(row.id);
+        return (
+          <SuggestionRowActions
+            accepting={accepting}
+            disabled={checking || trackAllPending || accepting || dismissing}
+            dismissing={dismissing}
+            onAccept={() => acceptSuggestion(row.id)}
+            onDismiss={() => dismissPromptSuggestion(row.id)}
+            suggestion={row}
+          />
+        );
+      },
     },
   ];
 
@@ -220,17 +293,17 @@ export function PromptSuggestions({
   const trackAllAction =
     !checking && suggestions.length > 1 ? (
       <Button
-        disabled={actionsDisabled}
-        onClick={() => acceptAll.mutate()}
+        disabled={trackAllPending}
+        onClick={acceptAllSuggestions}
         size="sm"
         variant="outline"
       >
-        {acceptAll.isPending ? (
+        {trackAllPending ? (
           <StatusSpinner />
         ) : (
           <HugeiconsIcon icon={PlusSignIcon} size={14} />
         )}
-        {acceptAll.isPending ? "Adding…" : `Track all (${suggestions.length})`}
+        {trackAllPending ? "Adding…" : `Track all (${suggestions.length})`}
       </Button>
     ) : null;
 

--- a/apps/dashboard/src/components/geo/prompt-suggestions.tsx
+++ b/apps/dashboard/src/components/geo/prompt-suggestions.tsx
@@ -2,180 +2,205 @@
 
 import { Cancel01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Badge } from "@notra/ui/components/ui/badge";
-import { Card } from "@notra/ui/components/ui/card";
-import { Google } from "@notra/ui/components/ui/svgs/google";
-import { useId } from "react";
 
 import { Button } from "@/components/button";
+import { SearchConsoleToolbar } from "@/components/geo/search-console-card";
 import { StatusSpinner } from "@/components/geo/status-spinner";
+import { Table, type TableColumn } from "@/components/motion/table";
+import { TruncateWithTooltip } from "@/components/truncate-with-tooltip";
+import { TABLE_ROW_HEIGHT } from "@/constants/table";
 import {
   useGeoSuggestionAccept,
   useGeoSuggestionDismiss,
   useGeoSuggestions,
   useGeoSuggestionsAcceptAll,
   useGscAnalyzing,
+  useGscCardDismissal,
+  useGscStatus,
 } from "@/lib/hooks/use-geo";
-import { cn } from "@/lib/utils";
 import type {
   PromptSuggestionsProps,
-  SuggestionEvidenceProps,
-  SuggestionRowProps,
-  SuggestionStatusRowProps,
+  SuggestionRowActionsProps,
 } from "@/types/components/geo";
-import type { GeoSuggestionKeyword } from "@/types/geo";
+import type { GeoPromptSuggestion } from "@/types/geo";
+import { tableHeightFor } from "@/utils/table";
 
-const MAX_VISIBLE_KEYWORDS = 4;
-
-const compactNumber = new Intl.NumberFormat("en", {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
-
-function countedLabel(count: number, singular: string, plural: string): string {
-  return `${compactNumber.format(count)} ${count === 1 ? singular : plural}`;
+function totalImpressions(suggestion: GeoPromptSuggestion): number {
+  return suggestion.keywords.reduce(
+    (total, keyword) => total + keyword.impressions,
+    0
+  );
 }
 
-function keywordMetrics(
-  impressions: number,
-  clicks: number,
-  position: number,
-  positionLabel = "position"
-): string {
-  return `${countedLabel(impressions, "impression", "impressions")} · ${countedLabel(clicks, "click", "clicks")} · ${positionLabel} ${position.toFixed(1)}`;
+function totalClicks(suggestion: GeoPromptSuggestion): number {
+  return suggestion.keywords.reduce(
+    (total, keyword) => total + keyword.clicks,
+    0
+  );
 }
 
-function keywordTitle(keyword: GeoSuggestionKeyword): string {
-  return keywordMetrics(keyword.impressions, keyword.clicks, keyword.position);
-}
-
-function summarize(keywords: GeoSuggestionKeyword[]): string {
-  if (keywords.length === 0) {
-    return "No ranking queries yet";
+function bestPosition(suggestion: GeoPromptSuggestion): number | null {
+  if (suggestion.keywords.length === 0) {
+    return null;
   }
-  let impressions = 0;
-  let clicks = 0;
-  let bestPosition = Number.POSITIVE_INFINITY;
-  for (const keyword of keywords) {
-    impressions += keyword.impressions;
-    clicks += keyword.clicks;
-    if (keyword.position < bestPosition) {
-      bestPosition = keyword.position;
-    }
-  }
-  return keywordMetrics(
-    impressions,
-    clicks,
-    bestPosition,
-    keywords.length === 1 ? "position" : "best position"
-  );
+  return Math.min(...suggestion.keywords.map((keyword) => keyword.position));
 }
 
-function StatusRow({
-  action,
-  description,
-  icon,
-  title,
-  titleId,
-}: SuggestionStatusRowProps) {
-  return (
-    <div className="flex items-start gap-3 px-4 py-3">
-      <div className="mt-0.5 shrink-0">{icon}</div>
-      <div className="min-w-0 flex-1">
-        <p className="text-sm leading-snug font-medium" id={titleId}>
-          {title}
-        </p>
-        <p className="text-muted-foreground text-sm leading-snug">
-          {description}
-        </p>
-      </div>
-      {action ? <div className="shrink-0">{action}</div> : null}
-    </div>
-  );
-}
-
-function SuggestionEvidence({ keywords }: SuggestionEvidenceProps) {
-  const visible = keywords.slice(0, MAX_VISIBLE_KEYWORDS);
-  const hidden = keywords.length - visible.length;
-
-  return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-      {visible.map((keyword) => (
-        <Badge
-          className="font-normal"
-          key={keyword.query}
-          title={keywordTitle(keyword)}
-          variant="secondary"
-        >
-          {keyword.query}
-        </Badge>
-      ))}
-      {hidden > 0 ? (
-        <span className="text-muted-foreground text-xs">+{hidden} more</span>
-      ) : null}
-      <span className="text-muted-foreground text-xs">
-        {summarize(keywords)}
-      </span>
-    </div>
-  );
-}
-
-function SuggestionRow({
+function SuggestionRowActions({
   checking,
   organizationId,
   suggestion,
-}: SuggestionRowProps) {
+}: SuggestionRowActionsProps) {
   const accept = useGeoSuggestionAccept(organizationId);
   const dismiss = useGeoSuggestionDismiss(organizationId);
   const busy = checking || accept.isPending || dismiss.isPending;
 
   return (
-    <div className="flex items-start gap-3 px-4 py-3">
-      <div className="min-w-0 flex-1 space-y-1">
-        <p className="text-sm leading-snug font-medium">{suggestion.prompt}</p>
-        <SuggestionEvidence keywords={suggestion.keywords} />
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
-        <Button
-          disabled={busy}
-          onClick={() => accept.mutate({ suggestionId: suggestion.id })}
-          size="sm"
-          variant="outline"
-        >
-          {accept.isPending ? (
-            <StatusSpinner />
-          ) : (
-            <HugeiconsIcon icon={PlusSignIcon} size={14} />
-          )}
-          {accept.isPending ? "Adding…" : "Track"}
-        </Button>
-        <Button
-          aria-label="Dismiss suggestion"
-          disabled={busy}
-          onClick={() => dismiss.mutate({ suggestionId: suggestion.id })}
-          size="icon-sm"
-          variant="ghost"
-        >
-          <HugeiconsIcon icon={Cancel01Icon} size={16} />
-        </Button>
-      </div>
+    <div className="flex items-center justify-end gap-1">
+      <Button
+        disabled={busy}
+        onClick={() => accept.mutate({ suggestionId: suggestion.id })}
+        size="sm"
+        variant="outline"
+      >
+        {accept.isPending ? (
+          <StatusSpinner />
+        ) : (
+          <HugeiconsIcon icon={PlusSignIcon} size={14} />
+        )}
+        {accept.isPending ? "Adding…" : "Track"}
+      </Button>
+      <Button
+        aria-label={`Dismiss ${suggestion.prompt}`}
+        disabled={busy}
+        onClick={() => dismiss.mutate({ suggestionId: suggestion.id })}
+        size="icon-sm"
+        variant="ghost"
+      >
+        <HugeiconsIcon icon={Cancel01Icon} size={16} />
+      </Button>
     </div>
   );
 }
 
-export function PromptSuggestions({ organizationId }: PromptSuggestionsProps) {
-  const headingId = useId();
+export function PromptSuggestions({
+  organizationId,
+  callbackPath,
+}: PromptSuggestionsProps) {
   const { data } = useGeoSuggestions(organizationId);
+  const { data: searchConsoleStatus, isPending: isSearchConsolePending } =
+    useGscStatus(organizationId);
+  const { dismiss, dismissed } = useGscCardDismissal(organizationId);
   const checking = useGscAnalyzing(organizationId);
   const acceptAll = useGeoSuggestionsAcceptAll(organizationId);
   const suggestions = data?.suggestions ?? [];
   const hasSuggestions = suggestions.length > 0;
+  const connectPromo =
+    !isSearchConsolePending &&
+    searchConsoleStatus !== undefined &&
+    !searchConsoleStatus.connected;
+  const showSearchConsole = !(
+    dismissed &&
+    (isSearchConsolePending || !searchConsoleStatus || connectPromo)
+  );
 
-  if (!checking && !hasSuggestions) {
+  const columns: TableColumn<GeoPromptSuggestion>[] = [
+    {
+      key: "prompt",
+      header: (
+        <span className="inline-flex items-center gap-1.5">
+          Suggested prompt
+          <span className="text-muted-foreground font-normal tabular-nums">
+            ({suggestions.length})
+          </span>
+        </span>
+      ),
+      minWidth: "18rem",
+      sortable: true,
+      width: "1.5fr",
+      cell: (row) => (
+        <TruncateWithTooltip className="font-medium">
+          {row.prompt}
+        </TruncateWithTooltip>
+      ),
+    },
+    {
+      key: "queries",
+      header: "Search queries",
+      minWidth: "12rem",
+      sortable: true,
+      width: "1fr",
+      cell: (row) => (
+        <TruncateWithTooltip className="text-muted-foreground">
+          {row.keywords.map((keyword) => keyword.query).join(", ") || "-"}
+        </TruncateWithTooltip>
+      ),
+      sortValue: (row) =>
+        row.keywords.map((keyword) => keyword.query).join(", "),
+    },
+    {
+      key: "impressions",
+      align: "right",
+      header: "Impressions",
+      sortable: true,
+      width: "8.5rem",
+      cell: (row) => (
+        <span className="text-muted-foreground tabular-nums">
+          {totalImpressions(row).toLocaleString()}
+        </span>
+      ),
+      sortValue: totalImpressions,
+    },
+    {
+      key: "clicks",
+      align: "right",
+      header: "Clicks",
+      sortable: true,
+      width: "6.5rem",
+      cell: (row) => (
+        <span className="text-muted-foreground tabular-nums">
+          {totalClicks(row).toLocaleString()}
+        </span>
+      ),
+      sortValue: totalClicks,
+    },
+    {
+      key: "position",
+      align: "right",
+      header: "Best position",
+      sortable: true,
+      width: "8rem",
+      cell: (row) => {
+        const position = bestPosition(row);
+        return (
+          <span className="text-muted-foreground tabular-nums">
+            {position === null ? "-" : position.toFixed(1)}
+          </span>
+        );
+      },
+      sortValue: (row) => bestPosition(row) ?? Number.MAX_SAFE_INTEGER,
+    },
+    {
+      key: "actions",
+      align: "right",
+      header: "",
+      minWidth: "8.5rem",
+      width: "8.5rem",
+      cell: (row) => (
+        <SuggestionRowActions
+          checking={checking}
+          organizationId={organizationId}
+          suggestion={row}
+        />
+      ),
+    },
+  ];
+
+  if (!(checking || hasSuggestions || showSearchConsole)) {
     return null;
   }
 
-  const headerAction =
+  const trackAllAction =
     !checking && suggestions.length > 1 ? (
       <Button
         disabled={acceptAll.isPending}
@@ -192,50 +217,45 @@ export function PromptSuggestions({ organizationId }: PromptSuggestionsProps) {
       </Button>
     ) : null;
 
+  const toolbar = showSearchConsole ? (
+    <SearchConsoleToolbar
+      action={trackAllAction}
+      callbackPath={callbackPath}
+      isPending={isSearchConsolePending}
+      onDismiss={connectPromo ? dismiss : undefined}
+      organizationId={organizationId}
+      status={searchConsoleStatus}
+    />
+  ) : (
+    <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+      <div className="min-w-0 space-y-1">
+        <div className="flex items-center gap-2">
+          {checking ? <StatusSpinner /> : null}
+          <p className="text-sm leading-snug font-medium">Suggested prompts</p>
+        </div>
+        <p className="text-muted-foreground text-xs leading-snug">
+          Based on queries your site already ranks for
+        </p>
+      </div>
+      {trackAllAction}
+    </div>
+  );
+
   return (
-    <Card
-      aria-busy={checking}
-      aria-labelledby={headingId}
-      className="gap-0 py-0"
-      role="region"
-    >
-      {checking ? (
-        <output className="block">
-          <StatusRow
-            description="Looking through queries your site already ranks for."
-            icon={<StatusSpinner />}
-            title="Checking for prompt suggestions…"
-            titleId={headingId}
-          />
-        </output>
-      ) : (
-        <StatusRow
-          action={headerAction}
-          description="You already rank for these searches. Track how AI assistants answer the same questions."
-          icon={
-            <span className="inline-flex size-5 items-center justify-center">
-              <Google className="size-4" />
-            </span>
-          }
-          title="Suggested from Google Search"
-          titleId={headingId}
-        />
-      )}
-      {hasSuggestions ? (
-        <>
-          <div className="border-border/80 mx-4 border-t" />
-          <div className={cn(suggestions.length > 1 && "divide-y")}>
-            {suggestions.map((suggestion) => (
-              <SuggestionRow
-                checking={checking}
-                key={suggestion.id}
-                organizationId={organizationId}
-                suggestion={suggestion}
-              />
-            ))}
-          </div>
-        </>
-      ) : null}
-    </Card>
+    <section aria-busy={checking} aria-label="Suggested prompts">
+      <Table
+        className="rounded-2xl"
+        columns={columns}
+        data={suggestions}
+        defaultSort={{ key: "impressions", direction: "desc" }}
+        emptyState="No Google Search suggestions yet"
+        getRowId={(row) => row.id}
+        height={tableHeightFor(Math.max(suggestions.length, checking ? 3 : 1))}
+        loading={checking && !hasSuggestions}
+        resizable
+        rowHeight={TABLE_ROW_HEIGHT}
+        toolbar={toolbar}
+      />
+    </section>
   );
 }

--- a/apps/dashboard/src/components/geo/search-console-card.tsx
+++ b/apps/dashboard/src/components/geo/search-console-card.tsx
@@ -11,7 +11,6 @@ import {
   ResponsiveDialogTrigger,
 } from "@notra/ui/components/shared/responsive-dialog";
 import { Badge } from "@notra/ui/components/ui/badge";
-import { Card } from "@notra/ui/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,23 +35,21 @@ import { useGeoProjectScope } from "@/components/providers/geo-project-provider"
 import { GSC_OAUTH_AUTHORIZE_PATH } from "@/constants/google-search-console";
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import {
-  useGscCardDismissal,
   useGscDisconnect,
   useGscSelectSite,
   useGscSites,
-  useGscStatus,
   useGscSync,
   useGeoProjects,
 } from "@/lib/hooks/use-geo";
 import { useGscConnectionToast } from "@/lib/hooks/use-gsc-connection-toast";
 import { cn } from "@/lib/utils";
 import type {
-  SearchConsoleCardProps,
   SearchConsoleConnectActionProps,
   SearchConsoleConnectedStateProps,
   SearchConsoleHeaderRowProps,
   SearchConsolePropertyPickerProps,
   SearchConsoleSelectSiteStateProps,
+  SearchConsoleToolbarProps,
 } from "@/types/components/geo";
 import type { GeoSearchConsoleStatus } from "@/types/google-search-console";
 import { formatRelative } from "@/utils/format-relative";
@@ -289,6 +286,7 @@ function connectedMeta(status: GeoSearchConsoleStatus): string {
 }
 
 function ConnectedState({
+  action,
   organizationId,
   callbackPath,
   status,
@@ -343,10 +341,23 @@ function ConnectedState({
 
   return (
     <>
-      <div className="flex items-center gap-3 px-4 py-3">
+      <div
+        aria-label="Google Search Console"
+        className="flex flex-wrap items-center gap-3 px-4 py-3"
+        role="region"
+      >
+        <span className="inline-flex size-5 shrink-0 items-center justify-center">
+          <Google className="size-4" />
+        </span>
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex flex-wrap items-center gap-2">
-            <p className="truncate text-sm leading-snug font-medium">
+            <p className="text-sm leading-snug font-medium">
+              Google Search Console
+            </p>
+            <span className="text-muted-foreground text-xs" aria-hidden>
+              ·
+            </span>
+            <p className="text-muted-foreground truncate text-sm leading-snug">
               {formatGscSiteUrl(status.siteUrl ?? "")}
             </p>
             {status.weeklySyncScheduled ? (
@@ -360,15 +371,6 @@ function ConnectedState({
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <Button
-            disabled={busy}
-            onClick={() => sync.mutate()}
-            size="sm"
-            variant="outline"
-          >
-            {sync.isPending ? <StatusSpinner /> : null}
-            {sync.isPending ? "Syncing…" : "Sync now"}
-          </Button>
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -398,6 +400,16 @@ function ConnectedState({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          <Button
+            disabled={busy}
+            onClick={() => sync.mutate()}
+            size="sm"
+            variant="outline"
+          >
+            {sync.isPending ? <StatusSpinner /> : null}
+            {sync.isPending ? "Syncing…" : "Sync now"}
+          </Button>
+          {action}
         </div>
       </div>
       <ResponsiveDialog onOpenChange={setChangeOpen} open={changeOpen}>
@@ -417,15 +429,17 @@ function ConnectedState({
   );
 }
 
-export function SearchConsoleCard({
+export function SearchConsoleToolbar({
+  action,
   organizationId,
   callbackPath,
-}: SearchConsoleCardProps) {
+  isPending,
+  onDismiss,
+  status,
+}: SearchConsoleToolbarProps) {
   const headingId = useId();
   const { projectId } = useGeoProjectScope();
   useGscConnectionToast();
-  const { data: status, isPending } = useGscStatus(organizationId);
-  const { dismiss, dismissed } = useGscCardDismissal(organizationId);
   const { data: projectsData } = useGeoProjects(organizationId);
   const { data: brandData } = useBrandSettings(organizationId);
 
@@ -439,14 +453,25 @@ export function SearchConsoleCard({
       (voice) => voice.id === activeProject?.brandSettingsId
     )?.websiteUrl ?? null;
 
-  const connectPromo = !isPending && status !== undefined && !status.connected;
-
-  if (dismissed && (isPending || !status || connectPromo)) {
-    return null;
+  if (
+    !isPending &&
+    status?.connected &&
+    status.status === "active" &&
+    status.siteUrl
+  ) {
+    return (
+      <ConnectedState
+        action={action}
+        callbackPath={callbackPath}
+        organizationId={organizationId}
+        status={status}
+        websiteUrl={websiteUrl}
+      />
+    );
   }
 
   let body: ReactNode = null;
-  let headerAction: ReactNode = null;
+  let headerAction = action;
 
   if (isPending || !status) {
     body = (
@@ -456,13 +481,21 @@ export function SearchConsoleCard({
       </div>
     );
   } else if (!status.connected || status.status === "reauth_required") {
-    headerAction = (
+    const connectAction = (
       <ConnectAction
         callbackPath={callbackPath}
         configured={status.configured}
         organizationId={organizationId}
         reauth={status.status === "reauth_required"}
       />
+    );
+    headerAction = action ? (
+      <div className="flex items-center gap-2">
+        {connectAction}
+        {action}
+      </div>
+    ) : (
+      connectAction
     );
     if (status.status === "reauth_required") {
       body = (
@@ -471,15 +504,6 @@ export function SearchConsoleCard({
         </p>
       );
     }
-  } else if (status.siteUrl) {
-    body = (
-      <ConnectedState
-        callbackPath={callbackPath}
-        organizationId={organizationId}
-        status={status}
-        websiteUrl={websiteUrl}
-      />
-    );
   } else {
     body = (
       <SelectSiteState
@@ -493,15 +517,10 @@ export function SearchConsoleCard({
   }
 
   return (
-    <Card
-      aria-busy={isPending}
-      aria-labelledby={headingId}
-      className="gap-0 py-0"
-      role="region"
-    >
+    <div aria-busy={isPending} aria-labelledby={headingId} role="region">
       <HeaderRow
         action={headerAction}
-        onDismiss={connectPromo ? dismiss : undefined}
+        onDismiss={onDismiss}
         titleId={headingId}
       />
       {body ? (
@@ -510,6 +529,6 @@ export function SearchConsoleCard({
           {body}
         </>
       ) : null}
-    </Card>
+    </div>
   );
 }

--- a/apps/dashboard/src/components/geo/skeleton-parts.tsx
+++ b/apps/dashboard/src/components/geo/skeleton-parts.tsx
@@ -30,10 +30,11 @@ export function GeoSectionSkeleton({
   );
 }
 
-export function GeoTableSkeleton({ rows }: GeoTableSkeletonProps) {
+export function GeoTableSkeleton({ rows, toolbar }: GeoTableSkeletonProps) {
   const id = useId();
   return (
     <div className="border-border overflow-hidden rounded-2xl border">
+      {toolbar ? <div className="border-border border-b">{toolbar}</div> : null}
       <div className="bg-muted/40 flex h-10 items-center justify-between px-4">
         <Skeleton className="h-3.5 w-28" />
         <Skeleton className="h-3.5 w-16" />

--- a/apps/dashboard/src/components/motion/table/index.tsx
+++ b/apps/dashboard/src/components/motion/table/index.tsx
@@ -62,6 +62,7 @@ export function Table<T>({
   onRowClick,
   onRowPointerEnter,
   isRowPinned,
+  toolbar,
   className,
 }: TableProps<T>) {
   "use no memo";
@@ -286,49 +287,54 @@ export function Table<T>({
   return (
     <div className={cn("w-full text-sm", className)}>
       {/* Overlap (>= rounded-2xl) hides the header's side border in the body radius. */}
-      <div
-        className="border-border bg-muted overflow-hidden rounded-t-2xl border border-b-0 pb-5"
-        ref={headerScrollRef}
-        style={scrolls ? { scrollbarGutter: "stable" } : undefined}
-      >
-        <table
-          className={cn(
-            "border-collapse",
-            sized ? "w-max min-w-full" : "w-full"
-          )}
-          style={{ tableLayout: "fixed" }}
+      <div className="border-border bg-muted overflow-hidden rounded-t-2xl border border-b-0 pb-5">
+        {toolbar ? (
+          <div className="border-border bg-background border-b">{toolbar}</div>
+        ) : null}
+        <div
+          className="overflow-hidden"
+          ref={headerScrollRef}
+          style={scrolls ? { scrollbarGutter: "stable" } : undefined}
         >
-          {columnGroup}
-          <TableHeader
-            activeColumn={hasColumnMenu ? activeColumn : null}
-            allSelected={allSelected}
-            columns={orderedColumns}
-            dragKey={dragKey}
-            dropIndex={dropIndex}
-            minColumnWidth={minColumnWidth}
-            onColumnActivate={hasColumnMenu ? activateColumn : undefined}
-            onColumnDeactivate={hasColumnMenu ? deactivateColumn : undefined}
-            onColumnRename={onColumnRename}
-            onDeleteColumn={onDeleteColumn}
-            onInsertColumn={onInsertColumn}
-            onReorderEnd={endReorder}
-            onReorderMove={moveReorder}
-            onReorderStart={startReorder}
-            onResizeEnd={endResize}
-            onResizeMove={moveResize}
-            onResizeStart={startResize}
-            onToggleAll={toggleAll}
-            onToggleSort={toggleSort}
-            reduce={!!reduce}
-            reorderable={reorderable}
-            resizable={resizable}
-            rowHeight={rowHeight}
-            selectable={selectable}
-            someSelected={someSelected}
-            sort={sort}
-            thRefs={thRefs}
-          />
-        </table>
+          <table
+            className={cn(
+              "border-collapse",
+              sized ? "w-max min-w-full" : "w-full"
+            )}
+            style={{ tableLayout: "fixed" }}
+          >
+            {columnGroup}
+            <TableHeader
+              activeColumn={hasColumnMenu ? activeColumn : null}
+              allSelected={allSelected}
+              columns={orderedColumns}
+              dragKey={dragKey}
+              dropIndex={dropIndex}
+              minColumnWidth={minColumnWidth}
+              onColumnActivate={hasColumnMenu ? activateColumn : undefined}
+              onColumnDeactivate={hasColumnMenu ? deactivateColumn : undefined}
+              onColumnRename={onColumnRename}
+              onDeleteColumn={onDeleteColumn}
+              onInsertColumn={onInsertColumn}
+              onReorderEnd={endReorder}
+              onReorderMove={moveReorder}
+              onReorderStart={startReorder}
+              onResizeEnd={endResize}
+              onResizeMove={moveResize}
+              onResizeStart={startResize}
+              onToggleAll={toggleAll}
+              onToggleSort={toggleSort}
+              reduce={!!reduce}
+              reorderable={reorderable}
+              resizable={resizable}
+              rowHeight={rowHeight}
+              selectable={selectable}
+              someSelected={someSelected}
+              sort={sort}
+              thRefs={thRefs}
+            />
+          </table>
+        </div>
       </div>
 
       <div

--- a/apps/dashboard/src/components/motion/table/types.ts
+++ b/apps/dashboard/src/components/motion/table/types.ts
@@ -83,6 +83,8 @@ export interface TableProps<T> {
   onRowPointerEnter?: (row: T) => void;
   /** Keep matching rows first after sort. They scroll with the table (not sticky). */
   isRowPinned?: (row: T) => boolean;
+  /** Content rendered above the column headers inside the table surface. */
+  toolbar?: ReactNode;
   emptyState?: ReactNode;
   className?: string;
 }

--- a/apps/dashboard/src/types/components/geo.ts
+++ b/apps/dashboard/src/types/components/geo.ts
@@ -11,8 +11,9 @@ export interface PromptSuggestionsProps {
 export interface SuggestionRowActionsProps {
   accepting: boolean;
   disabled: boolean;
+  dismissing: boolean;
   onAccept: () => void;
-  organizationId: string;
+  onDismiss: () => void;
   suggestion: GeoPromptSuggestion;
 }
 

--- a/apps/dashboard/src/types/components/geo.ts
+++ b/apps/dashboard/src/types/components/geo.ts
@@ -9,7 +9,9 @@ export interface PromptSuggestionsProps {
 }
 
 export interface SuggestionRowActionsProps {
-  checking: boolean;
+  accepting: boolean;
+  disabled: boolean;
+  onAccept: () => void;
   organizationId: string;
   suggestion: GeoPromptSuggestion;
 }

--- a/apps/dashboard/src/types/components/geo.ts
+++ b/apps/dashboard/src/types/components/geo.ts
@@ -1,33 +1,26 @@
 import type { ReactNode } from "react";
 
-import type { GeoPromptSuggestion, GeoSuggestionKeyword } from "@/types/geo";
+import type { GeoPromptSuggestion } from "@/types/geo";
 import type { GeoSearchConsoleStatus } from "@/types/google-search-console";
 
 export interface PromptSuggestionsProps {
   organizationId: string;
+  callbackPath: string;
 }
 
-export interface SuggestionStatusRowProps {
-  action?: ReactNode;
-  description: string;
-  icon: ReactNode;
-  title: string;
-  titleId?: string;
-}
-
-export interface SuggestionEvidenceProps {
-  keywords: GeoSuggestionKeyword[];
-}
-
-export interface SuggestionRowProps {
+export interface SuggestionRowActionsProps {
   checking: boolean;
   organizationId: string;
   suggestion: GeoPromptSuggestion;
 }
 
-export interface SearchConsoleCardProps {
+export interface SearchConsoleToolbarProps {
+  action?: ReactNode;
   organizationId: string;
   callbackPath: string;
+  isPending: boolean;
+  onDismiss?: () => void;
+  status: GeoSearchConsoleStatus | undefined;
 }
 
 export interface SearchConsoleHeaderRowProps {
@@ -58,6 +51,7 @@ export interface SearchConsolePropertyPickerProps {
 }
 
 export interface SearchConsoleConnectedStateProps {
+  action?: ReactNode;
   organizationId: string;
   callbackPath: string;
   status: GeoSearchConsoleStatus;

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -1745,6 +1745,7 @@ export interface GeoSectionSkeletonProps {
 
 export interface GeoTableSkeletonProps {
   rows: number;
+  toolbar?: ReactNode;
 }
 
 export interface GeoSettingsSkeletonSectionProps {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the separate Search Console card and suggestion list on the geo prompts page with one sortable, resizable table. The Search Console connection state, sync control, and connect prompt now render as the table toolbar instead of a separate card.

- Suggestion rows show prompt, search queries, impressions, clicks, and best position with sorting and column resizing.
- Accepting or dismissing a row disables only that row's actions; other rows stay interactive.
- Track all waits for in-flight row requests and skips running entirely if any of them failed.
- Dismissing the connect prompt collapses the toolbar to a compact "Suggested prompts" header that keeps the Track all action; the dismissal persists across visits.
- The loading skeleton matches the new table and toolbar layout.

<sup>Written for commit e687641e3cc6c76cebb937080db87ff5a8bb3bd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

