### PR TITLE
fix(geo): prevent overview skeleton from flashing during navigation

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/loading.tsx
@@ -1,5 +1,0 @@
-import { GeoPageSkeleton } from "./skeleton";
-
-export default function Loading() {
-  return <GeoPageSkeleton />;
-}


### PR DESCRIPTION
### Description
Prevents the GEO overview loading skeleton and heading from flashing while users navigate to Traffic or another GEO page. The overly broad route-level loading boundary is removed, while every page-specific loading state remains unchanged. React Doctor reported no issues; lint and type checks could not run because this workspace has no installed `node_modules`. This change was AI-assisted.

### Screenshot/Recording (if applicable)
Not included; this only changes which existing loading boundary is used during navigation.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the GEO overview loading skeleton and heading from flashing when navigating to Traffic or another GEO page. Removes the route-level loading boundary; page-specific loading states are unchanged.

<sup>Written for commit 4a53e9f9c6deda8201924f8d84ab836fcc3f6f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

