### PR TITLE
fix(ui): remove dropdown backdrops

### DIFF
--- a/apps/dashboard/src/components/content/content-chat-activity-panel.tsx
+++ b/apps/dashboard/src/components/content/content-chat-activity-panel.tsx
@@ -203,7 +203,6 @@ export function ContentChatActivityPanel({
             <DropdownMenuContent
               align="end"
               className="max-h-72 w-52"
-              showBackdrop={false}
               sideOffset={6}
             >
               {isHistoryLoading ? (

--- a/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
+++ b/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
@@ -284,7 +284,6 @@ export function ChatHistoryNav() {
                         <DropdownMenuContent
                           align="start"
                           className="w-44"
-                          showBackdrop={false}
                           side="right"
                           sideOffset={6}
                         >

--- a/apps/dashboard/src/components/dashboard/chat-topbar-title.tsx
+++ b/apps/dashboard/src/components/dashboard/chat-topbar-title.tsx
@@ -215,7 +215,6 @@ export function ChatTopbarTitle({ chatId }: ChatTopbarTitleProps) {
                 <DropdownMenuContent
                   align="start"
                   className="w-44"
-                  showBackdrop={false}
                   sideOffset={6}
                 >
                   <DropdownMenuItem

--- a/apps/web/src/components/blog-copy-article.tsx
+++ b/apps/web/src/components/blog-copy-article.tsx
@@ -111,7 +111,6 @@ export function BlogCopyArticle({
         <DropdownMenuContent
           align="end"
           className="w-80 p-2"
-          showBackdrop={false}
         >
           <DropdownMenuItem
             className="px-2 py-2"

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -539,7 +539,6 @@ function MessageMarkdownTable({
             <DropdownMenuContent
               align="end"
               className="w-44 min-w-44"
-              showBackdrop={false}
             >
               <DropdownMenuItem
                 className="whitespace-nowrap"

--- a/packages/ui/src/components/brainless/chatgpt/chatgpt-model-selector.tsx
+++ b/packages/ui/src/components/brainless/chatgpt/chatgpt-model-selector.tsx
@@ -79,7 +79,6 @@ export function ChatgptModelSelector({
       <DropdownMenuContent
         align="end"
         className={cn("w-64", MENU_SURFACE)}
-        showBackdrop={false}
         side="top"
         sideOffset={8}
       >

--- a/packages/ui/src/components/brainless/claude-chat/claude-chat-model-selector.tsx
+++ b/packages/ui/src/components/brainless/claude-chat/claude-chat-model-selector.tsx
@@ -89,7 +89,6 @@ export function ClaudeChatModelSelector({
       <DropdownMenuContent
         align="end"
         className={cn("w-64", MENU_SURFACE)}
-        showBackdrop={false}
         side="top"
         sideOffset={8}
       >

--- a/packages/ui/src/components/brainless/gemini/gemini-model-selector.tsx
+++ b/packages/ui/src/components/brainless/gemini/gemini-model-selector.tsx
@@ -106,7 +106,6 @@ export function GeminiModelSelector({
       <DropdownMenuContent
         align="end"
         className={MENU_SURFACE}
-        showBackdrop={false}
         side="top"
         sideOffset={10}
       >

--- a/packages/ui/src/components/brainless/perplexity/perplexity-composer.tsx
+++ b/packages/ui/src/components/brainless/perplexity/perplexity-composer.tsx
@@ -211,7 +211,6 @@ export function PerplexityComposer({
             <DropdownMenuContent
               align="start"
               className="min-w-52 rounded-[1.2rem] p-1.5 shadow-[0_8px_28px_rgba(0,0,0,0.12)]"
-              showBackdrop={false}
               side="top"
               sideOffset={8}
             >

--- a/packages/ui/src/components/brainless/perplexity/perplexity-model-selector.tsx
+++ b/packages/ui/src/components/brainless/perplexity/perplexity-model-selector.tsx
@@ -102,7 +102,6 @@ export function PerplexityModelSelector({
       <DropdownMenuContent
         align="end"
         className={MENU_SURFACE}
-        showBackdrop={false}
         side="top"
         sideOffset={10}
       >

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -23,24 +23,15 @@ function DropdownMenuContent({
   alignOffset = 0,
   side = "bottom",
   sideOffset = 4,
-  showBackdrop = true,
   className,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  > & {
-    showBackdrop?: boolean;
-  }) {
+  >) {
   return (
     <MenuPrimitive.Portal>
-      {showBackdrop ? (
-        <MenuPrimitive.Backdrop
-          className="data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-40 bg-black/8 duration-100 data-closed:animate-out data-open:animate-in dark:bg-black/30"
-          data-slot="dropdown-menu-backdrop"
-        />
-      ) : null}
       <MenuPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
@@ -163,7 +154,6 @@ function DropdownMenuSubContent({
         className
       )}
       data-slot="dropdown-menu-sub-content"
-      showBackdrop={false}
       side={side}
       sideOffset={sideOffset}
       {...props}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dark backdrop overlay from dropdown menus so they no longer dim the page behind them.

- Deletes the `showBackdrop` prop from `DropdownMenuContent` and all 10 call sites across dashboard, web, and UI packages.
- Submenus already had backdrops disabled; this makes all dropdowns behave consistently.

<sup>Written for commit 04b0e5fe289e69d0aadf16a10c75e4fd38d97595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

