### PR TITLE
fix(dashboard): style outline buttons in light mode

### DIFF
--- a/apps/dashboard/src/components/button.tsx
+++ b/apps/dashboard/src/components/button.tsx
@@ -9,7 +9,7 @@ const CTA_PRIMARY =
   "corner-squircle rounded-[1rem] shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.08)_inset] hover:bg-primary/90 supports-[corner-shape:round]:rounded-[1.25rem]";
 
 const CTA_OUTLINE =
-  "corner-squircle rounded-[1rem] shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.05)_inset] supports-[corner-shape:round]:rounded-[1.25rem]";
+  "corner-squircle rounded-[1rem] shadow-[0px_0px_0px_2.5px_rgba(0,0,0,0.05)_inset] supports-[corner-shape:round]:rounded-[1.25rem] dark:shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.05)_inset]";
 
 function isDefaultVariant(variant: ComponentProps<typeof UiButton>["variant"]) {
   return variant === undefined || variant === "default";


### PR DESCRIPTION
### Description
Adds a subtle dark inset border to outline CTA buttons in light mode while preserving the existing dark-mode styling.

### Screenshot/Recording (if applicable)
<img width="960" height="330" alt="image" src="https://github.com/user-attachments/assets/a626766f-81e5-4ec9-b6be-8b998dbbdfc3" />


<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes outline CTA buttons in the dashboard so they show a visible border in light mode. Outline buttons now use a dark inset border in light mode, while dark mode keeps the existing white inset border.

<sup>Written for commit c7b1acdaf36759259938e4b61748ceedb95fd571. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

