### PR TITLE
ci(codeql): ignore unknown-directive alerts for workflow directives

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: Notra CodeQL config
+
+query-filters:
+  - exclude:
+      id: js/unknown-directive


### PR DESCRIPTION
## Summary

CodeQL's \`js/unknown-directive\` query flags every \`"use workflow"\` and \`"use step"\` prologue in \`apps/dashboard/src/workflows/\` (see the bot comments on #746). Those are Vercel Workflow DevKit directives compiled by the \`workflow\` SWC transform (\`withWorkflow\` in \`next.config.ts\`); removing them would unregister the workflows and steps. The query only knows \`"use strict"\`, \`"use client"\` and \`"use server"\`, so every finding is a false positive.

This adds \`.github/codeql/codeql-config.yml\` with a \`query-filters\` entry excluding that single query. Everything else CodeQL runs is unchanged.

## One-time setup needed after merge

The repo uses CodeQL **default setup** (no workflow file), which only picks up a config file through the \`github-codeql-config-file\` repository property:

1. Org settings → Repository → Custom properties: define a string property named \`github-codeql-config-file\` (if it does not exist yet).
2. On \`usenotra/notra\`, set it to \`.github/codeql/codeql-config.yml\`.

GitHub then merges this file into the generated default-setup configuration. Docs: https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/editing-your-configuration-of-default-setup

Until the property is set, the file is inert and the existing alerts can be dismissed as false positives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CodeQL config that stops `js/unknown-directive` from flagging Vercel Workflow DevKit directives (`"use workflow"`, `"use step"`) as false positives.

- CodeQL's `js/unknown-directive` query only recognizes standard directives, so it reported every workflow and step prologue.
- The new `.github/codeql/codeql-config.yml` excludes that single query; all other CodeQL checks are unchanged.

**Migration**
- Set the `github-codeql-config-file` repository property to `.github/codeql/codeql-config.yml` so default setup picks it up.
- Until the property is set, the config file is inert and existing alerts can be dismissed as false positives.

<sup>Written for commit 8f9184571ff513745e8b49605cc8d22a0d531fc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

