### PR TITLE
fix(geo): show purpose labels in AI traffic log and pin table resize handles

### DIFF
--- a/apps/dashboard/src/components/geo/citations-table.tsx
+++ b/apps/dashboard/src/components/geo/citations-table.tsx
@@ -19,6 +19,7 @@ import {
   AI_TRAFFIC_PURPOSE_DESCRIPTIONS,
   AI_TRAFFIC_PURPOSE_LABELS,
   GEO_CITATIONS_ROW_HEIGHT,
+  GEO_PURPOSE_COLUMN_WIDTH,
 } from "@/constants/geo";
 import { AI_TRAFFIC_PURPOSE_ICONS } from "@/constants/geo-purpose-icons";
 import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
@@ -112,7 +113,7 @@ function PurposeCell({ entry }: { entry: GeoTrafficLogEntry }) {
           />
         }
       >
-        <PurposeBadge category={entry.category} compact tooltip={false} />
+        <PurposeBadge category={entry.category} tooltip={false} />
         {entry.wantsMarkdown ? <MarkdownBadge /> : null}
       </HoverCardTrigger>
       <TrafficBreakdownCard
@@ -199,7 +200,7 @@ const CITATIONS_COLUMNS: TableColumn<GeoTrafficLogEntry>[] = [
   {
     key: "category",
     header: "Purpose",
-    width: "6.5rem",
+    width: GEO_PURPOSE_COLUMN_WIDTH,
     sortable: true,
     sortValue: (entry) =>
       AI_TRAFFIC_PURPOSE_LABELS[entry.category] ?? entry.category,

--- a/apps/dashboard/src/components/motion/table/table-header.tsx
+++ b/apps/dashboard/src/components/motion/table/table-header.tsx
@@ -224,7 +224,7 @@ export function TableHeader<T>({
                     : undefined
                 }
                 className={cn(
-                  "group bg-muted text-muted-foreground p-0 font-medium",
+                  "group bg-muted text-muted-foreground relative p-0 font-medium",
                   "data-[drop=true]:before:bg-primary data-[drop=true]:before:absolute data-[drop=true]:before:inset-y-0 data-[drop=true]:before:left-0 data-[drop=true]:before:w-0.5",
                   "data-[dropend=true]:after:bg-primary data-[dropend=true]:after:absolute data-[dropend=true]:after:inset-y-0 data-[dropend=true]:after:right-0 data-[dropend=true]:after:w-0.5"
                 )}

--- a/apps/dashboard/src/constants/geo.ts
+++ b/apps/dashboard/src/constants/geo.ts
@@ -361,6 +361,7 @@ export const GEO_TRAFFIC_SOURCES_PAGE_PARAM = "sourcesPage";
 export const GEO_TRAFFIC_PAGES_PAGE_PARAM = "topPagesPage";
 export const GEO_TRAFFIC_LOG_PAGE_PARAM = "logPage";
 export const GEO_CITATIONS_ROW_HEIGHT = 40;
+export const GEO_PURPOSE_COLUMN_WIDTH = "12.5rem";
 export const GEO_CITATIONS_LIVE_INTERVAL_MS = 5000;
 export const GEO_INGEST_PATH = "/api/geo/ingest";
 export const GEO_INGEST_SNIPPET_FALLBACK =


### PR DESCRIPTION
## Summary
- The AI traffic log (Recent citations) rendered the Purpose badge in compact icon-only mode inside a 6.5rem column. It now shows the label (Model training, Search index, Cited in answer, Referral) in a 12.5rem column driven by a new `GEO_PURPOSE_COLUMN_WIDTH` constant. Path is `1fr`, so long URLs truncate earlier (full path still on hover). The markdown flag stays a single icon badge.
- The motion table's column resize handle is `absolute top-0 right-0 h-full`, but the `<th>` was not positioned, so every handle escaped to the viewport as a 6px x full-height bar at the page's right edge (lavender on hover). Dragging it by accident froze all columns to pixel widths and squeezed one, which is what made Country show as "Nether...". Added `relative` to the header cell so the handle stays inside its column.

## Verification
- Rendered `CitationsTable` with sample rows at 1280, 960 and 760px viewports: labels and markdown badge fit, Country stays 168px and unclipped, table overflows horizontally instead of squeezing when space runs out. Resize handle measures 6x40px inside the header instead of 6x800px at the page edge.
- `ultracite check` clean on changed files (two pre-existing `no-nested-ternary` warnings in table-header untouched); `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two dashboard UI bugs: the AI traffic log now shows full purpose labels instead of compact icon-only badges, and table column resize handles no longer escape to the viewport edge.

- Purpose column uses new `GEO_PURPOSE_COLUMN_WIDTH` (12.5rem) and renders labels like "Model training" and "Search index"; the markdown flag stays a single icon badge.
- Added `relative` positioning to header cells so the resize handle stays inside its column instead of a 6px-wide full-height bar at the page's right edge.

<sup>Written for commit 6c469bdd79636eb0a47ce6c24b7a03f78d97254a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

