### PR TITLE
fix(geo): align property favicon with label

### DIFF
--- a/apps/dashboard/src/components/geo/search-console-card.tsx
+++ b/apps/dashboard/src/components/geo/search-console-card.tsx
@@ -163,7 +163,10 @@ function PropertyPicker({
                 const label = formatGscSiteUrl(value);
                 return (
                   <>
-                    <span aria-hidden="true">
+                    <span
+                      aria-hidden="true"
+                      className="flex shrink-0 items-center"
+                    >
                       <ProjectLogo
                         domain={getGscSiteDomain(value)}
                         name={label}
@@ -180,7 +183,10 @@ function PropertyPicker({
               const label = formatGscSiteUrl(site.siteUrl);
               return (
                 <SelectItem key={site.siteUrl} value={site.siteUrl}>
-                  <span aria-hidden="true">
+                  <span
+                    aria-hidden="true"
+                    className="flex shrink-0 items-center"
+                  >
                     <ProjectLogo
                       domain={getGscSiteDomain(site.siteUrl)}
                       name={label}


### PR DESCRIPTION
### Description
align the favicon with the domain name in the choose property google search console

### Screenshot/Recording (if applicable)
<img width="505" height="265" alt="image" src="https://github.com/user-attachments/assets/cfd30808-3370-4195-8757-bd4a886a0cf3" />


<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the property favicon alignment in the Google Search Console picker so the icon lines up with the domain name.

<sup>Written for commit 53e758565e7ebb68501db9bc790beab81733ae9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

