### PR TITLE
fix(ui): center tab indicator vertically

### DIFF
--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -60,7 +60,7 @@ function TabsList({
       >
         {children}
         {variant === "default" ? (
-          <TabsPrimitive.Indicator className="pointer-events-none absolute bottom-0 left-0 z-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) rounded-md bg-background shadow-[0_1px_2px_rgba(0,0,0,0.08)] transition-[width,translate] duration-200 ease-in-out dark:bg-foreground/10" />
+          <TabsPrimitive.Indicator className="pointer-events-none absolute top-0 left-0 z-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) translate-y-(--active-tab-top) rounded-md bg-background shadow-[0_1px_2px_rgba(0,0,0,0.08)] transition-[width,translate] duration-200 ease-in-out dark:bg-foreground/10" />
         ) : null}
       </TabsPrimitive.List>
     </TabsLayoutIdContext.Provider>


### PR DESCRIPTION
### Description
Fixes the active tab indicator positioning so it is vertically centered with equal top and bottom padding. Logos and labels remain correctly centered.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the active tab indicator so it's vertically centered with equal top and bottom padding. The indicator was previously anchored to the bottom of the tab list and left off-center; it's now anchored to the top and shifted by the matching offset. Logos and labels are unaffected.

<sup>Written for commit bb5b5c5b3281ea70f636ec4bb4d99f47ded16e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

