### PR TITLE
fix(security): validate all API route bodies and server action inputs with zod

### DIFF
--- a/apps/console/src/lib/auth/admin-actions.ts
+++ b/apps/console/src/lib/auth/admin-actions.ts
@@ -10,15 +10,19 @@ import { hasAdminRole } from "@/lib/auth/role";
 import { OrganizationActionError } from "@/lib/organizations/errors";
 import { requireSession } from "@/lib/organizations/guards";
 import { runOrganizationAction } from "@/lib/organizations/run-action";
+import { validateActionInput } from "@/lib/organizations/validate-input";
+import { listUsersInputSchema } from "@/schemas/auth-actions";
 import type { ImpersonationUser, ListUsersInput } from "@/types/auth";
 import type { ActionResult } from "@/types/organization";
+import { escapeLikePattern } from "@/utils/sql";
 
 export async function listUsersAction(
-  input?: ListUsersInput
+  rawInput?: ListUsersInput
 ): Promise<ActionResult<ImpersonationUser[]>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(listUsersInputSchema, rawInput);
 
       if (!hasAdminRole(session.user.role)) {
         return yield* Effect.fail(
@@ -28,15 +32,16 @@ export async function listUsersAction(
         );
       }
 
-      const search = input?.search?.trim();
+      const search = input?.search;
+      const searchPattern = search ? `%${escapeLikePattern(search)}%` : null;
 
       const rows = yield* Effect.tryPromise({
         try: () =>
           db.query.users.findMany({
-            where: search
+            where: searchPattern
               ? or(
-                  ilike(users.name, `%${search}%`),
-                  ilike(users.email, `%${search}%`)
+                  ilike(users.name, searchPattern),
+                  ilike(users.email, searchPattern)
                 )
               : undefined,
             columns: {

--- a/apps/console/src/lib/auth/password-actions.ts
+++ b/apps/console/src/lib/auth/password-actions.ts
@@ -16,7 +16,10 @@ import { authenticateResolvingOrgSelection } from "@/lib/auth/org-selection";
 import { sanitizeReturnTo } from "@/lib/auth/return-to";
 import { ensureLocalUser } from "@/lib/auth/sync";
 import { readWorkOSError } from "@/lib/auth/workos-error";
-import { loginSchema, verificationCodeSchema } from "@/schemas/auth";
+import {
+  signInWithPasswordInputSchema,
+  verifyEmailCodeInputSchema,
+} from "@/schemas/auth-actions";
 import { getClientIpFromHeaders, ratelimit } from "@/utils/ratelimit";
 
 const VERIFICATION_REQUIRED_CODE = "email_verification_required";
@@ -96,9 +99,9 @@ const runAuthFlow = (
   Effect.runPromise(flow.pipe(Effect.catch(mapAuthFailure(email))));
 
 export async function signInWithPasswordAction(
-  input: SignInWithPasswordInput
+  rawInput: SignInWithPasswordInput
 ): Promise<AuthFlowResult> {
-  const parsed = loginSchema.safeParse(input);
+  const parsed = signInWithPasswordInputSchema.safeParse(rawInput);
 
   if (!parsed.success) {
     return {
@@ -122,20 +125,20 @@ export async function signInWithPasswordAction(
         })
       );
 
-      return yield* completeAuthentication(response, input.returnTo);
+      return yield* completeAuthentication(response, parsed.data.returnTo);
     })
   );
 }
 
 export async function verifyEmailCodeAction(
-  input: VerifyEmailCodeInput
+  rawInput: VerifyEmailCodeInput
 ): Promise<AuthFlowResult> {
-  const codeValidation = verificationCodeSchema.safeParse(input.code);
+  const parsed = verifyEmailCodeInputSchema.safeParse(rawInput);
 
-  if (!codeValidation.success) {
+  if (!parsed.success) {
     return {
       status: "error",
-      message: codeValidation.error.issues[0]?.message ?? "Invalid code",
+      message: parsed.error.issues[0]?.message ?? "Invalid code",
     };
   }
 
@@ -145,12 +148,12 @@ export async function verifyEmailCodeAction(
       const response = yield* authenticateResolvingOrgSelection(() =>
         getWorkOS().userManagement.authenticateWithEmailVerification({
           clientId: getClientId(),
-          code: codeValidation.data,
-          pendingAuthenticationToken: input.pendingAuthenticationToken,
+          code: parsed.data.code,
+          pendingAuthenticationToken: parsed.data.pendingAuthenticationToken,
         })
       );
 
-      return yield* completeAuthentication(response, input.returnTo);
+      return yield* completeAuthentication(response, parsed.data.returnTo);
     })
   );
 }

--- a/apps/console/src/lib/auth/social-actions.ts
+++ b/apps/console/src/lib/auth/social-actions.ts
@@ -12,9 +12,19 @@ import {
   SOCIAL_AUTH_STATE_MAX_AGE_SECONDS,
 } from "@/constants/social-auth";
 import { sanitizeReturnTo } from "@/lib/auth/return-to";
+import { startSocialSignInInputSchema } from "@/schemas/auth-actions";
 import { getClientIpFromHeaders, ratelimit } from "@/utils/ratelimit";
 
-export async function startSocialSignInAction(input: StartSocialSignInInput) {
+export async function startSocialSignInAction(
+  rawInput: StartSocialSignInInput
+) {
+  const parsed = startSocialSignInInputSchema.safeParse(rawInput);
+
+  if (!parsed.success) {
+    redirect("/login");
+  }
+
+  const input = parsed.data;
   const mappedProvider = SOCIAL_AUTH_PROVIDERS[input.provider];
 
   if (!mappedProvider) {

--- a/apps/console/src/lib/auth/user-actions.ts
+++ b/apps/console/src/lib/auth/user-actions.ts
@@ -2,7 +2,12 @@
 
 import { signOut } from "@workos-inc/authkit-nextjs";
 
-export async function signOutAction(options?: { returnTo?: string }) {
+import { signOutOptionsSchema } from "@/schemas/auth-actions";
+import type { SignOutActionOptions } from "@/types/auth";
+
+export async function signOutAction(options?: SignOutActionOptions) {
+  const parsed = signOutOptionsSchema.safeParse(options);
+  const returnTo = parsed.success ? parsed.data?.returnTo : undefined;
   const appUrl = process.env.CONSOLE_APP_URL ?? "http://localhost:3003";
-  await signOut({ returnTo: options?.returnTo ?? `${appUrl}/login` });
+  await signOut({ returnTo: returnTo ?? `${appUrl}/login` });
 }

--- a/apps/console/src/lib/organizations/actions.ts
+++ b/apps/console/src/lib/organizations/actions.ts
@@ -12,31 +12,18 @@ import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
 import { OrganizationActionError } from "@/lib/organizations/errors";
 import { requireMembership, requireSession } from "@/lib/organizations/guards";
 import { runOrganizationAction } from "@/lib/organizations/run-action";
+import { validateActionInput } from "@/lib/organizations/validate-input";
 import { ensureWorkOSOrganizationWithMembers } from "@/lib/organizations/workos-sync";
-import { organizationSlugSchema } from "@/schemas/organization";
+import {
+  createOrganizationInputSchema,
+  setActiveOrganizationInputSchema,
+} from "@/schemas/organization";
 import type {
   ActionResult,
   CreateOrganizationInput,
   OrganizationRow,
   SetActiveOrganizationInput,
 } from "@/types/organization";
-
-const validateSlug = Effect.fn("organizations.actions.validateSlug")(function* (
-  rawSlug: string
-) {
-  const validation = organizationSlugSchema.safeParse(rawSlug.trim());
-
-  if (!validation.success) {
-    return yield* Effect.fail(
-      new OrganizationActionError({
-        message:
-          validation.error.issues[0]?.message ?? "Invalid organization slug",
-      })
-    );
-  }
-
-  return validation.data;
-});
 
 const tryDb = <T>(run: () => Promise<T>, message: string) =>
   Effect.tryPromise({
@@ -45,12 +32,16 @@ const tryDb = <T>(run: () => Promise<T>, message: string) =>
   });
 
 export async function createOrganizationAction(
-  input: CreateOrganizationInput
+  rawInput: CreateOrganizationInput
 ): Promise<ActionResult<OrganizationRow>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
-      const slug = yield* validateSlug(input.slug);
+      const input = yield* validateActionInput(
+        createOrganizationInputSchema,
+        rawInput
+      );
+      const { slug } = input;
 
       const existing = yield* tryDb(
         () =>
@@ -220,11 +211,15 @@ function findOrganizationForSelection(input: SetActiveOrganizationInput) {
 }
 
 export async function setActiveOrganizationAction(
-  input: SetActiveOrganizationInput
+  rawInput: SetActiveOrganizationInput
 ): Promise<ActionResult<OrganizationRow>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        setActiveOrganizationInputSchema,
+        rawInput
+      );
 
       const organization = yield* tryDb(
         () => findOrganizationForSelection(input),

--- a/apps/console/src/lib/organizations/validate-input.ts
+++ b/apps/console/src/lib/organizations/validate-input.ts
@@ -1,0 +1,24 @@
+import { Effect } from "effect";
+import type * as z from "zod";
+
+import { OrganizationActionError } from "@/lib/organizations/errors";
+
+const DEFAULT_INVALID_INPUT_MESSAGE = "Invalid input";
+
+export function validateActionInput<Schema extends z.ZodType>(
+  schema: Schema,
+  input: unknown
+): Effect.Effect<z.output<Schema>, OrganizationActionError> {
+  const result = schema.safeParse(input);
+
+  if (!result.success) {
+    return Effect.fail(
+      new OrganizationActionError({
+        message:
+          result.error.issues[0]?.message ?? DEFAULT_INVALID_INPUT_MESSAGE,
+      })
+    );
+  }
+
+  return Effect.succeed(result.data);
+}

--- a/apps/console/src/schemas/auth-actions.ts
+++ b/apps/console/src/schemas/auth-actions.ts
@@ -1,0 +1,42 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+import { loginSchema, verificationCodeSchema } from "@/schemas/auth";
+
+const RETURN_TO_MAX_LENGTH = 2048;
+const AUTH_TOKEN_MAX_LENGTH = 4096;
+const USER_SEARCH_MAX_LENGTH = 100;
+
+const returnToSchema = z.string().max(RETURN_TO_MAX_LENGTH).nullish();
+
+export const signInWithPasswordInputSchema = loginSchema.extend({
+  returnTo: returnToSchema,
+});
+
+export const verifyEmailCodeInputSchema = z.object({
+  pendingAuthenticationToken: z
+    .string()
+    .min(1, "Verification session is missing")
+    .max(AUTH_TOKEN_MAX_LENGTH),
+  code: verificationCodeSchema,
+  returnTo: returnToSchema,
+});
+
+const socialAuthProviderSchema = z.enum(["google", "github"]);
+
+export const startSocialSignInInputSchema = z.object({
+  provider: socialAuthProviderSchema,
+  returnTo: returnToSchema,
+});
+
+export const signOutOptionsSchema = z
+  .object({
+    returnTo: z.string().min(1).max(RETURN_TO_MAX_LENGTH).optional(),
+  })
+  .optional();
+
+export const listUsersInputSchema = z
+  .object({
+    search: z.string().trim().max(USER_SEARCH_MAX_LENGTH).optional(),
+  })
+  .optional();

--- a/apps/console/src/schemas/organization.ts
+++ b/apps/console/src/schemas/organization.ts
@@ -3,7 +3,7 @@ import * as z from "zod";
 
 import { RESERVED_ORGANIZATION_SLUGS } from "@/constants/organization";
 
-export const organizationSlugSchema = z
+const organizationSlugSchema = z
   .string()
   .slugify()
   .min(3, "Organization slug must be at least 3 characters long")
@@ -16,7 +16,7 @@ export const organizationSlugSchema = z
     "This slug is reserved and cannot be used for an organization"
   );
 
-export const organizationNameSchema = z
+const organizationNameSchema = z
   .string()
   .min(2, "Organization name must be at least 2 characters")
   .max(100, "Organization name must be at most 100 characters");
@@ -24,4 +24,37 @@ export const organizationNameSchema = z
 export const createOrganizationSchema = z.object({
   name: organizationNameSchema,
   slug: organizationSlugSchema,
+});
+
+const ORGANIZATION_LOGO_MAX_LENGTH = 2048;
+const ORGANIZATION_SLUG_LOOKUP_MAX_LENGTH = 63;
+
+const organizationIdSchema = z.string().min(1);
+
+const organizationLogoSchema = z
+  .string()
+  .trim()
+  .url("Logo must be a valid URL")
+  .max(ORGANIZATION_LOGO_MAX_LENGTH, "Logo URL is too long");
+
+const trimmedOrganizationSlugSchema = z
+  .string()
+  .trim()
+  .pipe(organizationSlugSchema);
+
+export const createOrganizationInputSchema = z.object({
+  name: organizationNameSchema,
+  slug: trimmedOrganizationSlugSchema,
+  logo: organizationLogoSchema.optional(),
+  keepCurrentActiveOrganization: z.boolean().optional(),
+});
+
+export const setActiveOrganizationInputSchema = z.object({
+  organizationId: organizationIdSchema.optional(),
+  organizationSlug: z
+    .string()
+    .trim()
+    .min(1)
+    .max(ORGANIZATION_SLUG_LOOKUP_MAX_LENGTH)
+    .optional(),
 });

--- a/apps/console/src/types/auth.ts
+++ b/apps/console/src/types/auth.ts
@@ -93,3 +93,7 @@ export interface ConsoleLoginFormProps {
   initialError?: string;
   initialPendingVerification?: PendingVerification;
 }
+
+export interface SignOutActionOptions {
+  returnTo?: string;
+}

--- a/apps/console/src/utils/sql.ts
+++ b/apps/console/src/utils/sql.ts
@@ -1,0 +1,5 @@
+const LIKE_SPECIAL_CHARACTERS_REGEX = /[\\%_]/g;
+
+export function escapeLikePattern(value: string) {
+  return value.replace(LIKE_SPECIAL_CHARACTERS_REGEX, "\\$&");
+}

--- a/apps/dashboard/src/app/api/webhooks/workos/route.ts
+++ b/apps/dashboard/src/app/api/webhooks/workos/route.ts
@@ -7,6 +7,7 @@ import {
   removeMembershipFromWebhook,
   upsertMembershipFromWebhook,
 } from "@/lib/auth/webhook-sync";
+import { workosWebhookPayloadSchema } from "@/schemas/workos-webhook";
 
 function handleMembershipEvent(event: WorkOSEvent) {
   switch (event.event) {
@@ -33,12 +34,26 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: "missing_signature" }, { status: 401 });
   }
 
+  const rawBody = await request.text();
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = JSON.parse(rawBody);
+  } catch {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  const parsedPayload = workosWebhookPayloadSchema.safeParse(rawPayload);
+
+  if (!parsedPayload.success) {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
   let event: WorkOSEvent;
 
   try {
-    const payload = await request.json();
     event = await getWorkOS().webhooks.constructEvent({
-      payload,
+      payload: rawBody,
       sigHeader,
       secret,
     });

--- a/apps/dashboard/src/lib/auth/actions.ts
+++ b/apps/dashboard/src/lib/auth/actions.ts
@@ -10,8 +10,16 @@ import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
 import { isSessionBanned } from "@/lib/auth/banned";
 import { getAuthSession } from "@/lib/auth/server";
 import { retryTransientDbError } from "@/lib/db/retry";
+import { organizationSlugParamSchema } from "@/schemas/auth/organization";
 
-export async function validateOrganizationAccess(slug: string) {
+export async function validateOrganizationAccess(rawSlug: string) {
+  const slugValidation = organizationSlugParamSchema.safeParse(rawSlug);
+
+  if (!slugValidation.success) {
+    notFound();
+  }
+
+  const slug = slugValidation.data;
   const session = await getAuthSession();
 
   if (!session?.user) {

--- a/apps/dashboard/src/lib/auth/password-actions.ts
+++ b/apps/dashboard/src/lib/auth/password-actions.ts
@@ -18,9 +18,11 @@ import { syncAuthenticatedUser } from "@/lib/auth/sync";
 import { readWorkOSError } from "@/lib/auth/workos-error";
 import { sendResetPasswordAction } from "@/lib/email/actions";
 import {
-  loginSchema,
-  signupSchema,
-  verificationCodeSchema,
+  forgotPasswordInputSchema,
+  resetPasswordInputSchema,
+  signInWithPasswordInputSchema,
+  signUpWithPasswordInputSchema,
+  verifyEmailCodeInputSchema,
 } from "@/schemas/auth/credentials";
 import type {
   ForgotPasswordInput,
@@ -135,9 +137,9 @@ const runAuthFlow = (
   Effect.runPromise(flow.pipe(Effect.catch(mapAuthFailure(email))));
 
 export async function signInWithPasswordAction(
-  input: SignInWithPasswordInput
+  rawInput: SignInWithPasswordInput
 ): Promise<AuthFlowResult> {
-  const parsed = loginSchema.safeParse(input);
+  const parsed = signInWithPasswordInputSchema.safeParse(rawInput);
 
   if (!parsed.success) {
     return {
@@ -161,15 +163,15 @@ export async function signInWithPasswordAction(
         })
       );
 
-      return yield* completeAuthentication(response, input.returnTo);
+      return yield* completeAuthentication(response, parsed.data.returnTo);
     })
   );
 }
 
 export async function signUpWithPasswordAction(
-  input: SignUpWithPasswordInput
+  rawInput: SignUpWithPasswordInput
 ): Promise<AuthFlowResult> {
-  const parsed = signupSchema.safeParse(input);
+  const parsed = signUpWithPasswordInputSchema.safeParse(rawInput);
 
   if (!parsed.success) {
     return {
@@ -182,7 +184,7 @@ export async function signUpWithPasswordAction(
     return { status: "error", message: RATE_LIMITED_MESSAGE };
   }
 
-  const [firstName, ...rest] = (input.name ?? "")
+  const [firstName, ...rest] = (parsed.data.name ?? "")
     .trim()
     .split(NAME_SPLIT_REGEX);
 
@@ -206,20 +208,20 @@ export async function signUpWithPasswordAction(
         })
       );
 
-      return yield* completeAuthentication(response, input.returnTo);
+      return yield* completeAuthentication(response, parsed.data.returnTo);
     })
   );
 }
 
 export async function verifyEmailCodeAction(
-  input: VerifyEmailCodeInput
+  rawInput: VerifyEmailCodeInput
 ): Promise<AuthFlowResult> {
-  const codeValidation = verificationCodeSchema.safeParse(input.code);
+  const parsed = verifyEmailCodeInputSchema.safeParse(rawInput);
 
-  if (!codeValidation.success) {
+  if (!parsed.success) {
     return {
       status: "error",
-      message: codeValidation.error.issues[0]?.message ?? "Invalid code",
+      message: parsed.error.issues[0]?.message ?? "Invalid code",
     };
   }
 
@@ -229,19 +231,27 @@ export async function verifyEmailCodeAction(
       const response = yield* authenticateResolvingOrgSelection(() =>
         getWorkOS().userManagement.authenticateWithEmailVerification({
           clientId: getClientId(),
-          code: codeValidation.data,
-          pendingAuthenticationToken: input.pendingAuthenticationToken,
+          code: parsed.data.code,
+          pendingAuthenticationToken: parsed.data.pendingAuthenticationToken,
         })
       );
 
-      return yield* completeAuthentication(response, input.returnTo);
+      return yield* completeAuthentication(response, parsed.data.returnTo);
     })
   );
 }
 
 export async function forgotPasswordAction(
-  input: ForgotPasswordInput
+  rawInput: ForgotPasswordInput
 ): Promise<{ sent: boolean }> {
+  const parsed = forgotPasswordInputSchema.safeParse(rawInput);
+
+  if (!parsed.success) {
+    return { sent: false };
+  }
+
+  const input = parsed.data;
+
   if (await isRateLimited(ratelimit.forgotPassword, input.email)) {
     return { sent: false };
   }
@@ -274,8 +284,19 @@ export async function forgotPasswordAction(
 }
 
 export async function resetPasswordAction(
-  input: ResetPasswordInput
+  rawInput: ResetPasswordInput
 ): Promise<AuthFlowResult> {
+  const parsed = resetPasswordInputSchema.safeParse(rawInput);
+
+  if (!parsed.success) {
+    return {
+      status: "error",
+      message: parsed.error.issues[0]?.message ?? "Invalid password reset",
+    };
+  }
+
+  const input = parsed.data;
+
   return Effect.runPromise(
     tryWorkOSAuth(() =>
       getWorkOS().userManagement.resetPassword({

--- a/apps/dashboard/src/lib/auth/social-actions.ts
+++ b/apps/dashboard/src/lib/auth/social-actions.ts
@@ -12,9 +12,19 @@ import {
   SOCIAL_AUTH_STATE_MAX_AGE_SECONDS,
 } from "@/constants/social-auth";
 import { sanitizeReturnTo } from "@/lib/auth/return-to";
+import { startSocialSignInInputSchema } from "@/schemas/auth/social";
 import { getClientIpFromHeaders, ratelimit } from "@/utils/ratelimit";
 
-export async function startSocialSignInAction(input: StartSocialSignInInput) {
+export async function startSocialSignInAction(
+  rawInput: StartSocialSignInInput
+) {
+  const parsed = startSocialSignInInputSchema.safeParse(rawInput);
+
+  if (!parsed.success) {
+    redirect("/login");
+  }
+
+  const input = parsed.data;
   const mappedProvider = SOCIAL_AUTH_PROVIDERS[input.provider];
 
   if (!mappedProvider) {

--- a/apps/dashboard/src/lib/auth/user-actions.ts
+++ b/apps/dashboard/src/lib/auth/user-actions.ts
@@ -10,8 +10,18 @@ import { sendResetPasswordAction } from "@/lib/email/actions";
 import { OrganizationActionError } from "@/lib/organizations/errors";
 import { requireSession } from "@/lib/organizations/guards";
 import { runOrganizationAction } from "@/lib/organizations/run-action";
+import { validateActionInput } from "@/lib/organizations/validate-input";
+import {
+  signOutOptionsSchema,
+  unlinkAccountInputSchema,
+  updateUserInputSchema,
+} from "@/schemas/auth/user-actions";
 import type { SessionUser } from "@/types/auth/session";
-import type { UpdateUserInput } from "@/types/auth/user-actions";
+import type {
+  SignOutActionOptions,
+  UnlinkAccountInput,
+  UpdateUserInput,
+} from "@/types/auth/user-actions";
 import type { AccountInfo, ActionResult } from "@/types/organizations/actions";
 
 const tryAction = <T>(run: () => Promise<T>, message: string) =>
@@ -20,16 +30,18 @@ const tryAction = <T>(run: () => Promise<T>, message: string) =>
     catch: (cause) => new OrganizationActionError({ message, cause }),
   });
 
-export async function signOutAction(options?: { returnTo?: string }) {
-  await signOut(options);
+export async function signOutAction(options?: SignOutActionOptions) {
+  const parsed = signOutOptionsSchema.safeParse(options);
+  await signOut(parsed.success ? parsed.data : undefined);
 }
 
 export async function updateUserAction(
-  input: UpdateUserInput
+  rawInput: UpdateUserInput
 ): Promise<ActionResult<SessionUser>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(updateUserInputSchema, rawInput);
 
       const updates: Partial<{
         name: string;
@@ -182,12 +194,16 @@ export async function listAccountsAction(): Promise<
   );
 }
 
-export async function unlinkAccountAction(input: {
-  providerId: string;
-}): Promise<ActionResult<{ removed: boolean }>> {
+export async function unlinkAccountAction(
+  rawInput: UnlinkAccountInput
+): Promise<ActionResult<{ removed: boolean }>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        unlinkAccountInputSchema,
+        rawInput
+      );
 
       yield* tryAction(
         () =>

--- a/apps/dashboard/src/lib/organizations/actions.ts
+++ b/apps/dashboard/src/lib/organizations/actions.ts
@@ -26,6 +26,7 @@ import {
   resolveOrganizationId,
 } from "@/lib/organizations/guards";
 import { runOrganizationAction } from "@/lib/organizations/run-action";
+import { validateActionInput } from "@/lib/organizations/validate-input";
 import {
   ensureWorkOSOrganizationWithMembers,
   removeMembershipFromWorkOS,
@@ -33,9 +34,16 @@ import {
   updateMembershipRoleInWorkOS,
 } from "@/lib/organizations/workos-sync";
 import {
-  memberRoleSchema,
-  organizationSlugSchema,
-} from "@/schemas/organization";
+  createOrganizationInputSchema,
+  invitationActionInputSchema,
+  inviteMemberInputSchema,
+  organizationLookupQueryInputSchema,
+  organizationScopedQueryInputSchema,
+  removeMemberInputSchema,
+  setActiveOrganizationInputSchema,
+  updateMemberRoleInputSchema,
+  updateOrganizationInputSchema,
+} from "@/schemas/organizations/actions";
 import type {
   ActionResult,
   CreateOrganizationInput,
@@ -52,23 +60,6 @@ import type {
   UpdateMemberRoleInput,
   UpdateOrganizationInput,
 } from "@/types/organizations/actions";
-
-const validateSlug = Effect.fn("organizations.actions.validateSlug")(function* (
-  rawSlug: string
-) {
-  const validation = organizationSlugSchema.safeParse(rawSlug.trim());
-
-  if (!validation.success) {
-    return yield* Effect.fail(
-      new OrganizationActionError({
-        message:
-          validation.error.issues[0]?.message ?? "Invalid organization slug",
-      })
-    );
-  }
-
-  return validation.data;
-});
 
 const enforceTeamMembersLimit = Effect.fn(
   "organizations.actions.enforceTeamMembersLimit"
@@ -206,12 +197,16 @@ const requireInvitationManagement = Effect.fn(
 });
 
 export async function createOrganizationAction(
-  input: CreateOrganizationInput
+  rawInput: CreateOrganizationInput
 ): Promise<ActionResult<OrganizationRow>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
-      const slug = yield* validateSlug(input.slug);
+      const input = yield* validateActionInput(
+        createOrganizationInputSchema,
+        rawInput
+      );
+      const { slug } = input;
 
       const existing = yield* tryDb(
         () =>
@@ -341,11 +336,15 @@ export async function createOrganizationAction(
 }
 
 export async function updateOrganizationAction(
-  input: UpdateOrganizationInput
+  rawInput: UpdateOrganizationInput
 ): Promise<ActionResult<OrganizationRow>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        updateOrganizationInputSchema,
+        rawInput
+      );
       yield* requireManagerMembership(session, input.organizationId);
 
       const updates: Partial<{
@@ -363,7 +362,7 @@ export async function updateOrganizationAction(
       }
 
       if (input.data.slug !== undefined) {
-        updates.slug = yield* validateSlug(input.data.slug);
+        updates.slug = input.data.slug;
       }
 
       const [organization] = yield* tryDb(
@@ -448,11 +447,15 @@ function findOrganizationForSelection(input: SetActiveOrganizationInput) {
 }
 
 export async function setActiveOrganizationAction(
-  input: SetActiveOrganizationInput
+  rawInput: SetActiveOrganizationInput
 ): Promise<ActionResult<OrganizationRow>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        setActiveOrganizationInputSchema,
+        rawInput
+      );
 
       const organization = yield* tryDb(
         () => findOrganizationForSelection(input),
@@ -480,12 +483,16 @@ export async function setActiveOrganizationAction(
   );
 }
 
-export async function getFullOrganizationAction(input?: {
+export async function getFullOrganizationAction(rawInput?: {
   query?: { organizationId?: string; organizationSlug?: string };
 }): Promise<ActionResult<FullOrganization | null>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        organizationLookupQueryInputSchema,
+        rawInput
+      );
 
       let organizationId = input?.query?.organizationId;
 
@@ -548,11 +555,15 @@ export async function getFullOrganizationAction(input?: {
 }
 
 export async function listMembersAction(
-  input?: ListMembersInput
+  rawInput?: ListMembersInput
 ): Promise<ActionResult<MembersListResult>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        organizationScopedQueryInputSchema,
+        rawInput
+      );
       const organizationId = yield* resolveOrganizationId(
         session,
         input?.query?.organizationId
@@ -580,11 +591,15 @@ export async function listMembersAction(
 }
 
 export async function updateMemberRoleAction(
-  input: UpdateMemberRoleInput
+  rawInput: UpdateMemberRoleInput
 ): Promise<ActionResult<MemberWithUser | null>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        updateMemberRoleInputSchema,
+        rawInput
+      );
 
       const member = yield* tryDb(
         () =>
@@ -605,18 +620,7 @@ export async function updateMemberRoleAction(
         member.organizationId
       );
 
-      const roleValidation = memberRoleSchema.safeParse(input.role);
-
-      if (!roleValidation.success) {
-        return yield* Effect.fail(
-          new OrganizationActionError({ message: "Invalid role" })
-        );
-      }
-
-      if (
-        roleValidation.data === "owner" &&
-        callerMembership.role !== "owner"
-      ) {
+      if (input.role === "owner" && callerMembership.role !== "owner") {
         return yield* Effect.fail(
           new OrganizationActionError({
             message: "Only the organization owner can assign the owner role",
@@ -666,11 +670,15 @@ export async function updateMemberRoleAction(
 }
 
 export async function removeMemberAction(
-  input: RemoveMemberInput
+  rawInput: RemoveMemberInput
 ): Promise<ActionResult<{ removed: boolean }>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        removeMemberInputSchema,
+        rawInput
+      );
       const organizationId = yield* resolveOrganizationId(
         session,
         input.organizationId
@@ -738,12 +746,16 @@ export async function removeMemberAction(
   );
 }
 
-export async function listInvitationsAction(input?: {
+export async function listInvitationsAction(rawInput?: {
   query?: { organizationId?: string };
 }): Promise<ActionResult<InvitationSummary[]>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        organizationScopedQueryInputSchema,
+        rawInput
+      );
       const organizationId = yield* resolveOrganizationId(
         session,
         input?.query?.organizationId
@@ -766,11 +778,15 @@ export async function listInvitationsAction(input?: {
 }
 
 export async function inviteMemberAction(
-  input: InviteMemberInput
+  rawInput: InviteMemberInput
 ): Promise<ActionResult<InvitationSummary>> {
   return runOrganizationAction(
     Effect.gen(function* () {
       const session = yield* requireSession();
+      const input = yield* validateActionInput(
+        inviteMemberInputSchema,
+        rawInput
+      );
       const organizationId = yield* resolveOrganizationId(
         session,
         input.organizationId
@@ -780,18 +796,7 @@ export async function inviteMemberAction(
         organizationId
       );
 
-      const roleValidation = memberRoleSchema.safeParse(input.role);
-
-      if (!roleValidation.success) {
-        return yield* Effect.fail(
-          new OrganizationActionError({ message: "Invalid role" })
-        );
-      }
-
-      if (
-        roleValidation.data === "owner" &&
-        callerMembership.role !== "owner"
-      ) {
+      if (input.role === "owner" && callerMembership.role !== "owner") {
         return yield* Effect.fail(
           new OrganizationActionError({
             message: "Only the organization owner can assign the owner role",
@@ -827,10 +832,14 @@ export async function inviteMemberAction(
 }
 
 export async function cancelInvitationAction(
-  input: InvitationActionInput
+  rawInput: InvitationActionInput
 ): Promise<ActionResult<InvitationSummary>> {
   return runOrganizationAction(
     Effect.gen(function* () {
+      const input = yield* validateActionInput(
+        invitationActionInputSchema,
+        rawInput
+      );
       yield* requireInvitationManagement(input.invitationId);
 
       const revoked = yield* tryWorkOS(
@@ -844,10 +853,14 @@ export async function cancelInvitationAction(
 }
 
 export async function resendInvitationAction(
-  input: InvitationActionInput
+  rawInput: InvitationActionInput
 ): Promise<ActionResult<InvitationSummary>> {
   return runOrganizationAction(
     Effect.gen(function* () {
+      const input = yield* validateActionInput(
+        invitationActionInputSchema,
+        rawInput
+      );
       yield* requireInvitationManagement(input.invitationId);
 
       const invitation = yield* tryWorkOS(

--- a/apps/dashboard/src/lib/organizations/validate-input.ts
+++ b/apps/dashboard/src/lib/organizations/validate-input.ts
@@ -1,0 +1,24 @@
+import { Effect } from "effect";
+import type * as z from "zod";
+
+import { OrganizationActionError } from "@/lib/organizations/errors";
+
+const DEFAULT_INVALID_INPUT_MESSAGE = "Invalid input";
+
+export function validateActionInput<Schema extends z.ZodType>(
+  schema: Schema,
+  input: unknown
+): Effect.Effect<z.output<Schema>, OrganizationActionError> {
+  const result = schema.safeParse(input);
+
+  if (!result.success) {
+    return Effect.fail(
+      new OrganizationActionError({
+        message:
+          result.error.issues[0]?.message ?? DEFAULT_INVALID_INPUT_MESSAGE,
+      })
+    );
+  }
+
+  return Effect.succeed(result.data);
+}

--- a/apps/dashboard/src/schemas/auth/credentials.ts
+++ b/apps/dashboard/src/schemas/auth/credentials.ts
@@ -1,6 +1,8 @@
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 
+import { returnToSchema } from "@/schemas/auth/return-to";
+
 export const signupSchema = z.object({
   email: z
     .string()
@@ -24,6 +26,45 @@ export const loginSchema = z.object({
     .max(128, "Password must be at most 128 characters"),
 });
 
-export const verificationCodeSchema = z
+const verificationCodeSchema = z
   .string()
   .regex(/^\d{6}$/, "Enter the 6-digit code from your email");
+
+const AUTH_NAME_MAX_LENGTH = 100;
+const AUTH_TOKEN_MAX_LENGTH = 4096;
+const RESET_PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 128;
+
+export const signInWithPasswordInputSchema = loginSchema.extend({
+  returnTo: returnToSchema,
+});
+
+export const signUpWithPasswordInputSchema = signupSchema.extend({
+  name: z
+    .string()
+    .trim()
+    .max(AUTH_NAME_MAX_LENGTH, "Name must be at most 100 characters")
+    .optional(),
+  returnTo: returnToSchema,
+});
+
+export const verifyEmailCodeInputSchema = z.object({
+  pendingAuthenticationToken: z
+    .string()
+    .min(1, "Verification session is missing")
+    .max(AUTH_TOKEN_MAX_LENGTH),
+  code: verificationCodeSchema,
+  returnTo: returnToSchema,
+});
+
+export const forgotPasswordInputSchema = z.object({
+  email: loginSchema.shape.email,
+});
+
+export const resetPasswordInputSchema = z.object({
+  token: z.string().min(1, "Reset token is missing").max(AUTH_TOKEN_MAX_LENGTH),
+  newPassword: z
+    .string()
+    .min(RESET_PASSWORD_MIN_LENGTH, "Password must be at least 8 characters")
+    .max(PASSWORD_MAX_LENGTH, "Password must be at most 128 characters"),
+});

--- a/apps/dashboard/src/schemas/auth/organization.ts
+++ b/apps/dashboard/src/schemas/auth/organization.ts
@@ -1,3 +1,11 @@
 import z from "zod";
 
 export const organizationIdSchema = z.string().min(1);
+
+const ORGANIZATION_SLUG_MAX_LENGTH = 63;
+
+export const organizationSlugParamSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(ORGANIZATION_SLUG_MAX_LENGTH);

--- a/apps/dashboard/src/schemas/auth/return-to.ts
+++ b/apps/dashboard/src/schemas/auth/return-to.ts
@@ -1,0 +1,6 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+export const RETURN_TO_MAX_LENGTH = 2048;
+
+export const returnToSchema = z.string().max(RETURN_TO_MAX_LENGTH).nullish();

--- a/apps/dashboard/src/schemas/auth/social.ts
+++ b/apps/dashboard/src/schemas/auth/social.ts
@@ -1,0 +1,11 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+import { returnToSchema } from "@/schemas/auth/return-to";
+
+const socialAuthProviderSchema = z.enum(["google", "github"]);
+
+export const startSocialSignInInputSchema = z.object({
+  provider: socialAuthProviderSchema,
+  returnTo: returnToSchema,
+});

--- a/apps/dashboard/src/schemas/auth/user-actions.ts
+++ b/apps/dashboard/src/schemas/auth/user-actions.ts
@@ -1,0 +1,36 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+import { RETURN_TO_MAX_LENGTH } from "@/schemas/auth/return-to";
+
+const USER_NAME_MAX_LENGTH = 100;
+const USER_IMAGE_URL_MAX_LENGTH = 2048;
+const PROVIDER_ID_MAX_LENGTH = 64;
+
+export const updateUserInputSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .max(USER_NAME_MAX_LENGTH, "Name must be at most 100 characters")
+    .optional(),
+  image: z
+    .string()
+    .trim()
+    .url("Image must be a valid URL")
+    .max(USER_IMAGE_URL_MAX_LENGTH, "Image URL is too long")
+    .nullable()
+    .optional(),
+  hidePersonalData: z.boolean().optional(),
+  showAgentStats: z.boolean().optional(),
+});
+
+export const unlinkAccountInputSchema = z.object({
+  providerId: z.string().trim().min(1).max(PROVIDER_ID_MAX_LENGTH),
+});
+
+export const signOutOptionsSchema = z
+  .object({
+    returnTo: z.string().min(1).max(RETURN_TO_MAX_LENGTH).optional(),
+  })
+  .optional();

--- a/apps/dashboard/src/schemas/organizations/actions.ts
+++ b/apps/dashboard/src/schemas/organizations/actions.ts
@@ -1,0 +1,101 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+import { organizationIdSchema } from "@/schemas/auth/organization";
+import {
+  memberRoleSchema,
+  organizationNameSchema,
+  organizationSlugSchema,
+} from "@/schemas/organization";
+
+const ORGANIZATION_LOGO_MAX_LENGTH = 2048;
+const ORGANIZATION_SLUG_LOOKUP_MAX_LENGTH = 63;
+const MEMBER_EMAIL_MAX_LENGTH = 254;
+const MEMBER_ID_MAX_LENGTH = 255;
+const INVITATION_ID_MAX_LENGTH = 255;
+
+const trimmedOrganizationSlugSchema = z
+  .string()
+  .trim()
+  .pipe(organizationSlugSchema);
+
+const organizationSlugLookupSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(ORGANIZATION_SLUG_LOOKUP_MAX_LENGTH);
+
+const organizationLogoSchema = z
+  .string()
+  .trim()
+  .url("Logo must be a valid URL")
+  .max(ORGANIZATION_LOGO_MAX_LENGTH, "Logo URL is too long");
+
+const memberEmailSchema = z
+  .string()
+  .trim()
+  .email("Please enter a valid email address")
+  .max(MEMBER_EMAIL_MAX_LENGTH, "Email address is too long");
+
+export const createOrganizationInputSchema = z.object({
+  name: organizationNameSchema,
+  slug: trimmedOrganizationSlugSchema,
+  logo: organizationLogoSchema.optional(),
+  keepCurrentActiveOrganization: z.boolean().optional(),
+});
+
+export const updateOrganizationInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  data: z.object({
+    name: organizationNameSchema.optional(),
+    slug: trimmedOrganizationSlugSchema.optional(),
+    logo: organizationLogoSchema.optional(),
+  }),
+});
+
+export const setActiveOrganizationInputSchema = z.object({
+  organizationId: organizationIdSchema.optional(),
+  organizationSlug: organizationSlugLookupSchema.optional(),
+});
+
+export const organizationLookupQueryInputSchema = z
+  .object({
+    query: z
+      .object({
+        organizationId: organizationIdSchema.optional(),
+        organizationSlug: organizationSlugLookupSchema.optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+export const organizationScopedQueryInputSchema = z
+  .object({
+    query: z
+      .object({
+        organizationId: organizationIdSchema.optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+export const inviteMemberInputSchema = z.object({
+  email: memberEmailSchema,
+  role: memberRoleSchema,
+  organizationId: organizationIdSchema.optional(),
+});
+
+export const invitationActionInputSchema = z.object({
+  invitationId: z.string().trim().min(1).max(INVITATION_ID_MAX_LENGTH),
+});
+
+export const updateMemberRoleInputSchema = z.object({
+  memberId: z.string().trim().min(1).max(MEMBER_ID_MAX_LENGTH),
+  role: memberRoleSchema,
+  organizationId: organizationIdSchema.optional(),
+});
+
+export const removeMemberInputSchema = z.object({
+  memberIdOrEmail: z.string().trim().min(1).max(MEMBER_EMAIL_MAX_LENGTH),
+  organizationId: organizationIdSchema.optional(),
+});

--- a/apps/dashboard/src/schemas/workos-webhook.ts
+++ b/apps/dashboard/src/schemas/workos-webhook.ts
@@ -1,0 +1,9 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+export const workosWebhookPayloadSchema = z.object({
+  id: z.string().min(1),
+  event: z.string().min(1),
+  data: z.record(z.string(), z.unknown()),
+  created_at: z.string().min(1),
+});

--- a/apps/dashboard/src/types/auth/user-actions.ts
+++ b/apps/dashboard/src/types/auth/user-actions.ts
@@ -4,3 +4,11 @@ export interface UpdateUserInput {
   hidePersonalData?: boolean;
   showAgentStats?: boolean;
 }
+
+export interface UnlinkAccountInput {
+  providerId: string;
+}
+
+export interface SignOutActionOptions {
+  returnTo?: string;
+}

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import type { MarbleWebhookPayload } from "~types/marble";
 
+import { marbleWebhookPayloadSchema } from "@/schemas/marble-webhook";
 import {
   handleMarbleWebhookEvent,
   revalidateMarbleContent,
@@ -37,13 +37,21 @@ export async function POST(request: Request) {
     return jsonError("Invalid signature", 400);
   }
 
-  let payload: MarbleWebhookPayload;
+  let rawPayload: unknown;
 
   try {
-    payload = JSON.parse(bodyText) as MarbleWebhookPayload;
+    rawPayload = JSON.parse(bodyText);
   } catch {
     return jsonError("Invalid JSON payload", 400);
   }
+
+  const parsed = marbleWebhookPayloadSchema.safeParse(rawPayload);
+
+  if (!parsed.success) {
+    return jsonError("Invalid payload structure", 400);
+  }
+
+  const payload = parsed.data;
 
   if (!((payload.event ?? payload.type) && payload.data)) {
     return jsonError("Invalid payload structure", 400);

--- a/apps/web/src/app/ask/route.ts
+++ b/apps/web/src/app/ask/route.ts
@@ -1,15 +1,23 @@
+import { askRequestSchema } from "@/schemas/ask";
 import { buildAgentJson } from "@/utils/agent-metadata";
 
 export async function POST(request: Request) {
-  const body = await request.json().catch(() => ({}));
-  const streaming = body?.prefer?.streaming === true;
+  const rawBody: unknown = await request.json().catch(() => null);
+  const parsed = askRequestSchema.safeParse(rawBody ?? {});
+
+  if (!parsed.success) {
+    return Response.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const body = parsed.data;
+  const streaming = body.prefer?.streaming === true;
   const agent = buildAgentJson();
   const result = {
     _meta: {
       response_type: "answer",
       version: "1.0",
     },
-    query: typeof body?.query === "string" ? body.query : null,
+    query: body.query ?? null,
     answer:
       "Notra turns shipped work into changelogs, launch posts, blog posts, marketing assets, and social updates in a saved brand voice.",
     resources: [agent.api.openapi, agent.api.auth, agent.mcp.docs],

--- a/apps/web/src/schemas/ask.ts
+++ b/apps/web/src/schemas/ask.ts
@@ -1,0 +1,13 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+const ASK_QUERY_MAX_LENGTH = 2000;
+
+export const askRequestSchema = z.object({
+  query: z.string().max(ASK_QUERY_MAX_LENGTH).optional(),
+  prefer: z
+    .object({
+      streaming: z.boolean().optional(),
+    })
+    .optional(),
+});

--- a/apps/web/src/schemas/marble-webhook.ts
+++ b/apps/web/src/schemas/marble-webhook.ts
@@ -1,0 +1,30 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+const marbleWebhookEventSchema = z.templateLiteral([
+  z.string(),
+  ".",
+  z.string(),
+]);
+
+const optionalStringSchema = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined);
+
+const marbleWebhookCategorySchema = z
+  .union([z.string(), z.object({ slug: optionalStringSchema })])
+  .nullish()
+  .transform((value) => value ?? undefined);
+
+export const marbleWebhookPayloadSchema = z.object({
+  event: marbleWebhookEventSchema.optional(),
+  type: marbleWebhookEventSchema.optional(),
+  data: z
+    .object({
+      slug: optionalStringSchema,
+      category: marbleWebhookCategorySchema,
+      categorySlug: optionalStringSchema,
+    })
+    .optional(),
+});


### PR DESCRIPTION
## Summary

Audit of every API route handler (Next.js `route.ts` in web, dashboard, console; the oRPC routers; every Hono route in `apps/api`) and every `"use server"` action found 3 routes and 24 server actions that read request input without a Zod schema. This PR closes all of them.

### API routes

- `apps/web/src/app/ask/route.ts`: body parsed with `askRequestSchema` (was raw `request.json()` with ad-hoc `typeof` checks). Invalid bodies now return 400; a missing body still works.
- `apps/web/src/app/api/revalidate/route.ts`: Marble webhook payload parsed with `marbleWebhookPayloadSchema` (was `JSON.parse(...) as MarbleWebhookPayload`). The `as` assertion is gone.
- `apps/dashboard/src/app/api/webhooks/workos/route.ts`: payload shape validated with `workosWebhookPayloadSchema` before the SDK sees it. The route now reads `request.text()` and hands the raw string to `constructEvent`, so the HMAC is verified over the exact bytes WorkOS sent rather than a re-stringified object. Malformed payloads return 400.

### Server actions

New `validateActionInput(schema, input)` helper (`lib/organizations/validate-input.ts` in dashboard and console) that fails the Effect with `OrganizationActionError` using the first Zod issue message, so callers get the same `{ data, error }` shape as before.

Dashboard:
- `organizations/actions.ts`: every action now validates its whole input via `schemas/organizations/actions.ts` (create/update org incl. name + logo URL, set active, get full, list members, update member role, remove member, list/invite/cancel/resend invitations). The old slug-only and role-only checks are subsumed by the schemas.
- `auth/password-actions.ts`: sign in, sign up, verify code, forgot password, reset password all validate the full input (returnTo, tokens, name, email, password policy).
- `auth/user-actions.ts`: `updateUserAction` (name length, image must be a URL, booleans), `unlinkAccountAction`, `signOutAction`.
- `auth/social-actions.ts`: provider is now an enum, returnTo validated.
- `auth/actions.ts`: `validateOrganizationAccess` validates the slug param and 404s on garbage.

Console:
- `organizations/actions.ts`: create + set active validated.
- `auth/password-actions.ts`, `auth/social-actions.ts`, `auth/user-actions.ts`: same as dashboard.
- `auth/admin-actions.ts`: `listUsersAction` validates `search` (max 100 chars) and escapes `%`, `_`, `\` before building the `ilike` pattern.

### Behavior notes

- Reset password enforces min 8 chars server-side (matches the existing form; signup stays at 10).
- Org name uses the existing `organizationNameSchema` (2 to 100 chars); logo and user image must be valid URLs (both are produced by the upload flow or dicebear today).
- Types in `types/` are unchanged; the schemas match them so no call sites needed edits.

## Test plan

- [x] `tsc --noEmit` clean for dashboard and console; web has no new errors (remaining ones are the pre-existing generated `.source/server` imports)
- [x] `bun run check` passes, `oxfmt --check` clean on all touched files
- [x] `bun run knip` (pre-commit hook) exits 0
- [ ] Smoke test: sign in, create org, invite member, update profile image, WorkOS membership webhook in staging


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Zod validation to every API route body and server action input across `web`, `dashboard`, and `console`, closing gaps where unvalidated data reached handlers. Invalid bodies now return 400; invalid server action inputs produce the same `{ data, error }` result shape as before.

**Notable changes**

- WorkOS webhook verifies the HMAC over raw request text instead of a re-stringified object.
- Server actions use a shared `validateActionInput` helper that surfaces the first Zod issue message.
- Social auth provider is an enum; `returnTo` is capped at 2048 characters.
- Reset password enforces a minimum of 8 characters server-side (signup stays at 10).
- Organization name, logo URL, and user image URL are validated with existing or new schemas.
- `listUsersAction` escapes `%`, `_`, and `\` in search input before building the `ilike` pattern.
- Existing TypeScript types are unchanged; no call-site edits were required.

<sup>Written for commit 5afe6f463ad8e40feab98d66bbf130dc87bc3114. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

