### PR TITLE
feat(geo): import prompts and competitors from CSV

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PlusSignIcon } from "@hugeicons/core-free-icons";
+import { PlusSignIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -13,6 +13,7 @@ import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { CompetitorEditDialog } from "@/components/geo/competitor-edit-dialog";
 import { CompetitorShareCard } from "@/components/geo/competitor-share-card";
 import { CompetitorsTable } from "@/components/geo/competitors-table";
+import { CompetitorsCsvImportDialog } from "@/components/geo/geo-csv-import-dialog";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
 import { PageContainer } from "@/components/layout/container";
 import {
@@ -69,8 +70,11 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
   const { competitors } = useGeoCompetitorsDb(organizationId);
   const isScanning = useIsGeoScanning(organizationId);
   const [managerOpen, setManagerOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
-  useHotkey("C", () => setManagerOpen(true), { enabled: !managerOpen });
+  useHotkey("C", () => setManagerOpen(true), {
+    enabled: !managerOpen && !importOpen,
+  });
 
   if (isPending) {
     return <GeoPageSkeleton />;
@@ -118,7 +122,7 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
-        <header className="flex items-center justify-between">
+        <header className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
             <h1 className="text-3xl font-bold tracking-tight">Competitors</h1>
             <p className="text-muted-foreground">
@@ -127,6 +131,14 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
           </div>
           <div className="flex items-center gap-2">
             <GeoRangePicker control={geoRange} />
+            <Button
+              className="gap-1.5"
+              onClick={() => setImportOpen(true)}
+              variant="outline"
+            >
+              <HugeiconsIcon className="size-4" icon={Upload01Icon} />
+              Import CSV
+            </Button>
             <Button className="gap-1.5" onClick={() => setManagerOpen(true)}>
               <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
               Add Competitor
@@ -155,6 +167,11 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
         competitor={null}
         onOpenChange={setManagerOpen}
         open={managerOpen}
+        organizationId={organizationId}
+      />
+      <CompetitorsCsvImportDialog
+        onOpenChange={setImportOpen}
+        open={importOpen}
         organizationId={organizationId}
       />
     </PageContainer>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PlusSignIcon } from "@hugeicons/core-free-icons";
+import { PlusSignIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -11,6 +11,7 @@ import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
 import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { ConversationsCard } from "@/components/geo/conversations-card";
+import { PromptsCsvImportDialog } from "@/components/geo/geo-csv-import-dialog";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
 import { PromptAddDialog } from "@/components/geo/prompt-add-dialog";
 import { PromptSuggestions } from "@/components/geo/prompt-suggestions";
@@ -70,8 +71,9 @@ function GeoPromptsPageContent({ organizationSlug }: PageClientProps) {
   );
   const isScanning = useIsGeoScanning(organizationId);
   const [addOpen, setAddOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
-  useHotkey("P", () => setAddOpen(true), { enabled: !addOpen });
+  useHotkey("P", () => setAddOpen(true), { enabled: !addOpen && !importOpen });
 
   if (isPending) {
     return <GeoPromptsSkeleton />;
@@ -126,6 +128,14 @@ function GeoPromptsPageContent({ organizationSlug }: PageClientProps) {
           </div>
           <div className="flex items-center gap-2">
             <GeoRangePicker control={geoRange} />
+            <Button
+              className="gap-1.5"
+              onClick={() => setImportOpen(true)}
+              variant="outline"
+            >
+              <HugeiconsIcon className="size-4" icon={Upload01Icon} />
+              Import CSV
+            </Button>
             <Button className="gap-1.5" onClick={() => setAddOpen(true)}>
               <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
               Add Prompt
@@ -151,6 +161,11 @@ function GeoPromptsPageContent({ organizationSlug }: PageClientProps) {
       <PromptAddDialog
         onOpenChange={setAddOpen}
         open={addOpen}
+        organizationId={organizationId}
+      />
+      <PromptsCsvImportDialog
+        onOpenChange={setImportOpen}
+        open={importOpen}
         organizationId={organizationId}
       />
     </PageContainer>

--- a/apps/dashboard/src/components/geo/geo-csv-import-dialog.tsx
+++ b/apps/dashboard/src/components/geo/geo-csv-import-dialog.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import {
+  Alert02Icon,
+  Csv01Icon,
+  Download01Icon,
+  Upload01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Dropzone } from "@notra/ui/components/kibo-ui/dropzone";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@notra/ui/components/shared/responsive-dialog";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/button";
+import { StatusSpinner } from "@/components/geo/status-spinner";
+import {
+  GEO_CSV_IMPORT_ACCEPT,
+  GEO_CSV_IMPORT_MAX_BYTES,
+  GEO_CSV_IMPORT_MAX_ISSUES_SHOWN,
+  GEO_IMPORT_COPY,
+} from "@/constants/geo-import";
+import { parseCompetitorsCsv, parsePromptsCsv } from "@/lib/geo/csv-import";
+import {
+  useGeoImportCompetitors,
+  useGeoImportPrompts,
+} from "@/lib/hooks/use-geo";
+import { cn } from "@/lib/utils";
+import type {
+  GeoCsvImportDialogProps,
+  GeoCsvIssue,
+  GeoCsvSelection,
+  GeoImportDialogProps,
+} from "@/types/geo-import";
+import { downloadBlob } from "@/utils/download";
+import { formatCsvFileSize, geoImportNoun } from "@/utils/geo-import";
+
+function CsvIssueList({ issues }: { issues: GeoCsvIssue[] }) {
+  const visible = issues.slice(0, GEO_CSV_IMPORT_MAX_ISSUES_SHOWN);
+  const hidden = issues.length - visible.length;
+  return (
+    <ul className="space-y-1 text-xs">
+      {visible.map((issue) => (
+        <li
+          className="text-muted-foreground flex gap-2"
+          key={`${issue.line}:${issue.message}`}
+        >
+          <span className="shrink-0 tabular-nums">Line {issue.line}</span>
+          <span className="text-foreground">{issue.message}</span>
+        </li>
+      ))}
+      {hidden > 0 ? (
+        <li className="text-muted-foreground">and {hidden} more</li>
+      ) : null}
+    </ul>
+  );
+}
+
+function CsvSummaryRow({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone?: "warning";
+}) {
+  return (
+    <div className="flex items-center justify-between px-3 py-2">
+      <span className="text-muted-foreground flex items-center gap-1.5">
+        {tone === "warning" ? (
+          <HugeiconsIcon
+            className="size-3.5 text-amber-600 dark:text-amber-400"
+            icon={Alert02Icon}
+          />
+        ) : null}
+        {label}
+      </span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+function GeoCsvImportDialog<TRow>({
+  open,
+  onOpenChange,
+  kind,
+  parse,
+  onImport,
+  isPending,
+}: GeoCsvImportDialogProps<TRow>) {
+  const [selection, setSelection] = useState<GeoCsvSelection<TRow> | null>(
+    null
+  );
+  const copy = GEO_IMPORT_COPY[kind];
+  const rows = selection?.result.rows ?? [];
+  const issues = selection?.result.issues ?? [];
+  const duplicates = selection?.result.duplicates ?? 0;
+  const canImport = rows.length > 0 && !isPending;
+
+  const close = () => {
+    setSelection(null);
+    onOpenChange(false);
+  };
+
+  const handleDrop = async (files: File[]) => {
+    const file = files.at(0);
+    if (!file) {
+      return;
+    }
+    try {
+      const text = await file.text();
+      setSelection({ file, result: parse(text) });
+    } catch {
+      toast.error("Could not read that file");
+    }
+  };
+
+  const handleImport = async () => {
+    if (!canImport) {
+      return;
+    }
+    await onImport(rows);
+    close();
+  };
+
+  const downloadTemplate = () => {
+    downloadBlob(
+      new Blob([copy.template], { type: "text/csv;charset=utf-8" }),
+      copy.templateFilename
+    );
+  };
+
+  return (
+    <ResponsiveDialog
+      onOpenChange={(next) => {
+        if (next) {
+          onOpenChange(true);
+          return;
+        }
+        close();
+      }}
+      open={open}
+    >
+      <ResponsiveDialogContent className="sm:max-w-md">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>{copy.title}</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            {copy.description}
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <div className="space-y-3 px-4 md:px-0">
+          <Dropzone
+            accept={GEO_CSV_IMPORT_ACCEPT}
+            className={cn(
+              "border-dashed p-6 transition-colors",
+              selection && "border-solid"
+            )}
+            disabled={isPending}
+            maxFiles={1}
+            maxSize={GEO_CSV_IMPORT_MAX_BYTES}
+            onDrop={handleDrop}
+            onError={(error) => toast.error(error.message)}
+            src={selection ? [selection.file] : undefined}
+          >
+            {selection ? (
+              <div className="flex w-full items-center gap-3 text-left">
+                <div className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-lg">
+                  <HugeiconsIcon className="size-4" icon={Csv01Icon} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">
+                    {selection.file.name}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {formatCsvFileSize(selection.file.size)} · Drop another file
+                    to replace
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-1.5 text-center">
+                <div className="bg-muted text-muted-foreground flex size-9 items-center justify-center rounded-lg">
+                  <HugeiconsIcon className="size-4" icon={Upload01Icon} />
+                </div>
+                <p className="text-sm font-medium">Drop your CSV here</p>
+                <p className="text-muted-foreground text-xs">
+                  or click to browse · up to{" "}
+                  {formatCsvFileSize(GEO_CSV_IMPORT_MAX_BYTES)}
+                </p>
+              </div>
+            )}
+          </Dropzone>
+          {selection ? (
+            <div className="divide-y rounded-lg border text-sm">
+              <CsvSummaryRow label="Ready to import" value={rows.length} />
+              {duplicates > 0 ? (
+                <CsvSummaryRow label="Duplicates skipped" value={duplicates} />
+              ) : null}
+              {issues.length > 0 ? (
+                <div className="space-y-2 pb-3">
+                  <CsvSummaryRow
+                    label="Rows with problems"
+                    tone="warning"
+                    value={issues.length}
+                  />
+                  <div className="px-3">
+                    <CsvIssueList issues={issues} />
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+          <div className="flex justify-end">
+            <Button
+              className="h-auto shrink-0 gap-1 px-0 text-xs"
+              onClick={downloadTemplate}
+              size="xs"
+              type="button"
+              variant="link"
+            >
+              <HugeiconsIcon className="size-3" icon={Download01Icon} />
+              Download template
+            </Button>
+          </div>
+        </div>
+        <ResponsiveDialogFooter>
+          <Button
+            disabled={isPending}
+            onClick={close}
+            type="button"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button disabled={!canImport} onClick={handleImport} type="button">
+            {isPending ? <StatusSpinner /> : null}
+            {rows.length > 0
+              ? `Import ${rows.length} ${geoImportNoun(kind, rows.length)}`
+              : `Import ${copy.nounPlural}`}
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}
+
+export function PromptsCsvImportDialog({
+  open,
+  onOpenChange,
+  organizationId,
+}: GeoImportDialogProps) {
+  const importPrompts = useGeoImportPrompts(organizationId);
+  return (
+    <GeoCsvImportDialog
+      isPending={importPrompts.isPending}
+      kind="prompts"
+      onImport={(rows) => importPrompts.mutateAsync(rows)}
+      onOpenChange={onOpenChange}
+      open={open}
+      parse={parsePromptsCsv}
+    />
+  );
+}
+
+export function CompetitorsCsvImportDialog({
+  open,
+  onOpenChange,
+  organizationId,
+}: GeoImportDialogProps) {
+  const importCompetitors = useGeoImportCompetitors(organizationId);
+  return (
+    <GeoCsvImportDialog
+      isPending={importCompetitors.isPending}
+      kind="competitors"
+      onImport={(rows) => importCompetitors.mutateAsync(rows)}
+      onOpenChange={onOpenChange}
+      open={open}
+      parse={parseCompetitorsCsv}
+    />
+  );
+}

--- a/apps/dashboard/src/components/geo/geo-csv-import-dialog.tsx
+++ b/apps/dashboard/src/components/geo/geo-csv-import-dialog.tsx
@@ -16,6 +16,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@notra/ui/components/shared/responsive-dialog";
+import { Effect } from "effect";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -27,7 +28,11 @@ import {
   GEO_CSV_IMPORT_MAX_ISSUES_SHOWN,
   GEO_IMPORT_COPY,
 } from "@/constants/geo-import";
-import { parseCompetitorsCsv, parsePromptsCsv } from "@/lib/geo/csv-import";
+import {
+  parseCompetitorsCsv,
+  parsePromptsCsv,
+  readGeoCsvFile,
+} from "@/lib/geo/csv-import";
 import {
   useGeoImportCompetitors,
   useGeoImportPrompts,
@@ -110,25 +115,33 @@ function GeoCsvImportDialog<TRow>({
     onOpenChange(false);
   };
 
-  const handleDrop = async (files: File[]) => {
+  const handleDrop = (files: File[]) => {
     const file = files.at(0);
     if (!file) {
       return;
     }
-    try {
-      const text = await file.text();
-      setSelection({ file, result: parse(text) });
-    } catch {
-      toast.error("Could not read that file");
-    }
+    Effect.runFork(
+      readGeoCsvFile(file, parse).pipe(
+        Effect.match({
+          onSuccess: setSelection,
+          onFailure: () => toast.error("Could not read that file"),
+        })
+      )
+    );
   };
 
-  const handleImport = async () => {
+  const handleImport = () => {
     if (!canImport) {
       return;
     }
-    await onImport(rows);
-    close();
+    Effect.runFork(
+      Effect.tryPromise(() => onImport(rows)).pipe(
+        Effect.match({
+          onSuccess: close,
+          onFailure: () => undefined,
+        })
+      )
+    );
   };
 
   const downloadTemplate = () => {

--- a/apps/dashboard/src/constants/geo-import.ts
+++ b/apps/dashboard/src/constants/geo-import.ts
@@ -1,0 +1,60 @@
+import type { GeoImportKind, GeoImportKindCopy } from "@/types/geo-import";
+
+export const GEO_CSV_IMPORT_MAX_BYTES = 1024 * 1024;
+export const GEO_CSV_IMPORT_MAX_ROWS = 500;
+export const GEO_CSV_IMPORT_MAX_ISSUES_SHOWN = 5;
+export const GEO_CSV_IMPORT_ACCEPT = {
+  "text/csv": [".csv"],
+  "text/plain": [".csv"],
+  "application/csv": [".csv"],
+  "application/vnd.ms-excel": [".csv"],
+};
+export const GEO_CSV_SYNONYM_SEPARATOR = "|";
+export const GEO_CSV_TRUE_VALUES = new Set(["true", "yes", "y", "1", "on"]);
+export const GEO_CSV_FALSE_VALUES = new Set(["false", "no", "n", "0", "off"]);
+
+export const GEO_PROMPTS_CSV_COLUMNS = {
+  prompt: "prompt",
+  enabled: "enabled",
+} as const;
+
+export const GEO_COMPETITORS_CSV_COLUMNS = {
+  name: "name",
+  domain: "domain",
+  kind: "kind",
+  synonyms: "synonyms",
+} as const;
+
+export const GEO_PROMPTS_CSV_TEMPLATE = [
+  "prompt,enabled",
+  "what tools should I use for automating changelogs,true",
+  "best AI visibility platforms for B2B SaaS,true",
+  "how do I track brand mentions in ChatGPT,false",
+].join("\n");
+
+export const GEO_COMPETITORS_CSV_TEMPLATE = [
+  "name,domain,kind,synonyms",
+  "Acme Analytics,acme.com,direct,Acme|Acme Inc",
+  "Globex,globex.io,indirect,",
+].join("\n");
+
+export const GEO_IMPORT_COPY: Record<GeoImportKind, GeoImportKindCopy> = {
+  prompts: {
+    title: "Import prompts",
+    description: "One prompt per row. Optional enabled column.",
+    noun: "prompt",
+    nounPlural: "prompts",
+    columns: "prompt, enabled",
+    templateFilename: "notra-prompts-template.csv",
+    template: GEO_PROMPTS_CSV_TEMPLATE,
+  },
+  competitors: {
+    title: "Import competitors",
+    description: "One competitor per row. Optional domain, kind and synonyms.",
+    noun: "competitor",
+    nounPlural: "competitors",
+    columns: "name, domain, kind, synonyms",
+    templateFilename: "notra-competitors-template.csv",
+    template: GEO_COMPETITORS_CSV_TEMPLATE,
+  },
+};

--- a/apps/dashboard/src/constants/geo.ts
+++ b/apps/dashboard/src/constants/geo.ts
@@ -793,6 +793,9 @@ export const GEO_EMPTY_TRAFFIC_RESPONSE: AiTrafficResponse = {
 
 export const GEO_MAX_ALIASES = 10;
 export const GEO_MAX_COMPETITORS = 25;
+export const GEO_COMPETITOR_MAX_SYNONYMS = 8;
+export const GEO_SHORT_FIELD_MAX_LENGTH = 128;
+export const GEO_DOMAIN_REGEX = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/;
 /** Debounce before persisting GEO settings. Short enough for toggles. */
 export const GEO_SETTINGS_AUTO_SAVE_MS = 800;
 export const GEO_MAX_LANGUAGES = 4;

--- a/apps/dashboard/src/lib/csv/parse.ts
+++ b/apps/dashboard/src/lib/csv/parse.ts
@@ -4,17 +4,42 @@ const BYTE_ORDER_MARK = "﻿";
 const CANDIDATE_DELIMITERS = [",", ";", "\t"] as const;
 const QUOTE = '"';
 
-function firstLine(text: string): string {
-  const newlineIndex = text.search(/\r\n|\n|\r/);
-  return newlineIndex === -1 ? text : text.slice(0, newlineIndex);
+function headerSample(text: string): string {
+  let inQuotes = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === QUOTE) {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (!inQuotes && (char === "\n" || char === "\r")) {
+      return text.slice(0, index);
+    }
+  }
+  return text;
+}
+
+function countOutsideQuotes(sample: string, delimiter: string): number {
+  let count = 0;
+  let inQuotes = false;
+  for (const char of sample) {
+    if (char === QUOTE) {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (!inQuotes && char === delimiter) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function detectCsvDelimiter(text: string): string {
-  const sample = firstLine(text);
+  const sample = headerSample(text);
   let best: string = CANDIDATE_DELIMITERS[0];
   let bestCount = -1;
   for (const delimiter of CANDIDATE_DELIMITERS) {
-    const count = sample.split(delimiter).length - 1;
+    const count = countOutsideQuotes(sample, delimiter);
     if (count > bestCount) {
       best = delimiter;
       bestCount = count;

--- a/apps/dashboard/src/lib/csv/parse.ts
+++ b/apps/dashboard/src/lib/csv/parse.ts
@@ -1,0 +1,130 @@
+import type { CsvDocument, CsvRecord } from "@/types/csv";
+
+const BYTE_ORDER_MARK = "﻿";
+const CANDIDATE_DELIMITERS = [",", ";", "\t"] as const;
+const QUOTE = '"';
+
+function firstLine(text: string): string {
+  const newlineIndex = text.search(/\r\n|\n|\r/);
+  return newlineIndex === -1 ? text : text.slice(0, newlineIndex);
+}
+
+function detectCsvDelimiter(text: string): string {
+  const sample = firstLine(text);
+  let best: string = CANDIDATE_DELIMITERS[0];
+  let bestCount = -1;
+  for (const delimiter of CANDIDATE_DELIMITERS) {
+    const count = sample.split(delimiter).length - 1;
+    if (count > bestCount) {
+      best = delimiter;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function isBlankRecord(cells: string[]): boolean {
+  return cells.every((cell) => cell.trim().length === 0);
+}
+
+function parseCsvRecords(text: string, delimiter: string): CsvRecord[] {
+  const source = text.startsWith(BYTE_ORDER_MARK) ? text.slice(1) : text;
+  const records: CsvRecord[] = [];
+  let cells: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let line = 1;
+  let recordLine = 1;
+
+  const endRecord = () => {
+    cells.push(field);
+    if (!isBlankRecord(cells)) {
+      records.push({ line: recordLine, cells });
+    }
+    cells = [];
+    field = "";
+  };
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (inQuotes) {
+      if (char === QUOTE && next === QUOTE) {
+        field += QUOTE;
+        index += 1;
+        continue;
+      }
+      if (char === QUOTE) {
+        inQuotes = false;
+        continue;
+      }
+      if (char === "\r" && next === "\n") {
+        field += "\n";
+        line += 1;
+        index += 1;
+        continue;
+      }
+      if (char === "\n" || char === "\r") {
+        line += 1;
+      }
+      field += char;
+      continue;
+    }
+
+    if (char === QUOTE) {
+      inQuotes = true;
+      continue;
+    }
+    if (char === delimiter) {
+      cells.push(field);
+      field = "";
+      continue;
+    }
+    if (char === "\r" || char === "\n") {
+      if (char === "\r" && next === "\n") {
+        index += 1;
+      }
+      endRecord();
+      line += 1;
+      recordLine = line;
+      continue;
+    }
+    field += char;
+  }
+
+  if (field.length > 0 || cells.length > 0) {
+    endRecord();
+  }
+
+  return records;
+}
+
+function normalizeCsvHeaderCell(cell: string): string {
+  return cell.trim().toLowerCase();
+}
+
+export function parseCsv(text: string): CsvDocument {
+  const delimiter = detectCsvDelimiter(text);
+  const records = parseCsvRecords(text, delimiter);
+  const [headerRecord, ...rest] = records;
+  if (!headerRecord) {
+    return { delimiter, header: [], records: [] };
+  }
+  return {
+    delimiter,
+    header: headerRecord.cells.map(normalizeCsvHeaderCell),
+    records: rest,
+  };
+}
+
+export function csvColumnIndex(header: string[], name: string): number {
+  return header.indexOf(normalizeCsvHeaderCell(name));
+}
+
+export function csvCell(record: CsvRecord, index: number): string {
+  if (index < 0) {
+    return "";
+  }
+  return (record.cells[index] ?? "").trim();
+}

--- a/apps/dashboard/src/lib/geo/csv-import.ts
+++ b/apps/dashboard/src/lib/geo/csv-import.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import type { ZodType } from "zod";
 
 import { GEO_MAX_COMPETITORS } from "@/constants/geo";
@@ -12,6 +13,7 @@ import {
 } from "@/constants/geo-import";
 import { csvCell, csvColumnIndex, parseCsv } from "@/lib/csv/parse";
 import { competitorKey } from "@/lib/geo/domain";
+import { GeoCsvReadError } from "@/lib/geo/errors";
 import { promptKey } from "@/lib/geo/prompt-key";
 import {
   geoCompetitorImportRowSchema,
@@ -22,6 +24,7 @@ import type {
   GeoCompetitorImportRow,
   GeoCsvIssue,
   GeoCsvParseResult,
+  GeoCsvSelection,
   GeoImportKind,
   GeoPromptImportRow,
 } from "@/types/geo-import";
@@ -176,3 +179,15 @@ export function parseCompetitorsCsv(
 ): GeoCsvParseResult<GeoCompetitorImportRow> {
   return readCsvRows(text, competitorsReader, "competitors");
 }
+
+export const readGeoCsvFile = Effect.fn("geo.csvRead")(function* <TRow>(
+  file: File,
+  parse: (text: string) => GeoCsvParseResult<TRow>
+) {
+  const text = yield* Effect.tryPromise({
+    try: () => file.text(),
+    catch: (cause) => new GeoCsvReadError({ cause }),
+  });
+  const selection: GeoCsvSelection<TRow> = { file, result: parse(text) };
+  return selection;
+});

--- a/apps/dashboard/src/lib/geo/csv-import.ts
+++ b/apps/dashboard/src/lib/geo/csv-import.ts
@@ -1,0 +1,178 @@
+import type { ZodType } from "zod";
+
+import { GEO_MAX_COMPETITORS } from "@/constants/geo";
+import {
+  GEO_COMPETITORS_CSV_COLUMNS,
+  GEO_CSV_FALSE_VALUES,
+  GEO_CSV_IMPORT_MAX_ROWS,
+  GEO_CSV_SYNONYM_SEPARATOR,
+  GEO_CSV_TRUE_VALUES,
+  GEO_IMPORT_COPY,
+  GEO_PROMPTS_CSV_COLUMNS,
+} from "@/constants/geo-import";
+import { csvCell, csvColumnIndex, parseCsv } from "@/lib/csv/parse";
+import { competitorKey } from "@/lib/geo/domain";
+import { promptKey } from "@/lib/geo/prompt-key";
+import {
+  geoCompetitorImportRowSchema,
+  geoPromptImportRowSchema,
+} from "@/schemas/geo-import";
+import type { CsvDocument, CsvRecord } from "@/types/csv";
+import type {
+  GeoCompetitorImportRow,
+  GeoCsvIssue,
+  GeoCsvParseResult,
+  GeoImportKind,
+  GeoPromptImportRow,
+} from "@/types/geo-import";
+
+interface CsvRowReader<TRow> {
+  requiredColumn: string;
+  maxRows: number;
+  schema: ZodType<TRow>;
+  toRaw: (record: CsvRecord, document: CsvDocument) => unknown;
+  keyOf: (row: TRow) => string;
+}
+
+function emptyResult<TRow>(issues: GeoCsvIssue[]): GeoCsvParseResult<TRow> {
+  return { rows: [], issues, duplicates: 0, total: 0 };
+}
+
+function toCsvBoolean(cell: string): boolean | string | undefined {
+  if (cell.length === 0) {
+    return undefined;
+  }
+  const normalized = cell.toLowerCase();
+  if (GEO_CSV_TRUE_VALUES.has(normalized)) {
+    return true;
+  }
+  if (GEO_CSV_FALSE_VALUES.has(normalized)) {
+    return false;
+  }
+  return cell;
+}
+
+function toOptionalCell(cell: string): string | undefined {
+  return cell.length === 0 ? undefined : cell;
+}
+
+function toSynonyms(cell: string): string[] | undefined {
+  if (cell.length === 0) {
+    return undefined;
+  }
+  return cell
+    .split(GEO_CSV_SYNONYM_SEPARATOR)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function readCsvRows<TRow>(
+  text: string,
+  reader: CsvRowReader<TRow>,
+  kind: GeoImportKind
+): GeoCsvParseResult<TRow> {
+  const document = parseCsv(text);
+  if (document.header.length === 0) {
+    return emptyResult([{ line: 1, message: "The file is empty" }]);
+  }
+  if (csvColumnIndex(document.header, reader.requiredColumn) === -1) {
+    return emptyResult([
+      {
+        line: 1,
+        message: `Missing required column "${reader.requiredColumn}". Expected columns: ${GEO_IMPORT_COPY[kind].columns}`,
+      },
+    ]);
+  }
+
+  const rows: TRow[] = [];
+  const issues: GeoCsvIssue[] = [];
+  const seen = new Set<string>();
+  let duplicates = 0;
+
+  for (const record of document.records) {
+    if (rows.length >= reader.maxRows) {
+      issues.push({
+        line: record.line,
+        message: `Only the first ${reader.maxRows} rows are imported`,
+      });
+      break;
+    }
+    const parsed = reader.schema.safeParse(reader.toRaw(record, document));
+    if (!parsed.success) {
+      const message = parsed.error.issues.at(0)?.message ?? "Invalid row";
+      issues.push({ line: record.line, message });
+      continue;
+    }
+    const key = reader.keyOf(parsed.data);
+    if (seen.has(key)) {
+      duplicates += 1;
+      continue;
+    }
+    seen.add(key);
+    rows.push(parsed.data);
+  }
+
+  return { rows, issues, duplicates, total: document.records.length };
+}
+
+const promptsReader: CsvRowReader<GeoPromptImportRow> = {
+  requiredColumn: GEO_PROMPTS_CSV_COLUMNS.prompt,
+  maxRows: GEO_CSV_IMPORT_MAX_ROWS,
+  schema: geoPromptImportRowSchema,
+  toRaw: (record, document) => ({
+    prompt: csvCell(
+      record,
+      csvColumnIndex(document.header, GEO_PROMPTS_CSV_COLUMNS.prompt)
+    ),
+    enabled: toCsvBoolean(
+      csvCell(
+        record,
+        csvColumnIndex(document.header, GEO_PROMPTS_CSV_COLUMNS.enabled)
+      )
+    ),
+  }),
+  keyOf: (row) => promptKey(row.prompt),
+};
+
+const competitorsReader: CsvRowReader<GeoCompetitorImportRow> = {
+  requiredColumn: GEO_COMPETITORS_CSV_COLUMNS.name,
+  maxRows: GEO_MAX_COMPETITORS,
+  schema: geoCompetitorImportRowSchema,
+  toRaw: (record, document) => ({
+    name: csvCell(
+      record,
+      csvColumnIndex(document.header, GEO_COMPETITORS_CSV_COLUMNS.name)
+    ),
+    domain: toOptionalCell(
+      csvCell(
+        record,
+        csvColumnIndex(document.header, GEO_COMPETITORS_CSV_COLUMNS.domain)
+      )
+    ),
+    kind: toOptionalCell(
+      csvCell(
+        record,
+        csvColumnIndex(document.header, GEO_COMPETITORS_CSV_COLUMNS.kind)
+      ).toLowerCase()
+    ),
+    synonyms: toSynonyms(
+      csvCell(
+        record,
+        csvColumnIndex(document.header, GEO_COMPETITORS_CSV_COLUMNS.synonyms)
+      )
+    ),
+  }),
+  keyOf: (row) => competitorKey(row.name),
+};
+
+export function parsePromptsCsv(
+  text: string
+): GeoCsvParseResult<GeoPromptImportRow> {
+  return readCsvRows(text, promptsReader, "prompts");
+}
+
+export function parseCompetitorsCsv(
+  text: string
+): GeoCsvParseResult<GeoCompetitorImportRow> {
+  return readCsvRows(text, competitorsReader, "competitors");
+}

--- a/apps/dashboard/src/lib/geo/discover.ts
+++ b/apps/dashboard/src/lib/geo/discover.ts
@@ -1,7 +1,7 @@
 import { gateway } from "@notra/ai/gateway";
 import { scrapeWebsiteForBrandAnalysis } from "@notra/ai/utils/context-dev";
 import { db } from "@notra/db/drizzle";
-import { geoPrompts, geoSettings } from "@notra/db/schema";
+import { geoSettings } from "@notra/db/schema";
 import { generateText, Output } from "ai";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
@@ -27,7 +27,7 @@ import {
 import { readGeoCache, writeGeoCache } from "@/lib/geo/cache";
 import { competitorKey, normalizeCompetitorDomain } from "@/lib/geo/domain";
 import { GeoDiscoveryError } from "@/lib/geo/errors";
-import { syncGeoCompetitors } from "@/lib/geo/programs";
+import { insertGeoPrompts, reconcileGeoCompetitors } from "@/lib/geo/programs";
 import { ensureGeoProject } from "@/lib/geo/projects";
 import { withGeoScanStatus } from "@/lib/geo/scan-status";
 import {
@@ -40,6 +40,7 @@ import type {
   GeoCompetitorSeed,
   GeoDiscoverWebsiteResult,
   GeoGenerateFromWebsiteResult,
+  GeoPromptInsert,
   GeoScopeInput,
   GeoWebsiteDiscovery,
 } from "@/types/geo";
@@ -227,11 +228,6 @@ export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
       discovery.aliases,
       GEO_DISCOVERY_ALIAS_LIMIT
     );
-    const competitors = unionValues(
-      existing?.competitors ?? [],
-      discovery.competitors.map((entry) => entry.name),
-      GEO_DISCOVERY_COMPETITOR_LIMIT
-    );
     const companyName = existing?.companyName ?? discovery.companyName;
 
     yield* Effect.tryPromise({
@@ -244,12 +240,12 @@ export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
             projectId,
             companyName,
             aliases,
-            competitors,
+            competitors: [],
             enabled: true,
           })
           .onConflictDoUpdate({
             target: geoSettings.projectId,
-            set: { companyName, aliases, competitors },
+            set: { companyName, aliases },
           }),
       catch: (cause) =>
         new GeoDiscoveryError({
@@ -258,71 +254,55 @@ export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
         }),
     });
 
-    yield* syncGeoCompetitors(
+    const competitorRows = yield* reconcileGeoCompetitors(
       organizationId,
       projectId,
-      buildCompetitorSeeds(competitors, discovery.competitors)
+      (current) =>
+        buildCompetitorSeeds(
+          unionValues(
+            current.map((competitor) => competitor.name),
+            discovery.competitors.map((entry) => entry.name),
+            GEO_DISCOVERY_COMPETITOR_LIMIT
+          ),
+          discovery.competitors
+        )
     );
+    const competitors = competitorRows.map((competitor) => competitor.name);
 
-    const existingPrompts = yield* Effect.tryPromise({
-      try: () =>
-        db.query.geoPrompts.findMany({
-          columns: { prompt: true },
-          where: eq(geoPrompts.projectId, projectId),
-        }),
-      catch: (cause) =>
-        new GeoDiscoveryError({ message: "Failed to load GEO prompts", cause }),
-    });
-
-    const seen = new Set(
-      existingPrompts.map((row) => normalizeKey(row.prompt))
-    );
     const brandTerms = buildBrandTerms({ companyName, aliases });
-    const values: {
-      id: string;
-      organizationId: string;
-      projectId: string;
-      prompt: string;
-      title: string | null;
-    }[] = [];
+    const entries: GeoPromptInsert[] = [];
     for (const entry of discovery.prompts) {
       const trimmed = entry.prompt.trim();
       const title = entry.title.trim().slice(0, GEO_GAP_TITLE_MAX_LENGTH);
-      const key = normalizeKey(trimmed);
       if (
         trimmed.length < MIN_PROMPT_LENGTH ||
         trimmed.length > MAX_PROMPT_LENGTH ||
-        seen.has(key) ||
         promptMentionsBrand(trimmed, brandTerms)
       ) {
         continue;
       }
-      seen.add(key);
-      values.push({
-        id: crypto.randomUUID(),
-        organizationId,
-        projectId,
-        prompt: trimmed,
-        title: title.length > 0 ? title : null,
-      });
+      entries.push({ prompt: trimmed, title: title.length > 0 ? title : null });
     }
 
-    if (values.length > 0) {
-      yield* Effect.tryPromise({
-        try: () => db.insert(geoPrompts).values(values),
-        catch: (cause) =>
+    const inserted = yield* insertGeoPrompts(
+      organizationId,
+      projectId,
+      entries
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
           new GeoDiscoveryError({
             message: "Failed to save GEO prompts",
             cause,
-          }),
-      });
-    }
+          })
+      )
+    );
 
     const summary: GeoGenerateFromWebsiteResult = {
       companyName,
       aliases,
       competitors,
-      promptsAdded: values.length,
+      promptsAdded: inserted.length,
     };
 
     // Newly created settings default to enabled; an existing disabled row is

--- a/apps/dashboard/src/lib/geo/errors.ts
+++ b/apps/dashboard/src/lib/geo/errors.ts
@@ -20,6 +20,10 @@ export class GeoDatabaseError extends Data.TaggedError("GeoDatabaseError")<{
   readonly cause: unknown;
 }> {}
 
+export class GeoCsvReadError extends Data.TaggedError("GeoCsvReadError")<{
+  readonly cause: unknown;
+}> {}
+
 export class GeoPromptDuplicateError extends Data.TaggedError(
   "GeoPromptDuplicateError"
 )<{

--- a/apps/dashboard/src/lib/geo/errors.ts
+++ b/apps/dashboard/src/lib/geo/errors.ts
@@ -30,6 +30,12 @@ export class GeoPromptNotFoundError extends Data.TaggedError(
   readonly promptId: string;
 }> {}
 
+export class GeoCompetitorLimitError extends Data.TaggedError(
+  "GeoCompetitorLimitError"
+)<{
+  readonly limit: number;
+}> {}
+
 export class GeoSettingsMissingError extends Data.TaggedError(
   "GeoSettingsMissingError"
 )<{
@@ -133,6 +139,7 @@ export class GeoWriterStartError extends Data.TaggedError(
 export type GeoRouterError =
   | GeoBrandIdentityMissingError
   | GeoBrandIdentityNotFoundError
+  | GeoCompetitorLimitError
   | GeoContentBriefNotFoundError
   | GeoContentBriefStateError
   | GeoDatabaseError

--- a/apps/dashboard/src/lib/geo/errors.ts
+++ b/apps/dashboard/src/lib/geo/errors.ts
@@ -20,9 +20,11 @@ export class GeoDatabaseError extends Data.TaggedError("GeoDatabaseError")<{
   readonly cause: unknown;
 }> {}
 
-export class GeoPromptCreateFailedError extends Data.TaggedError(
-  "GeoPromptCreateFailedError"
-)<Record<string, never>> {}
+export class GeoPromptDuplicateError extends Data.TaggedError(
+  "GeoPromptDuplicateError"
+)<{
+  readonly prompt: string;
+}> {}
 
 export class GeoPromptNotFoundError extends Data.TaggedError(
   "GeoPromptNotFoundError"
@@ -146,7 +148,7 @@ export type GeoRouterError =
   | GeoDiscoveryError
   | GeoProjectCreateFailedError
   | GeoProjectNotFoundError
-  | GeoPromptCreateFailedError
+  | GeoPromptDuplicateError
   | GeoPromptNotFoundError
   | GeoSampleDataDisabledError
   | GeoScanStartError

--- a/apps/dashboard/src/lib/geo/lock.ts
+++ b/apps/dashboard/src/lib/geo/lock.ts
@@ -1,0 +1,12 @@
+import { sql } from "drizzle-orm";
+
+import type { DbTransaction } from "@/types/db";
+
+export async function lockGeoProject(
+  tx: DbTransaction,
+  projectId: string
+): Promise<void> {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${`geo-project:${projectId}`}, 0))`
+  );
+}

--- a/apps/dashboard/src/lib/geo/lock.ts
+++ b/apps/dashboard/src/lib/geo/lock.ts
@@ -1,12 +1,17 @@
 import { sql } from "drizzle-orm";
+import type { Effect } from "effect";
 
+import { geoDb } from "@/lib/geo/effect";
+import type { GeoDatabaseError } from "@/lib/geo/errors";
 import type { DbTransaction } from "@/types/db";
 
-export async function lockGeoProject(
+export function lockGeoProject(
   tx: DbTransaction,
   projectId: string
-): Promise<void> {
-  await tx.execute(
-    sql`SELECT pg_advisory_xact_lock(hashtextextended(${`geo-project:${projectId}`}, 0))`
-  );
+): Effect.Effect<void, GeoDatabaseError> {
+  return geoDb("project lock failed", async () => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`geo-project:${projectId}`}, 0))`
+    );
+  });
 }

--- a/apps/dashboard/src/lib/geo/onboarding.ts
+++ b/apps/dashboard/src/lib/geo/onboarding.ts
@@ -1,7 +1,4 @@
 import { extractCompetitors, searchBrands } from "@notra/ai/utils/context-dev";
-import { db } from "@notra/db/drizzle";
-import { geoPrompts } from "@notra/db/schema";
-import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 
 import {
@@ -14,11 +11,9 @@ import {
 import { readGeoCache, writeGeoCache } from "@/lib/geo/cache";
 import { discoverGeoWebsite } from "@/lib/geo/discover";
 import { normalizeCompetitorDomain } from "@/lib/geo/domain";
-import { geoDb } from "@/lib/geo/effect";
 import { GeoDiscoveryError, GeoSettingsMissingError } from "@/lib/geo/errors";
 import { loadGeoModelCatalog } from "@/lib/geo/model-catalog";
-import { upsertGeoSettings } from "@/lib/geo/programs";
-import { promptKey } from "@/lib/geo/prompt-key";
+import { insertGeoPrompts, upsertGeoSettings } from "@/lib/geo/programs";
 import {
   buildBrandTerms,
   promptMentionsBrand,
@@ -29,6 +24,7 @@ import type {
   GeoCompetitorSuggestionsResponse,
   GeoOnboardingBrandInput,
   GeoOnboardingBrandResult,
+  GeoPromptInsert,
   GeoScopeInput,
 } from "@/types/geo";
 import { resolveTrackedEngines } from "@/utils/geo-engines";
@@ -65,46 +61,28 @@ export const saveGeoOnboardingBrand = Effect.fn("geo.onboardingBrand")(
 
     const projectId = settings.projectId;
 
-    const existingPrompts = yield* geoDb("prompts lookup failed", () =>
-      db.query.geoPrompts.findMany({
-        columns: { prompt: true },
-        where: eq(geoPrompts.projectId, projectId),
-      })
-    );
-    const seen = new Set(existingPrompts.map((row) => promptKey(row.prompt)));
     const brandTerms = buildBrandTerms({
       companyName: input.companyName,
       aliases: input.aliases,
     });
-    const values = input.prompts.flatMap((entry) => {
+    const entries: GeoPromptInsert[] = input.prompts.flatMap((entry) => {
       const prompt = entry.prompt.trim();
       const title = entry.title.trim().slice(0, GEO_GAP_TITLE_MAX_LENGTH);
-      const key = promptKey(prompt);
-      if (seen.has(key) || promptMentionsBrand(prompt, brandTerms)) {
+      if (promptMentionsBrand(prompt, brandTerms)) {
         return [];
       }
-      seen.add(key);
-      return [
-        {
-          id: crypto.randomUUID(),
-          organizationId,
-          projectId,
-          prompt,
-          title: title.length > 0 ? title : null,
-        },
-      ];
+      return [{ prompt, title: title.length > 0 ? title : null }];
     });
-
-    if (values.length > 0) {
-      yield* geoDb("prompts insert failed", () =>
-        db.insert(geoPrompts).values(values)
-      );
-    }
+    const inserted = yield* insertGeoPrompts(
+      organizationId,
+      projectId,
+      entries
+    );
 
     const result: GeoOnboardingBrandResult = {
       projectId,
       companyName: settings.companyName,
-      promptsAdded: values.length,
+      promptsAdded: inserted.length,
     };
     return result;
   }

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -39,12 +39,14 @@ import {
   GEO_COMPETITOR_DETAIL_DAYS,
   GEO_COMPETITOR_SHARE_LIMIT,
   GEO_JOURNEY_DETAIL_LIMIT,
+  GEO_MAX_COMPETITORS,
 } from "@/constants/geo";
 import { GEO_MODEL_CATALOG_STATIC } from "@/constants/geo-model-catalog";
 import { hasZdrEntitlement } from "@/lib/billing/subscription";
 import { competitorKey } from "@/lib/geo/domain";
 import { geoDb, geoQuery } from "@/lib/geo/effect";
 import {
+  GeoCompetitorLimitError,
   GeoPromptCreateFailedError,
   GeoPromptNotFoundError,
   GeoScanStartError,
@@ -66,6 +68,7 @@ import {
   requireGeoProject,
   resolveGeoScope,
 } from "@/lib/geo/projects";
+import { promptKey } from "@/lib/geo/prompt-key";
 import { buildGeoPrompts } from "@/lib/geo/prompts";
 import { withGeoScanStatus } from "@/lib/geo/scan-status";
 import { syncGeoScanSchedule } from "@/lib/geo/schedule";
@@ -95,6 +98,12 @@ import type {
   GeoTrafficSource,
   GeoWindowInput,
 } from "@/types/geo";
+import type {
+  GeoCompetitorImportRow,
+  GeoCompetitorsImportResult,
+  GeoImportResult,
+  GeoPromptImportRow,
+} from "@/types/geo-import";
 import { toGeoTrafficTotals, toGeoVisitorType } from "@/utils/ai-traffic";
 import { getGeoModelCatalogEntry } from "@/utils/geo-model-catalog";
 import { groupGeoSparklinePoints } from "@/utils/geo-sparkline";
@@ -333,6 +342,83 @@ export const deleteGeoCompetitor = Effect.fn("geo.competitorDelete")(function* (
   const response: GeoCompetitorsResponse = { competitors };
   return response;
 });
+
+export const importGeoCompetitors = Effect.fn("geo.competitorsImport")(
+  function* (
+    scopeInput: GeoScopeInput,
+    rows: readonly GeoCompetitorImportRow[]
+  ) {
+    const scope = yield* requireGeoProject(scopeInput);
+    const current = yield* loadCompetitorsByProject(scope.projectId);
+    const entries: Required<GeoCompetitorSeed>[] = current.map(
+      (competitor) => ({
+        name: competitor.name,
+        domain: competitor.domain,
+        synonyms: competitor.synonyms,
+        kind: competitor.kind,
+        color: competitor.color,
+      })
+    );
+    const indexByKey = new Map(
+      entries.map((entry, index) => [competitorKey(entry.name), index])
+    );
+    const seen = new Set<string>();
+    let imported = 0;
+    let updated = 0;
+    let skipped = 0;
+
+    for (const row of rows) {
+      const name = row.name.trim();
+      const key = competitorKey(name);
+      if (seen.has(key)) {
+        skipped += 1;
+        continue;
+      }
+      seen.add(key);
+      const index = indexByKey.get(key);
+      const previous = index === undefined ? undefined : entries[index];
+      if (index === undefined || !previous) {
+        entries.push({
+          name,
+          domain: row.domain ?? null,
+          synonyms: row.synonyms ?? [],
+          kind: row.kind ?? "direct",
+          color: null,
+        });
+        indexByKey.set(key, entries.length - 1);
+        imported += 1;
+        continue;
+      }
+      entries[index] = {
+        name: previous.name,
+        domain: row.domain ?? previous.domain,
+        synonyms: row.synonyms ?? previous.synonyms,
+        kind: row.kind ?? previous.kind,
+        color: previous.color,
+      };
+      updated += 1;
+    }
+
+    if (entries.length > GEO_MAX_COMPETITORS) {
+      return yield* Effect.fail(
+        new GeoCompetitorLimitError({ limit: GEO_MAX_COMPETITORS })
+      );
+    }
+
+    const competitors = yield* syncGeoCompetitors(
+      scope.organizationId,
+      scope.projectId,
+      entries
+    );
+    const result: GeoCompetitorsImportResult = {
+      imported,
+      updated,
+      skipped,
+      competitors,
+    };
+    return result;
+  }
+);
 
 export const upsertGeoSettings = Effect.fn("geo.settingsUpsert")(function* (
   input: GeoSettingsUpsertInput
@@ -965,6 +1051,51 @@ export const createGeoPrompt = Effect.fn("geo.promptsCreate")(function* (
   }
 
   return toTrackedPrompt(row);
+});
+
+export const importGeoPrompts = Effect.fn("geo.promptsImport")(function* (
+  input: GeoScopeInput,
+  rows: readonly GeoPromptImportRow[]
+) {
+  const scope = yield* requireGeoProject(input);
+  const projectId = scope.projectId;
+  const existing = yield* geoDb("prompts lookup failed", () =>
+    db.query.geoPrompts.findMany({
+      columns: { prompt: true },
+      where: eq(geoPrompts.projectId, projectId),
+    })
+  );
+  const seen = new Set(existing.map((row) => promptKey(row.prompt)));
+  const values = rows.flatMap((row) => {
+    const prompt = row.prompt.trim();
+    const key = promptKey(prompt);
+    if (seen.has(key)) {
+      return [];
+    }
+    seen.add(key);
+    return [
+      {
+        id: crypto.randomUUID(),
+        organizationId: scope.organizationId,
+        projectId,
+        prompt,
+        enabled: row.enabled ?? true,
+      },
+    ];
+  });
+
+  if (values.length > 0) {
+    yield* geoDb("prompts import failed", () =>
+      db.insert(geoPrompts).values(values)
+    );
+  }
+
+  const result: GeoImportResult = {
+    imported: values.length,
+    updated: 0,
+    skipped: rows.length - values.length,
+  };
+  return result;
 });
 
 export const deleteGeoPrompt = Effect.fn("geo.promptsDelete")(function* (

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -169,16 +169,25 @@ const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
     const outcome = yield* geoDb("competitors sync failed", () =>
       db.transaction(async (tx): Promise<GeoCompetitorReconcileOutcome> => {
         await lockGeoProject(tx, projectId);
-        const [existing, settingsRow] = await Promise.all([
-          tx.query.geoCompetitors.findMany({
-            where: eq(geoCompetitors.projectId, projectId),
-            orderBy: [asc(geoCompetitors.createdAt)],
-          }),
-          tx.query.geoSettings.findFirst({
-            columns: { competitors: true },
-            where: eq(geoSettings.projectId, projectId),
-          }),
-        ]);
+        const [existing, settingsRow] = await Effect.runPromise(
+          Effect.all(
+            [
+              Effect.promise(() =>
+                tx.query.geoCompetitors.findMany({
+                  where: eq(geoCompetitors.projectId, projectId),
+                  orderBy: [asc(geoCompetitors.createdAt)],
+                })
+              ),
+              Effect.promise(() =>
+                tx.query.geoSettings.findFirst({
+                  columns: { competitors: true },
+                  where: eq(geoSettings.projectId, projectId),
+                })
+              ),
+            ],
+            { concurrency: "unbounded" }
+          )
+        );
         const current = mergeLegacyCompetitors(
           existing.map(toGeoCompetitor),
           settingsRow?.competitors ?? []

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -47,13 +47,14 @@ import { competitorKey } from "@/lib/geo/domain";
 import { geoDb, geoQuery } from "@/lib/geo/effect";
 import {
   GeoCompetitorLimitError,
-  GeoPromptCreateFailedError,
+  GeoPromptDuplicateError,
   GeoPromptNotFoundError,
   GeoScanStartError,
   GeoSettingsDisabledError,
   GeoSettingsMissingError,
 } from "@/lib/geo/errors";
 import { geoHiddenSourceParams } from "@/lib/geo/hidden-sources";
+import { lockGeoProject } from "@/lib/geo/lock";
 import {
   toGeoCompetitor,
   toGeoSettings,
@@ -78,6 +79,8 @@ import type {
   AiTrafficResponse,
   GeoCompetitor,
   GeoCompetitorDetailResponse,
+  GeoCompetitorMerge,
+  GeoCompetitorReconcileOutcome,
   GeoCompetitorSeed,
   GeoCompetitorShareResponse,
   GeoCompetitorsResponse,
@@ -156,87 +159,123 @@ export const loadGeoSettings = Effect.fn("geo.settings")(function* (
   return response;
 });
 
+const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
+  function* (
+    organizationId: string,
+    projectId: string,
+    merge: GeoCompetitorMerge,
+    limit?: number
+  ) {
+    const outcome = yield* geoDb("competitors sync failed", () =>
+      db.transaction(async (tx): Promise<GeoCompetitorReconcileOutcome> => {
+        await lockGeoProject(tx, projectId);
+        const existing = await tx.query.geoCompetitors.findMany({
+          where: eq(geoCompetitors.projectId, projectId),
+          orderBy: [asc(geoCompetitors.createdAt)],
+        });
+        const settingsRow = await tx.query.geoSettings.findFirst({
+          columns: { competitors: true },
+          where: eq(geoSettings.projectId, projectId),
+        });
+        const current = mergeLegacyCompetitors(
+          existing.map(toGeoCompetitor),
+          settingsRow?.competitors ?? []
+        );
+        const entries = merge(current);
+        const existingByName = new Map(
+          existing.map((row) => [competitorKey(row.name), row])
+        );
+
+        const resolved: Required<GeoCompetitorSeed>[] = [];
+        const seen = new Set<string>();
+        for (const entry of entries) {
+          const name = entry.name.trim();
+          const key = competitorKey(name);
+          if (name.length === 0 || seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          const previous = existingByName.get(key);
+          resolved.push({
+            name,
+            domain: entry.domain ?? previous?.domain ?? null,
+            synonyms: entry.synonyms ?? previous?.synonyms ?? [],
+            kind: entry.kind ?? previous?.kind ?? "direct",
+            color: entry.color ?? previous?.color ?? null,
+          });
+        }
+
+        if (limit !== undefined && resolved.length > limit) {
+          return { status: "limit" };
+        }
+
+        const staleIds = existing.flatMap((row) =>
+          seen.has(competitorKey(row.name)) ? [] : [row.id]
+        );
+        if (staleIds.length > 0) {
+          await tx
+            .delete(geoCompetitors)
+            .where(inArray(geoCompetitors.id, staleIds));
+        }
+
+        if (resolved.length > 0) {
+          await tx
+            .insert(geoCompetitors)
+            .values(
+              resolved.map((entry) => ({
+                id: crypto.randomUUID(),
+                organizationId,
+                projectId,
+                name: entry.name,
+                domain: entry.domain,
+                synonyms: entry.synonyms,
+                kind: entry.kind,
+                color: entry.color,
+              }))
+            )
+            .onConflictDoUpdate({
+              target: [geoCompetitors.projectId, geoCompetitors.name],
+              set: {
+                domain: sql`excluded.domain`,
+                synonyms: sql`excluded.synonyms`,
+                kind: sql`excluded.kind`,
+                color: sql`excluded.color`,
+              },
+            });
+        }
+
+        await tx
+          .update(geoSettings)
+          .set({ competitors: resolved.map((entry) => entry.name) })
+          .where(eq(geoSettings.projectId, projectId));
+
+        const rows = await tx.query.geoCompetitors.findMany({
+          where: eq(geoCompetitors.projectId, projectId),
+          orderBy: [asc(geoCompetitors.createdAt)],
+        });
+        return { status: "ok", competitors: rows.map(toGeoCompetitor) };
+      })
+    );
+
+    if (outcome.status === "limit") {
+      return yield* Effect.fail(
+        new GeoCompetitorLimitError({ limit: limit ?? GEO_MAX_COMPETITORS })
+      );
+    }
+    return outcome.competitors;
+  }
+);
+
 export const syncGeoCompetitors = Effect.fn("geo.competitorsSync")(function* (
   organizationId: string,
   projectId: string,
   entries: readonly GeoCompetitorSeed[]
 ) {
-  const rows = yield* geoDb("competitors sync failed", () =>
-    db.transaction(async (tx) => {
-      const existing = await tx.query.geoCompetitors.findMany({
-        where: eq(geoCompetitors.projectId, projectId),
-      });
-      const existingByName = new Map(
-        existing.map((row) => [competitorKey(row.name), row])
-      );
-
-      const resolved: Required<GeoCompetitorSeed>[] = [];
-      const seen = new Set<string>();
-      for (const entry of entries) {
-        const name = entry.name.trim();
-        const key = competitorKey(name);
-        if (name.length === 0 || seen.has(key)) {
-          continue;
-        }
-        seen.add(key);
-        const previous = existingByName.get(key);
-        resolved.push({
-          name,
-          domain: entry.domain ?? previous?.domain ?? null,
-          synonyms: entry.synonyms ?? previous?.synonyms ?? [],
-          kind: entry.kind ?? previous?.kind ?? "direct",
-          color: entry.color ?? previous?.color ?? null,
-        });
-      }
-
-      const staleIds = existing.flatMap((row) =>
-        seen.has(competitorKey(row.name)) ? [] : [row.id]
-      );
-      if (staleIds.length > 0) {
-        await tx
-          .delete(geoCompetitors)
-          .where(inArray(geoCompetitors.id, staleIds));
-      }
-
-      if (resolved.length > 0) {
-        await tx
-          .insert(geoCompetitors)
-          .values(
-            resolved.map((entry) => ({
-              id: crypto.randomUUID(),
-              organizationId,
-              projectId,
-              name: entry.name,
-              domain: entry.domain,
-              synonyms: entry.synonyms,
-              kind: entry.kind,
-              color: entry.color,
-            }))
-          )
-          .onConflictDoUpdate({
-            target: [geoCompetitors.projectId, geoCompetitors.name],
-            set: {
-              domain: sql`excluded.domain`,
-              synonyms: sql`excluded.synonyms`,
-              kind: sql`excluded.kind`,
-              color: sql`excluded.color`,
-            },
-          });
-      }
-
-      await tx
-        .update(geoSettings)
-        .set({ competitors: resolved.map((entry) => entry.name) })
-        .where(eq(geoSettings.projectId, projectId));
-
-      return await tx.query.geoCompetitors.findMany({
-        where: eq(geoCompetitors.projectId, projectId),
-        orderBy: [asc(geoCompetitors.createdAt)],
-      });
-    })
+  return yield* reconcileGeoCompetitors(
+    organizationId,
+    projectId,
+    () => entries
   );
-
-  return rows.map(toGeoCompetitor);
 });
 
 const loadCompetitorsByProject = Effect.fn("geo.competitorsByProject")(
@@ -286,38 +325,38 @@ export const upsertGeoCompetitor = Effect.fn("geo.competitorUpsert")(function* (
   input: GeoCompetitorUpsertInput
 ) {
   const scope = yield* requireGeoProject(scopeInput);
-  const current = yield* loadCompetitorsByProject(scope.projectId);
   const key = competitorKey(input.previousName ?? input.name);
-  const entries: GeoCompetitorSeed[] = current.map((competitor) =>
-    competitorKey(competitor.name) === key
-      ? {
-          name: input.name.trim(),
-          domain: input.domain,
-          synonyms: input.synonyms ?? competitor.synonyms,
-          kind: input.kind ?? competitor.kind,
-          color: input.color ?? competitor.color,
-        }
-      : competitor
-  );
-
-  if (
-    !entries.some(
-      (entry) => competitorKey(entry.name) === competitorKey(input.name)
-    )
-  ) {
-    entries.push({
-      name: input.name.trim(),
-      domain: input.domain,
-      synonyms: input.synonyms ?? [],
-      kind: input.kind ?? "direct",
-      color: input.color ?? null,
-    });
-  }
-
-  const competitors = yield* syncGeoCompetitors(
+  const competitors = yield* reconcileGeoCompetitors(
     scope.organizationId,
     scope.projectId,
-    entries
+    (current) => {
+      const entries: GeoCompetitorSeed[] = current.map((competitor) =>
+        competitorKey(competitor.name) === key
+          ? {
+              name: input.name.trim(),
+              domain: input.domain,
+              synonyms: input.synonyms ?? competitor.synonyms,
+              kind: input.kind ?? competitor.kind,
+              color: input.color ?? competitor.color,
+            }
+          : competitor
+      );
+
+      if (
+        !entries.some(
+          (entry) => competitorKey(entry.name) === competitorKey(input.name)
+        )
+      ) {
+        entries.push({
+          name: input.name.trim(),
+          domain: input.domain,
+          synonyms: input.synonyms ?? [],
+          kind: input.kind ?? "direct",
+          color: input.color ?? null,
+        });
+      }
+      return entries;
+    }
   );
   const response: GeoCompetitorsResponse = { competitors };
   return response;
@@ -328,16 +367,12 @@ export const deleteGeoCompetitor = Effect.fn("geo.competitorDelete")(function* (
   name: string
 ) {
   const scope = yield* requireGeoProject(scopeInput);
-  const current = yield* loadCompetitorsByProject(scope.projectId);
   const key = competitorKey(name);
-  const entries: GeoCompetitorSeed[] = current.filter(
-    (competitor) => competitorKey(competitor.name) !== key
-  );
-
-  const competitors = yield* syncGeoCompetitors(
+  const competitors = yield* reconcileGeoCompetitors(
     scope.organizationId,
     scope.projectId,
-    entries
+    (current) =>
+      current.filter((competitor) => competitorKey(competitor.name) !== key)
   );
   const response: GeoCompetitorsResponse = { competitors };
   return response;
@@ -349,67 +384,67 @@ export const importGeoCompetitors = Effect.fn("geo.competitorsImport")(
     rows: readonly GeoCompetitorImportRow[]
   ) {
     const scope = yield* requireGeoProject(scopeInput);
-    const current = yield* loadCompetitorsByProject(scope.projectId);
-    const entries: Required<GeoCompetitorSeed>[] = current.map(
-      (competitor) => ({
-        name: competitor.name,
-        domain: competitor.domain,
-        synonyms: competitor.synonyms,
-        kind: competitor.kind,
-        color: competitor.color,
-      })
-    );
-    const indexByKey = new Map(
-      entries.map((entry, index) => [competitorKey(entry.name), index])
-    );
-    const seen = new Set<string>();
     let imported = 0;
     let updated = 0;
     let skipped = 0;
 
-    for (const row of rows) {
-      const name = row.name.trim();
-      const key = competitorKey(name);
-      if (seen.has(key)) {
-        skipped += 1;
-        continue;
-      }
-      seen.add(key);
-      const index = indexByKey.get(key);
-      const previous = index === undefined ? undefined : entries[index];
-      if (index === undefined || !previous) {
-        entries.push({
-          name,
-          domain: row.domain ?? null,
-          synonyms: row.synonyms ?? [],
-          kind: row.kind ?? "direct",
-          color: null,
-        });
-        indexByKey.set(key, entries.length - 1);
-        imported += 1;
-        continue;
-      }
-      entries[index] = {
-        name: previous.name,
-        domain: row.domain ?? previous.domain,
-        synonyms: row.synonyms ?? previous.synonyms,
-        kind: row.kind ?? previous.kind,
-        color: previous.color,
-      };
-      updated += 1;
-    }
-
-    if (entries.length > GEO_MAX_COMPETITORS) {
-      return yield* Effect.fail(
-        new GeoCompetitorLimitError({ limit: GEO_MAX_COMPETITORS })
-      );
-    }
-
-    const competitors = yield* syncGeoCompetitors(
+    const competitors = yield* reconcileGeoCompetitors(
       scope.organizationId,
       scope.projectId,
-      entries
+      (current) => {
+        imported = 0;
+        updated = 0;
+        skipped = 0;
+        const entries: Required<GeoCompetitorSeed>[] = current.map(
+          (competitor) => ({
+            name: competitor.name,
+            domain: competitor.domain,
+            synonyms: competitor.synonyms,
+            kind: competitor.kind,
+            color: competitor.color,
+          })
+        );
+        const indexByKey = new Map(
+          entries.map((entry, index) => [competitorKey(entry.name), index])
+        );
+        const seen = new Set<string>();
+
+        for (const row of rows) {
+          const name = row.name.trim();
+          const key = competitorKey(name);
+          if (seen.has(key)) {
+            skipped += 1;
+            continue;
+          }
+          seen.add(key);
+          const index = indexByKey.get(key);
+          const previous = index === undefined ? undefined : entries[index];
+          if (index === undefined || !previous) {
+            entries.push({
+              name,
+              domain: row.domain ?? null,
+              synonyms: row.synonyms ?? [],
+              kind: row.kind ?? "direct",
+              color: null,
+            });
+            indexByKey.set(key, entries.length - 1);
+            imported += 1;
+            continue;
+          }
+          entries[index] = {
+            name: previous.name,
+            domain: row.domain ?? previous.domain,
+            synonyms: row.synonyms ?? previous.synonyms,
+            kind: row.kind ?? previous.kind,
+            color: previous.color,
+          };
+          updated += 1;
+        }
+        return entries;
+      },
+      GEO_MAX_COMPETITORS
     );
+
     const result: GeoCompetitorsImportResult = {
       imported,
       updated,
@@ -1033,21 +1068,35 @@ export const createGeoPrompt = Effect.fn("geo.promptsCreate")(function* (
 ) {
   const scope = yield* requireGeoProject(input);
   const projectId = scope.projectId;
-  const rows = yield* geoDb("prompt create failed", () =>
-    db
-      .insert(geoPrompts)
-      .values({
-        id: id ?? crypto.randomUUID(),
-        organizationId: scope.organizationId,
-        projectId,
-        prompt,
-      })
-      .returning()
+  const key = promptKey(prompt);
+  const row = yield* geoDb("prompt create failed", () =>
+    db.transaction(async (tx) => {
+      await lockGeoProject(tx, projectId);
+      const duplicate = await tx.query.geoPrompts.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(geoPrompts.projectId, projectId),
+          sql`lower(trim(${geoPrompts.prompt})) = ${key}`
+        ),
+      });
+      if (duplicate) {
+        return null;
+      }
+      const rows = await tx
+        .insert(geoPrompts)
+        .values({
+          id: id ?? crypto.randomUUID(),
+          organizationId: scope.organizationId,
+          projectId,
+          prompt,
+        })
+        .returning();
+      return rows.at(0) ?? null;
+    })
   );
 
-  const row = rows.at(0);
   if (!row) {
-    return yield* Effect.fail(new GeoPromptCreateFailedError({}));
+    return yield* Effect.fail(new GeoPromptDuplicateError({ prompt }));
   }
 
   return toTrackedPrompt(row);
@@ -1059,41 +1108,43 @@ export const importGeoPrompts = Effect.fn("geo.promptsImport")(function* (
 ) {
   const scope = yield* requireGeoProject(input);
   const projectId = scope.projectId;
-  const existing = yield* geoDb("prompts lookup failed", () =>
-    db.query.geoPrompts.findMany({
-      columns: { prompt: true },
-      where: eq(geoPrompts.projectId, projectId),
+  const imported = yield* geoDb("prompts import failed", () =>
+    db.transaction(async (tx) => {
+      await lockGeoProject(tx, projectId);
+      const existing = await tx.query.geoPrompts.findMany({
+        columns: { prompt: true },
+        where: eq(geoPrompts.projectId, projectId),
+      });
+      const seen = new Set(existing.map((row) => promptKey(row.prompt)));
+      const values = rows.flatMap((row) => {
+        const prompt = row.prompt.trim();
+        const key = promptKey(prompt);
+        if (seen.has(key)) {
+          return [];
+        }
+        seen.add(key);
+        return [
+          {
+            id: crypto.randomUUID(),
+            organizationId: scope.organizationId,
+            projectId,
+            prompt,
+            enabled: row.enabled ?? true,
+          },
+        ];
+      });
+
+      if (values.length > 0) {
+        await tx.insert(geoPrompts).values(values);
+      }
+      return values.length;
     })
   );
-  const seen = new Set(existing.map((row) => promptKey(row.prompt)));
-  const values = rows.flatMap((row) => {
-    const prompt = row.prompt.trim();
-    const key = promptKey(prompt);
-    if (seen.has(key)) {
-      return [];
-    }
-    seen.add(key);
-    return [
-      {
-        id: crypto.randomUUID(),
-        organizationId: scope.organizationId,
-        projectId,
-        prompt,
-        enabled: row.enabled ?? true,
-      },
-    ];
-  });
-
-  if (values.length > 0) {
-    yield* geoDb("prompts import failed", () =>
-      db.insert(geoPrompts).values(values)
-    );
-  }
 
   const result: GeoImportResult = {
-    imported: values.length,
+    imported,
     updated: 0,
-    skipped: rows.length - values.length,
+    skipped: rows.length - imported,
   };
   return result;
 });

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -75,6 +75,7 @@ import { withGeoScanStatus } from "@/lib/geo/scan-status";
 import { syncGeoScanSchedule } from "@/lib/geo/schedule";
 import { geoTrafficWindowParams } from "@/lib/geo/window";
 import { startGeoScanRun } from "@/lib/workflows/start";
+import type { DbTransaction } from "@/types/db";
 import type {
   AiTrafficResponse,
   GeoCompetitor,
@@ -159,6 +160,123 @@ export const loadGeoSettings = Effect.fn("geo.settings")(function* (
   return response;
 });
 
+const reconcileCompetitorsInTransaction = Effect.fn(
+  "geo.competitorsReconcileTx"
+)(function* (
+  tx: DbTransaction,
+  organizationId: string,
+  projectId: string,
+  merge: GeoCompetitorMerge,
+  limit?: number
+) {
+  yield* lockGeoProject(tx, projectId);
+  const [existing, settingsRow] = yield* Effect.all(
+    [
+      geoDb("competitors lookup failed", () =>
+        tx.query.geoCompetitors.findMany({
+          where: eq(geoCompetitors.projectId, projectId),
+          orderBy: [asc(geoCompetitors.createdAt)],
+        })
+      ),
+      geoDb("settings lookup failed", () =>
+        tx.query.geoSettings.findFirst({
+          columns: { competitors: true },
+          where: eq(geoSettings.projectId, projectId),
+        })
+      ),
+    ],
+    { concurrency: "unbounded" }
+  );
+  const current = mergeLegacyCompetitors(
+    existing.map(toGeoCompetitor),
+    settingsRow?.competitors ?? []
+  );
+  const entries = merge(current);
+  const existingByName = new Map(
+    existing.map((row) => [competitorKey(row.name), row])
+  );
+
+  const resolved: Required<GeoCompetitorSeed>[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const name = entry.name.trim();
+    const key = competitorKey(name);
+    if (name.length === 0 || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const previous = existingByName.get(key);
+    resolved.push({
+      name,
+      domain: entry.domain ?? previous?.domain ?? null,
+      synonyms: entry.synonyms ?? previous?.synonyms ?? [],
+      kind: entry.kind ?? previous?.kind ?? "direct",
+      color: entry.color ?? previous?.color ?? null,
+    });
+  }
+
+  if (limit !== undefined && resolved.length > limit) {
+    const overLimit: GeoCompetitorReconcileOutcome = { status: "limit" };
+    return overLimit;
+  }
+
+  const staleIds = existing.flatMap((row) =>
+    seen.has(competitorKey(row.name)) ? [] : [row.id]
+  );
+  if (staleIds.length > 0) {
+    yield* geoDb("competitors delete failed", () =>
+      tx.delete(geoCompetitors).where(inArray(geoCompetitors.id, staleIds))
+    );
+  }
+
+  if (resolved.length > 0) {
+    yield* geoDb("competitors upsert failed", () =>
+      tx
+        .insert(geoCompetitors)
+        .values(
+          resolved.map((entry) => ({
+            id: crypto.randomUUID(),
+            organizationId,
+            projectId,
+            name: entry.name,
+            domain: entry.domain,
+            synonyms: entry.synonyms,
+            kind: entry.kind,
+            color: entry.color,
+          }))
+        )
+        .onConflictDoUpdate({
+          target: [geoCompetitors.projectId, geoCompetitors.name],
+          set: {
+            domain: sql`excluded.domain`,
+            synonyms: sql`excluded.synonyms`,
+            kind: sql`excluded.kind`,
+            color: sql`excluded.color`,
+          },
+        })
+    );
+  }
+
+  yield* geoDb("settings update failed", () =>
+    tx
+      .update(geoSettings)
+      .set({ competitors: resolved.map((entry) => entry.name) })
+      .where(eq(geoSettings.projectId, projectId))
+  );
+
+  const rows = yield* geoDb("competitors lookup failed", () =>
+    tx.query.geoCompetitors.findMany({
+      where: eq(geoCompetitors.projectId, projectId),
+      orderBy: [asc(geoCompetitors.createdAt)],
+    })
+  );
+  const outcome: GeoCompetitorReconcileOutcome = {
+    status: "ok",
+    competitors: rows.map(toGeoCompetitor),
+  };
+  return outcome;
+});
+
 const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
   function* (
     organizationId: string,
@@ -167,105 +285,17 @@ const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
     limit?: number
   ) {
     const outcome = yield* geoDb("competitors sync failed", () =>
-      db.transaction(async (tx): Promise<GeoCompetitorReconcileOutcome> => {
-        await lockGeoProject(tx, projectId);
-        const [existing, settingsRow] = await Effect.runPromise(
-          Effect.all(
-            [
-              Effect.promise(() =>
-                tx.query.geoCompetitors.findMany({
-                  where: eq(geoCompetitors.projectId, projectId),
-                  orderBy: [asc(geoCompetitors.createdAt)],
-                })
-              ),
-              Effect.promise(() =>
-                tx.query.geoSettings.findFirst({
-                  columns: { competitors: true },
-                  where: eq(geoSettings.projectId, projectId),
-                })
-              ),
-            ],
-            { concurrency: "unbounded" }
+      db.transaction((tx) =>
+        Effect.runPromise(
+          reconcileCompetitorsInTransaction(
+            tx,
+            organizationId,
+            projectId,
+            merge,
+            limit
           )
-        );
-        const current = mergeLegacyCompetitors(
-          existing.map(toGeoCompetitor),
-          settingsRow?.competitors ?? []
-        );
-        const entries = merge(current);
-        const existingByName = new Map(
-          existing.map((row) => [competitorKey(row.name), row])
-        );
-
-        const resolved: Required<GeoCompetitorSeed>[] = [];
-        const seen = new Set<string>();
-        for (const entry of entries) {
-          const name = entry.name.trim();
-          const key = competitorKey(name);
-          if (name.length === 0 || seen.has(key)) {
-            continue;
-          }
-          seen.add(key);
-          const previous = existingByName.get(key);
-          resolved.push({
-            name,
-            domain: entry.domain ?? previous?.domain ?? null,
-            synonyms: entry.synonyms ?? previous?.synonyms ?? [],
-            kind: entry.kind ?? previous?.kind ?? "direct",
-            color: entry.color ?? previous?.color ?? null,
-          });
-        }
-
-        if (limit !== undefined && resolved.length > limit) {
-          return { status: "limit" };
-        }
-
-        const staleIds = existing.flatMap((row) =>
-          seen.has(competitorKey(row.name)) ? [] : [row.id]
-        );
-        if (staleIds.length > 0) {
-          await tx
-            .delete(geoCompetitors)
-            .where(inArray(geoCompetitors.id, staleIds));
-        }
-
-        if (resolved.length > 0) {
-          await tx
-            .insert(geoCompetitors)
-            .values(
-              resolved.map((entry) => ({
-                id: crypto.randomUUID(),
-                organizationId,
-                projectId,
-                name: entry.name,
-                domain: entry.domain,
-                synonyms: entry.synonyms,
-                kind: entry.kind,
-                color: entry.color,
-              }))
-            )
-            .onConflictDoUpdate({
-              target: [geoCompetitors.projectId, geoCompetitors.name],
-              set: {
-                domain: sql`excluded.domain`,
-                synonyms: sql`excluded.synonyms`,
-                kind: sql`excluded.kind`,
-                color: sql`excluded.color`,
-              },
-            });
-        }
-
-        await tx
-          .update(geoSettings)
-          .set({ competitors: resolved.map((entry) => entry.name) })
-          .where(eq(geoSettings.projectId, projectId));
-
-        const rows = await tx.query.geoCompetitors.findMany({
-          where: eq(geoCompetitors.projectId, projectId),
-          orderBy: [asc(geoCompetitors.createdAt)],
-        });
-        return { status: "ok", competitors: rows.map(toGeoCompetitor) };
-      })
+        )
+      )
     );
 
     if (outcome.status === "limit") {
@@ -1072,38 +1102,58 @@ export const listGeoPrompts = Effect.fn("geo.promptsList")(function* (
   return response;
 });
 
+const createPromptInTransaction = Effect.fn("geo.promptsCreateTx")(function* (
+  tx: DbTransaction,
+  organizationId: string,
+  projectId: string,
+  prompt: string,
+  id?: string
+) {
+  yield* lockGeoProject(tx, projectId);
+  const duplicate = yield* geoDb("prompt lookup failed", () =>
+    tx.query.geoPrompts.findFirst({
+      columns: { id: true },
+      where: and(
+        eq(geoPrompts.projectId, projectId),
+        sql`lower(trim(${geoPrompts.prompt})) = ${promptKey(prompt)}`
+      ),
+    })
+  );
+  if (duplicate) {
+    return null;
+  }
+  const rows = yield* geoDb("prompt create failed", () =>
+    tx
+      .insert(geoPrompts)
+      .values({
+        id: id ?? crypto.randomUUID(),
+        organizationId,
+        projectId,
+        prompt,
+      })
+      .returning()
+  );
+  return rows.at(0) ?? null;
+});
+
 export const createGeoPrompt = Effect.fn("geo.promptsCreate")(function* (
   input: GeoScopeInput,
   prompt: string,
   id?: string
 ) {
   const scope = yield* requireGeoProject(input);
-  const projectId = scope.projectId;
-  const key = promptKey(prompt);
   const row = yield* geoDb("prompt create failed", () =>
-    db.transaction(async (tx) => {
-      await lockGeoProject(tx, projectId);
-      const duplicate = await tx.query.geoPrompts.findFirst({
-        columns: { id: true },
-        where: and(
-          eq(geoPrompts.projectId, projectId),
-          sql`lower(trim(${geoPrompts.prompt})) = ${key}`
-        ),
-      });
-      if (duplicate) {
-        return null;
-      }
-      const rows = await tx
-        .insert(geoPrompts)
-        .values({
-          id: id ?? crypto.randomUUID(),
-          organizationId: scope.organizationId,
-          projectId,
+    db.transaction((tx) =>
+      Effect.runPromise(
+        createPromptInTransaction(
+          tx,
+          scope.organizationId,
+          scope.projectId,
           prompt,
-        })
-        .returning();
-      return rows.at(0) ?? null;
-    })
+          id
+        )
+      )
+    )
   );
 
   if (!row) {
@@ -1113,43 +1163,62 @@ export const createGeoPrompt = Effect.fn("geo.promptsCreate")(function* (
   return toTrackedPrompt(row);
 });
 
+const importPromptsInTransaction = Effect.fn("geo.promptsImportTx")(function* (
+  tx: DbTransaction,
+  organizationId: string,
+  projectId: string,
+  rows: readonly GeoPromptImportRow[]
+) {
+  yield* lockGeoProject(tx, projectId);
+  const existing = yield* geoDb("prompts lookup failed", () =>
+    tx.query.geoPrompts.findMany({
+      columns: { prompt: true },
+      where: eq(geoPrompts.projectId, projectId),
+    })
+  );
+  const seen = new Set(existing.map((row) => promptKey(row.prompt)));
+  const values = rows.flatMap((row) => {
+    const prompt = row.prompt.trim();
+    const key = promptKey(prompt);
+    if (seen.has(key)) {
+      return [];
+    }
+    seen.add(key);
+    return [
+      {
+        id: crypto.randomUUID(),
+        organizationId,
+        projectId,
+        prompt,
+        enabled: row.enabled ?? true,
+      },
+    ];
+  });
+
+  if (values.length > 0) {
+    yield* geoDb("prompts insert failed", () =>
+      tx.insert(geoPrompts).values(values)
+    );
+  }
+  return values.length;
+});
+
 export const importGeoPrompts = Effect.fn("geo.promptsImport")(function* (
   input: GeoScopeInput,
   rows: readonly GeoPromptImportRow[]
 ) {
   const scope = yield* requireGeoProject(input);
-  const projectId = scope.projectId;
   const imported = yield* geoDb("prompts import failed", () =>
-    db.transaction(async (tx) => {
-      await lockGeoProject(tx, projectId);
-      const existing = await tx.query.geoPrompts.findMany({
-        columns: { prompt: true },
-        where: eq(geoPrompts.projectId, projectId),
-      });
-      const seen = new Set(existing.map((row) => promptKey(row.prompt)));
-      const values = rows.flatMap((row) => {
-        const prompt = row.prompt.trim();
-        const key = promptKey(prompt);
-        if (seen.has(key)) {
-          return [];
-        }
-        seen.add(key);
-        return [
-          {
-            id: crypto.randomUUID(),
-            organizationId: scope.organizationId,
-            projectId,
-            prompt,
-            enabled: row.enabled ?? true,
-          },
-        ];
-      });
-
-      if (values.length > 0) {
-        await tx.insert(geoPrompts).values(values);
-      }
-      return values.length;
-    })
+    db.transaction((tx) =>
+      Effect.runPromise(
+        importPromptsInTransaction(
+          tx,
+          scope.organizationId,
+          scope.projectId,
+          rows
+        )
+      )
+    )
   );
 
   const result: GeoImportResult = {

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -169,14 +169,16 @@ const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
     const outcome = yield* geoDb("competitors sync failed", () =>
       db.transaction(async (tx): Promise<GeoCompetitorReconcileOutcome> => {
         await lockGeoProject(tx, projectId);
-        const existing = await tx.query.geoCompetitors.findMany({
-          where: eq(geoCompetitors.projectId, projectId),
-          orderBy: [asc(geoCompetitors.createdAt)],
-        });
-        const settingsRow = await tx.query.geoSettings.findFirst({
-          columns: { competitors: true },
-          where: eq(geoSettings.projectId, projectId),
-        });
+        const [existing, settingsRow] = await Promise.all([
+          tx.query.geoCompetitors.findMany({
+            where: eq(geoCompetitors.projectId, projectId),
+            orderBy: [asc(geoCompetitors.createdAt)],
+          }),
+          tx.query.geoSettings.findFirst({
+            columns: { competitors: true },
+            where: eq(geoSettings.projectId, projectId),
+          }),
+        ]);
         const current = mergeLegacyCompetitors(
           existing.map(toGeoCompetitor),
           settingsRow?.competitors ?? []

--- a/apps/dashboard/src/lib/geo/programs.ts
+++ b/apps/dashboard/src/lib/geo/programs.ts
@@ -86,9 +86,11 @@ import type {
   GeoCompetitorShareResponse,
   GeoCompetitorsResponse,
   GeoCompetitorUpsertInput,
+  GeoInsertedPrompt,
   GeoJourneyDetailResponse,
   GeoLanguageShareResponse,
   GeoOverviewResponse,
+  GeoPromptInsert,
   GeoPromptResultsResponse,
   GeoScopeInput,
   GeoSettingsResponse,
@@ -277,7 +279,7 @@ const reconcileCompetitorsInTransaction = Effect.fn(
   return outcome;
 });
 
-const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
+export const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
   function* (
     organizationId: string,
     projectId: string,
@@ -306,18 +308,6 @@ const reconcileGeoCompetitors = Effect.fn("geo.competitorsReconcile")(
     return outcome.competitors;
   }
 );
-
-export const syncGeoCompetitors = Effect.fn("geo.competitorsSync")(function* (
-  organizationId: string,
-  projectId: string,
-  entries: readonly GeoCompetitorSeed[]
-) {
-  return yield* reconcileGeoCompetitors(
-    organizationId,
-    projectId,
-    () => entries
-  );
-});
 
 const loadCompetitorsByProject = Effect.fn("geo.competitorsByProject")(
   function* (projectId: string) {
@@ -559,7 +549,7 @@ export const upsertGeoSettings = Effect.fn("geo.settingsUpsert")(function* (
         projectId,
         companyName: input.companyName,
         aliases: input.aliases,
-        competitors: input.competitors,
+        competitors: [],
         languages: input.languages,
         engines,
         enforceZdr,
@@ -572,7 +562,6 @@ export const upsertGeoSettings = Effect.fn("geo.settingsUpsert")(function* (
         set: {
           companyName: input.companyName,
           aliases: input.aliases,
-          competitors: input.competitors,
           languages: input.languages,
           engines,
           enforceZdr,
@@ -583,10 +572,10 @@ export const upsertGeoSettings = Effect.fn("geo.settingsUpsert")(function* (
       })
   );
 
-  yield* syncGeoCompetitors(
+  yield* reconcileGeoCompetitors(
     input.organizationId,
     projectId,
-    input.competitors.map((name) => ({ name, domain: null }))
+    (current) => current
   );
 
   const existingMessageId = existingSettings?.qstashMessageId ?? null;
@@ -1163,11 +1152,11 @@ export const createGeoPrompt = Effect.fn("geo.promptsCreate")(function* (
   return toTrackedPrompt(row);
 });
 
-const importPromptsInTransaction = Effect.fn("geo.promptsImportTx")(function* (
+const insertPromptsInTransaction = Effect.fn("geo.promptsInsertTx")(function* (
   tx: DbTransaction,
   organizationId: string,
   projectId: string,
-  rows: readonly GeoPromptImportRow[]
+  entries: readonly GeoPromptInsert[]
 ) {
   yield* lockGeoProject(tx, projectId);
   const existing = yield* geoDb("prompts lookup failed", () =>
@@ -1177,10 +1166,10 @@ const importPromptsInTransaction = Effect.fn("geo.promptsImportTx")(function* (
     })
   );
   const seen = new Set(existing.map((row) => promptKey(row.prompt)));
-  const values = rows.flatMap((row) => {
-    const prompt = row.prompt.trim();
+  const values = entries.flatMap((entry) => {
+    const prompt = entry.prompt.trim();
     const key = promptKey(prompt);
-    if (seen.has(key)) {
+    if (prompt.length === 0 || seen.has(key)) {
       return [];
     }
     seen.add(key);
@@ -1190,17 +1179,38 @@ const importPromptsInTransaction = Effect.fn("geo.promptsImportTx")(function* (
         organizationId,
         projectId,
         prompt,
-        enabled: row.enabled ?? true,
+        title: entry.title ?? null,
+        enabled: entry.enabled ?? true,
       },
     ];
   });
 
-  if (values.length > 0) {
-    yield* geoDb("prompts insert failed", () =>
-      tx.insert(geoPrompts).values(values)
-    );
+  if (values.length === 0) {
+    const none: GeoInsertedPrompt[] = [];
+    return none;
   }
-  return values.length;
+  const rows = yield* geoDb("prompts insert failed", () =>
+    tx
+      .insert(geoPrompts)
+      .values(values)
+      .returning({ id: geoPrompts.id, prompt: geoPrompts.prompt })
+  );
+  const inserted: GeoInsertedPrompt[] = rows;
+  return inserted;
+});
+
+export const insertGeoPrompts = Effect.fn("geo.promptsInsert")(function* (
+  organizationId: string,
+  projectId: string,
+  entries: readonly GeoPromptInsert[]
+) {
+  return yield* geoDb("prompts insert failed", () =>
+    db.transaction((tx) =>
+      Effect.runPromise(
+        insertPromptsInTransaction(tx, organizationId, projectId, entries)
+      )
+    )
+  );
 });
 
 export const importGeoPrompts = Effect.fn("geo.promptsImport")(function* (
@@ -1208,23 +1218,16 @@ export const importGeoPrompts = Effect.fn("geo.promptsImport")(function* (
   rows: readonly GeoPromptImportRow[]
 ) {
   const scope = yield* requireGeoProject(input);
-  const imported = yield* geoDb("prompts import failed", () =>
-    db.transaction((tx) =>
-      Effect.runPromise(
-        importPromptsInTransaction(
-          tx,
-          scope.organizationId,
-          scope.projectId,
-          rows
-        )
-      )
-    )
+  const inserted = yield* insertGeoPrompts(
+    scope.organizationId,
+    scope.projectId,
+    rows
   );
 
   const result: GeoImportResult = {
-    imported,
+    imported: inserted.length,
     updated: 0,
-    skipped: rows.length - imported,
+    skipped: rows.length - inserted.length,
   };
   return result;
 });

--- a/apps/dashboard/src/lib/geo/sample-data.ts
+++ b/apps/dashboard/src/lib/geo/sample-data.ts
@@ -9,7 +9,6 @@ import { EMPTY_GEO_CHECK_GROUNDING } from "@notra/db/constants/geo-checks";
 import { db } from "@notra/db/drizzle";
 import {
   brandSettings,
-  geoCompetitors,
   geoPromptSequences,
   geoPrompts,
   geoScans,
@@ -47,9 +46,9 @@ import {
   GeoSampleDataDisabledError,
   GeoTinybirdError,
 } from "@/lib/geo/errors";
+import { insertGeoPrompts, reconcileGeoCompetitors } from "@/lib/geo/programs";
 import { customPromptScanId } from "@/lib/geo/prompts";
 import type {
-  GeoCompetitorSeed,
   GeoSampleDataClearResponse,
   GeoSampleDataResponse,
   GeoScopeInput,
@@ -504,72 +503,28 @@ export const seedGeoSampleData = Effect.fn("geo.sampleData")(function* (
     );
   }
 
-  const existingCompetitors = yield* geoDb("competitors lookup failed", () =>
-    db.query.geoCompetitors.findMany({
-      where: eq(geoCompetitors.projectId, projectId),
-    })
-  );
-  const existingCompetitorKeys = new Set(
-    existingCompetitors.map((row) => competitorKey(row.name))
-  );
-  const competitorsToAdd: GeoCompetitorSeed[] = GEO_SAMPLE_COMPETITORS.filter(
-    (entry) => !existingCompetitorKeys.has(competitorKey(entry.name))
-  );
-
-  if (competitorsToAdd.length > 0) {
-    yield* geoDb("competitors insert failed", () =>
-      db.insert(geoCompetitors).values(
-        competitorsToAdd.map((entry) => ({
-          id: crypto.randomUUID(),
-          organizationId: input.organizationId,
-          projectId,
-          name: entry.name,
-          domain: entry.domain,
-          synonyms: entry.synonyms ?? [],
-          kind: entry.kind ?? "direct",
-          color: entry.color ?? null,
-        }))
-      )
+  let competitorsAdded = 0;
+  yield* reconcileGeoCompetitors(input.organizationId, projectId, (current) => {
+    const currentKeys = new Set(
+      current.map((competitor) => competitorKey(competitor.name))
     );
-  }
-
-  const allCompetitorNames = [
-    ...existingCompetitors.map((row) => row.name),
-    ...competitorsToAdd.map((entry) => entry.name),
-  ];
-  yield* geoDb("settings competitors stamp failed", () =>
-    db
-      .update(geoSettings)
-      .set({ competitors: allCompetitorNames })
-      .where(eq(geoSettings.projectId, projectId))
-  );
+    const missing = GEO_SAMPLE_COMPETITORS.filter(
+      (entry) => !currentKeys.has(competitorKey(entry.name))
+    );
+    competitorsAdded = missing.length;
+    return [...current, ...missing];
+  });
 
   const existingPrompts = yield* geoDb("prompts lookup failed", () =>
     db.query.geoPrompts.findMany({
       where: eq(geoPrompts.projectId, projectId),
     })
   );
-  const existingPromptTexts = new Set(existingPrompts.map((row) => row.prompt));
-  const promptsToAdd = GEO_SAMPLE_PROMPTS.filter(
-    (prompt) => !existingPromptTexts.has(prompt.english)
+  const insertedPrompts = yield* insertGeoPrompts(
+    input.organizationId,
+    projectId,
+    GEO_SAMPLE_PROMPTS.map((prompt) => ({ prompt: prompt.english }))
   );
-
-  const insertedPrompts =
-    promptsToAdd.length > 0
-      ? yield* geoDb("prompts insert failed", () =>
-          db
-            .insert(geoPrompts)
-            .values(
-              promptsToAdd.map((prompt) => ({
-                id: crypto.randomUUID(),
-                organizationId: input.organizationId,
-                projectId,
-                prompt: prompt.english,
-              }))
-            )
-            .returning({ id: geoPrompts.id, prompt: geoPrompts.prompt })
-        )
-      : [];
 
   const promptByEnglish = new Map(
     GEO_SAMPLE_PROMPTS.map((prompt) => [prompt.english, prompt])
@@ -653,7 +608,7 @@ export const seedGeoSampleData = Effect.fn("geo.sampleData")(function* (
   const response: GeoSampleDataResponse = {
     projectId,
     promptsAdded: insertedPrompts.length,
-    competitorsAdded: competitorsToAdd.length,
+    competitorsAdded,
     sequencesAdded: insertedSequences.length,
     mentionChecks: mentionChecks.length,
     trafficEvents: trafficEvents.length,

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -61,6 +61,10 @@ import type {
   GeoTrafficPagesResponse,
 } from "@/types/geo";
 import type {
+  GeoCompetitorImportRow,
+  GeoPromptImportRow,
+} from "@/types/geo-import";
+import type {
   GeoSearchConsoleStatus,
   GscSelectSiteInput,
   GscSitesResponse,
@@ -72,6 +76,7 @@ import {
 } from "@/utils/ai-traffic";
 import { toErrorMessage } from "@/utils/error-message";
 import { geoCompetitorDetailPath } from "@/utils/geo-competitors";
+import { describeGeoImportResult } from "@/utils/geo-import";
 import { withGeoProject } from "@/utils/geo-paths";
 import { toGeoWindowInput } from "@/utils/geo-range";
 
@@ -418,6 +423,42 @@ export function useGeoGenerateFromWebsite(organizationId: string) {
       toast.error(
         toErrorMessage(error, "Failed to generate GEO tracking from website")
       );
+    },
+  });
+}
+
+export function useGeoImportPrompts(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (rows: GeoPromptImportRow[]) =>
+      dashboardOrpc.geo.promptsImport.call({ organizationId, projectId, rows }),
+    onSuccess: async (result) => {
+      await invalidatePromptQueries(queryClient, organizationId, projectId);
+      toast.success(describeGeoImportResult("prompts", result));
+    },
+    onError: (error) => {
+      toast.error(toErrorMessage(error, "Failed to import prompts"));
+    },
+  });
+}
+
+export function useGeoImportCompetitors(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (rows: GeoCompetitorImportRow[]) =>
+      dashboardOrpc.geo.competitorsImport.call({
+        organizationId,
+        projectId,
+        rows,
+      }),
+    onSuccess: async (result) => {
+      await invalidateCompetitorQueries(queryClient, organizationId, projectId);
+      toast.success(describeGeoImportResult("competitors", result));
+    },
+    onError: (error) => {
+      toast.error(toErrorMessage(error, "Failed to import competitors"));
     },
   });
 }

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -52,6 +52,8 @@ import {
   createGeoPrompt,
   deleteGeoCompetitor,
   deleteGeoPrompt,
+  importGeoCompetitors,
+  importGeoPrompts,
   listGeoPrompts,
   loadAiTraffic,
   loadGeoCompetitorDetail,
@@ -97,6 +99,7 @@ import {
   aiTrafficInputSchema,
   geoBrandSearchInputSchema,
   geoCompetitorDeleteInputSchema,
+  geoCompetitorsImportInputSchema,
   geoCompetitorDetailInputSchema,
   geoCompetitorSuggestionsInputSchema,
   geoCompetitorUpsertInputSchema,
@@ -107,6 +110,7 @@ import {
   geoOrganizationInputSchema,
   geoProjectCreateInputSchema,
   geoPromptCreateInputSchema,
+  geoPromptsImportInputSchema,
   geoPromptDeleteInputSchema,
   geoPromptToggleInputSchema,
   geoSequenceCreateInputSchema,
@@ -365,6 +369,11 @@ export const geoRouter = {
   competitorDelete: authorizedProcedure
     .input(geoCompetitorDeleteInputSchema)
     .handler(geoOpenHandler((input) => deleteGeoCompetitor(input, input.name))),
+  competitorsImport: authorizedProcedure
+    .input(geoCompetitorsImportInputSchema)
+    .handler(
+      geoOpenHandler((input) => importGeoCompetitors(input, input.rows))
+    ),
   competitorDetail: authorizedProcedure
     .input(geoCompetitorDetailInputSchema)
     .handler(
@@ -456,6 +465,9 @@ export const geoRouter = {
     .handler(
       geoHandler((input) => createGeoPrompt(input, input.prompt, input.id))
     ),
+  promptsImport: authorizedProcedure
+    .input(geoPromptsImportInputSchema)
+    .handler(geoHandler((input) => importGeoPrompts(input, input.rows))),
   promptsDelete: authorizedProcedure
     .input(geoPromptDeleteInputSchema)
     .handler(

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -14,8 +14,8 @@ import {
 } from "@notra/ai/qstash/triggers";
 import { db } from "@notra/db/drizzle";
 import { geoPromptSuggestions, geoPrompts, projects } from "@notra/db/schema";
-import { and, asc, desc, eq } from "drizzle-orm";
-import type { Effect } from "effect";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { Effect } from "effect";
 
 import { GEO_SAMPLE_DATA_ENABLED } from "@/constants/geo";
 import {
@@ -41,6 +41,7 @@ import { buildGeoIngestToken } from "@/lib/geo-ingest/token";
 import { discoverGeoWebsite, generateGeoFromWebsite } from "@/lib/geo/discover";
 import type { GeoRouterError } from "@/lib/geo/errors";
 import { loadGeoContentGaps } from "@/lib/geo/gaps";
+import { lockGeoProject } from "@/lib/geo/lock";
 import { toTrackedPrompt } from "@/lib/geo/mappers";
 import { loadGeoModelCatalog } from "@/lib/geo/model-catalog";
 import {
@@ -74,6 +75,7 @@ import {
   upsertGeoSettings,
 } from "@/lib/geo/programs";
 import { createGeoProject, listGeoProjects } from "@/lib/geo/projects";
+import { promptKey } from "@/lib/geo/prompt-key";
 import { clearGeoSampleData, seedGeoSampleData } from "@/lib/geo/sample-data";
 import { runGeoSequenceNow } from "@/lib/geo/scan";
 import { syncGscSuggestions } from "@/lib/geo/search-console";
@@ -129,6 +131,7 @@ import {
 } from "@/schemas/geo";
 import { gscSelectSiteInputSchema } from "@/schemas/google-search-console";
 import type { AuthenticatedUser } from "@/types/auth/organization";
+import type { DbTransaction } from "@/types/db";
 import type {
   GeoBrandSearchHandlerInput,
   GeoCompetitorSuggestionsHandlerInput,
@@ -290,20 +293,19 @@ async function requireDefaultProjectId(
   return row.id;
 }
 
-type GeoTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
-
 async function acceptSuggestionInTx(
-  tx: GeoTransaction,
+  tx: DbTransaction,
   organizationId: string,
   projectId: string,
   suggestion: Pick<GeoPromptSuggestionRow, "id" | "prompt" | "title">
 ): Promise<GeoTrackedPrompt> {
+  await Effect.runPromise(lockGeoProject(tx, projectId));
   // Reuse an identical tracked prompt instead of creating a duplicate.
   const existing = await tx.query.geoPrompts.findFirst({
     where: and(
       eq(geoPrompts.organizationId, organizationId),
       eq(geoPrompts.projectId, projectId),
-      eq(geoPrompts.prompt, suggestion.prompt)
+      sql`lower(trim(${geoPrompts.prompt})) = ${promptKey(suggestion.prompt)}`
     ),
   });
   const promptRow =

--- a/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
+++ b/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
@@ -27,6 +27,10 @@ export function toGeoOrpcError(failure: GeoRouterError): Error {
       return badRequest(failure.message);
     case "GeoSequenceCreateFailedError":
       return badRequest("Failed to create conversation");
+    case "GeoCompetitorLimitError":
+      return badRequest(
+        `You can track up to ${failure.limit} competitors. Remove some before importing more.`
+      );
     case "GeoSettingsMissingError":
       return badRequest("Configure your brand tracking settings first");
     case "GeoSettingsDisabledError":

--- a/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
+++ b/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
@@ -4,8 +4,8 @@ import { badRequest, notFound, paymentRequired } from "@/lib/orpc/utils/errors";
 
 export function toGeoOrpcError(failure: GeoRouterError): Error {
   switch (failure._tag) {
-    case "GeoPromptCreateFailedError":
-      return badRequest("Failed to create prompt");
+    case "GeoPromptDuplicateError":
+      return badRequest("This prompt is already tracked");
     case "GeoPromptNotFoundError":
       return notFound("Prompt not found");
     case "GeoProjectNotFoundError":

--- a/apps/dashboard/src/schemas/geo-import.ts
+++ b/apps/dashboard/src/schemas/geo-import.ts
@@ -1,0 +1,55 @@
+import { array, boolean, enum as enumType, object, string } from "zod";
+
+import {
+  GEO_COMPETITOR_MAX_SYNONYMS,
+  GEO_DOMAIN_REGEX,
+  GEO_PROMPT_MAX_LENGTH,
+  GEO_PROMPT_MIN_LENGTH,
+  GEO_SHORT_FIELD_MAX_LENGTH,
+} from "@/constants/geo";
+import { normalizeCompetitorDomain } from "@/lib/geo/domain";
+
+export const geoCompetitorDomainSchema = string()
+  .trim()
+  .max(GEO_SHORT_FIELD_MAX_LENGTH)
+  .transform(normalizeCompetitorDomain)
+  .refine((value) => value === null || GEO_DOMAIN_REGEX.test(value), {
+    message: "Enter a domain like example.com",
+  });
+
+export const geoPromptImportRowSchema = object({
+  prompt: string()
+    .trim()
+    .min(GEO_PROMPT_MIN_LENGTH, {
+      message: `Prompt must be at least ${GEO_PROMPT_MIN_LENGTH} characters`,
+    })
+    .max(GEO_PROMPT_MAX_LENGTH, {
+      message: `Prompt must be at most ${GEO_PROMPT_MAX_LENGTH} characters`,
+    }),
+  enabled: boolean({ message: "Enabled must be true or false" }).optional(),
+});
+
+export const geoCompetitorImportRowSchema = object({
+  name: string()
+    .trim()
+    .min(1, { message: "Name is required" })
+    .max(GEO_SHORT_FIELD_MAX_LENGTH, {
+      message: `Name must be at most ${GEO_SHORT_FIELD_MAX_LENGTH} characters`,
+    }),
+  domain: geoCompetitorDomainSchema.nullable().optional(),
+  kind: enumType(["direct", "indirect"], {
+    message: "Kind must be direct or indirect",
+  }).optional(),
+  synonyms: array(
+    string()
+      .trim()
+      .min(1, { message: "Synonyms cannot be empty" })
+      .max(GEO_SHORT_FIELD_MAX_LENGTH, {
+        message: `Synonyms must be at most ${GEO_SHORT_FIELD_MAX_LENGTH} characters`,
+      })
+  )
+    .max(GEO_COMPETITOR_MAX_SYNONYMS, {
+      message: `Use at most ${GEO_COMPETITOR_MAX_SYNONYMS} synonyms`,
+    })
+    .optional(),
+});

--- a/apps/dashboard/src/schemas/geo.ts
+++ b/apps/dashboard/src/schemas/geo.ts
@@ -5,6 +5,7 @@ import { array, boolean, enum as enumType, number, object, string } from "zod";
 import {
   GEO_BRAND_SEARCH_MAX_QUERY_LENGTH,
   GEO_BRAND_SEARCH_MIN_QUERY_LENGTH,
+  GEO_COMPETITOR_MAX_SYNONYMS,
   GEO_DISCOVERY_MAX_ALIASES,
   GEO_DISCOVERY_MAX_COMPETITORS,
   GEO_DISCOVERY_MAX_PROMPTS,
@@ -19,11 +20,17 @@ import {
   GEO_PROMPT_MAX_LENGTH,
   GEO_PROMPT_MIN_LENGTH,
   GEO_SCAN_INTERVAL_HOURS,
+  GEO_SHORT_FIELD_MAX_LENGTH,
   GEO_SEQUENCE_MAX_TURNS,
   GEO_WRITER_TOPIC_MAX_LENGTH,
   GEO_WRITER_TOPIC_MIN_LENGTH,
 } from "@/constants/geo";
-import { normalizeCompetitorDomain } from "@/lib/geo/domain";
+import { GEO_CSV_IMPORT_MAX_ROWS } from "@/constants/geo-import";
+import {
+  geoCompetitorDomainSchema,
+  geoCompetitorImportRowSchema,
+  geoPromptImportRowSchema,
+} from "@/schemas/geo-import";
 import { publicWebsiteUrlSchema } from "@/schemas/url";
 
 const GEO_SUPPORTED_LANGUAGE_SET = new Set<string>(SUPPORTED_LANGUAGES);
@@ -41,11 +48,8 @@ const MAX_AI_TRAFFIC_LOG_LIMIT = 200;
 const MAX_AI_TRAFFIC_PAGES_LIMIT = 500;
 const MAX_AI_TRAFFIC_JOURNEYS_LIMIT = 100;
 const MAX_GEO_FIELD_LENGTH = 1024;
-const MAX_GEO_SHORT_FIELD_LENGTH = 128;
-const MAX_GEO_COMPETITOR_SYNONYMS = 8;
 const MAX_GEO_URL_LENGTH = 2048;
 const MAX_GEO_METHOD_LENGTH = 16;
-const GEO_DOMAIN_REGEX = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/;
 const MIN_PROMPT_LENGTH = GEO_PROMPT_MIN_LENGTH;
 const MAX_PROMPT_LENGTH = GEO_PROMPT_MAX_LENGTH;
 
@@ -72,12 +76,12 @@ export const geoSettingsUpsertInputSchema = geoOrganizationInputSchema.extend({
         message: "Unsupported language",
       }
     ),
-  engines: array(string().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH))
+  engines: array(string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH))
     .min(1)
     .max(GEO_MAX_ENGINES),
   enforceZdr: boolean(),
   nonZdrApprovedEngines: array(
-    string().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH)
+    string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH)
   ).max(GEO_MAX_ENGINES),
   enabled: boolean(),
   scanIntervalHours: number().refine(
@@ -86,30 +90,22 @@ export const geoSettingsUpsertInputSchema = geoOrganizationInputSchema.extend({
   ),
 });
 
-export const geoCompetitorDomainSchema = string()
-  .trim()
-  .max(MAX_GEO_SHORT_FIELD_LENGTH)
-  .transform(normalizeCompetitorDomain)
-  .refine((value) => value === null || GEO_DOMAIN_REGEX.test(value), {
-    message: "Enter a domain like example.com",
-  });
-
 export const geoCompetitorUpsertInputSchema = geoOrganizationInputSchema.extend(
   {
-    name: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
+    name: string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
     previousName: string()
       .trim()
       .min(1)
-      .max(MAX_GEO_SHORT_FIELD_LENGTH)
+      .max(GEO_SHORT_FIELD_MAX_LENGTH)
       .optional(),
     domain: geoCompetitorDomainSchema.nullable(),
-    synonyms: array(string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH))
-      .max(MAX_GEO_COMPETITOR_SYNONYMS)
+    synonyms: array(string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH))
+      .max(GEO_COMPETITOR_MAX_SYNONYMS)
       .optional(),
     kind: enumType(["direct", "indirect"]).optional(),
     color: string()
       .trim()
-      .max(MAX_GEO_SHORT_FIELD_LENGTH)
+      .max(GEO_SHORT_FIELD_MAX_LENGTH)
       .nullable()
       .optional(),
   }
@@ -117,13 +113,13 @@ export const geoCompetitorUpsertInputSchema = geoOrganizationInputSchema.extend(
 
 export const geoCompetitorDeleteInputSchema = geoOrganizationInputSchema.extend(
   {
-    name: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
+    name: string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
   }
 );
 
 export const geoCompetitorDetailInputSchema = geoOrganizationInputSchema.extend(
   {
-    brand: string().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
+    brand: string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
     ...geoWindowFields,
   }
 );
@@ -134,7 +130,7 @@ export const geoTranslationResultSchema = object({
 
 export const geoSequenceCreateInputSchema = geoOrganizationInputSchema.extend({
   id: string().uuid().optional(),
-  name: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
+  name: string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
   steps: array(string().trim().min(MIN_PROMPT_LENGTH).max(MAX_PROMPT_LENGTH))
     .min(1)
     .max(GEO_SEQUENCE_MAX_TURNS),
@@ -142,7 +138,7 @@ export const geoSequenceCreateInputSchema = geoOrganizationInputSchema.extend({
 
 export const geoSequenceUpdateInputSchema = geoOrganizationInputSchema.extend({
   sequenceId: string().min(1),
-  name: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
+  name: string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
   steps: array(string().trim().min(MIN_PROMPT_LENGTH).max(MAX_PROMPT_LENGTH))
     .min(1)
     .max(GEO_SEQUENCE_MAX_TURNS)
@@ -164,7 +160,7 @@ export const geoSequenceRunInputSchema = geoOrganizationInputSchema.extend({
 
 export const geoProjectCreateInputSchema = object({
   organizationId: string().min(1),
-  name: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
+  name: string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
   brandSettingsId: string().min(1),
 });
 
@@ -186,6 +182,15 @@ export const geoPromptToggleInputSchema = geoOrganizationInputSchema.extend({
   enabled: boolean(),
 });
 
+export const geoPromptsImportInputSchema = geoOrganizationInputSchema.extend({
+  rows: array(geoPromptImportRowSchema).min(1).max(GEO_CSV_IMPORT_MAX_ROWS),
+});
+
+export const geoCompetitorsImportInputSchema =
+  geoOrganizationInputSchema.extend({
+    rows: array(geoCompetitorImportRowSchema).min(1).max(GEO_MAX_COMPETITORS),
+  });
+
 export const geoGenerateFromWebsiteInputSchema =
   geoOrganizationInputSchema.extend({
     url: publicWebsiteUrlSchema,
@@ -202,8 +207,8 @@ const geoTrackingLanguagesSchema = array(string().min(1))
   );
 
 export const geoOnboardingBrandInputSchema = geoOrganizationInputSchema.extend({
-  companyName: string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
-  aliases: array(string().trim().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH)).max(
+  companyName: string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
+  aliases: array(string().trim().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH)).max(
     GEO_MAX_ALIASES
   ),
   prompts: array(
@@ -213,12 +218,12 @@ export const geoOnboardingBrandInputSchema = geoOrganizationInputSchema.extend({
     })
   ).max(GEO_ONBOARDING_MAX_PROMPTS),
   languages: geoTrackingLanguagesSchema.optional(),
-  engines: array(string().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH))
+  engines: array(string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH))
     .min(1)
     .max(GEO_MAX_ENGINES)
     .optional(),
   enforceZdr: boolean().optional(),
-  nonZdrApprovedEngines: array(string().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH))
+  nonZdrApprovedEngines: array(string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH))
     .max(GEO_MAX_ENGINES)
     .optional(),
 });
@@ -297,26 +302,26 @@ export const geoTrafficLogInputSchema = geoOrganizationInputSchema.extend({
 });
 
 export const geoRequestPayloadSchema = object({
-  timestamp: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
+  timestamp: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
   method: string().min(1).max(MAX_GEO_METHOD_LENGTH),
   url: string().min(1).max(MAX_GEO_URL_LENGTH),
-  ip: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
+  ip: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
   geo: object({
-    country: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
-    region: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
-    city: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
-    timezone: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
-    latitude: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
-    longitude: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
+    country: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
+    region: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
+    city: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
+    timezone: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
+    latitude: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
+    longitude: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
   }).optional(),
   referer: string().max(MAX_GEO_URL_LENGTH).optional(),
   userAgent: string().max(MAX_GEO_FIELD_LENGTH).optional(),
   accept: string().max(MAX_GEO_FIELD_LENGTH).optional(),
   acceptLanguage: string().max(MAX_GEO_FIELD_LENGTH).optional(),
-  requestId: string().max(MAX_GEO_SHORT_FIELD_LENGTH).optional(),
+  requestId: string().max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
   signals: object({
     clientHints: boolean(),
-    fetchMode: string().max(MAX_GEO_SHORT_FIELD_LENGTH).nullable(),
+    fetchMode: string().max(GEO_SHORT_FIELD_MAX_LENGTH).nullable(),
     tracing: boolean(),
   }).optional(),
 });
@@ -327,7 +332,7 @@ export const geoTrafficJourneysInputSchema = geoOrganizationInputSchema.extend({
 });
 
 export const geoJourneyDetailInputSchema = geoOrganizationInputSchema.extend({
-  journeyId: string().min(1).max(MAX_GEO_SHORT_FIELD_LENGTH),
+  journeyId: string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
   ...geoWindowFields,
 });
 

--- a/apps/dashboard/src/types/csv.ts
+++ b/apps/dashboard/src/types/csv.ts
@@ -1,0 +1,10 @@
+export interface CsvRecord {
+  line: number;
+  cells: string[];
+}
+
+export interface CsvDocument {
+  delimiter: string;
+  header: string[];
+  records: CsvRecord[];
+}

--- a/apps/dashboard/src/types/db.ts
+++ b/apps/dashboard/src/types/db.ts
@@ -1,0 +1,3 @@
+import type { db } from "@notra/db/drizzle";
+
+export type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/apps/dashboard/src/types/geo-import.ts
+++ b/apps/dashboard/src/types/geo-import.ts
@@ -1,0 +1,67 @@
+import type { GeoCompetitor, GeoCompetitorKind } from "@/types/geo";
+
+export type GeoImportKind = "prompts" | "competitors";
+
+export interface GeoPromptImportRow {
+  prompt: string;
+  enabled?: boolean;
+}
+
+export interface GeoCompetitorImportRow {
+  name: string;
+  domain?: string | null;
+  kind?: GeoCompetitorKind;
+  synonyms?: string[];
+}
+
+export interface GeoCsvIssue {
+  line: number;
+  message: string;
+}
+
+export interface GeoCsvParseResult<TRow> {
+  rows: TRow[];
+  issues: GeoCsvIssue[];
+  duplicates: number;
+  total: number;
+}
+
+export interface GeoImportResult {
+  imported: number;
+  updated: number;
+  skipped: number;
+}
+
+export interface GeoCompetitorsImportResult extends GeoImportResult {
+  competitors: GeoCompetitor[];
+}
+
+export interface GeoImportKindCopy {
+  title: string;
+  description: string;
+  noun: string;
+  nounPlural: string;
+  columns: string;
+  templateFilename: string;
+  template: string;
+}
+
+export interface GeoCsvSelection<TRow> {
+  file: File;
+  result: GeoCsvParseResult<TRow>;
+}
+
+export interface GeoCsvImportDialogProps<TRow> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  kind: GeoImportKind;
+  parse: (text: string) => GeoCsvParseResult<TRow>;
+  onImport: (rows: TRow[]) => Promise<unknown>;
+  isPending: boolean;
+}
+
+export interface GeoImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+}

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -1599,6 +1599,14 @@ export interface GeoCompetitorRow {
   updatedAt: Date;
 }
 
+export type GeoCompetitorMerge = (
+  current: GeoCompetitor[]
+) => readonly GeoCompetitorSeed[];
+
+export type GeoCompetitorReconcileOutcome =
+  | { status: "limit" }
+  | { status: "ok"; competitors: GeoCompetitor[] };
+
 export interface GeoCompetitorsResponse {
   competitors: GeoCompetitor[];
 }

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -1607,6 +1607,17 @@ export type GeoCompetitorReconcileOutcome =
   | { status: "limit" }
   | { status: "ok"; competitors: GeoCompetitor[] };
 
+export interface GeoPromptInsert {
+  prompt: string;
+  title?: string | null;
+  enabled?: boolean;
+}
+
+export interface GeoInsertedPrompt {
+  id: string;
+  prompt: string;
+}
+
 export interface GeoCompetitorsResponse {
   competitors: GeoCompetitor[];
 }

--- a/apps/dashboard/src/utils/geo-import.ts
+++ b/apps/dashboard/src/utils/geo-import.ts
@@ -1,0 +1,42 @@
+import { GEO_IMPORT_COPY } from "@/constants/geo-import";
+import type { GeoImportKind, GeoImportResult } from "@/types/geo-import";
+
+export function geoImportNoun(kind: GeoImportKind, count: number): string {
+  const copy = GEO_IMPORT_COPY[kind];
+  return count === 1 ? copy.noun : copy.nounPlural;
+}
+
+export function describeGeoImportResult(
+  kind: GeoImportKind,
+  result: GeoImportResult
+): string {
+  const parts: string[] = [];
+  if (result.imported > 0) {
+    parts.push(
+      `Imported ${result.imported} ${geoImportNoun(kind, result.imported)}`
+    );
+  }
+  if (result.updated > 0) {
+    parts.push(`updated ${result.updated}`);
+  }
+  if (result.skipped > 0) {
+    parts.push(
+      `skipped ${result.skipped} duplicate${result.skipped === 1 ? "" : "s"}`
+    );
+  }
+  if (parts.length === 0) {
+    return `No new ${GEO_IMPORT_COPY[kind].nounPlural} to import`;
+  }
+  return parts.join(", ");
+}
+
+export function formatCsvFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const kilobytes = bytes / 1024;
+  if (kilobytes < 1024) {
+    return `${kilobytes.toFixed(kilobytes < 10 ? 1 : 0)} KB`;
+  }
+  return `${(kilobytes / 1024).toFixed(1)} MB`;
+}


### PR DESCRIPTION
## What

Adds an **Import CSV** button next to *Add Prompt* / *Add Competitor* on the GEO pages. It opens a dropzone dialog (kibo-ui `Dropzone` from `@notra/ui`) that parses the file client-side, shows how many rows are ready plus any per-line problems, and imports in one request.

## CSV format

Header row required (case-insensitive); `,` `;` or tab delimiters auto-detected; unknown columns ignored. A "Download template" link in the dialog produces these files.

```csv
prompt,enabled
what tools should I use for automating changelogs,true
```

```csv
name,domain,kind,synonyms
Acme Analytics,acme.com,direct,Acme|Acme Inc
```

## Backend

- New oRPC procedures `geo.promptsImport` and `geo.competitorsImport`, both with Zod input schemas (`geoPromptsImportInputSchema`, `geoCompetitorsImportInputSchema`) validating every row: prompt length, `enabled` boolean, competitor name, normalized domain, `kind` enum, synonyms list.
- `importGeoPrompts`: dedupes against existing prompts (case-insensitive) and within the batch, single bulk insert.
- `importGeoCompetitors`: merges into the existing set through the existing `syncGeoCompetitors` transaction; existing names get domain/kind/synonyms updated only where the CSV provides them. Exceeding `GEO_MAX_COMPETITORS` returns a 400 via the new `GeoCompetitorLimitError`.
- Both return `{ imported, updated, skipped }`, surfaced in the success toast.

## Notes

- Small RFC 4180 parser in `lib/csv/parse.ts`; no new dependency (`react-dropzone` already ships with `@notra/ui`).
- `geoCompetitorDomainSchema` moved to the client-safe `schemas/geo-import.ts` so the dialog can reuse the exact row schemas for the preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Import CSV button to the GEO prompts and competitors pages, so users can bulk-import rows in one request instead of using the add dialog one at a time. All prompt and competitor writes (imports, single creation, edits, deletes, settings saves, discovery, sample data) now run through shared deduping helpers inside a transaction guarded by a per-project advisory lock, so no writer acts on a stale snapshot.

**Import behavior**
- CSV needs a header row; comma, semicolon, or tab delimiters are auto-detected, unknown columns are ignored, and a template download is in the dialog.
- The dialog previews rows ready, duplicates, and per-line problems before submitting.
- Prompt imports dedupe case-insensitively and skip duplicates; single prompt creation now rejects duplicates.
- Competitor imports merge into existing competitors, updating only fields the CSV provides; exceeding 25 competitors returns a 400.
- Both procedures return imported, updated, and skipped counts, surfaced in the success toast.

<sup>Written for commit a2feada18a068842bcbf08ba0b04a50f578c0bcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

