### PR TITLE
fix(dashboard): align destructive button radius

### DIFF
--- a/apps/dashboard/src/components/button.tsx
+++ b/apps/dashboard/src/components/button.tsx
@@ -5,11 +5,7 @@ import {
 import { cn } from "@notra/ui/lib/utils";
 import type { ComponentProps } from "react";
 
-const CTA_PRIMARY =
-  "corner-squircle rounded-[1rem] shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.08)_inset] hover:bg-primary/90 supports-[corner-shape:round]:rounded-[1.25rem]";
-
-const CTA_OUTLINE =
-  "corner-squircle rounded-[1rem] shadow-[0px_0px_0px_2.5px_rgba(0,0,0,0.05)_inset] supports-[corner-shape:round]:rounded-[1.25rem] dark:shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.05)_inset]";
+import { CTA_DESTRUCTIVE, CTA_OUTLINE, CTA_PRIMARY } from "@/constants/button";
 
 function isDefaultVariant(variant: ComponentProps<typeof UiButton>["variant"]) {
   return variant === undefined || variant === "default";
@@ -21,6 +17,9 @@ function ctaClass(variant: ComponentProps<typeof UiButton>["variant"]) {
   }
   if (variant === "outline") {
     return CTA_OUTLINE;
+  }
+  if (variant === "destructive") {
+    return CTA_DESTRUCTIVE;
   }
   return null;
 }

--- a/apps/dashboard/src/constants/button.ts
+++ b/apps/dashboard/src/constants/button.ts
@@ -1,0 +1,8 @@
+export const CTA_PRIMARY =
+  "corner-squircle rounded-[1rem] shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.08)_inset] hover:bg-primary/90 supports-[corner-shape:round]:rounded-[1.25rem]";
+
+export const CTA_OUTLINE =
+  "corner-squircle rounded-[1rem] shadow-[0px_0px_0px_2.5px_rgba(0,0,0,0.05)_inset] supports-[corner-shape:round]:rounded-[1.25rem] dark:shadow-[0px_0px_0px_2.5px_rgba(255,255,255,0.05)_inset]";
+
+export const CTA_DESTRUCTIVE =
+  "corner-squircle rounded-[1rem] supports-[corner-shape:round]:rounded-[1.25rem]";


### PR DESCRIPTION
### Description

Aligns the destructive dashboard button with the primary and outline variants by applying the same `1rem` radius and `1.25rem` squircle-supported radius. CTA style constants were also moved to the dedicated constants directory.

### Screenshot/Recording (if applicable)
<img width="950" height="320" alt="IMG_8124" src="https://github.com/user-attachments/assets/adfd4878-ee8f-4f35-8111-2c403c0a8a0e" />


<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously the destructive button used a different corner radius; now it uses the same 1rem radius and 1.25rem squircle-supported radius as the primary and outline variants. CTA style constants were also moved to `apps/dashboard/src/constants/button.ts`.

<sup>Written for commit 452792eaf3afb6c4b0071f0afe0b53fe91c31b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

