### PR TITLE
fix(geo): prevent conversation action overlap

### DIFF
--- a/apps/dashboard/src/components/geo/conversations-card.tsx
+++ b/apps/dashboard/src/components/geo/conversations-card.tsx
@@ -27,7 +27,7 @@ import type { ConversationsCardProps, GeoPromptSequence } from "@/types/geo";
 import { tableHeightFor } from "@/utils/table";
 
 const CONVERSATION_TURNS_WIDTH = "4.5rem";
-const CONVERSATION_ACTIONS_WIDTH = "9rem";
+const CONVERSATION_ACTIONS_WIDTH = "11.25rem";
 
 function ConversationRowActions({
   sequence,
@@ -87,6 +87,7 @@ function ConversationRowActions({
                   : `Enable ${sequence.name}`
               }
               checked={sequence.enabled}
+              className="mx-2"
               disabled={isPending}
               onCheckedChange={onToggle}
               onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the geo conversation action layout so the enable/disable toggle no longer overlaps adjacent elements in the conversations card.

<sup>Written for commit 8a77dcd1821d88ccaf8862f6ae844afbbf89d665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

