### PR TITLE
fix(geo): polish mention activity views

### DIFF
--- a/apps/dashboard/src/app/design-system/geo-demo/page.tsx
+++ b/apps/dashboard/src/app/design-system/geo-demo/page.tsx
@@ -1,0 +1,24 @@
+import { MentionRateCard } from "@/components/geo/mention-rate-card";
+import { MentionTrendCard } from "@/components/geo/mention-trend-card";
+import {
+  DESIGN_SYSTEM_GEO_OVERVIEW,
+  DESIGN_SYSTEM_GEO_POINTS,
+} from "@/constants/design-system-geo";
+
+export default function GeoDemoPage() {
+  return (
+    <main className="bg-muted/30 min-h-screen p-8 lg:p-12">
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-3 lg:grid-cols-12">
+        <div className="lg:col-span-5">
+          <MentionRateCard
+            engines={DESIGN_SYSTEM_GEO_OVERVIEW}
+            timeseriesPoints={DESIGN_SYSTEM_GEO_POINTS}
+          />
+        </div>
+        <div className="h-[430px] lg:col-span-7">
+          <MentionTrendCard points={DESIGN_SYSTEM_GEO_POINTS} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/components/evilcharts/charts/echarts-area-chart.tsx
+++ b/apps/dashboard/src/components/evilcharts/charts/echarts-area-chart.tsx
@@ -74,6 +74,7 @@ import type {
   ChartMarker,
   TooltipBodyItem,
   TooltipEmptyLabel,
+  TooltipLabelFormatter,
   TooltipLayout,
   TooltipValueFormatter,
 } from "@/types/charts";
@@ -262,6 +263,7 @@ export interface YAxisProps {
   tickFormatter?: (value: number, index: number) => string; // formats y tick labels
   label?: string; // axis title, rotated alongside the tick labels
   hideDots?: boolean; // hides the tick dots beside this axis's labels
+  scale?: boolean; // when true, choose a data-relative range instead of forcing zero into view
 }
 
 /** Presence shows the y value axis. Renders nothing. */
@@ -283,6 +285,8 @@ export interface TooltipProps {
   position?: TooltipPosition; // "variable" follows both axes (default); "fixed" pins the tooltip near the top and sits beside the pointer's X
   layout?: TooltipLayout; // "rows" is the default swatch list; "bars" ranks series as a mini bar chart
   valueFormatter?: TooltipValueFormatter;
+  labelKey?: string; // optional row key used for the tooltip heading instead of the x-axis value
+  labelFormatter?: TooltipLabelFormatter;
   barMax?: number; // bar layout: scale tracks to this ceiling (e.g. 100 for percents); omit to scale to the hovered max
   confine?: boolean; // keep the tooltip inside the chart rect (default true); false lets small sparklines overflow
   // When set, tooltip rows come from these data keys at the hovered index
@@ -342,6 +346,7 @@ type YAxisSlot = {
   tickFormatter?: (value: number, index: number) => string;
   label?: string;
   hideDots: boolean;
+  scale: boolean;
 };
 type TooltipSlot = {
   present: boolean;
@@ -352,6 +357,8 @@ type TooltipSlot = {
   position: TooltipPosition;
   layout: TooltipLayout;
   valueFormatter?: TooltipValueFormatter;
+  labelKey?: string;
+  labelFormatter?: TooltipLabelFormatter;
   barMax?: number;
   confine: boolean;
   rowKeys?: readonly string[];
@@ -387,7 +394,7 @@ type CollectedConfig = {
 function collectConfig(children: ReactNode): CollectedConfig {
   const areas: AreaSeriesConfig[] = [];
   let xAxis: XAxisSlot = { present: false, hideDots: false };
-  let yAxis: YAxisSlot = { present: false, hideDots: false };
+  let yAxis: YAxisSlot = { present: false, hideDots: false, scale: false };
   let showGrid = false;
   let gridVariant: GridLineVariant = "dashed";
   let tooltip: TooltipSlot = {
@@ -458,6 +465,7 @@ function collectConfig(children: ReactNode): CollectedConfig {
         tickFormatter: props.tickFormatter,
         label: props.label,
         hideDots: props.hideDots ?? false,
+        scale: props.scale ?? false,
       };
     } else if (type === Grid) {
       showGrid = true;
@@ -474,6 +482,8 @@ function collectConfig(children: ReactNode): CollectedConfig {
         position: props.position ?? "variable",
         layout: props.layout ?? "rows",
         valueFormatter: props.valueFormatter,
+        labelKey: props.labelKey,
+        labelFormatter: props.labelFormatter,
         barMax: props.barMax,
         confine: props.confine ?? true,
         rowKeys: props.rowKeys,
@@ -970,6 +980,7 @@ function buildMainAxes(ctx: OptionBuildContext): {
     type: "value",
     show: yAxisSlot.present || showGrid,
     max: isExpanded ? 1 : undefined,
+    scale: !isExpanded && yAxisSlot.scale,
     // Axis title — rendered rotated alongside the tick labels, same styling.
     name: isLoading ? undefined : yAxisSlot.label,
     nameLocation: "middle",
@@ -1042,11 +1053,19 @@ function createTooltipFormatter(ctx: OptionBuildContext) {
       name?: string;
       dataIndex?: number;
     };
-    // Label shows the RAW axis value — matches ChartTooltipContent (no tick formatter).
-    const axisValue = first.axisValue ?? first.name ?? "";
-    const label = String(axisValue);
     const hoveredRow =
       typeof first.dataIndex === "number" ? data[first.dataIndex] : undefined;
+    // Label shows the raw axis value unless the tooltip opts into a more
+    // descriptive value held on the hovered row.
+    const axisValue = first.axisValue ?? first.name ?? "";
+    const labelValue =
+      tooltipSlot.labelKey && hoveredRow?.[tooltipSlot.labelKey] != null
+        ? hoveredRow[tooltipSlot.labelKey]
+        : axisValue;
+    const rawLabel = String(labelValue);
+    const label = tooltipSlot.labelFormatter
+      ? tooltipSlot.labelFormatter(rawLabel)
+      : rawLabel;
     const rowKeys = tooltipSlot.rowKeys;
     if (rowKeys && rowKeys.length > 0 && typeof first.dataIndex === "number") {
       const items = tooltipItemsFromRow(

--- a/apps/dashboard/src/components/evilcharts/ui/echarts-tooltip.tsx
+++ b/apps/dashboard/src/components/evilcharts/ui/echarts-tooltip.tsx
@@ -230,10 +230,9 @@ function tooltipActivityRow(item: TooltipBodyItem, max: number): string {
       ? tooltipColorSwatchHtml(item.paint)
       : tooltipIndicatorHtml(item.key, item.colorsCount));
   const width = tooltipBarWidth(item.value ?? 0, max);
-  return `<div class="relative grid h-8 grid-cols-[2rem_minmax(0,1fr)_auto] overflow-hidden rounded-[7px] border border-white/[0.14] bg-white/[0.025]${item.dimmed}">
+  return `<div class="relative grid h-8 grid-cols-[minmax(0,1fr)_auto] overflow-hidden rounded-[7px] border border-white/[0.14] bg-white/[0.025]${item.dimmed}">
           <span class="absolute inset-y-0 left-0 rounded-r-[5px] bg-white/[0.16]" style="width:${width}%;${TOOLTIP_BAR_MOTION_STYLE}"></span>
-          <span class="relative flex items-center justify-center text-white">${indicatorHtml}</span>
-          <span class="relative flex min-w-0 items-center px-2.5 text-[11px] font-medium text-zinc-200"><span class="truncate">${escapeHtml(item.labelText)}</span></span>
+          <span class="relative flex min-w-0 items-center gap-2 px-2.5 text-[11px] font-medium text-zinc-200">${indicatorHtml}<span class="truncate">${escapeHtml(item.labelText)}</span></span>
           <span class="relative flex min-w-9 items-center justify-end px-2.5 font-mono text-[11px] font-semibold text-white tabular-nums" style="${TOOLTIP_VALUE_MOTION_STYLE}">${escapeHtml(item.valueText)}</span>
         </div>`;
 }

--- a/apps/dashboard/src/components/evilcharts/ui/echarts-tooltip.tsx
+++ b/apps/dashboard/src/components/evilcharts/ui/echarts-tooltip.tsx
@@ -223,12 +223,38 @@ export function tooltipEmptyBody(label: string): string {
   return `<span class="text-muted-foreground">${escapeHtml(label)}</span>`;
 }
 
+function tooltipActivityRow(item: TooltipBodyItem, max: number): string {
+  const indicatorHtml =
+    item.indicatorHtml ??
+    (item.paint
+      ? tooltipColorSwatchHtml(item.paint)
+      : tooltipIndicatorHtml(item.key, item.colorsCount));
+  const width = tooltipBarWidth(item.value ?? 0, max);
+  return `<div class="relative grid h-8 grid-cols-[2rem_minmax(0,1fr)_auto] overflow-hidden rounded-[7px] border border-white/[0.14] bg-white/[0.025]${item.dimmed}">
+          <span class="absolute inset-y-0 left-0 rounded-r-[5px] bg-white/[0.16]" style="width:${width}%;${TOOLTIP_BAR_MOTION_STYLE}"></span>
+          <span class="relative flex items-center justify-center text-white">${indicatorHtml}</span>
+          <span class="relative flex min-w-0 items-center px-2.5 text-[11px] font-medium text-zinc-200"><span class="truncate">${escapeHtml(item.labelText)}</span></span>
+          <span class="relative flex min-w-9 items-center justify-end px-2.5 font-mono text-[11px] font-semibold text-white tabular-nums" style="${TOOLTIP_VALUE_MOTION_STYLE}">${escapeHtml(item.valueText)}</span>
+        </div>`;
+}
+
+function tooltipActivityBody(items: readonly TooltipBodyItem[]): string {
+  const ranked = [...items].sort(
+    (left, right) => (right.value ?? -1) - (left.value ?? -1)
+  );
+  const total = ranked.reduce((sum, item) => sum + (item.value ?? 0), 0);
+  return ranked.map((item) => tooltipActivityRow(item, total)).join("");
+}
+
 export function composeTooltipBody(
   items: readonly TooltipBodyItem[],
   layout: TooltipLayout,
   barMax?: number
 ): string {
-  if (layout !== "bars") {
+  if (layout === "activity") {
+    return tooltipActivityBody(items);
+  }
+  if (layout === "rows") {
     return items
       .map((item) =>
         tooltipRow({
@@ -291,13 +317,14 @@ export function tooltipShell({
   layout?: TooltipLayout;
 }): string {
   const isBars = layout === "bars";
+  const isActivity = layout === "activity";
   const header =
     label.length > 0
-      ? `<div class="font-medium text-foreground">${escapeHtml(label)}</div>`
+      ? `<div class="${isActivity ? "px-0.5 text-[11px] font-medium text-zinc-400" : "font-medium text-foreground"}">${escapeHtml(label)}</div>`
       : "";
-  return `<div class="grid ${isBars ? "min-w-56 gap-2.5 px-3 py-2.5" : "min-w-32 gap-1.5 px-2.5 py-1.5"} items-start border border-border/50 text-xs shadow-[0_12px_40px_-8px_rgba(0,0,0,0.45),0_0_0_1px_rgba(255,255,255,0.04)_inset] ${roundnessClass[roundness]} ${tooltipVariantClass[variant]}">
+  return `<div class="grid ${isActivity ? "min-w-60 gap-2 border-white/10 bg-[#111113] px-2.5 py-2.5" : `${isBars ? "min-w-56 gap-2.5 px-3 py-2.5" : "min-w-32 gap-1.5 px-2.5 py-1.5"} border-border/50 ${tooltipVariantClass[variant]}`} items-start border text-xs shadow-[0_12px_40px_-8px_rgba(0,0,0,0.55),0_0_0_1px_rgba(255,255,255,0.04)_inset] ${roundnessClass[roundness]}">
       ${header}
-      <div class="grid ${isBars ? "gap-2.5" : "gap-1.5"}" style="transition:opacity 0.24s ease">${body}</div>
+      <div class="grid ${isBars ? "gap-2.5" : isActivity ? "gap-1" : "gap-1.5"}" style="transition:opacity 0.24s ease">${body}</div>
     </div>`;
 }
 

--- a/apps/dashboard/src/components/geo/engine-icon.tsx
+++ b/apps/dashboard/src/components/geo/engine-icon.tsx
@@ -24,6 +24,8 @@ import { FirecrawlDark } from "@notra/ui/components/ui/svgs/firecrawlDark";
 import { Firefox } from "@notra/ui/components/ui/svgs/firefox";
 import { Gemini } from "@notra/ui/components/ui/svgs/gemini";
 import { Google } from "@notra/ui/components/ui/svgs/google";
+import { Grok } from "@notra/ui/components/ui/svgs/grok";
+import { GrokDark } from "@notra/ui/components/ui/svgs/grokDark";
 import { Huawei } from "@notra/ui/components/ui/svgs/huawei";
 import { Kagi } from "@notra/ui/components/ui/svgs/kagi";
 import { Kimi } from "@notra/ui/components/ui/svgs/kimi";
@@ -40,8 +42,6 @@ import { OpencodeDark } from "@notra/ui/components/ui/svgs/opencodeDark";
 import { Perplexity } from "@notra/ui/components/ui/svgs/perplexity";
 import { Qwen } from "@notra/ui/components/ui/svgs/qwen";
 import { QwenDark } from "@notra/ui/components/ui/svgs/qwenDark";
-import { SpaceXai } from "@notra/ui/components/ui/svgs/spacexai";
-import { SpaceXaiDark } from "@notra/ui/components/ui/svgs/spacexaiDark";
 import { Tavily } from "@notra/ui/components/ui/svgs/tavily";
 import { Tencent } from "@notra/ui/components/ui/svgs/tencent";
 import { TikTok } from "@notra/ui/components/ui/svgs/tikTok";
@@ -67,7 +67,11 @@ export function EngineIcon(props: EngineIconProps) {
   );
 }
 
-function EngineIconGraphic({ engine, className }: EngineIconProps) {
+function EngineIconGraphic({
+  engine,
+  className,
+  darkSurface,
+}: EngineIconProps) {
   const key = resolveEngineIconKey(engine);
   if (!key) {
     const parsed = splitModelId(engine);
@@ -82,6 +86,9 @@ function EngineIconGraphic({ engine, className }: EngineIconProps) {
   const iconClass = cn("size-4 shrink-0", className);
 
   if (key === "openai") {
+    if (darkSurface) {
+      return <OpenaiDark className={iconClass} />;
+    }
     return (
       <>
         <Openai className={cn(iconClass, "block dark:hidden")} />
@@ -90,9 +97,12 @@ function EngineIconGraphic({ engine, className }: EngineIconProps) {
     );
   }
   if (key === "grok") {
-    return themedIcon(SpaceXai, SpaceXaiDark, iconClass);
+    return themedIcon(Grok, GrokDark, iconClass, darkSurface);
   }
   if (key === "qwen") {
+    if (darkSurface) {
+      return <QwenDark className={iconClass} />;
+    }
     return (
       <>
         <Qwen className={cn(iconClass, "block dark:hidden")} />
@@ -107,7 +117,9 @@ function EngineIconGraphic({ engine, className }: EngineIconProps) {
     return <Gemini className={cn(iconClass, "overflow-visible")} />;
   }
   if (key === "perplexity") {
-    return <Perplexity className={iconClass} />;
+    return (
+      <Perplexity className={cn(iconClass, darkSurface && "brightness-150")} />
+    );
   }
   if (key === "mistral") {
     return <Mistral className={iconClass} />;
@@ -146,19 +158,19 @@ function EngineIconGraphic({ engine, className }: EngineIconProps) {
     return <Kimi className={iconClass} />;
   }
   if (key === "apple") {
-    return themedIcon(Apple, AppleDark, iconClass);
+    return themedIcon(Apple, AppleDark, iconClass, darkSurface);
   }
   if (key === "tiktok") {
-    return themedIcon(TikTok, TikTokDark, iconClass);
+    return themedIcon(TikTok, TikTokDark, iconClass, darkSurface);
   }
   if (key === "manus") {
-    return themedIcon(Manus, ManusDark, iconClass);
+    return themedIcon(Manus, ManusDark, iconClass, darkSurface);
   }
   if (key === "firecrawl") {
-    return themedIcon(Firecrawl, FirecrawlDark, iconClass);
+    return themedIcon(Firecrawl, FirecrawlDark, iconClass, darkSurface);
   }
   if (key === "opencode") {
-    return themedIcon(Opencode, OpencodeDark, iconClass);
+    return themedIcon(Opencode, OpencodeDark, iconClass, darkSurface);
   }
   const simple = SIMPLE_ICONS[key];
   if (simple) {
@@ -197,8 +209,12 @@ const SIMPLE_ICONS: Partial<
 function themedIcon(
   Light: ComponentType<SVGProps<SVGSVGElement>>,
   Dark: ComponentType<SVGProps<SVGSVGElement>>,
-  iconClass: string
+  iconClass: string,
+  darkSurface = false
 ) {
+  if (darkSurface) {
+    return <Dark className={iconClass} />;
+  }
   return (
     <>
       <Light className={cn(iconClass, "block dark:hidden")} />
@@ -222,7 +238,11 @@ export function engineIconHtml(engine: string): string {
           aria-hidden="true"
           className="inline-flex size-3.5 shrink-0 items-center justify-center"
         >
-          <EngineIcon className={TOOLTIP_ICON_CLASS} engine={engine} />
+          <EngineIcon
+            className={TOOLTIP_ICON_CLASS}
+            darkSurface
+            engine={engine}
+          />
         </span>
       )
     : providerLogoImgHtml(engine);

--- a/apps/dashboard/src/components/geo/geo-stat-delta.tsx
+++ b/apps/dashboard/src/components/geo/geo-stat-delta.tsx
@@ -25,6 +25,12 @@ const TONE_CLASS: Record<GeoStatDeltaTone, string> = {
   flat: "bg-muted text-muted-foreground",
 };
 
+const PLAIN_TONE_CLASS: Record<GeoStatDeltaTone, string> = {
+  up: "text-geo-up",
+  down: "text-geo-down",
+  flat: "text-muted-foreground",
+};
+
 const ICON_RING_CLASS: Record<GeoStatDeltaTone, string> = {
   up: "bg-geo-up text-white",
   down: "bg-geo-down text-white",
@@ -36,6 +42,12 @@ const TONE_ICON = {
   down: ArrowDown01Icon,
   flat: MinusSignIcon,
 } as const;
+
+const TONE_ARROW: Record<GeoStatDeltaTone, string> = {
+  up: "↑",
+  down: "↓",
+  flat: "−",
+};
 
 function GeoStatDeltaIcon({ tone }: { tone: GeoStatDeltaTone }) {
   return (
@@ -54,6 +66,7 @@ function GeoStatDeltaIcon({ tone }: { tone: GeoStatDeltaTone }) {
 export function GeoStatDelta({
   delta,
   kind = "mentions",
+  variant = "pill",
   label,
   hint,
   className,
@@ -64,15 +77,29 @@ export function GeoStatDelta({
 
   const tone = geoStatDeltaTone(delta, kind);
   const formatted = formatGeoStatDelta(delta, kind);
-  const pill = (
-    <span className={cn(PILL_CLASS, TONE_CLASS[tone], className)}>
-      <GeoStatDeltaIcon tone={tone} />
-      {formatted}
-    </span>
-  );
+  const displayedValue =
+    variant === "plain" ? formatted.replace(/^[+-]/, "") : formatted;
+  const content =
+    variant === "plain" ? (
+      <span
+        className={cn(
+          "inline-flex shrink-0 items-center gap-0.5 text-sm font-medium tabular-nums",
+          PLAIN_TONE_CLASS[tone],
+          className
+        )}
+      >
+        <span aria-hidden="true">{TONE_ARROW[tone]}</span>
+        {displayedValue}
+      </span>
+    ) : (
+      <span className={cn(PILL_CLASS, TONE_CLASS[tone], className)}>
+        <GeoStatDeltaIcon tone={tone} />
+        {formatted}
+      </span>
+    );
 
   if (!hint) {
-    return pill;
+    return content;
   }
 
   return (
@@ -88,7 +115,7 @@ export function GeoStatDelta({
           />
         }
       >
-        {pill}
+        {content}
       </TooltipTrigger>
       <TooltipContent>{hint}</TooltipContent>
     </Tooltip>

--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -23,7 +23,6 @@ import {
   GEO_EMPTY_TIMESERIES,
   GEO_FAMILY_STAT_TREND_HINT,
   GEO_MENTION_SUMMARY_LESS,
-  GEO_MENTION_SUMMARY_MORE,
   GEO_MENTION_SUMMARY_VISIBLE,
   GEO_MENTIONS_LABEL,
 } from "@/constants/geo";
@@ -82,7 +81,7 @@ function ProviderRow({
         clickable ? `Open ${name} mention breakdown` : `${name}, no mentions`
       }
       className={cn(
-        "flex w-full items-center gap-3 border-b px-1 py-2.5 text-left transition-colors",
+        "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-1.5 border-b py-2 text-left transition-colors",
         clickable ? "hover:bg-muted/50 cursor-pointer" : "cursor-default"
       )}
       disabled={!clickable}
@@ -93,7 +92,9 @@ function ProviderRow({
         {rank}
       </span>
       <span className="flex min-w-0 flex-1 items-center gap-2">
-        <EngineIcon engine={family.family} />
+        <span className="flex size-7 shrink-0 items-center justify-center">
+          <EngineIcon engine={family.family} />
+        </span>
         <span className="truncate text-sm font-medium">{name}</span>
       </span>
       <span className="flex shrink-0 items-center justify-end gap-2">
@@ -107,8 +108,8 @@ function ProviderRow({
         </span>
         <GeoStatDelta
           delta={mentionDelta}
-          hint={GEO_FAMILY_STAT_TREND_HINT}
           label={`${name} mentions`}
+          variant="plain"
         />
       </span>
     </button>
@@ -142,19 +143,23 @@ function ProviderList({
 
 function ProviderToggle({
   expanded,
+  hiddenCount,
   onToggle,
 }: {
   expanded: boolean;
+  hiddenCount: number;
   onToggle: () => void;
 }) {
   return (
     <button
       aria-expanded={expanded}
-      className="text-muted-foreground hover:text-foreground focus-visible:ring-ring flex min-h-8 w-full items-center gap-1 px-1 text-xs transition-colors outline-none focus-visible:ring-2"
+      className="text-muted-foreground hover:text-foreground focus-visible:ring-ring -mx-4 -mb-4 flex min-h-10 w-[calc(100%+2rem)] items-center justify-between pr-6 pl-9 text-sm transition-colors outline-none focus-visible:ring-2"
       onClick={onToggle}
       type="button"
     >
-      {expanded ? GEO_MENTION_SUMMARY_LESS : GEO_MENTION_SUMMARY_MORE}
+      {expanded
+        ? GEO_MENTION_SUMMARY_LESS
+        : `Tracking ${hiddenCount.toLocaleString()} more`}
       <HugeiconsIcon
         className={cn(
           "transition-transform duration-200 ease-out",
@@ -186,7 +191,11 @@ function ProviderOverlay({
     return expanded ? (
       <div className={OVERLAY_CLASS}>
         <ProviderList onOpen={onOpen} rows={rows} startRank={startRank} />
-        <ProviderToggle expanded onToggle={onToggle} />
+        <ProviderToggle
+          expanded
+          hiddenCount={rows.length}
+          onToggle={onToggle}
+        />
       </div>
     ) : null;
   }
@@ -226,7 +235,11 @@ function ProviderOverlay({
                 />
               </m.div>
             ))}
-            <ProviderToggle expanded onToggle={onToggle} />
+            <ProviderToggle
+              expanded
+              hiddenCount={rows.length}
+              onToggle={onToggle}
+            />
           </m.div>
         ) : null}
       </AnimatePresence>
@@ -288,8 +301,10 @@ export function MentionRateCard({
   return (
     <div className="relative h-full" ref={rootRef}>
       <InstrumentModule
+        bodyClassName={cn(expanded && "rounded-b-none")}
         className={cn("h-full overflow-visible", expanded && "rounded-b-none")}
         eyebrow={GEO_MENTIONS_LABEL}
+        variant="table"
       >
         {ranked.length === 0 || !totals ? (
           <InstrumentEmpty
@@ -301,7 +316,7 @@ export function MentionRateCard({
         ) : (
           <div className="flex flex-col gap-4">
             <div className="flex items-end gap-2">
-              <p className="text-4xl leading-none font-semibold tracking-tight tabular-nums">
+              <p className="text-3xl leading-none font-semibold tracking-tight tabular-nums">
                 {totals.mentions.toLocaleString()}
               </p>
               <GeoStatDelta
@@ -309,15 +324,16 @@ export function MentionRateCard({
                 delta={overviewDelta}
                 hint={GEO_FAMILY_STAT_TREND_HINT}
                 label={GEO_MENTIONS_LABEL}
+                variant="plain"
               />
             </div>
 
-            <div>
-              <div className="text-muted-foreground flex items-center justify-between gap-3 px-1 pb-1.5 text-xs">
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center justify-between gap-3 text-sm font-medium">
                 <span>Provider</span>
                 <span>Mentions</span>
               </div>
-              <div className="border-border relative border-t">
+              <div className="border-border relative [&>button:last-of-type]:border-b-0">
                 <ProviderList
                   onOpen={setSelected}
                   rows={visible}
@@ -328,6 +344,7 @@ export function MentionRateCard({
                     {expanded ? null : (
                       <ProviderToggle
                         expanded={false}
+                        hiddenCount={hidden.length}
                         onToggle={() => setExpanded(true)}
                       />
                     )}

--- a/apps/dashboard/src/components/geo/mention-trend-agents.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-agents.tsx
@@ -6,6 +6,8 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
 
@@ -13,28 +15,24 @@ import { EngineIcon } from "@/components/geo/engine-icon";
 import {
   GEO_FILTER_TRIGGER_CLASS,
   GEO_MENTION_TREND_AGENT_ICON_LIMIT,
-  GEO_MENTION_TREND_ALL_AGENTS_LABEL,
+  GEO_MENTION_TREND_ALL_PROVIDERS_LABEL,
 } from "@/constants/geo";
 import { cn } from "@/lib/utils";
 import type { MentionTrendAgentsPickerProps } from "@/types/geo";
 
 export function MentionTrendAgentsPicker({
   series,
-  hiddenKeys,
+  activeKeys,
   onToggle,
   disabled = false,
 }: MentionTrendAgentsPickerProps) {
-  const visible = series.filter((entry) => !hiddenKeys.has(entry.key));
-  const preview = visible.slice(0, GEO_MENTION_TREND_AGENT_ICON_LIMIT);
-  const count = visible.length;
-  const label =
-    count > 0 && count === series.length
-      ? GEO_MENTION_TREND_ALL_AGENTS_LABEL
-      : `${count} ${count === 1 ? "agent" : "agents"}`;
-  const accessibleLabel =
-    visible.length > 0
-      ? `Mention trend agents: ${visible.map((entry) => entry.label).join(", ")}`
-      : "Mention trend agents: none selected";
+  const preview = series.slice(0, GEO_MENTION_TREND_AGENT_ICON_LIMIT);
+  const active = series.filter((entry) => activeKeys.has(entry.key));
+  const accessibleLabel = `Mention activity for all providers. ${
+    active.length === 0
+      ? "No individual lines shown"
+      : `Individual lines shown for ${active.map((entry) => entry.label).join(", ")}`
+  }`;
 
   return (
     <DropdownMenu>
@@ -47,18 +45,18 @@ export function MentionTrendAgentsPicker({
         disabled={disabled}
       >
         {preview.length > 0 ? (
-          <span className="flex items-center -space-x-1.5 pr-0.5">
+          <span className="flex -space-x-1 pr-1">
             {preview.map((entry) => (
               <span
-                className="bg-background ring-background relative flex size-4 items-center justify-center overflow-hidden rounded-full ring-2"
+                className="bg-background flex size-5 shrink-0 items-center justify-center rounded-full"
                 key={entry.key}
               >
-                <EngineIcon className="size-3.5" engine={entry.engine} />
+                <EngineIcon className="size-4" engine={entry.engine} />
               </span>
             ))}
           </span>
         ) : null}
-        <span>{label}</span>
+        <span>{GEO_MENTION_TREND_ALL_PROVIDERS_LABEL}</span>
         <HugeiconsIcon
           className="text-muted-foreground"
           icon={ArrowUpDownIcon}
@@ -66,20 +64,19 @@ export function MentionTrendAgentsPicker({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-52">
-        {series.map((entry) => {
-          const hidden = hiddenKeys.has(entry.key);
-          return (
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Show individual activity</DropdownMenuLabel>
+          {series.map((entry) => (
             <DropdownMenuCheckboxItem
-              checked={!hidden}
-              disabled={!hidden && visible.length <= 1}
+              checked={activeKeys.has(entry.key)}
               key={entry.key}
               onCheckedChange={() => onToggle(entry.key)}
             >
               <EngineIcon className="size-3.5" engine={entry.engine} />
               {entry.label}
             </DropdownMenuCheckboxItem>
-          );
-        })}
+          ))}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/dashboard/src/components/geo/mention-trend-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-card.tsx
@@ -10,11 +10,13 @@ import {
   InstrumentEmpty,
   InstrumentModule,
 } from "@/components/instrument/instrument-module";
-import { CHART_MUTED_COLOR } from "@/constants/charts";
+import { CHART_MUTED_COLOR, CHART_PRIMARY_COLOR } from "@/constants/charts";
 import {
   GEO_MENTION_ACTIVITY_LABEL,
-  GEO_MENTION_TREND_AVERAGE_KEY,
-  GEO_MENTION_TREND_AVERAGE_LABEL,
+  GEO_MENTION_TREND_LINE_KEY,
+  GEO_MENTION_TREND_LINE_LABEL,
+  GEO_MENTION_TREND_TOTAL_KEY,
+  GEO_MENTION_TREND_TOTAL_LABEL,
 } from "@/constants/geo";
 import type { ChartConfig } from "@/types/charts";
 import type {
@@ -22,20 +24,21 @@ import type {
   MentionTrendRow,
   MentionTrendSeries,
 } from "@/types/geo";
-import { todayIsoDate } from "@/utils/analytics-charts";
+import { formatFullDayLabel, todayIsoDate } from "@/utils/analytics-charts";
 import { accountSeriesColors, seriesColors } from "@/utils/chart-colors";
 import { chartKey } from "@/utils/chart-keys";
 import {
   buildMentionTrendRows,
-  fitMentionTrendAverage,
+  fitMentionTrendLine,
   formatChartInteger,
   formatEngineFamily,
   mentionTrendEmptyLabel,
 } from "@/utils/geo-charts";
 import { geoScanEmptyMessage } from "@/utils/geo-scan";
 
+const TOTAL_STROKE_WIDTH = 2;
 const ENGINE_STROKE_WIDTH = 1.5;
-const AVERAGE_STROKE_WIDTH = 2;
+const TREND_STROKE_WIDTH = 1.5;
 
 function mentionTrendSeries(engines: readonly string[]): MentionTrendSeries[] {
   return engines.map((engine) => ({
@@ -58,18 +61,12 @@ function hasIncompleteTail(rows: readonly MentionTrendRow[]): boolean {
   return rows.at(-1)?.rawDay === todayIsoDate();
 }
 
-function toggleHiddenSeries(
-  hiddenKeys: ReadonlySet<string>,
-  key: string,
-  allKeys: readonly string[]
+function toggleActiveSeries(
+  activeKeys: ReadonlySet<string>,
+  key: string
 ): Set<string> {
-  const next = new Set(hiddenKeys);
-  if (next.has(key)) {
-    next.delete(key);
-    return next;
-  }
-  const visibleCount = allKeys.filter((item) => !next.has(item)).length;
-  if (visibleCount <= 1) {
+  const next = new Set(activeKeys);
+  if (next.delete(key)) {
     return next;
   }
   next.add(key);
@@ -80,7 +77,7 @@ export function MentionTrendCard({
   points,
   isScanning = false,
 }: MentionTrendCardProps) {
-  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(() => new Set());
+  const [activeKeys, setActiveKeys] = useState<Set<string>>(() => new Set());
 
   const { rows, engines } = useMemo(
     () => buildMentionTrendRows(points),
@@ -88,33 +85,21 @@ export function MentionTrendCard({
   );
   const series = useMemo(() => mentionTrendSeries(engines), [engines]);
   const allKeys = useMemo(() => series.map((entry) => entry.key), [series]);
-  const effectiveHiddenKeys = useMemo(() => {
-    const current = new Set(allKeys);
-    const hidden = new Set([...hiddenKeys].filter((key) => current.has(key)));
-    if (allKeys.length > 0 && hidden.size >= allKeys.length) {
-      return new Set<string>();
-    }
-    return hidden;
-  }, [allKeys, hiddenKeys]);
-  const visibleSeries = useMemo(
-    () => series.filter((entry) => !effectiveHiddenKeys.has(entry.key)),
-    [series, effectiveHiddenKeys]
-  );
-  const visibleKeys = useMemo(
-    () => visibleSeries.map((entry) => entry.key),
-    [visibleSeries]
-  );
   const chartRows = useMemo(() => {
-    const averages = fitMentionTrendAverage(rows, visibleKeys);
+    const trend = fitMentionTrendLine(rows, GEO_MENTION_TREND_TOTAL_KEY);
     return rows.map((row, index) => ({
       ...row,
-      [GEO_MENTION_TREND_AVERAGE_KEY]: averages[index] ?? null,
+      [GEO_MENTION_TREND_LINE_KEY]: trend[index] ?? null,
     }));
-  }, [rows, visibleKeys]);
+  }, [rows]);
   const config = useMemo(() => {
     const trendConfig: ChartConfig = {
-      [GEO_MENTION_TREND_AVERAGE_KEY]: {
-        label: GEO_MENTION_TREND_AVERAGE_LABEL,
+      [GEO_MENTION_TREND_TOTAL_KEY]: {
+        label: GEO_MENTION_TREND_TOTAL_LABEL,
+        colors: seriesColors(CHART_PRIMARY_COLOR),
+      },
+      [GEO_MENTION_TREND_LINE_KEY]: {
+        label: GEO_MENTION_TREND_LINE_LABEL,
         colors: seriesColors(CHART_MUTED_COLOR),
       },
     };
@@ -130,15 +115,12 @@ export function MentionTrendCard({
   const markIncompleteTail = hasIncompleteTail(rows);
   const sampledDays = sampledDayCount(rows, engines);
 
-  const handleToggle = useCallback(
-    (key: string) => {
-      setHiddenKeys((previous) => toggleHiddenSeries(previous, key, allKeys));
-    },
-    [allKeys]
-  );
+  const handleToggle = useCallback((key: string) => {
+    setActiveKeys((previous) => toggleActiveSeries(previous, key));
+  }, []);
 
   const emptyMessage =
-    sampledDays === 0 || visibleSeries.length === 0
+    sampledDays === 0
       ? geoScanEmptyMessage(isScanning, "Run a scan to see your mention trend")
       : null;
 
@@ -146,15 +128,16 @@ export function MentionTrendCard({
     <InstrumentModule
       action={
         <MentionTrendAgentsPicker
+          activeKeys={activeKeys}
           disabled={emptyMessage !== null}
-          hiddenKeys={effectiveHiddenKeys}
           onToggle={handleToggle}
           series={series}
         />
       }
-      bodyClassName="flex min-h-0 flex-1 flex-col"
+      bodyClassName="flex min-h-0 flex-1 flex-col px-4 pt-1 pb-4"
       className="h-full"
       eyebrow={GEO_MENTION_ACTIVITY_LABEL}
+      variant="table"
     >
       {emptyMessage ? (
         <InstrumentEmpty
@@ -175,38 +158,51 @@ export function MentionTrendCard({
         >
           <EChartsAreaChart.Grid variant="solid" />
           <EChartsAreaChart.XAxis dataKey="day" />
-          <EChartsAreaChart.YAxis />
-          {series.map((entry) => (
-            <EChartsAreaChart.Area
-              dataKey={entry.key}
-              enableBufferLine={markIncompleteTail}
-              gapMissing
-              key={entry.key}
-              strokeVariant="solid"
-              strokeWidth={ENGINE_STROKE_WIDTH}
-              variant="gradient"
-              visible={!effectiveHiddenKeys.has(entry.key)}
-            >
-              <EChartsAreaChart.ActiveDot variant="border" />
-            </EChartsAreaChart.Area>
-          ))}
+          <EChartsAreaChart.YAxis scale />
+          <EChartsAreaChart.Area
+            dataKey={GEO_MENTION_TREND_TOTAL_KEY}
+            enableBufferLine={markIncompleteTail}
+            gapMissing
+            strokeVariant="solid"
+            strokeWidth={TOTAL_STROKE_WIDTH}
+            variant="gradient"
+          >
+            <EChartsAreaChart.ActiveDot variant="border" />
+          </EChartsAreaChart.Area>
+          {series.map((entry) =>
+            activeKeys.has(entry.key) ? (
+              <EChartsAreaChart.Area
+                dataKey={entry.key}
+                enableBufferLine={markIncompleteTail}
+                gapMissing
+                key={entry.key}
+                strokeVariant="solid"
+                strokeWidth={ENGINE_STROKE_WIDTH}
+                variant="none"
+              >
+                <EChartsAreaChart.ActiveDot variant="border" />
+              </EChartsAreaChart.Area>
+            ) : null
+          )}
           <EChartsAreaChart.Area
             curveType="linear"
-            dataKey={GEO_MENTION_TREND_AVERAGE_KEY}
+            dataKey={GEO_MENTION_TREND_LINE_KEY}
             gapMissing
             strokeVariant="dashed"
-            strokeWidth={AVERAGE_STROKE_WIDTH}
+            strokeWidth={TREND_STROKE_WIDTH}
             variant="none"
           />
           <EChartsAreaChart.Tooltip
             confine={false}
-            emptyLabel={(row) => mentionTrendEmptyLabel(row, visibleKeys)}
+            emptyLabel={(row) => mentionTrendEmptyLabel(row, allKeys)}
             hideZeros
-            layout="bars"
+            labelFormatter={formatFullDayLabel}
+            labelKey="rawDay"
+            layout="activity"
             position="fixed"
-            rowKeys={visibleKeys}
+            roundness="xl"
+            rowKeys={allKeys}
             valueFormatter={formatChartInteger}
-            variant="frosted-glass"
           />
         </EChartsAreaChart>
       )}

--- a/apps/dashboard/src/components/instrument/instrument-module.tsx
+++ b/apps/dashboard/src/components/instrument/instrument-module.tsx
@@ -24,22 +24,35 @@ export function InstrumentModule({
   variant = "flat",
   bareBody = false,
 }: InstrumentModuleProps) {
-  if (variant === "panel") {
+  if (variant !== "flat") {
+    const tableHeader = variant === "table";
+    let headerClassName =
+      "border-border bg-muted min-h-24 content-start rounded-t-2xl border border-b-0 pt-4 pb-9";
+    let contentClassName =
+      "border-border bg-card relative -mt-9 flex flex-1 flex-col rounded-2xl border p-6";
+
+    if (bareBody) {
+      headerClassName = "px-1";
+      contentClassName = "flex flex-1 flex-col p-0";
+    } else if (tableHeader) {
+      headerClassName =
+        "border-border bg-muted h-[4.25rem] content-center rounded-t-2xl border border-b-0 pb-5";
+      contentClassName =
+        "border-border bg-card relative -mt-5 flex flex-1 flex-col rounded-2xl border p-4";
+    }
+
     return (
       <Card
         className={cn(
           "min-w-0 flex-1 overflow-visible rounded-2xl bg-transparent p-0 ring-0",
+          tableHeader && "gap-0",
           className
         )}
       >
-        <CardHeader
-          className={
-            bareBody
-              ? "px-1"
-              : "border-border bg-muted min-h-24 content-start rounded-t-2xl border border-b-0 pt-4 pb-9"
-          }
-        >
-          <CardTitle>{eyebrow}</CardTitle>
+        <CardHeader className={headerClassName}>
+          <CardTitle className={tableHeader ? "text-sm capitalize" : undefined}>
+            {eyebrow}
+          </CardTitle>
           {description && <CardDescription>{description}</CardDescription>}
           {(readout || action) && (
             <CardAction className="flex min-w-0 items-center gap-2">
@@ -52,14 +65,7 @@ export function InstrumentModule({
             </CardAction>
           )}
         </CardHeader>
-        <CardContent
-          className={cn(
-            bareBody
-              ? "flex flex-1 flex-col p-0"
-              : "border-border bg-card relative -mt-9 flex flex-1 flex-col rounded-2xl border p-6",
-            bodyClassName
-          )}
-        >
+        <CardContent className={cn(contentClassName, bodyClassName)}>
           {children}
         </CardContent>
       </Card>

--- a/apps/dashboard/src/constants/design-system-geo.ts
+++ b/apps/dashboard/src/constants/design-system-geo.ts
@@ -1,0 +1,59 @@
+import type { GeoOverviewEngine, GeoTimeseriesPoint } from "@/types/geo";
+
+const PROVIDERS = [
+  { engine: "openai/gpt-5.4-grounded", baseline: 18, growth: 0.5 },
+  {
+    engine: "anthropic/claude-sonnet-4.6-grounded",
+    baseline: 14,
+    growth: 0.35,
+  },
+  { engine: "google/gemini-3-flash-grounded", baseline: 11, growth: 0.28 },
+  { engine: "perplexity/sonar", baseline: 8, growth: 0.22 },
+  { engine: "xai/grok-4", baseline: 6, growth: 0.18 },
+  { engine: "mistral/mistral-large", baseline: 4, growth: 0.12 },
+] as const;
+
+const WAVE = [0, 2, -1, 3, 1, 4, 0, -2, 2, 5, 1, 3] as const;
+
+export const DESIGN_SYSTEM_GEO_POINTS: GeoTimeseriesPoint[] = Array.from(
+  { length: 30 },
+  (_, dayIndex) => {
+    const date = new Date(Date.UTC(2026, 6, 21 + dayIndex))
+      .toISOString()
+      .slice(0, 10);
+    return PROVIDERS.map((provider, providerIndex) => ({
+      day: date,
+      engine: provider.engine,
+      checks: 64,
+      mentions: Math.max(
+        0,
+        Math.round(
+          provider.baseline +
+            dayIndex * provider.growth +
+            (WAVE[(dayIndex + providerIndex * 2) % WAVE.length] ?? 0)
+        )
+      ),
+    }));
+  }
+).flat();
+
+export const DESIGN_SYSTEM_GEO_OVERVIEW: GeoOverviewEngine[] = PROVIDERS.map(
+  (provider) => {
+    const providerPoints = DESIGN_SYSTEM_GEO_POINTS.filter(
+      (point) => point.engine === provider.engine
+    );
+    const checks = providerPoints.reduce((sum, point) => sum + point.checks, 0);
+    const mentions = providerPoints.reduce(
+      (sum, point) => sum + point.mentions,
+      0
+    );
+    return {
+      engine: provider.engine,
+      checks,
+      mentions,
+      mentionRate: checks > 0 ? mentions / checks : 0,
+      avgPosition: null,
+      lastCheckedAt: "2026-08-19T12:00:00.000Z",
+    };
+  }
+);

--- a/apps/dashboard/src/constants/geo.ts
+++ b/apps/dashboard/src/constants/geo.ts
@@ -645,15 +645,14 @@ export const GEO_PROMPT_PREVIEW_ROW_HEIGHT = 72;
 export const GEO_PROMPT_NO_MENTION = "No engine named you";
 
 export const GEO_MENTION_TREND_TOTAL_KEY = "total";
-export const GEO_MENTION_TREND_TOTAL_LABEL = "All engines";
+export const GEO_MENTION_TREND_TOTAL_LABEL = "All providers";
 export const GEO_DEFAULT_RANGE: GeoRangePreset = "30d";
-export const GEO_MENTION_TREND_AVERAGE_KEY = "average";
-export const GEO_MENTION_TREND_AVERAGE_LABEL = "Average";
+export const GEO_MENTION_TREND_LINE_KEY = "trend";
+export const GEO_MENTION_TREND_LINE_LABEL = "Trend";
 export const GEO_MENTION_TREND_AGENT_ICON_LIMIT = 4;
-export const GEO_MENTION_TREND_ALL_AGENTS_LABEL = "All agents";
+export const GEO_MENTION_TREND_ALL_PROVIDERS_LABEL = "All providers";
 export const GEO_MENTION_ACTIVITY_LABEL = "Mention activity";
 export const GEO_MENTION_SUMMARY_VISIBLE = 5;
-export const GEO_MENTION_SUMMARY_MORE = "Show more";
 export const GEO_MENTION_SUMMARY_LESS = "Show less";
 export const GEO_RANGE_PRESETS = [
   { value: "today", label: "Today" },

--- a/apps/dashboard/src/types/charts.ts
+++ b/apps/dashboard/src/types/charts.ts
@@ -57,9 +57,11 @@ export interface GridProps {
   lineType?: "solid" | "dashed";
 }
 
-export type TooltipLayout = "rows" | "bars";
+export type TooltipLayout = "rows" | "bars" | "activity";
 
 export type TooltipValueFormatter = (value: number) => string;
+
+export type TooltipLabelFormatter = (value: string) => string;
 
 export type TooltipEmptyLabel =
   | string

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -172,6 +172,7 @@ export interface EngineFamilyStatTrends {
 export interface GeoStatDeltaProps {
   delta: number | null;
   kind?: GeoStatDeltaKind;
+  variant?: "pill" | "plain";
   label?: string;
   hint?: string;
   className?: string;
@@ -1196,7 +1197,7 @@ export interface GeoRangePickerProps {
 
 export interface MentionTrendAgentsPickerProps {
   series: readonly MentionTrendSeries[];
-  hiddenKeys: ReadonlySet<string>;
+  activeKeys: ReadonlySet<string>;
   onToggle: (key: string) => void;
   disabled?: boolean;
 }
@@ -1269,6 +1270,7 @@ export interface GeoSkinMessageProps {
 export interface EngineIconProps {
   engine: string;
   className?: string;
+  darkSurface?: boolean;
 }
 
 export interface GeoProviderWordmarkProps {

--- a/apps/dashboard/src/types/instrument.ts
+++ b/apps/dashboard/src/types/instrument.ts
@@ -13,7 +13,7 @@ export interface InstrumentModuleProps {
   children: ReactNode;
   className?: string;
   bodyClassName?: string;
-  variant?: "flat" | "panel";
+  variant?: "flat" | "panel" | "table";
   bareBody?: boolean;
 }
 

--- a/apps/dashboard/src/utils/analytics-charts.ts
+++ b/apps/dashboard/src/utils/analytics-charts.ts
@@ -36,6 +36,13 @@ const sparklineDayLabelFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
+const fullDayLabelFormatter = new Intl.DateTimeFormat("en-NZ", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
 export const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 export function formatMetric(value: number | null): string {
@@ -63,6 +70,14 @@ export function formatSparklineDayLabel(day: string): string {
     return day;
   }
   return sparklineDayLabelFormatter.format(date);
+}
+
+export function formatFullDayLabel(day: string): string {
+  const date = new Date(`${day}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) {
+    return day;
+  }
+  return fullDayLabelFormatter.format(date);
 }
 
 export function accountSeriesKey(

--- a/apps/dashboard/src/utils/geo-charts.test.ts
+++ b/apps/dashboard/src/utils/geo-charts.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MentionTrendRow } from "@/types/geo";
+import { fitMentionTrendLine } from "@/utils/geo-charts";
+
+const TOTAL_KEY = "total";
+
+describe("fitMentionTrendLine", () => {
+  test("projects through today without fitting today's partial total", () => {
+    const rows: MentionTrendRow[] = [
+      { day: "Aug 25", rawDay: "2026-08-25", [TOTAL_KEY]: 10 },
+      { day: "Aug 26", rawDay: "2026-08-26", [TOTAL_KEY]: 20 },
+      { day: "Aug 27", rawDay: "2026-08-27", [TOTAL_KEY]: 2 },
+    ];
+
+    expect(fitMentionTrendLine(rows, TOTAL_KEY, "2026-08-27")).toEqual([
+      10, 20, 30,
+    ]);
+  });
+});

--- a/apps/dashboard/src/utils/geo-charts.ts
+++ b/apps/dashboard/src/utils/geo-charts.ts
@@ -162,7 +162,8 @@ export function listDaysThrough(firstDay: string, lastDay: string): string[] {
 
 export function fitMentionTrendLine(
   rows: readonly MentionTrendRow[],
-  key: string
+  key: string,
+  today = todayIsoDate()
 ): (number | null)[] {
   let count = 0;
   let sumIndex = 0;
@@ -170,20 +171,24 @@ export function fitMentionTrendLine(
   let sumProduct = 0;
   let sumSquares = 0;
   let firstIndex: number | null = null;
-  let lastIndex: number | null = null;
+  let lastObservedIndex: number | null = null;
   for (const [index, row] of rows.entries()) {
     const value = row[key];
-    if (typeof value === "number") {
-      count += 1;
-      sumIndex += index;
-      sumValue += value;
-      sumProduct += index * value;
-      sumSquares += index * index;
-      firstIndex ??= index;
-      lastIndex = index;
+    if (typeof value !== "number") {
+      continue;
     }
+    lastObservedIndex = index;
+    if (row.rawDay === today) {
+      continue;
+    }
+    count += 1;
+    sumIndex += index;
+    sumValue += value;
+    sumProduct += index * value;
+    sumSquares += index * index;
+    firstIndex ??= index;
   }
-  if (count === 0 || firstIndex === null || lastIndex === null) {
+  if (count === 0 || firstIndex === null || lastObservedIndex === null) {
     return rows.map(() => null);
   }
 
@@ -195,7 +200,7 @@ export function fitMentionTrendLine(
   const intercept = (sumValue - slope * sumIndex) / count;
 
   return rows.map((_, index) =>
-    index >= firstIndex && index <= lastIndex
+    index >= firstIndex && index <= lastObservedIndex
       ? Math.max(0, intercept + slope * index)
       : null
   );

--- a/apps/dashboard/src/utils/geo-charts.ts
+++ b/apps/dashboard/src/utils/geo-charts.ts
@@ -160,35 +160,45 @@ export function listDaysThrough(firstDay: string, lastDay: string): string[] {
   return days;
 }
 
-function visibleEngineStats(
-  row: MentionTrendRow,
-  keys: readonly string[]
-): { total: number; count: number } | null {
-  let total = 0;
+export function fitMentionTrendLine(
+  rows: readonly MentionTrendRow[],
+  key: string
+): (number | null)[] {
   let count = 0;
-  for (const key of keys) {
+  let sumIndex = 0;
+  let sumValue = 0;
+  let sumProduct = 0;
+  let sumSquares = 0;
+  let firstIndex: number | null = null;
+  let lastIndex: number | null = null;
+  for (const [index, row] of rows.entries()) {
     const value = row[key];
-    if (typeof value === "number" && value > 0) {
-      total += value;
+    if (typeof value === "number") {
       count += 1;
+      sumIndex += index;
+      sumValue += value;
+      sumProduct += index * value;
+      sumSquares += index * index;
+      firstIndex ??= index;
+      lastIndex = index;
     }
   }
-  return count > 0 ? { total, count } : null;
-}
+  if (count === 0 || firstIndex === null || lastIndex === null) {
+    return rows.map(() => null);
+  }
 
-function rowVisibleAverage(
-  row: MentionTrendRow,
-  keys: readonly string[]
-): number | null {
-  const stats = visibleEngineStats(row, keys);
-  return stats ? stats.total / stats.count : null;
-}
+  const denominator = count * sumSquares - sumIndex * sumIndex;
+  const slope =
+    denominator === 0
+      ? 0
+      : (count * sumProduct - sumIndex * sumValue) / denominator;
+  const intercept = (sumValue - slope * sumIndex) / count;
 
-export function fitMentionTrendAverage(
-  rows: readonly MentionTrendRow[],
-  keys: readonly string[]
-): (number | null)[] {
-  return rows.map((row) => rowVisibleAverage(row, keys));
+  return rows.map((_, index) =>
+    index >= firstIndex && index <= lastIndex
+      ? Math.max(0, intercept + slope * index)
+      : null
+  );
 }
 
 export function mentionTrendEmptyLabel(

--- a/apps/web/src/components/blog-copy-article.tsx
+++ b/apps/web/src/components/blog-copy-article.tsx
@@ -108,11 +108,7 @@ export function BlogCopyArticle({
             strokeWidth={2}
           />
         </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
-          className="w-80 p-2"
-          showBackdrop={false}
-        >
+        <DropdownMenuContent align="end" className="w-80 p-2">
           <DropdownMenuItem
             className="px-2 py-2"
             closeOnClick={false}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the geo mention activity views: the trend card now leads with a total plus a projected trend line instead of per-provider lines, and the rate card uses lighter delta styling.

**Mention trend card**
- Default view shows total mentions with a dashed linear-regression trend line; individual provider lines are opt-in via the dropdown.
- The trend line fits past days only and projects through today, so today's partial total doesn't skew the regression.
- Tooltip now shows full day labels, ranks providers by value, and uses dark-surface engine icons.
- Y axis can scale to the data range instead of forcing zero into view.

**Mention rate card & supporting changes**
- Deltas use a plain arrow style instead of colored pills, and the expand button now reads "Tracking X more."
- Added a geo demo page with mock data, a new `table` module variant, and renamed "agents" labels to "providers."

<sup>Written for commit f1033193ddc4554861f9d239c0b3a6f514a3618b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

