### PR TITLE
feat(geo): group AI traffic sources by vendor with hover breakdown

### DIFF
--- a/apps/dashboard/src/components/geo/ai-traffic-card.tsx
+++ b/apps/dashboard/src/components/geo/ai-traffic-card.tsx
@@ -208,17 +208,14 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
     [sources]
   );
   const trendRows = useMemo(() => buildTrafficTrendRows(points), [points]);
-  const groups = useMemo(() => groupTrafficSources(sources), [sources]);
+  const groups = groupTrafficSources(sources);
   const sparklineDays = useMemo(() => trafficSparklineDays(points), [points]);
   const canSparkline = hasTrafficSourceSeries(points);
-  const seriesByGroup = useMemo(() => {
-    if (!canSparkline) {
-      return new Map<string, { day: string; value: number }[]>();
-    }
-    const map = new Map<string, { day: string; value: number }[]>();
+  const seriesByGroup = new Map<string, { day: string; value: number }[]>();
+  if (canSparkline) {
     for (const group of groups) {
       const values = buildTrafficGroupSeries(points, group, sparklineDays);
-      map.set(
+      seriesByGroup.set(
         trafficGroupKey(group.visitorType, group.key),
         sparklineDays.map((day, index) => ({
           day,
@@ -226,130 +223,124 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
         }))
       );
     }
-    return map;
-  }, [canSparkline, points, groups, sparklineDays]);
+  }
 
-  const columns = useMemo<TableColumn<GeoTrafficSourceGroup>[]>(
-    () => [
-      {
-        key: "source",
-        header: "Source",
-        width: "1fr",
-        sortable: true,
-        cell: (row) => <TrafficSourceGroupCell group={row} />,
-        sortValue: (row) => row.label,
-      },
-      {
-        key: "category",
-        header: "Purpose",
-        width: "9.5rem",
-        sortable: true,
-        cell: (row) => {
-          const [single] = row.categories;
-          if (single === undefined) {
-            return null;
-          }
-          if (row.categories.length === 1) {
-            return <PurposeBadge category={single} />;
-          }
-          return (
-            <span className="flex items-center gap-1">
-              {row.categories.map((category) => (
-                <PurposeBadge category={category} compact key={category} />
-              ))}
-            </span>
-          );
-        },
-        sortValue: (row) => row.categories.join(","),
-      },
-      {
-        key: "visits",
-        header: "Visits",
-        width: "10.5rem",
-        sortable: true,
-        cell: (row) => {
-          const series = seriesByGroup.get(
-            trafficGroupKey(row.visitorType, row.key)
-          );
-          const showSpark =
-            series !== undefined && series.length >= GEO_SPARKLINE_MIN_POINTS;
-
-          return (
-            <span className="flex items-center gap-2">
-              {showSpark ? (
-                <GeoRateSparkline
-                  className={
-                    row.visitorType === "ai_referral"
-                      ? "text-geo-memory"
-                      : "text-geo-search"
-                  }
-                  points={series}
-                />
-              ) : null}
-              <span className="text-sm tabular-nums">
-                {row.visits.toLocaleString()}
-              </span>
-            </span>
-          );
-        },
-      },
-      {
-        key: "markdownVisits",
-        header: "Markdown",
-        width: "6.75rem",
-        sortable: true,
-        cell: (row) => {
-          if (row.markdownVisits <= 0) {
-            return <span className="tabular-nums">-</span>;
-          }
-
-          return (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <span className="cursor-default tabular-nums">
-                    {formatMarkdownShare(row.markdownVisits, row.visits)}
-                  </span>
-                }
-              />
-              <TooltipContent
-                align="start"
-                className="max-w-xs text-pretty"
-                side="top"
-              >
-                {row.markdownVisits.toLocaleString()} of{" "}
-                {row.visits.toLocaleString()} requests asked for markdown via
-                the Accept header
-              </TooltipContent>
-            </Tooltip>
-          );
-        },
-        sortValue: (row) =>
-          row.visits === 0 ? 0 : row.markdownVisits / row.visits,
-      },
-      {
-        key: "paths",
-        header: "Pages",
-        width: "5.625rem",
-        sortable: true,
-        cell: (row) => (
-          <span className="text-sm tabular-nums">{row.paths}</span>
-        ),
-      },
-      {
-        key: "lastSeenAt",
-        header: "Last seen",
-        width: "9.375rem",
-        sortable: true,
-        cell: (row) => (
-          <span className="text-muted-foreground text-[0.6875rem] whitespace-nowrap tabular-nums">
-            {formatAiTrafficTimestamp(row.lastSeenAt)}
+  const columns: TableColumn<GeoTrafficSourceGroup>[] = [
+    {
+      key: "source",
+      header: "Source",
+      width: "1fr",
+      sortable: true,
+      cell: (row) => <TrafficSourceGroupCell group={row} />,
+      sortValue: (row) => row.label,
+    },
+    {
+      key: "category",
+      header: "Purpose",
+      width: "9.5rem",
+      sortable: true,
+      cell: (row) => {
+        const [single] = row.categories;
+        if (single === undefined) {
+          return null;
+        }
+        if (row.categories.length === 1) {
+          return <PurposeBadge category={single} />;
+        }
+        return (
+          <span className="flex items-center gap-1">
+            {row.categories.map((category) => (
+              <PurposeBadge category={category} compact key={category} />
+            ))}
           </span>
-        ),
+        );
       },
-    ],
-    [seriesByGroup]
-  );
+      sortValue: (row) => row.categories.join(","),
+    },
+    {
+      key: "visits",
+      header: "Visits",
+      width: "10.5rem",
+      sortable: true,
+      cell: (row) => {
+        const series = seriesByGroup.get(
+          trafficGroupKey(row.visitorType, row.key)
+        );
+        const showSpark =
+          series !== undefined && series.length >= GEO_SPARKLINE_MIN_POINTS;
+
+        return (
+          <span className="flex items-center gap-2">
+            {showSpark ? (
+              <GeoRateSparkline
+                className={
+                  row.visitorType === "ai_referral"
+                    ? "text-geo-memory"
+                    : "text-geo-search"
+                }
+                points={series}
+              />
+            ) : null}
+            <span className="text-sm tabular-nums">
+              {row.visits.toLocaleString()}
+            </span>
+          </span>
+        );
+      },
+    },
+    {
+      key: "markdownVisits",
+      header: "Markdown",
+      width: "6.75rem",
+      sortable: true,
+      cell: (row) => {
+        if (row.markdownVisits <= 0) {
+          return <span className="tabular-nums">-</span>;
+        }
+
+        return (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="cursor-default tabular-nums">
+                  {formatMarkdownShare(row.markdownVisits, row.visits)}
+                </span>
+              }
+            />
+            <TooltipContent
+              align="start"
+              className="max-w-xs text-pretty"
+              side="top"
+            >
+              {row.markdownVisits.toLocaleString()} of{" "}
+              {row.visits.toLocaleString()} requests asked for markdown via the
+              Accept header
+            </TooltipContent>
+          </Tooltip>
+        );
+      },
+      sortValue: (row) =>
+        row.visits === 0 ? 0 : row.markdownVisits / row.visits,
+    },
+    {
+      key: "paths",
+      header: "Pages",
+      width: "5.625rem",
+      sortable: true,
+      cell: (row) => <span className="text-sm tabular-nums">{row.paths}</span>,
+    },
+    {
+      key: "lastSeenAt",
+      header: "Last seen",
+      width: "9.375rem",
+      sortable: true,
+      cell: (row) => (
+        <span className="text-muted-foreground text-[0.6875rem] whitespace-nowrap tabular-nums">
+          {formatAiTrafficTimestamp(row.lastSeenAt)}
+        </span>
+      ),
+    },
+  ];
 
   if (sources.length === 0) {
     return (

--- a/apps/dashboard/src/components/geo/ai-traffic-card.tsx
+++ b/apps/dashboard/src/components/geo/ai-traffic-card.tsx
@@ -8,10 +8,10 @@ import {
 import { useMemo } from "react";
 
 import { EChartsAreaChart } from "@/components/evilcharts/charts/echarts-area-chart";
-import { EngineIcon } from "@/components/geo/engine-icon";
 import { GeoRateSparkline } from "@/components/geo/geo-rate-sparkline";
 import { GeoStatDelta } from "@/components/geo/geo-stat-delta";
 import { PurposeBadge } from "@/components/geo/purpose-badge";
+import { TrafficSourceGroupCell } from "@/components/geo/traffic-source-group-cell";
 import {
   InstrumentEmpty,
   InstrumentSection,
@@ -30,22 +30,24 @@ import { TABLE_ROW_HEIGHT } from "@/constants/table";
 import type { ChartConfig } from "@/types/charts";
 import type {
   AiTrafficCardProps,
-  GeoTrafficSource,
+  GeoTrafficSourceGroup,
   GeoTrafficTotals,
   GeoTrafficTrendRow,
 } from "@/types/geo";
 import {
-  buildTrafficSourceSeries,
   buildTrafficTrendRows,
   formatAiTrafficTimestamp,
-  formatGeoSource,
   formatMarkdownShare,
   hasTrafficSourceSeries,
   toGeoTrafficPreviousTotals,
-  trafficSourceKey,
   trafficSparklineDays,
   trafficVisitDelta,
 } from "@/utils/ai-traffic";
+import {
+  buildTrafficGroupSeries,
+  groupTrafficSources,
+  trafficGroupKey,
+} from "@/utils/ai-traffic-groups";
 import { todayIsoDate } from "@/utils/analytics-charts";
 import { seriesColors } from "@/utils/chart-colors";
 import { formatChartInteger } from "@/utils/geo-charts";
@@ -206,22 +208,18 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
     [sources]
   );
   const trendRows = useMemo(() => buildTrafficTrendRows(points), [points]);
+  const groups = useMemo(() => groupTrafficSources(sources), [sources]);
   const sparklineDays = useMemo(() => trafficSparklineDays(points), [points]);
   const canSparkline = hasTrafficSourceSeries(points);
-  const seriesBySource = useMemo(() => {
+  const seriesByGroup = useMemo(() => {
     if (!canSparkline) {
       return new Map<string, { day: string; value: number }[]>();
     }
     const map = new Map<string, { day: string; value: number }[]>();
-    for (const source of sources) {
-      const values = buildTrafficSourceSeries(
-        points,
-        source.source,
-        source.visitorType,
-        sparklineDays
-      );
+    for (const group of groups) {
+      const values = buildTrafficGroupSeries(points, group, sparklineDays);
       map.set(
-        trafficSourceKey(source.source, source.visitorType),
+        trafficGroupKey(group.visitorType, group.key),
         sparklineDays.map((day, index) => ({
           day,
           value: values[index] ?? 0,
@@ -229,31 +227,40 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
       );
     }
     return map;
-  }, [canSparkline, points, sources, sparklineDays]);
+  }, [canSparkline, points, groups, sparklineDays]);
 
-  const columns = useMemo<TableColumn<GeoTrafficSource>[]>(
+  const columns = useMemo<TableColumn<GeoTrafficSourceGroup>[]>(
     () => [
       {
         key: "source",
         header: "Source",
         width: "1fr",
         sortable: true,
-        cell: (row) => (
-          <span className="flex min-w-0 items-center gap-2 text-sm font-medium">
-            <EngineIcon engine={row.source} />
-            <span className="truncate">
-              {formatGeoSource(row.source, row.visitorType)}
-            </span>
-          </span>
-        ),
-        sortValue: (row) => formatGeoSource(row.source, row.visitorType),
+        cell: (row) => <TrafficSourceGroupCell group={row} />,
+        sortValue: (row) => row.label,
       },
       {
         key: "category",
         header: "Purpose",
         width: "9.5rem",
         sortable: true,
-        cell: (row) => <PurposeBadge category={row.category} />,
+        cell: (row) => {
+          const [single] = row.categories;
+          if (single === undefined) {
+            return null;
+          }
+          if (row.categories.length === 1) {
+            return <PurposeBadge category={single} />;
+          }
+          return (
+            <span className="flex items-center gap-1">
+              {row.categories.map((category) => (
+                <PurposeBadge category={category} compact key={category} />
+              ))}
+            </span>
+          );
+        },
+        sortValue: (row) => row.categories.join(","),
       },
       {
         key: "visits",
@@ -261,8 +268,8 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
         width: "10.5rem",
         sortable: true,
         cell: (row) => {
-          const series = seriesBySource.get(
-            trafficSourceKey(row.source, row.visitorType)
+          const series = seriesByGroup.get(
+            trafficGroupKey(row.visitorType, row.key)
           );
           const showSpark =
             series !== undefined && series.length >= GEO_SPARKLINE_MIN_POINTS;
@@ -341,7 +348,7 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
         ),
       },
     ],
-    [seriesBySource]
+    [seriesByGroup]
   );
 
   if (sources.length === 0) {
@@ -366,11 +373,11 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
         <Table
           className="rounded-2xl"
           columns={columns}
-          data={sources}
+          data={groups}
           defaultSort={{ key: "visits", direction: "desc" }}
           emptyState="No AI traffic captured yet"
-          getRowId={(row) => `${row.visitorType}-${row.source}`}
-          height={tableHeightFor(sources.length)}
+          getRowId={(row) => trafficGroupKey(row.visitorType, row.key)}
+          height={tableHeightFor(groups.length)}
           resizable
           rowHeight={TABLE_ROW_HEIGHT}
         />

--- a/apps/dashboard/src/components/geo/ai-traffic-card.tsx
+++ b/apps/dashboard/src/components/geo/ai-traffic-card.tsx
@@ -10,7 +10,7 @@ import { useMemo } from "react";
 import { EChartsAreaChart } from "@/components/evilcharts/charts/echarts-area-chart";
 import { GeoRateSparkline } from "@/components/geo/geo-rate-sparkline";
 import { GeoStatDelta } from "@/components/geo/geo-stat-delta";
-import { PurposeBadge } from "@/components/geo/purpose-badge";
+import { TrafficPurposeCell } from "@/components/geo/traffic-purpose-cell";
 import { TrafficSourceGroupCell } from "@/components/geo/traffic-source-group-cell";
 import {
   InstrumentEmpty,
@@ -239,22 +239,7 @@ export function AiTrafficCard({ traffic }: AiTrafficCardProps) {
       header: "Purpose",
       width: "9.5rem",
       sortable: true,
-      cell: (row) => {
-        const [single] = row.categories;
-        if (single === undefined) {
-          return null;
-        }
-        if (row.categories.length === 1) {
-          return <PurposeBadge category={single} />;
-        }
-        return (
-          <span className="flex items-center gap-1">
-            {row.categories.map((category) => (
-              <PurposeBadge category={category} compact key={category} />
-            ))}
-          </span>
-        );
-      },
+      cell: (row) => <TrafficPurposeCell group={row} />,
       sortValue: (row) => row.categories.join(","),
     },
     {

--- a/apps/dashboard/src/components/geo/ai-traffic-card.tsx
+++ b/apps/dashboard/src/components/geo/ai-traffic-card.tsx
@@ -27,6 +27,7 @@ import {
   GEO_TRAFFIC_TREND_REFERRAL_LABEL,
 } from "@/constants/geo";
 import { TABLE_ROW_HEIGHT } from "@/constants/table";
+import { cn } from "@/lib/utils";
 import type { ChartConfig } from "@/types/charts";
 import type {
   AiTrafficCardProps,
@@ -139,8 +140,15 @@ function TrafficHero({
   );
 
   return (
-    <div className="border-border bg-card overflow-hidden rounded-2xl border">
-      <div className="divide-border grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+    <div>
+      <div
+        className={cn(
+          "divide-border grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0",
+          showTrend
+            ? "border-border bg-muted rounded-t-2xl border border-b-0 pb-5"
+            : "border-border bg-card overflow-hidden rounded-2xl border"
+        )}
+      >
         {metrics.map((metric) => (
           <div className="px-5 py-4" key={metric.key}>
             <p className="text-muted-foreground text-xs">{metric.label}</p>
@@ -159,7 +167,7 @@ function TrafficHero({
         ))}
       </div>
       {showTrend ? (
-        <div className="border-border border-t p-4">
+        <div className="border-border bg-card -mt-5 rounded-2xl border p-4">
           <EChartsAreaChart
             animation={false}
             chartOptions={HERO_CHART_OPTIONS}

--- a/apps/dashboard/src/components/geo/ai-traffic-log-card.tsx
+++ b/apps/dashboard/src/components/geo/ai-traffic-log-card.tsx
@@ -10,6 +10,7 @@ import {
 } from "@notra/ui/components/ui/dropdown-menu";
 import { type ReactNode, useState } from "react";
 
+import { Button } from "@/components/button";
 import { CitationsTable } from "@/components/geo/citations-table";
 import { GeoTableSkeleton } from "@/components/geo/skeleton-parts";
 import {
@@ -30,9 +31,6 @@ import {
 
 const TRAFFIC_LOG_HEIGHT = 416;
 const LOG_SKELETON_ROWS = 6;
-
-const FILTER_TRIGGER_CLASS =
-  "flex h-6 items-center gap-1 rounded-sm border border-border bg-background px-2 text-xs hover:bg-muted";
 
 export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
   const [filters, setFilters] = useState<GeoTrafficLogFilters>({
@@ -68,7 +66,7 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
   const filterRow = (
     <div className="flex items-center gap-2">
       <DropdownMenu>
-        <DropdownMenuTrigger className={FILTER_TRIGGER_CLASS}>
+        <DropdownMenuTrigger render={<Button size="sm" variant="outline" />}>
           {formatGeoTrafficFilterLabel(
             "All visitors",
             "visitors",
@@ -97,7 +95,7 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu>
-        <DropdownMenuTrigger className={FILTER_TRIGGER_CLASS}>
+        <DropdownMenuTrigger render={<Button size="sm" variant="outline" />}>
           {formatGeoTrafficFilterLabel(
             "All purposes",
             "purposes",
@@ -126,18 +124,18 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
         </DropdownMenuContent>
       </DropdownMenu>
       {total > 0 && (
-        <button
-          className={FILTER_TRIGGER_CLASS}
+        <Button
           onClick={() => setLive((current) => !current)}
-          type="button"
+          size="sm"
+          variant="outline"
         >
           <HugeiconsIcon
+            data-icon="inline-start"
             icon={live ? PauseIcon : PlayIcon}
-            size={12}
             strokeWidth={2}
           />
           {live ? "Pause live updates" : "Resume live updates"}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/apps/dashboard/src/components/geo/citations-table.tsx
+++ b/apps/dashboard/src/components/geo/citations-table.tsx
@@ -7,11 +7,6 @@ import {
   HoverCard,
   HoverCardTrigger,
 } from "@notra/ui/components/ui/hover-card";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@notra/ui/components/ui/tooltip";
 
 import { EngineIcon } from "@/components/geo/engine-icon";
 import { PurposeBadge } from "@/components/geo/purpose-badge";
@@ -20,9 +15,11 @@ import { CountryFlag } from "@/components/geo/twemoji";
 import { Table, type TableColumn } from "@/components/motion/table";
 import { TruncateWithTooltip } from "@/components/truncate-with-tooltip";
 import {
+  AI_TRAFFIC_PURPOSE_DESCRIPTIONS,
   AI_TRAFFIC_PURPOSE_LABELS,
   GEO_CITATIONS_ROW_HEIGHT,
 } from "@/constants/geo";
+import { AI_TRAFFIC_PURPOSE_ICONS } from "@/constants/geo-purpose-icons";
 import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
 import type { CitationsTableProps, GeoTrafficLogEntry } from "@/types/geo";
 import { countryName } from "@/utils/country";
@@ -77,29 +74,84 @@ function ProviderCell({ entry }: { entry: GeoTrafficLogEntry }) {
   );
 }
 
-function MarkdownFlag({ wantsMarkdown }: { wantsMarkdown: boolean }) {
-  if (!wantsMarkdown) {
-    return null;
-  }
+const MARKDOWN_HINT = "Asked for markdown via the Accept header";
+
+function MarkdownBadge() {
+  return (
+    <Badge aria-label="Markdown" className="px-1.5" variant="secondary">
+      <HugeiconsIcon
+        className="size-3 shrink-0"
+        icon={SourceCodeIcon}
+        strokeWidth={2}
+      />
+    </Badge>
+  );
+}
+
+function PurposeCell({ entry }: { entry: GeoTrafficLogEntry }) {
+  const purposeIcon = AI_TRAFFIC_PURPOSE_ICONS[entry.category];
+  const purposeLabel =
+    AI_TRAFFIC_PURPOSE_LABELS[entry.category] ?? entry.category;
+  const purposeDescription =
+    AI_TRAFFIC_PURPOSE_DESCRIPTIONS[entry.category] ?? entry.category;
 
   return (
-    <Tooltip>
-      <TooltipTrigger
-        render={<span className="inline-flex shrink-0 cursor-help" />}
-      >
-        <Badge aria-label="Markdown" className="px-1.5" variant="secondary">
-          <HugeiconsIcon
-            className="size-3 shrink-0"
-            icon={SourceCodeIcon}
-            strokeWidth={2}
+    <HoverCard>
+      <HoverCardTrigger
+        delay={GEO_TRAFFIC_HOVER_DELAY_MS}
+        render={
+          <button
+            aria-label={
+              entry.wantsMarkdown
+                ? `${purposeLabel}, requested markdown, show details`
+                : `${purposeLabel}, show details`
+            }
+            className="focus-visible:ring-ring/50 flex items-center gap-1 rounded-sm outline-hidden focus-visible:ring-[3px]"
+            type="button"
           />
-        </Badge>
-      </TooltipTrigger>
-      <TooltipContent align="start" className="max-w-xs text-pretty">
-        <span className="block font-medium">Markdown</span>
-        Asked for markdown via the Accept header
-      </TooltipContent>
-    </Tooltip>
+        }
+      >
+        <PurposeBadge category={entry.category} compact tooltip={false} />
+        {entry.wantsMarkdown ? <MarkdownBadge /> : null}
+      </HoverCardTrigger>
+      <TrafficBreakdownCard
+        icon={
+          purposeIcon ? (
+            <HugeiconsIcon
+              aria-hidden="true"
+              className="size-4 shrink-0"
+              icon={purposeIcon}
+              strokeWidth={2}
+            />
+          ) : null
+        }
+        title={purposeLabel}
+      >
+        <ul>
+          <li className="px-3 py-1.5">
+            <p className="text-muted-foreground text-xs text-pretty">
+              {purposeDescription}
+            </p>
+          </li>
+          {entry.wantsMarkdown ? (
+            <li className="flex items-start gap-2 px-3 py-1.5">
+              <HugeiconsIcon
+                aria-hidden="true"
+                className="text-muted-foreground mt-0.5 size-3.5 shrink-0"
+                icon={SourceCodeIcon}
+                strokeWidth={2}
+              />
+              <span className="flex min-w-0 flex-col">
+                <span className="text-xs font-medium">Markdown</span>
+                <span className="text-muted-foreground text-xs text-pretty">
+                  {MARKDOWN_HINT}
+                </span>
+              </span>
+            </li>
+          ) : null}
+        </ul>
+      </TrafficBreakdownCard>
+    </HoverCard>
   );
 }
 
@@ -150,12 +202,7 @@ const CITATIONS_COLUMNS: TableColumn<GeoTrafficLogEntry>[] = [
     sortable: true,
     sortValue: (entry) =>
       AI_TRAFFIC_PURPOSE_LABELS[entry.category] ?? entry.category,
-    cell: (entry) => (
-      <span className="flex items-center gap-1">
-        <PurposeBadge category={entry.category} compact />
-        <MarkdownFlag wantsMarkdown={entry.wantsMarkdown} />
-      </span>
-    ),
+    cell: (entry) => <PurposeCell entry={entry} />,
   },
   {
     key: "country",

--- a/apps/dashboard/src/components/geo/citations-table.tsx
+++ b/apps/dashboard/src/components/geo/citations-table.tsx
@@ -1,5 +1,12 @@
 "use client";
 
+import { SourceCodeIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Badge } from "@notra/ui/components/ui/badge";
+import {
+  HoverCard,
+  HoverCardTrigger,
+} from "@notra/ui/components/ui/hover-card";
 import {
   Tooltip,
   TooltipContent,
@@ -8,6 +15,7 @@ import {
 
 import { EngineIcon } from "@/components/geo/engine-icon";
 import { PurposeBadge } from "@/components/geo/purpose-badge";
+import { TrafficBreakdownCard } from "@/components/geo/traffic-breakdown-card";
 import { CountryFlag } from "@/components/geo/twemoji";
 import { Table, type TableColumn } from "@/components/motion/table";
 import { TruncateWithTooltip } from "@/components/truncate-with-tooltip";
@@ -15,6 +23,7 @@ import {
   AI_TRAFFIC_PURPOSE_LABELS,
   GEO_CITATIONS_ROW_HEIGHT,
 } from "@/constants/geo";
+import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
 import type { CitationsTableProps, GeoTrafficLogEntry } from "@/types/geo";
 import { countryName } from "@/utils/country";
 import {
@@ -24,49 +33,47 @@ import {
   formatCitationTimestamp,
 } from "@/utils/geo-citations";
 
-function ProviderTooltip({ entry }: { entry: GeoTrafficLogEntry }) {
-  const detail = citationProviderTooltip(entry);
-
-  return (
-    <div className="flex flex-col gap-2 text-left">
-      <div className="flex flex-col gap-0.5">
-        <p className="font-medium">{detail.title}</p>
-        {detail.raw ? (
-          <p className="text-muted-foreground font-mono text-[0.6875rem]">
-            {detail.raw}
-          </p>
-        ) : null}
-      </div>
-      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
-        <dt className="text-muted-foreground">Purpose</dt>
-        <dd className="m-0">{detail.purpose}</dd>
-        <dt className="text-muted-foreground">Confidence</dt>
-        <dd className="m-0">{detail.confidence}</dd>
-      </dl>
-    </div>
-  );
-}
-
 function ProviderCell({ entry }: { entry: GeoTrafficLogEntry }) {
-  const label = formatCitationProvider(
-    entry.agent,
-    entry.source,
-    entry.visitorType
-  );
+  const detail = citationProviderTooltip(entry);
+  const engine = entry.agent || entry.source;
   return (
-    <Tooltip>
-      <TooltipTrigger
+    <HoverCard>
+      <HoverCardTrigger
+        delay={GEO_TRAFFIC_HOVER_DELAY_MS}
         render={
-          <span className="inline-flex cursor-default items-center gap-2" />
+          <button
+            aria-label={`${detail.title}, show details`}
+            className="focus-visible:ring-ring/50 inline-flex max-w-full min-w-0 cursor-default items-center gap-2 rounded-sm text-left outline-hidden focus-visible:ring-[3px]"
+            type="button"
+          />
         }
       >
-        <EngineIcon engine={entry.agent || entry.source} />
-        <span className="truncate">{label}</span>
-      </TooltipTrigger>
-      <TooltipContent align="start" className="max-w-xs">
-        <ProviderTooltip entry={entry} />
-      </TooltipContent>
-    </Tooltip>
+        <EngineIcon engine={engine} />
+        <span className="truncate">{detail.title}</span>
+      </HoverCardTrigger>
+      <TrafficBreakdownCard
+        aside={
+          detail.raw ? (
+            <span className="block max-w-32 truncate font-mono">
+              {detail.raw}
+            </span>
+          ) : null
+        }
+        icon={<EngineIcon engine={engine} />}
+        title={detail.title}
+      >
+        <dl className="flex flex-col">
+          <div className="flex items-center justify-between gap-3 px-3 py-1.5">
+            <dt className="text-muted-foreground text-xs">Purpose</dt>
+            <dd className="m-0 text-xs font-medium">{detail.purpose}</dd>
+          </div>
+          <div className="flex items-center justify-between gap-3 px-3 py-1.5">
+            <dt className="text-muted-foreground text-xs">Confidence</dt>
+            <dd className="m-0 text-xs font-medium">{detail.confidence}</dd>
+          </div>
+        </dl>
+      </TrafficBreakdownCard>
+    </HoverCard>
   );
 }
 
@@ -78,14 +85,19 @@ function MarkdownFlag({ wantsMarkdown }: { wantsMarkdown: boolean }) {
   return (
     <Tooltip>
       <TooltipTrigger
-        render={
-          <span className="bg-muted text-muted-foreground cursor-default rounded-sm px-1.5 py-0.5 font-mono text-[0.6875rem]" />
-        }
+        render={<span className="inline-flex shrink-0 cursor-help" />}
       >
-        MD
+        <Badge aria-label="Markdown" className="px-1.5" variant="secondary">
+          <HugeiconsIcon
+            className="size-3 shrink-0"
+            icon={SourceCodeIcon}
+            strokeWidth={2}
+          />
+        </Badge>
       </TooltipTrigger>
       <TooltipContent align="start" className="max-w-xs text-pretty">
-        Requested markdown (Accept header)
+        <span className="block font-medium">Markdown</span>
+        Asked for markdown via the Accept header
       </TooltipContent>
     </Tooltip>
   );
@@ -128,23 +140,27 @@ const CITATIONS_COLUMNS: TableColumn<GeoTrafficLogEntry>[] = [
             {entry.path}
           </TruncateWithTooltip>
         </span>
-        <MarkdownFlag wantsMarkdown={entry.wantsMarkdown} />
       </span>
     ),
   },
   {
     key: "category",
     header: "Purpose",
-    width: "9.5rem",
+    width: "6.5rem",
     sortable: true,
     sortValue: (entry) =>
       AI_TRAFFIC_PURPOSE_LABELS[entry.category] ?? entry.category,
-    cell: (entry) => <PurposeBadge category={entry.category} />,
+    cell: (entry) => (
+      <span className="flex items-center gap-1">
+        <PurposeBadge category={entry.category} compact />
+        <MarkdownFlag wantsMarkdown={entry.wantsMarkdown} />
+      </span>
+    ),
   },
   {
     key: "country",
     header: "Country",
-    width: "9rem",
+    width: "10.5rem",
     sortable: true,
     sortValue: (row) => countryName(row.country),
     cell: (row) =>

--- a/apps/dashboard/src/components/geo/purpose-badge.tsx
+++ b/apps/dashboard/src/components/geo/purpose-badge.tsx
@@ -25,7 +25,7 @@ const PURPOSE_ICONS: Record<string, typeof QuotesIcon> = {
   "search-index": Search01Icon,
 };
 
-export function PurposeBadge({ category }: PurposeBadgeProps) {
+export function PurposeBadge({ category, compact = false }: PurposeBadgeProps) {
   const icon = PURPOSE_ICONS[category];
   const label = AI_TRAFFIC_PURPOSE_LABELS[category] ?? category;
   const description = AI_TRAFFIC_PURPOSE_DESCRIPTIONS[category] ?? category;
@@ -35,7 +35,11 @@ export function PurposeBadge({ category }: PurposeBadgeProps) {
       <TooltipTrigger
         render={<span className="inline-flex max-w-full cursor-help" />}
       >
-        <Badge className="gap-1 font-normal" variant="secondary">
+        <Badge
+          aria-label={compact ? label : undefined}
+          className={compact ? "px-1.5" : "gap-1 font-normal"}
+          variant="secondary"
+        >
           {icon ? (
             <HugeiconsIcon
               className="size-3 shrink-0"
@@ -43,10 +47,11 @@ export function PurposeBadge({ category }: PurposeBadgeProps) {
               strokeWidth={2}
             />
           ) : null}
-          {label}
+          {compact ? null : label}
         </Badge>
       </TooltipTrigger>
       <TooltipContent className="max-w-xs text-pretty">
+        {compact ? <span className="block font-medium">{label}</span> : null}
         {description}
       </TooltipContent>
     </Tooltip>

--- a/apps/dashboard/src/components/geo/purpose-badge.tsx
+++ b/apps/dashboard/src/components/geo/purpose-badge.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import {
-  Globe02Icon,
-  QuotesIcon,
-  Search01Icon,
-} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@notra/ui/components/ui/badge";
 import {
@@ -17,38 +12,45 @@ import {
   AI_TRAFFIC_PURPOSE_DESCRIPTIONS,
   AI_TRAFFIC_PURPOSE_LABELS,
 } from "@/constants/geo";
+import { AI_TRAFFIC_PURPOSE_ICONS } from "@/constants/geo-purpose-icons";
 import type { PurposeBadgeProps } from "@/types/geo";
 
-const PURPOSE_ICONS: Record<string, typeof QuotesIcon> = {
-  "assistant-browse": QuotesIcon,
-  "training-crawler": Globe02Icon,
-  "search-index": Search01Icon,
-};
-
-export function PurposeBadge({ category, compact = false }: PurposeBadgeProps) {
-  const icon = PURPOSE_ICONS[category];
+export function PurposeBadge({
+  category,
+  compact = false,
+  tooltip = true,
+}: PurposeBadgeProps) {
+  const icon = AI_TRAFFIC_PURPOSE_ICONS[category];
   const label = AI_TRAFFIC_PURPOSE_LABELS[category] ?? category;
   const description = AI_TRAFFIC_PURPOSE_DESCRIPTIONS[category] ?? category;
+
+  const badge = (
+    <Badge
+      aria-label={compact ? label : undefined}
+      className={compact ? "px-1.5" : "gap-1 font-normal"}
+      variant="secondary"
+    >
+      {icon ? (
+        <HugeiconsIcon
+          className="size-3 shrink-0"
+          icon={icon}
+          strokeWidth={2}
+        />
+      ) : null}
+      {compact ? null : label}
+    </Badge>
+  );
+
+  if (!tooltip) {
+    return badge;
+  }
 
   return (
     <Tooltip>
       <TooltipTrigger
         render={<span className="inline-flex max-w-full cursor-help" />}
       >
-        <Badge
-          aria-label={compact ? label : undefined}
-          className={compact ? "px-1.5" : "gap-1 font-normal"}
-          variant="secondary"
-        >
-          {icon ? (
-            <HugeiconsIcon
-              className="size-3 shrink-0"
-              icon={icon}
-              strokeWidth={2}
-            />
-          ) : null}
-          {compact ? null : label}
-        </Badge>
+        {badge}
       </TooltipTrigger>
       <TooltipContent className="max-w-xs text-pretty">
         {compact ? <span className="block font-medium">{label}</span> : null}

--- a/apps/dashboard/src/components/geo/traffic-breakdown-card.tsx
+++ b/apps/dashboard/src/components/geo/traffic-breakdown-card.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { HoverCardContent } from "@notra/ui/components/ui/hover-card";
+
+import type { TrafficBreakdownCardProps } from "@/types/geo";
+
+export function TrafficBreakdownCard({
+  icon,
+  title,
+  aside,
+  children,
+}: TrafficBreakdownCardProps) {
+  return (
+    <HoverCardContent
+      align="start"
+      className="w-80 rounded-2xl bg-transparent p-0 shadow-none ring-0"
+      side="bottom"
+    >
+      <div className="border-border bg-muted rounded-t-2xl border border-b-0 pb-5">
+        <div className="flex items-center justify-between gap-3 px-3 py-2">
+          <span className="text-foreground flex min-w-0 items-center gap-2 text-sm font-semibold">
+            {icon}
+            <span className="truncate">{title}</span>
+          </span>
+          {aside ? (
+            <span className="text-muted-foreground min-w-0 shrink-0 text-xs tabular-nums">
+              {aside}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div className="border-border bg-popover -mt-5 rounded-2xl border shadow-md">
+        <div className="max-h-72 overflow-y-auto py-1">{children}</div>
+      </div>
+    </HoverCardContent>
+  );
+}

--- a/apps/dashboard/src/components/geo/traffic-purpose-cell.tsx
+++ b/apps/dashboard/src/components/geo/traffic-purpose-cell.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  HoverCard,
+  HoverCardTrigger,
+} from "@notra/ui/components/ui/hover-card";
+
+import { PurposeBadge } from "@/components/geo/purpose-badge";
+import { TrafficBreakdownCard } from "@/components/geo/traffic-breakdown-card";
+import { TrafficSourceGroupIcon } from "@/components/geo/traffic-source-group-icon";
+import { AI_TRAFFIC_PURPOSE_LABELS } from "@/constants/geo";
+import { AI_TRAFFIC_PURPOSE_ICONS } from "@/constants/geo-purpose-icons";
+import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
+import type { TrafficPurposeCellProps } from "@/types/geo";
+import { formatGeoSource } from "@/utils/ai-traffic";
+import {
+  hasTrafficGroupBreakdown,
+  trafficGroupPurposeTotals,
+  trafficVisitShare,
+} from "@/utils/ai-traffic-groups";
+
+export function TrafficPurposeCell({ group }: TrafficPurposeCellProps) {
+  const [single] = group.categories;
+  if (single === undefined) {
+    return null;
+  }
+
+  if (!hasTrafficGroupBreakdown(group)) {
+    return <PurposeBadge category={single} />;
+  }
+
+  const totals = trafficGroupPurposeTotals(group);
+  const compact = group.categories.length > 1;
+  const purposeLabels = totals
+    .map((total) => AI_TRAFFIC_PURPOSE_LABELS[total.category] ?? total.category)
+    .join(", ");
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        delay={GEO_TRAFFIC_HOVER_DELAY_MS}
+        render={
+          <button
+            aria-label={`${group.label} purposes: ${purposeLabels}, show breakdown`}
+            className="focus-visible:ring-ring/50 flex max-w-full cursor-default items-center gap-1 rounded-sm outline-hidden focus-visible:ring-[3px]"
+            type="button"
+          />
+        }
+      >
+        {group.categories.map((category) => (
+          <PurposeBadge
+            category={category}
+            compact={compact}
+            key={category}
+            tooltip={false}
+          />
+        ))}
+      </HoverCardTrigger>
+      <TrafficBreakdownCard
+        aside={`${group.visits.toLocaleString()} visits`}
+        icon={<TrafficSourceGroupIcon group={group} />}
+        title={group.label}
+      >
+        <ul>
+          {totals.map((total) => {
+            const icon = AI_TRAFFIC_PURPOSE_ICONS[total.category];
+            return (
+              <li
+                className="flex items-center gap-2 px-3 py-1.5"
+                key={total.category}
+              >
+                {icon ? (
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    className="text-muted-foreground size-3.5 shrink-0"
+                    icon={icon}
+                    strokeWidth={2}
+                  />
+                ) : (
+                  <span aria-hidden="true" className="size-3.5 shrink-0" />
+                )}
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-xs font-medium">
+                    {AI_TRAFFIC_PURPOSE_LABELS[total.category] ??
+                      total.category}
+                  </span>
+                  <span className="text-muted-foreground truncate text-[0.6875rem]">
+                    {total.members
+                      .map((member) =>
+                        formatGeoSource(member, group.visitorType)
+                      )
+                      .join(", ")}
+                  </span>
+                </span>
+                <span className="flex shrink-0 flex-col items-end">
+                  <span className="text-xs font-medium tabular-nums">
+                    {total.visits.toLocaleString()}
+                  </span>
+                  <span className="text-muted-foreground text-[0.6875rem] tabular-nums">
+                    {trafficVisitShare(total.visits, group.visits)}
+                  </span>
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </TrafficBreakdownCard>
+    </HoverCard>
+  );
+}

--- a/apps/dashboard/src/components/geo/traffic-source-group-cell.tsx
+++ b/apps/dashboard/src/components/geo/traffic-source-group-cell.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Robot01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@notra/ui/components/ui/hover-card";
+
+import { EngineIcon } from "@/components/geo/engine-icon";
+import { AI_TRAFFIC_PURPOSE_LABELS } from "@/constants/geo";
+import { cn } from "@/lib/utils";
+import type {
+  TrafficSourceGroupCellProps,
+  TrafficSourceGroupIconProps,
+} from "@/types/geo";
+import { formatAiTrafficTimestamp } from "@/utils/ai-traffic";
+import { trafficGroupShare } from "@/utils/ai-traffic-groups";
+import { resolveEngineIconKey } from "@/utils/geo-engine-icon";
+
+const HOVER_OPEN_DELAY_MS = 150;
+
+function TrafficSourceGroupIcon({
+  group,
+  className,
+}: TrafficSourceGroupIconProps) {
+  if (group.icon === null) {
+    return (
+      <HugeiconsIcon
+        aria-hidden="true"
+        className={cn("text-muted-foreground size-4 shrink-0", className)}
+        icon={Robot01Icon}
+      />
+    );
+  }
+  return <EngineIcon className={className} engine={group.icon} />;
+}
+
+export function TrafficSourceGroupCell({ group }: TrafficSourceGroupCellProps) {
+  const label = (
+    <span className="flex min-w-0 items-center gap-2 text-sm font-medium">
+      <TrafficSourceGroupIcon group={group} />
+      <span className="truncate">{group.label}</span>
+    </span>
+  );
+
+  if (group.visitorType !== "crawler") {
+    return label;
+  }
+
+  const botCount = group.members.length;
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        delay={HOVER_OPEN_DELAY_MS}
+        render={
+          <span className="flex max-w-full min-w-0 cursor-default items-center gap-2" />
+        }
+      >
+        {label}
+        <span className="text-muted-foreground shrink-0 text-[0.6875rem] tabular-nums">
+          {botCount} {botCount === 1 ? "bot" : "bots"}
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-80 p-0" side="bottom">
+        <div className="border-border flex items-center justify-between gap-3 border-b px-3 py-2">
+          <span className="flex min-w-0 items-center gap-2 text-sm font-medium">
+            <TrafficSourceGroupIcon group={group} />
+            <span className="truncate">{group.label}</span>
+          </span>
+          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+            {group.visits.toLocaleString()} visits
+          </span>
+        </div>
+        <ul className="max-h-72 overflow-y-auto py-1">
+          {group.members.map((member) => (
+            <li
+              className="flex items-center gap-2 px-3 py-1.5"
+              key={member.source}
+            >
+              <TrafficSourceGroupIcon
+                className="size-3.5"
+                group={{
+                  key: member.source,
+                  label: member.source,
+                  icon: resolveEngineIconKey(member.source)
+                    ? member.source
+                    : null,
+                }}
+              />
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-xs font-medium">
+                  {member.source}
+                </span>
+                <span className="text-muted-foreground flex gap-2 text-[0.6875rem]">
+                  <span className="truncate">
+                    {AI_TRAFFIC_PURPOSE_LABELS[member.category] ??
+                      member.category}
+                  </span>
+                  <span className="shrink-0 tabular-nums">
+                    {formatAiTrafficTimestamp(member.lastSeenAt)}
+                  </span>
+                </span>
+              </span>
+              <span className="flex shrink-0 flex-col items-end">
+                <span className="text-xs font-medium tabular-nums">
+                  {member.visits.toLocaleString()}
+                </span>
+                <span className="text-muted-foreground text-[0.6875rem] tabular-nums">
+                  {trafficGroupShare(member, group)}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/apps/dashboard/src/components/geo/traffic-source-group-cell.tsx
+++ b/apps/dashboard/src/components/geo/traffic-source-group-cell.tsx
@@ -56,7 +56,11 @@ export function TrafficSourceGroupCell({ group }: TrafficSourceGroupCellProps) {
       <HoverCardTrigger
         delay={HOVER_OPEN_DELAY_MS}
         render={
-          <span className="flex max-w-full min-w-0 cursor-default items-center gap-2" />
+          <button
+            aria-label={`${group.label}: ${botCount} ${botCount === 1 ? "bot" : "bots"}, show breakdown`}
+            className="focus-visible:ring-ring/50 flex max-w-full min-w-0 cursor-default items-center gap-2 rounded-sm text-left outline-hidden focus-visible:ring-[3px]"
+            type="button"
+          />
         }
       >
         {label}

--- a/apps/dashboard/src/components/geo/traffic-source-group-cell.tsx
+++ b/apps/dashboard/src/components/geo/traffic-source-group-cell.tsx
@@ -1,41 +1,21 @@
 "use client";
 
-import { Robot01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import {
   HoverCard,
-  HoverCardContent,
   HoverCardTrigger,
 } from "@notra/ui/components/ui/hover-card";
 
-import { EngineIcon } from "@/components/geo/engine-icon";
+import { TrafficBreakdownCard } from "@/components/geo/traffic-breakdown-card";
+import { TrafficSourceGroupIcon } from "@/components/geo/traffic-source-group-icon";
 import { AI_TRAFFIC_PURPOSE_LABELS } from "@/constants/geo";
-import { cn } from "@/lib/utils";
-import type {
-  TrafficSourceGroupCellProps,
-  TrafficSourceGroupIconProps,
-} from "@/types/geo";
-import { formatAiTrafficTimestamp } from "@/utils/ai-traffic";
-import { trafficGroupShare } from "@/utils/ai-traffic-groups";
+import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
+import type { TrafficSourceGroupCellProps } from "@/types/geo";
+import { formatAiTrafficTimestamp, formatGeoSource } from "@/utils/ai-traffic";
+import {
+  hasTrafficGroupBreakdown,
+  trafficVisitShare,
+} from "@/utils/ai-traffic-groups";
 import { resolveEngineIconKey } from "@/utils/geo-engine-icon";
-
-const HOVER_OPEN_DELAY_MS = 150;
-
-function TrafficSourceGroupIcon({
-  group,
-  className,
-}: TrafficSourceGroupIconProps) {
-  if (group.icon === null) {
-    return (
-      <HugeiconsIcon
-        aria-hidden="true"
-        className={cn("text-muted-foreground size-4 shrink-0", className)}
-        icon={Robot01Icon}
-      />
-    );
-  }
-  return <EngineIcon className={className} engine={group.icon} />;
-}
 
 export function TrafficSourceGroupCell({ group }: TrafficSourceGroupCellProps) {
   const label = (
@@ -45,19 +25,21 @@ export function TrafficSourceGroupCell({ group }: TrafficSourceGroupCellProps) {
     </span>
   );
 
-  if (group.visitorType !== "crawler") {
+  if (!hasTrafficGroupBreakdown(group)) {
     return label;
   }
 
   const botCount = group.members.length;
+  const noun = group.visitorType === "crawler" ? "bot" : "source";
+  const botsLabel = `${botCount} ${botCount === 1 ? noun : `${noun}s`}`;
 
   return (
     <HoverCard>
       <HoverCardTrigger
-        delay={HOVER_OPEN_DELAY_MS}
+        delay={GEO_TRAFFIC_HOVER_DELAY_MS}
         render={
           <button
-            aria-label={`${group.label}: ${botCount} ${botCount === 1 ? "bot" : "bots"}, show breakdown`}
+            aria-label={`${group.label}: ${botsLabel}, show breakdown`}
             className="focus-visible:ring-ring/50 flex max-w-full min-w-0 cursor-default items-center gap-2 rounded-sm text-left outline-hidden focus-visible:ring-[3px]"
             type="button"
           />
@@ -65,20 +47,15 @@ export function TrafficSourceGroupCell({ group }: TrafficSourceGroupCellProps) {
       >
         {label}
         <span className="text-muted-foreground shrink-0 text-[0.6875rem] tabular-nums">
-          {botCount} {botCount === 1 ? "bot" : "bots"}
+          {botsLabel}
         </span>
       </HoverCardTrigger>
-      <HoverCardContent align="start" className="w-80 p-0" side="bottom">
-        <div className="border-border flex items-center justify-between gap-3 border-b px-3 py-2">
-          <span className="flex min-w-0 items-center gap-2 text-sm font-medium">
-            <TrafficSourceGroupIcon group={group} />
-            <span className="truncate">{group.label}</span>
-          </span>
-          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-            {group.visits.toLocaleString()} visits
-          </span>
-        </div>
-        <ul className="max-h-72 overflow-y-auto py-1">
+      <TrafficBreakdownCard
+        aside={`${group.visits.toLocaleString()} visits`}
+        icon={<TrafficSourceGroupIcon group={group} />}
+        title={group.label}
+      >
+        <ul>
           {group.members.map((member) => (
             <li
               className="flex items-center gap-2 px-3 py-1.5"
@@ -96,7 +73,7 @@ export function TrafficSourceGroupCell({ group }: TrafficSourceGroupCellProps) {
               />
               <span className="flex min-w-0 flex-1 flex-col">
                 <span className="truncate text-xs font-medium">
-                  {member.source}
+                  {formatGeoSource(member.source, member.visitorType)}
                 </span>
                 <span className="text-muted-foreground flex gap-2 text-[0.6875rem]">
                   <span className="truncate">
@@ -113,13 +90,13 @@ export function TrafficSourceGroupCell({ group }: TrafficSourceGroupCellProps) {
                   {member.visits.toLocaleString()}
                 </span>
                 <span className="text-muted-foreground text-[0.6875rem] tabular-nums">
-                  {trafficGroupShare(member, group)}
+                  {trafficVisitShare(member.visits, group.visits)}
                 </span>
               </span>
             </li>
           ))}
         </ul>
-      </HoverCardContent>
+      </TrafficBreakdownCard>
     </HoverCard>
   );
 }

--- a/apps/dashboard/src/components/geo/traffic-source-group-icon.tsx
+++ b/apps/dashboard/src/components/geo/traffic-source-group-icon.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Robot01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { EngineIcon } from "@/components/geo/engine-icon";
+import { cn } from "@/lib/utils";
+import type { TrafficSourceGroupIconProps } from "@/types/geo";
+
+export function TrafficSourceGroupIcon({
+  group,
+  className,
+}: TrafficSourceGroupIconProps) {
+  if (group.icon === null) {
+    return (
+      <HugeiconsIcon
+        aria-hidden="true"
+        className={cn("text-muted-foreground size-4 shrink-0", className)}
+        icon={Robot01Icon}
+      />
+    );
+  }
+  return <EngineIcon className={className} engine={group.icon} />;
+}

--- a/apps/dashboard/src/constants/geo-purpose-icons.ts
+++ b/apps/dashboard/src/constants/geo-purpose-icons.ts
@@ -1,0 +1,13 @@
+import {
+  CursorPointer02Icon,
+  Globe02Icon,
+  QuotesIcon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons";
+
+export const AI_TRAFFIC_PURPOSE_ICONS: Record<string, typeof QuotesIcon> = {
+  "assistant-browse": QuotesIcon,
+  "training-crawler": Globe02Icon,
+  "search-index": Search01Icon,
+  "assistant-referral": CursorPointer02Icon,
+};

--- a/apps/dashboard/src/constants/geo-traffic-hover.ts
+++ b/apps/dashboard/src/constants/geo-traffic-hover.ts
@@ -1,0 +1,1 @@
+export const GEO_TRAFFIC_HOVER_DELAY_MS = 150;

--- a/apps/dashboard/src/constants/geo.ts
+++ b/apps/dashboard/src/constants/geo.ts
@@ -13,6 +13,7 @@ import { LANGUAGE_FLAGS } from "@/constants/brand-identity";
 import { GEO_MODEL_CATALOG_SEED } from "@/constants/geo-model-catalog";
 import type {
   AiTrafficResponse,
+  EngineIconKey,
   GeoChatSkin,
   GeoCompetitorKind,
   GeoCompetitorShareTimeseriesPoint,
@@ -26,6 +27,7 @@ import type {
   GeoTimeseriesPoint,
   GeoTrafficLogPurposeOption,
   GeoTrafficLogVisitorOption,
+  GeoTrafficSourceGroupDefinition,
   GeoVisitorType,
 } from "@/types/geo";
 
@@ -527,6 +529,40 @@ export const AI_TRAFFIC_PURPOSE_DESCRIPTIONS: Record<string, string> = {
     "Fetched while an assistant was answering someone. A fetch is not proof of a citation",
   "assistant-referral":
     "A person clicked through to your site from an AI answer",
+};
+
+const GEO_TRAFFIC_GOOGLE_GROUP: GeoTrafficSourceGroupDefinition = {
+  key: "google",
+  label: "Google",
+  icon: "googlebot",
+};
+
+export const GEO_TRAFFIC_OTHER_GROUP: GeoTrafficSourceGroupDefinition = {
+  key: "other",
+  label: "Other",
+  icon: null,
+};
+
+export const GEO_TRAFFIC_GROUPS_BY_ENGINE: Partial<
+  Record<EngineIconKey, GeoTrafficSourceGroupDefinition>
+> = {
+  openai: { key: "chatgpt", label: "ChatGPT", icon: "openai" },
+  claude: { key: "claude", label: "Claude", icon: "claude" },
+  gemini: GEO_TRAFFIC_GOOGLE_GROUP,
+  google: GEO_TRAFFIC_GOOGLE_GROUP,
+  perplexity: { key: "perplexity", label: "Perplexity", icon: "perplexity" },
+  copilot: { key: "microsoft", label: "Microsoft", icon: "copilot" },
+  meta: { key: "meta", label: "Meta", icon: "meta-" },
+  amazon: { key: "amazon", label: "Amazon", icon: "amazonbot" },
+  apple: { key: "apple", label: "Apple", icon: "applebot" },
+  tiktok: { key: "bytedance", label: "ByteDance", icon: "bytespider" },
+  mistral: { key: "mistral", label: "Mistral", icon: "mistral" },
+  deepseek: { key: "deepseek", label: "DeepSeek", icon: "deepseek" },
+  grok: { key: "xai", label: "xAI", icon: "grok" },
+  qwen: { key: "alibaba", label: "Alibaba", icon: "qwen" },
+  commoncrawl: { key: "commoncrawl", label: "Common Crawl", icon: "ccbot" },
+  cohere: { key: "cohere", label: "Cohere", icon: "cohere" },
+  duckduckgo: { key: "duckduckgo", label: "DuckDuckGo", icon: "duckduckgo" },
 };
 
 export const GEO_TRAFFIC_TREND_CRAWLER_KEY = "crawler";

--- a/apps/dashboard/src/constants/geo.ts
+++ b/apps/dashboard/src/constants/geo.ts
@@ -563,6 +563,8 @@ export const GEO_TRAFFIC_GROUPS_BY_ENGINE: Partial<
   commoncrawl: { key: "commoncrawl", label: "Common Crawl", icon: "ccbot" },
   cohere: { key: "cohere", label: "Cohere", icon: "cohere" },
   duckduckgo: { key: "duckduckgo", label: "DuckDuckGo", icon: "duckduckgo" },
+  opencode: { key: "opencode", label: "OpenCode", icon: "opencode" },
+  cursor: { key: "cursor", label: "Cursor", icon: "cursor" },
 };
 
 export const GEO_TRAFFIC_TREND_CRAWLER_KEY = "crawler";

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -1222,6 +1222,7 @@ export interface CitationsTableProps {
 export interface PurposeBadgeProps {
   category: string;
   compact?: boolean;
+  tooltip?: boolean;
 }
 
 export interface GeoTrafficSourceGroupDefinition {
@@ -1242,6 +1243,23 @@ export interface GeoTrafficSourceGroup extends GeoTrafficSourceGroupDefinition {
 
 export interface TrafficSourceGroupCellProps {
   group: GeoTrafficSourceGroup;
+}
+
+export interface TrafficPurposeCellProps {
+  group: GeoTrafficSourceGroup;
+}
+
+export interface GeoTrafficPurposeTotal {
+  category: string;
+  visits: number;
+  members: string[];
+}
+
+export interface TrafficBreakdownCardProps {
+  icon: ReactNode;
+  title: string;
+  aside?: ReactNode;
+  children: ReactNode;
 }
 
 export interface TrafficSourceGroupIconProps {

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -1221,6 +1221,32 @@ export interface CitationsTableProps {
 
 export interface PurposeBadgeProps {
   category: string;
+  compact?: boolean;
+}
+
+export interface GeoTrafficSourceGroupDefinition {
+  key: string;
+  label: string;
+  icon: string | null;
+}
+
+export interface GeoTrafficSourceGroup extends GeoTrafficSourceGroupDefinition {
+  visitorType: GeoVisitorType;
+  visits: number;
+  markdownVisits: number;
+  paths: number;
+  lastSeenAt: string;
+  categories: string[];
+  members: GeoTrafficSource[];
+}
+
+export interface TrafficSourceGroupCellProps {
+  group: GeoTrafficSourceGroup;
+}
+
+export interface TrafficSourceGroupIconProps {
+  group: GeoTrafficSourceGroupDefinition;
+  className?: string;
 }
 
 export type EngineIconKey =

--- a/apps/dashboard/src/utils/ai-traffic-groups.test.ts
+++ b/apps/dashboard/src/utils/ai-traffic-groups.test.ts
@@ -5,6 +5,7 @@ import {
   buildTrafficGroupSeries,
   groupTrafficSources,
   resolveTrafficSourceGroup,
+  trafficGroupPurposeTotals,
 } from "@/utils/ai-traffic-groups";
 
 function crawler(
@@ -44,6 +45,19 @@ describe("resolveTrafficSourceGroup", () => {
     expect(
       resolveTrafficSourceGroup("Browser-imitating agent", "crawler").key
     ).toBe("other");
+  });
+
+  test("gives coding agents their own groups", () => {
+    expect(resolveTrafficSourceGroup("OpenCode", "crawler").key).toBe(
+      "opencode"
+    );
+    expect(resolveTrafficSourceGroup("Cursor", "crawler").key).toBe("cursor");
+  });
+
+  test("sends lesser known referrers to Other", () => {
+    expect(resolveTrafficSourceGroup("you.com", "ai_referral").key).toBe(
+      "other"
+    );
   });
 
   test("keeps referrals as their own labelled source", () => {
@@ -100,6 +114,30 @@ describe("groupTrafficSources", () => {
       "LinerBot",
     ]);
     expect(referral?.label).toBe("ChatGPT");
+  });
+});
+
+describe("trafficGroupPurposeTotals", () => {
+  test("sums visits per purpose and lists contributing bots", () => {
+    const [group] = groupTrafficSources([
+      crawler("GPTBot", "training-crawler", 40),
+      crawler("OAI-SearchBot", "search-index", 60),
+      crawler("OAI-AdsBot", "search-index", 5),
+      crawler("ChatGPT-User", "assistant-browse", 1),
+    ]);
+    if (group === undefined) {
+      throw new Error("expected a ChatGPT group");
+    }
+
+    expect(trafficGroupPurposeTotals(group)).toEqual([
+      {
+        category: "search-index",
+        visits: 65,
+        members: ["OAI-SearchBot", "OAI-AdsBot"],
+      },
+      { category: "training-crawler", visits: 40, members: ["GPTBot"] },
+      { category: "assistant-browse", visits: 1, members: ["ChatGPT-User"] },
+    ]);
   });
 });
 

--- a/apps/dashboard/src/utils/ai-traffic-groups.test.ts
+++ b/apps/dashboard/src/utils/ai-traffic-groups.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+
+import type { GeoTrafficPoint, GeoTrafficSource } from "@/types/geo";
+import {
+  buildTrafficGroupSeries,
+  groupTrafficSources,
+  resolveTrafficSourceGroup,
+} from "@/utils/ai-traffic-groups";
+
+function crawler(
+  source: string,
+  category: string,
+  visits: number,
+  overrides: Partial<GeoTrafficSource> = {}
+): GeoTrafficSource {
+  return {
+    source,
+    visitorType: "crawler",
+    agent: source,
+    category,
+    confidence: "verified",
+    visits,
+    markdownVisits: 0,
+    paths: 1,
+    lastSeenAt: "2026-08-20 10:00:00",
+    ...overrides,
+  };
+}
+
+describe("resolveTrafficSourceGroup", () => {
+  test("maps OpenAI bots to the ChatGPT group", () => {
+    expect(resolveTrafficSourceGroup("OAI-SearchBot", "crawler").key).toBe(
+      "chatgpt"
+    );
+    expect(resolveTrafficSourceGroup("GPTBot", "crawler").key).toBe("chatgpt");
+    expect(resolveTrafficSourceGroup("ChatGPT-User", "crawler").key).toBe(
+      "chatgpt"
+    );
+  });
+
+  test("puts lesser known crawlers into Other", () => {
+    expect(resolveTrafficSourceGroup("YouBot", "crawler").key).toBe("other");
+    expect(resolveTrafficSourceGroup("LinerBot", "crawler").key).toBe("other");
+    expect(
+      resolveTrafficSourceGroup("Browser-imitating agent", "crawler").key
+    ).toBe("other");
+  });
+
+  test("keeps referrals as their own labelled source", () => {
+    expect(resolveTrafficSourceGroup("chatgpt", "ai_referral")).toEqual({
+      key: "chatgpt",
+      label: "ChatGPT",
+      icon: "chatgpt",
+    });
+  });
+});
+
+describe("groupTrafficSources", () => {
+  test("aggregates visits, markdown, last seen and purposes per vendor", () => {
+    const sources: GeoTrafficSource[] = [
+      crawler("GPTBot", "training-crawler", 40, {
+        markdownVisits: 4,
+        paths: 12,
+        lastSeenAt: "2026-08-20 10:00:00",
+      }),
+      crawler("OAI-SearchBot", "search-index", 60, {
+        markdownVisits: 6,
+        paths: 8,
+        lastSeenAt: "2026-08-21 09:30:00",
+      }),
+      crawler("YouBot", "search-index", 3),
+      crawler("LinerBot", "search-index", 2),
+      {
+        ...crawler("chatgpt", "assistant-referral", 5),
+        visitorType: "ai_referral",
+      },
+    ];
+
+    const groups = groupTrafficSources(sources);
+    const chatgpt = groups.find(
+      (group) => group.key === "chatgpt" && group.visitorType === "crawler"
+    );
+    const other = groups.find((group) => group.key === "other");
+    const referral = groups.find(
+      (group) => group.visitorType === "ai_referral"
+    );
+
+    expect(groups).toHaveLength(3);
+    expect(chatgpt?.visits).toBe(100);
+    expect(chatgpt?.markdownVisits).toBe(10);
+    expect(chatgpt?.paths).toBe(12);
+    expect(chatgpt?.lastSeenAt).toBe("2026-08-21 09:30:00");
+    expect(chatgpt?.categories).toEqual(["search-index", "training-crawler"]);
+    expect(chatgpt?.members.map((member) => member.source)).toEqual([
+      "OAI-SearchBot",
+      "GPTBot",
+    ]);
+    expect(other?.members.map((member) => member.source)).toEqual([
+      "YouBot",
+      "LinerBot",
+    ]);
+    expect(referral?.label).toBe("ChatGPT");
+  });
+});
+
+describe("buildTrafficGroupSeries", () => {
+  test("sums member sources per day", () => {
+    const points: GeoTrafficPoint[] = [
+      {
+        day: "2026-08-20",
+        visitorType: "crawler",
+        source: "GPTBot",
+        visits: 2,
+      },
+      {
+        day: "2026-08-20",
+        visitorType: "crawler",
+        source: "OAI-SearchBot",
+        visits: 3,
+      },
+      {
+        day: "2026-08-21",
+        visitorType: "crawler",
+        source: "YouBot",
+        visits: 9,
+      },
+      {
+        day: "2026-08-21",
+        visitorType: "ai_referral",
+        source: "chatgpt",
+        visits: 7,
+      },
+    ];
+    const [chatgpt] = groupTrafficSources([
+      crawler("GPTBot", "training-crawler", 2),
+      crawler("OAI-SearchBot", "search-index", 3),
+    ]);
+    if (chatgpt === undefined) {
+      throw new Error("expected a ChatGPT group");
+    }
+
+    expect(
+      buildTrafficGroupSeries(points, chatgpt, ["2026-08-20", "2026-08-21"])
+    ).toEqual([5, 0]);
+  });
+});

--- a/apps/dashboard/src/utils/ai-traffic-groups.ts
+++ b/apps/dashboard/src/utils/ai-traffic-groups.ts
@@ -6,6 +6,7 @@ import {
 } from "@/constants/geo";
 import type {
   GeoTrafficPoint,
+  GeoTrafficPurposeTotal,
   GeoTrafficSource,
   GeoTrafficSourceGroup,
   GeoTrafficSourceGroupDefinition,
@@ -25,6 +26,11 @@ export function resolveTrafficSourceGroup(
   source: string,
   visitorType: GeoVisitorType
 ): GeoTrafficSourceGroupDefinition {
+  const engine = resolveEngineIconKey(source);
+  const group = engine ? GEO_TRAFFIC_GROUPS_BY_ENGINE[engine] : undefined;
+  if (group === undefined) {
+    return GEO_TRAFFIC_OTHER_GROUP;
+  }
   if (visitorType !== "crawler") {
     return {
       key: source,
@@ -32,9 +38,7 @@ export function resolveTrafficSourceGroup(
       icon: source,
     };
   }
-  const engine = resolveEngineIconKey(source);
-  const group = engine ? GEO_TRAFFIC_GROUPS_BY_ENGINE[engine] : undefined;
-  return group ?? GEO_TRAFFIC_OTHER_GROUP;
+  return group;
 }
 
 function laterTimestamp(left: string, right: string): string {
@@ -122,12 +126,40 @@ export function buildTrafficGroupSeries(
   return days.map((day) => byDay.get(day) ?? 0);
 }
 
-export function trafficGroupShare(
-  member: GeoTrafficSource,
+export function hasTrafficGroupBreakdown(
   group: GeoTrafficSourceGroup
-): string {
-  if (group.visits === 0) {
+): boolean {
+  return (
+    group.visitorType === "crawler" || group.key === GEO_TRAFFIC_OTHER_GROUP.key
+  );
+}
+
+export function trafficVisitShare(visits: number, total: number): string {
+  if (total === 0) {
     return "0%";
   }
-  return `${Math.round((member.visits / group.visits) * 100)}%`;
+  return `${Math.round((visits / total) * 100)}%`;
+}
+
+export function trafficGroupPurposeTotals(
+  group: GeoTrafficSourceGroup
+): GeoTrafficPurposeTotal[] {
+  const totals = new Map<string, GeoTrafficPurposeTotal>();
+  for (const member of group.members) {
+    if (member.category.length === 0) {
+      continue;
+    }
+    const existing = totals.get(member.category);
+    if (existing === undefined) {
+      totals.set(member.category, {
+        category: member.category,
+        visits: member.visits,
+        members: [member.source],
+      });
+      continue;
+    }
+    existing.visits += member.visits;
+    existing.members.push(member.source);
+  }
+  return [...totals.values()].sort((left, right) => right.visits - left.visits);
 }

--- a/apps/dashboard/src/utils/ai-traffic-groups.ts
+++ b/apps/dashboard/src/utils/ai-traffic-groups.ts
@@ -1,0 +1,133 @@
+import { parseClickHouseDateTime } from "@notra/analytics/utils/datetime";
+
+import {
+  GEO_TRAFFIC_GROUPS_BY_ENGINE,
+  GEO_TRAFFIC_OTHER_GROUP,
+} from "@/constants/geo";
+import type {
+  GeoTrafficPoint,
+  GeoTrafficSource,
+  GeoTrafficSourceGroup,
+  GeoTrafficSourceGroupDefinition,
+  GeoVisitorType,
+} from "@/types/geo";
+import { formatGeoSource, trafficDayKey } from "@/utils/ai-traffic";
+import { resolveEngineIconKey } from "@/utils/geo-engine-icon";
+
+export function trafficGroupKey(
+  visitorType: GeoVisitorType,
+  groupKey: string
+): string {
+  return `${visitorType}:${groupKey}`;
+}
+
+export function resolveTrafficSourceGroup(
+  source: string,
+  visitorType: GeoVisitorType
+): GeoTrafficSourceGroupDefinition {
+  if (visitorType !== "crawler") {
+    return {
+      key: source,
+      label: formatGeoSource(source, visitorType),
+      icon: source,
+    };
+  }
+  const engine = resolveEngineIconKey(source);
+  const group = engine ? GEO_TRAFFIC_GROUPS_BY_ENGINE[engine] : undefined;
+  return group ?? GEO_TRAFFIC_OTHER_GROUP;
+}
+
+function laterTimestamp(left: string, right: string): string {
+  const leftTime = parseClickHouseDateTime(left).getTime();
+  const rightTime = parseClickHouseDateTime(right).getTime();
+  if (Number.isNaN(leftTime)) {
+    return right;
+  }
+  if (Number.isNaN(rightTime)) {
+    return left;
+  }
+  return rightTime > leftTime ? right : left;
+}
+
+function byVisitsDesc(left: GeoTrafficSource, right: GeoTrafficSource): number {
+  return right.visits - left.visits;
+}
+
+export function groupTrafficSources(
+  sources: readonly GeoTrafficSource[]
+): GeoTrafficSourceGroup[] {
+  const groups = new Map<string, GeoTrafficSourceGroup>();
+
+  for (const source of sources) {
+    const definition = resolveTrafficSourceGroup(
+      source.source,
+      source.visitorType
+    );
+    const key = trafficGroupKey(source.visitorType, definition.key);
+    const existing = groups.get(key);
+    if (existing === undefined) {
+      groups.set(key, {
+        ...definition,
+        visitorType: source.visitorType,
+        visits: source.visits,
+        markdownVisits: source.markdownVisits,
+        paths: source.paths,
+        lastSeenAt: source.lastSeenAt,
+        categories: source.category ? [source.category] : [],
+        members: [source],
+      });
+      continue;
+    }
+    existing.visits += source.visits;
+    existing.markdownVisits += source.markdownVisits;
+    existing.paths = Math.max(existing.paths, source.paths);
+    existing.lastSeenAt = laterTimestamp(
+      existing.lastSeenAt,
+      source.lastSeenAt
+    );
+    existing.members.push(source);
+  }
+
+  const result = [...groups.values()];
+  for (const group of result) {
+    group.members.sort(byVisitsDesc);
+    group.categories = [
+      ...new Set(
+        group.members
+          .map((member) => member.category)
+          .filter((category) => category.length > 0)
+      ),
+    ];
+  }
+  return result;
+}
+
+export function buildTrafficGroupSeries(
+  points: readonly GeoTrafficPoint[],
+  group: GeoTrafficSourceGroup,
+  days: readonly string[]
+): number[] {
+  const memberSources = new Set(group.members.map((member) => member.source));
+  const byDay = new Map<string, number>();
+  for (const point of points) {
+    if (
+      point.visitorType !== group.visitorType ||
+      !memberSources.has(point.source)
+    ) {
+      continue;
+    }
+    const day = trafficDayKey(point.day);
+    byDay.set(day, (byDay.get(day) ?? 0) + point.visits);
+  }
+  return days.map((day) => byDay.get(day) ?? 0);
+}
+
+export function trafficGroupShare(
+  member: GeoTrafficSource,
+  group: GeoTrafficSourceGroup
+): string {
+  if (group.visits === 0) {
+    return "0%";
+  }
+  return `${Math.round((member.visits / group.visits) * 100)}%`;
+}

--- a/apps/dashboard/src/utils/ai-traffic-groups.ts
+++ b/apps/dashboard/src/utils/ai-traffic-groups.ts
@@ -91,13 +91,13 @@ export function groupTrafficSources(
   const result = [...groups.values()];
   for (const group of result) {
     group.members.sort(byVisitsDesc);
-    group.categories = [
-      ...new Set(
-        group.members
-          .map((member) => member.category)
-          .filter((category) => category.length > 0)
-      ),
-    ];
+    const categories = new Set<string>();
+    for (const member of group.members) {
+      if (member.category.length > 0) {
+        categories.add(member.category);
+      }
+    }
+    group.categories = [...categories];
   }
   return result;
 }

--- a/apps/dashboard/src/utils/ai-traffic.ts
+++ b/apps/dashboard/src/utils/ai-traffic.ts
@@ -186,13 +186,6 @@ export function trafficDayKey(day: string): string {
   return String(day).slice(0, 10);
 }
 
-export function trafficSourceKey(
-  source: string,
-  visitorType: GeoVisitorType
-): string {
-  return `${visitorType}:${source}`;
-}
-
 export function hasTrafficSourceSeries(
   points: readonly GeoTrafficPoint[]
 ): boolean {
@@ -236,23 +229,6 @@ export function buildTrafficTrendRows(
       [GEO_TRAFFIC_TREND_CRAWLER_KEY]: values.crawler,
       [GEO_TRAFFIC_TREND_REFERRAL_KEY]: values.aiReferral,
     }));
-}
-
-export function buildTrafficSourceSeries(
-  points: readonly GeoTrafficPoint[],
-  source: string,
-  visitorType: GeoVisitorType,
-  days: readonly string[]
-): number[] {
-  const byDay = new Map<string, number>();
-  for (const point of points) {
-    if (point.source !== source || point.visitorType !== visitorType) {
-      continue;
-    }
-    const day = trafficDayKey(point.day);
-    byDay.set(day, (byDay.get(day) ?? 0) + point.visits);
-  }
-  return days.map((day) => byDay.get(day) ?? 0);
 }
 
 export function isTrafficPagePending({


### PR DESCRIPTION
## Summary

The Sources table on the GEO AI Traffic page now groups crawler rows by vendor instead of listing every bot separately. GPTBot, OAI-SearchBot, ChatGPT-User and OAI-AdsBot roll up into one **ChatGPT** row, ClaudeBot, Claude-User and Claude-SearchBot into **Claude**, and so on. Lesser known crawlers (YouBot, LinerBot, Timpibot, heuristic agents, ...) land in an **Other** row.

Hovering a crawler row opens a breakdown card listing every bot in the group with its logo, purpose, last seen time, visit count and share of the group's visits.

The logs table is untouched; referral rows are already vendor level and stay as they are.

## Details

- Groups: ChatGPT, Claude, Google, Perplexity, Microsoft, Meta, Amazon, Apple, ByteDance, Mistral, DeepSeek, xAI, Alibaba, Common Crawl, Cohere, DuckDuckGo, Other. Membership is derived from the existing engine icon resolver so any bot that already has a vendor logo joins the matching group.
- Purpose column shows the single purpose badge when the group has one purpose, otherwise a row of compact icon-only badges (with tooltips) for each purpose in the group.
- Visits, markdown share and sparklines are summed across the group. Last seen is the latest across members.
- Pages is the max across members rather than the sum, since unique paths are counted per source in Tinybird and summing would overcount overlapping crawls. The per-bot figures are visible in the hover breakdown.
- `PurposeBadge` gains a `compact` prop. Two now-unused per-source helpers in `utils/ai-traffic.ts` were removed.

## Testing

- `bun test src/utils/ai-traffic-groups.test.ts` (grouping, Other bucket, referral passthrough, series summing)
- `tsc --noEmit` and oxlint clean on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups crawler rows in the GEO AI Traffic table by vendor, with hover cards showing member bots and per-purpose totals. Referral rows stay unchanged, and the log table uses the same breakdown card with compact purpose badges.

**Details**

- Visits, markdown, and sparklines are summed; Pages uses the max member count, and last seen comes from the latest member.
- Cursor and OpenCode get their own groups; unknown crawlers roll into an **Other** group.
- The hero card header is now dual-tone, matching the breakdown card styling.
- Log table providers open the same breakdown card with purpose and markdown combined into one hover card.

<sup>Written for commit 1aaaebdb445aeb66e22511940884c0c876da2aad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

