### PR TITLE
fix(auth): improve login error states

### DIFF
--- a/apps/dashboard/src/components/auth/signup-form.tsx
+++ b/apps/dashboard/src/components/auth/signup-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AuthEmailField } from "@notra/ui/components/shared/auth/auth-email-field";
+import { AuthFormError } from "@notra/ui/components/shared/auth/auth-form-error";
 import { AuthFormHeader } from "@notra/ui/components/shared/auth/auth-form-header";
 import { AuthOrDivider } from "@notra/ui/components/shared/auth/auth-or-divider";
 import { AuthPasswordField } from "@notra/ui/components/shared/auth/auth-password-field";
@@ -228,7 +229,7 @@ export function SignupForm({
             form.handleSubmit();
           }}
         >
-          <div className="grid gap-1">
+          <div className="grid gap-3">
             <form.Field
               name="email"
               validators={{
@@ -279,12 +280,7 @@ export function SignupForm({
             </form.Field>
           </div>
 
-          <p
-            aria-live="polite"
-            className="text-destructive mt-3 text-sm empty:hidden"
-          >
-            {formError}
-          </p>
+          <AuthFormError className="mt-4" error={formError} />
 
           <CtaButton
             className="mt-4 w-full"

--- a/packages/ui/src/components/shared/auth/auth-email-field.tsx
+++ b/packages/ui/src/components/shared/auth/auth-email-field.tsx
@@ -3,6 +3,7 @@
 import type { AuthEmailFieldProps } from "../../../lib/auth-types";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
+import { AuthFieldError } from "./auth-field-error";
 
 export function AuthEmailField({
   id,
@@ -31,13 +32,7 @@ export function AuthEmailField({
         type="email"
         value={value}
       />
-      <p
-        aria-live="polite"
-        className="min-h-5 text-destructive text-sm"
-        id={`${id}-error`}
-      >
-        {error}
-      </p>
+      <AuthFieldError error={error} id={`${id}-error`} />
     </div>
   );
 }

--- a/packages/ui/src/components/shared/auth/auth-field-error.tsx
+++ b/packages/ui/src/components/shared/auth/auth-field-error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import type { AuthFieldErrorProps } from "../../../lib/auth-types";
+
+const EASE_OUT = [0.23, 1, 0.32, 1] as const;
+
+export function AuthFieldError({ id, error }: AuthFieldErrorProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <div aria-live="polite" id={id}>
+      <AnimatePresence initial={false}>
+        {error && (
+          <motion.p
+            animate={{ height: "auto", opacity: 1 }}
+            className="overflow-hidden text-destructive text-sm"
+            exit={{ height: 0, opacity: 0 }}
+            initial={{ height: 0, opacity: 0 }}
+            transition={{
+              height: { duration: reduceMotion ? 0 : 0.2, ease: EASE_OUT },
+              opacity: { duration: 0.15, ease: "easeOut" },
+            }}
+          >
+            {error}
+          </motion.p>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/packages/ui/src/components/shared/auth/auth-field-error.tsx
+++ b/packages/ui/src/components/shared/auth/auth-field-error.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m,
+  useReducedMotion,
+} from "motion/react";
 import type { AuthFieldErrorProps } from "../../../lib/auth-types";
 
 const EASE_OUT = [0.23, 1, 0.32, 1] as const;
@@ -10,22 +16,24 @@ export function AuthFieldError({ id, error }: AuthFieldErrorProps) {
 
   return (
     <div aria-live="polite" id={id}>
-      <AnimatePresence initial={false}>
-        {error && (
-          <motion.p
-            animate={{ height: "auto", opacity: 1 }}
-            className="overflow-hidden text-destructive text-sm"
-            exit={{ height: 0, opacity: 0 }}
-            initial={{ height: 0, opacity: 0 }}
-            transition={{
-              height: { duration: reduceMotion ? 0 : 0.2, ease: EASE_OUT },
-              opacity: { duration: 0.15, ease: "easeOut" },
-            }}
-          >
-            {error}
-          </motion.p>
-        )}
-      </AnimatePresence>
+      <LazyMotion features={domAnimation} strict>
+        <AnimatePresence initial={false}>
+          {error && (
+            <m.p
+              animate={{ opacity: 1, y: 0 }}
+              className="text-destructive text-sm"
+              exit={{ opacity: 0, y: reduceMotion ? 0 : -2 }}
+              initial={{ opacity: 0, y: reduceMotion ? 0 : -2 }}
+              transition={{
+                duration: reduceMotion ? 0 : 0.15,
+                ease: EASE_OUT,
+              }}
+            >
+              {error}
+            </m.p>
+          )}
+        </AnimatePresence>
+      </LazyMotion>
     </div>
   );
 }

--- a/packages/ui/src/components/shared/auth/auth-form-error.tsx
+++ b/packages/ui/src/components/shared/auth/auth-form-error.tsx
@@ -3,7 +3,13 @@
 import { AlertCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@notra/ui/lib/utils";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m,
+  useReducedMotion,
+} from "motion/react";
 import type { AuthFormErrorProps } from "../../../lib/auth-types";
 
 const EASE_OUT = [0.23, 1, 0.32, 1] as const;
@@ -12,33 +18,34 @@ export function AuthFormError({ error, className }: AuthFormErrorProps) {
   const reduceMotion = useReducedMotion();
 
   return (
-    <AnimatePresence initial={false}>
-      {error && (
-        <motion.div
-          animate={{ height: "auto", opacity: 1 }}
-          className="overflow-hidden"
-          exit={{ height: 0, opacity: 0 }}
-          initial={{ height: 0, opacity: 0 }}
-          role="alert"
-          transition={{
-            height: { duration: reduceMotion ? 0 : 0.25, ease: EASE_OUT },
-            opacity: { duration: 0.2, ease: "easeOut" },
-          }}
-        >
-          <div
-            className={cn(
-              "flex items-start gap-2.5 rounded-xl border border-destructive/20 bg-destructive/10 px-3.5 py-2.5 text-destructive text-sm",
-              className
-            )}
+    <LazyMotion features={domAnimation} strict>
+      <AnimatePresence initial={false}>
+        {error && (
+          <m.div
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: reduceMotion ? 0 : -4 }}
+            initial={{ opacity: 0, y: reduceMotion ? 0 : -4 }}
+            role="alert"
+            transition={{
+              duration: reduceMotion ? 0 : 0.2,
+              ease: EASE_OUT,
+            }}
           >
-            <HugeiconsIcon
-              className="mt-0.5 size-4 shrink-0"
-              icon={AlertCircleIcon}
-            />
-            <p>{error}</p>
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
+            <div
+              className={cn(
+                "flex items-start gap-2.5 rounded-xl border border-destructive/20 bg-destructive/10 px-3.5 py-2.5 text-destructive text-sm",
+                className
+              )}
+            >
+              <HugeiconsIcon
+                className="mt-0.5 size-4 shrink-0"
+                icon={AlertCircleIcon}
+              />
+              <p>{error}</p>
+            </div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </LazyMotion>
   );
 }

--- a/packages/ui/src/components/shared/auth/auth-form-error.tsx
+++ b/packages/ui/src/components/shared/auth/auth-form-error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { cn } from "@notra/ui/lib/utils";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import type { AuthFormErrorProps } from "../../../lib/auth-types";
+
+const EASE_OUT = [0.23, 1, 0.32, 1] as const;
+
+export function AuthFormError({ error, className }: AuthFormErrorProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <AnimatePresence initial={false}>
+      {error && (
+        <motion.div
+          animate={{ height: "auto", opacity: 1 }}
+          className="overflow-hidden"
+          exit={{ height: 0, opacity: 0 }}
+          initial={{ height: 0, opacity: 0 }}
+          role="alert"
+          transition={{
+            height: { duration: reduceMotion ? 0 : 0.25, ease: EASE_OUT },
+            opacity: { duration: 0.2, ease: "easeOut" },
+          }}
+        >
+          <div
+            className={cn(
+              "flex items-start gap-2.5 rounded-xl border border-destructive/20 bg-destructive/10 px-3.5 py-2.5 text-destructive text-sm",
+              className
+            )}
+          >
+            <HugeiconsIcon
+              className="mt-0.5 size-4 shrink-0"
+              icon={AlertCircleIcon}
+            />
+            <p>{error}</p>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/ui/src/components/shared/auth/auth-password-field.tsx
+++ b/packages/ui/src/components/shared/auth/auth-password-field.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import type { AuthPasswordFieldProps } from "../../../lib/auth-types";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
+import { AuthFieldError } from "./auth-field-error";
 
 export function AuthPasswordField({
   id,
@@ -51,13 +52,7 @@ export function AuthPasswordField({
           )}
         </button>
       </div>
-      <p
-        aria-live="polite"
-        className="min-h-5 text-destructive text-sm"
-        id={`${id}-error`}
-      >
-        {error}
-      </p>
+      <AuthFieldError error={error} id={`${id}-error`} />
     </div>
   );
 }

--- a/packages/ui/src/components/shared/auth/email-verification-form.tsx
+++ b/packages/ui/src/components/shared/auth/email-verification-form.tsx
@@ -6,6 +6,7 @@ import type { EmailVerificationFormProps } from "../../../lib/auth-types";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
 import { CtaButton } from "../cta-button";
+import { AuthFormError } from "./auth-form-error";
 import { AuthFormHeader } from "./auth-form-header";
 
 const NON_DIGIT_REGEX = /\D/g;
@@ -91,24 +92,24 @@ export function EmailVerificationForm({
           />
         </div>
 
-        <p aria-live="polite" className="text-destructive text-sm empty:hidden">
-          {formError}
-        </p>
+        <div>
+          <AuthFormError className="mb-4" error={formError} />
 
-        <CtaButton
-          className="w-full"
-          disabled={isPending || code.length !== 6}
-          type="submit"
-        >
-          {isPending ? (
-            <>
-              <Loader2Icon className="size-4 animate-spin" />
-              Verifying...
-            </>
-          ) : (
-            "Verify email"
-          )}
-        </CtaButton>
+          <CtaButton
+            className="w-full"
+            disabled={isPending || code.length !== 6}
+            type="submit"
+          >
+            {isPending ? (
+              <>
+                <Loader2Icon className="size-4 animate-spin" />
+                Verifying...
+              </>
+            ) : (
+              "Verify email"
+            )}
+          </CtaButton>
+        </div>
       </form>
     </div>
   );

--- a/packages/ui/src/components/shared/auth/login-form.tsx
+++ b/packages/ui/src/components/shared/auth/login-form.tsx
@@ -19,6 +19,7 @@ import { Badge } from "../../ui/badge";
 import { Separator } from "../../ui/separator";
 import { CtaButton } from "../cta-button";
 import { AuthEmailField } from "./auth-email-field";
+import { AuthFormError } from "./auth-form-error";
 import { AuthFormHeader } from "./auth-form-header";
 import { AuthOrDivider } from "./auth-or-divider";
 import { AuthPasswordField } from "./auth-password-field";
@@ -177,7 +178,7 @@ export function LoginForm({
             form.handleSubmit();
           }}
         >
-          <div className="grid gap-1">
+          <div className="grid gap-3">
             <form.Field
               name="email"
               validators={{
@@ -220,12 +221,7 @@ export function LoginForm({
             </form.Field>
           </div>
 
-          <p
-            aria-live="polite"
-            className="mt-3 text-destructive text-sm empty:hidden"
-          >
-            {formError}
-          </p>
+          <AuthFormError className="mt-4" error={formError} />
 
           <div className="relative mt-4 pt-2">
             {lastMethod === "email" && (

--- a/packages/ui/src/lib/auth-types.ts
+++ b/packages/ui/src/lib/auth-types.ts
@@ -57,6 +57,16 @@ export interface AuthSocialButtonsProps {
   onSelect: (provider: SocialProvider) => void;
 }
 
+export interface AuthFieldErrorProps {
+  id: string;
+  error?: string;
+}
+
+export interface AuthFormErrorProps {
+  error: string | null;
+  className?: string;
+}
+
 export interface AuthEmailFieldProps {
   id: string;
   label: string;


### PR DESCRIPTION
### Description
Adds animated field-level and form-level authentication errors across login, signup, and email verification, with reduced-motion support. This removes reserved empty error space and gives submission failures clearer alert styling. AI assistance was used in preparing this change.

### Screenshot/Recording (if applicable)
https://cap.so/s/wpgfqj5xa09vj8h

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves auth error states across login, signup, and email verification by replacing static error text with animated field and form-level errors. Field errors no longer reserve empty space, and form errors now appear in an alert-style banner.

**New Features**
- Adds `AuthFieldError` and `AuthFormError` components with reduced-motion support.
- Adds alert icon styling to form-level errors so submission failures are easier to spot.

<sup>Written for commit dbd6c43a57d0199c3701c8ef7b4ed579a0935543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

