### PR TITLE
style(dashboard): unify GEO page header

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
@@ -130,11 +130,11 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-4 px-4 lg:px-6">
+      <div className="w-full space-y-6 px-4 lg:px-6">
         <header className="flex flex-wrap items-start justify-between gap-3">
           <div className="space-y-1">
             <h1 className="text-3xl font-bold tracking-tight">GEO</h1>
-            <p className="text-muted-foreground text-sm">
+            <p className="text-muted-foreground">
               How AI engines talk about {settings.companyName}
             </p>
           </div>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/skeleton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/skeleton.tsx
@@ -15,11 +15,11 @@ const ENGINE_ROW_COUNT = 4;
 export function GeoPageSkeleton() {
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-4 px-4 lg:px-6">
+      <div className="w-full space-y-6 px-4 lg:px-6">
         <header className="flex flex-wrap items-start justify-between gap-3">
           <div className="space-y-1">
             <h1 className="text-3xl font-bold tracking-tight">GEO</h1>
-            <p className="text-muted-foreground text-sm">
+            <p className="text-muted-foreground">
               How AI engines talk about your brand
             </p>
           </div>


### PR DESCRIPTION
### Description
Unifies the GEO overview header spacing and subtitle typography with the rest of the dashboard.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the GEO page header spacing and subtitle typography with the rest of the dashboard.

- Increases header container vertical spacing from `space-y-4` to `space-y-6`.
- Removes the `text-sm` class from the subtitle in both the page content and skeleton so it matches other dashboard headers.

<sup>Written for commit 8c814521d9fa869b425c1ed00ad0b1de9155baf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

