### PR TITLE
feat(web): feedback.md page and Notra's feedback.md

### DIFF
--- a/apps/web/src/app/(site)/feedback-md/page.tsx
+++ b/apps/web/src/app/(site)/feedback-md/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+
+import { FeedbackMdAnatomy } from "@/components/feedback-md/feedback-md-anatomy";
+import { FeedbackMdFaq } from "@/components/feedback-md/feedback-md-faq";
+import { FeedbackMdHero } from "@/components/feedback-md/feedback-md-hero";
+import { FeedbackMdPrinciples } from "@/components/feedback-md/feedback-md-principles";
+import { FeedbackMdSection } from "@/components/feedback-md/feedback-md-section";
+import { FeedbackMdSiblingsTable } from "@/components/feedback-md/feedback-md-siblings-table";
+import { FeedbackMdSteps } from "@/components/feedback-md/feedback-md-steps";
+import { FeedbackMdTerminalDemo } from "@/components/feedback-md/feedback-md-terminal-demo";
+import { FeedbackMdUpsell } from "@/components/feedback-md/feedback-md-upsell";
+import {
+  FEEDBACK_MD_DESCRIPTION,
+  FEEDBACK_MD_PAGE_PATH,
+  FEEDBACK_MD_TITLE,
+} from "@/lib/feedback-md/constants";
+import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
+import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
+import { SITE_URL } from "@/utils/urls";
+
+const title = FEEDBACK_MD_TITLE;
+const description = FEEDBACK_MD_DESCRIPTION;
+const url = `${SITE_URL}${FEEDBACK_MD_PAGE_PATH}`;
+
+const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+  { name: "Home", url: SITE_URL },
+  { name: "feedback.md", url },
+]);
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title,
+    description,
+    url,
+    type: "website",
+    siteName: "Notra",
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE.url],
+    site: TWITTER_HANDLE,
+    creator: TWITTER_HANDLE,
+  },
+};
+
+export default function FeedbackMdPage() {
+  return (
+    <div className="flex w-full flex-col items-center gap-8 pb-14 antialiased [font-synthesis:none]">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
+      <FeedbackMdHero />
+      <div className="flex w-[min(100%-3rem,62.5rem)] flex-col gap-14 pt-6">
+        <FeedbackMdTerminalDemo />
+
+        <FeedbackMdSection
+          description={FEEDBACK_MD_DESCRIPTION}
+          title={
+            <>
+              What is{" "}
+              <code className="rounded-md bg-[#1E1E1E0A] px-2 py-0.5 font-mono text-[0.85em] font-medium tracking-normal dark:bg-white/10">
+                feedback.md
+              </code>
+            </>
+          }
+        >
+          <FeedbackMdPrinciples />
+        </FeedbackMdSection>
+
+        <FeedbackMdSection
+          description="The whole file fits on one screen. Four headings, plain sentences and links an agent can follow. One is required. The rest make the feedback better."
+          title="Anatomy of a feedback.md"
+        >
+          <FeedbackMdAnatomy />
+        </FeedbackMdSection>
+
+        <FeedbackMdSection
+          description="Every file agents read today points one way. The site tells the agent what to read, how to sign in and how things should look. feedback.md points back."
+          title="Where it sits"
+        >
+          <FeedbackMdSiblingsTable />
+        </FeedbackMdSection>
+
+        <FeedbackMdSection
+          description="Paste this into your agent. It reads this page, asks you where feedback should go and writes the file."
+          title="Add it to your site"
+        >
+          <FeedbackMdSteps />
+        </FeedbackMdSection>
+
+        <FeedbackMdSection
+          description="Short answers to the questions we got while writing ours."
+          title="Questions"
+        >
+          <FeedbackMdFaq />
+        </FeedbackMdSection>
+      </div>
+      <div className="w-full pt-6">
+        <FeedbackMdUpsell />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/.well-known/api-catalog/route.ts
+++ b/apps/web/src/app/.well-known/api-catalog/route.ts
@@ -27,6 +27,12 @@ export function GET() {
               type: "text/markdown",
               title: "Notra agent authentication guide",
             },
+            {
+              href: siteUrl("/feedback.md"),
+              rel: "feedback",
+              type: "text/markdown",
+              title: "Notra agent feedback guide",
+            },
           ],
         },
       ],

--- a/apps/web/src/app/feedback.md/route.ts
+++ b/apps/web/src/app/feedback.md/route.ts
@@ -1,0 +1,6 @@
+import { buildNotraFeedbackMarkdown } from "@/lib/feedback-md/markdown";
+import { markdownResponse } from "@/utils/http";
+
+export function GET() {
+  return markdownResponse(buildNotraFeedbackMarkdown());
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -115,6 +115,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
+      url: `${SITE_URL}/feedback-md`,
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
+    },
+    {
       url: `${SITE_URL}/integrations`,
       lastModified: STATIC_PAGE_LAST_MODIFIED,
     },

--- a/apps/web/src/components/feedback-md/feedback-md-anatomy.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-anatomy.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+import { useEffect, useState } from "react";
+
+import { FeedbackMdFilePreview } from "@/components/feedback-md/feedback-md-file-preview";
+import {
+  FEEDBACK_MD_EXAMPLE_DISCLAIMER,
+  FEEDBACK_MD_SECTIONS,
+  FEEDBACK_MD_TEMPLATE,
+} from "@/lib/feedback-md/constants";
+import { feedbackMdHeadingId } from "@/lib/feedback-md/lines";
+
+const READING_LINE_RATIO = 0.39;
+
+function headingTop(heading: string): number | null {
+  const element = document.getElementById(feedbackMdHeadingId(heading));
+  return element ? element.getBoundingClientRect().top : null;
+}
+
+function headingAtReadingLine(): string | null {
+  const line = window.innerHeight * READING_LINE_RATIO;
+  let current: string | null = null;
+  for (const section of FEEDBACK_MD_SECTIONS) {
+    const top = headingTop(section.heading);
+    if (top !== null && top <= line) {
+      current = section.heading;
+    }
+  }
+  return current ?? FEEDBACK_MD_SECTIONS[0]?.heading ?? null;
+}
+
+export function FeedbackMdAnatomy() {
+  const [activeHeading, setActiveHeading] = useState<string | null>(null);
+
+  useEffect(() => {
+    let frame = 0;
+    const update = () => {
+      frame = 0;
+      setActiveHeading(headingAtReadingLine());
+    };
+    const schedule = () => {
+      if (frame === 0) {
+        frame = window.requestAnimationFrame(update);
+      }
+    };
+    update();
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule);
+    return () => {
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, []);
+
+  function scrollToHeading(heading: string) {
+    const top = headingTop(heading);
+    if (top === null) {
+      return;
+    }
+    setActiveHeading(heading);
+    window.scrollBy({
+      top: top - window.innerHeight * READING_LINE_RATIO + 1,
+      behavior: "smooth",
+    });
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] lg:gap-8">
+      <div className="flex flex-col gap-3">
+        <FeedbackMdFilePreview
+          activeHeading={activeHeading}
+          filename="usefall.com/feedback.md"
+          source={FEEDBACK_MD_TEMPLATE}
+        />
+        <p className="font-sans text-xs leading-5 text-[#1E1E1E80] dark:text-white/40">
+          {FEEDBACK_MD_EXAMPLE_DISCLAIMER}
+        </p>
+      </div>
+      <ol className="flex flex-col gap-5 lg:sticky lg:top-32 lg:self-start lg:pt-2">
+        {FEEDBACK_MD_SECTIONS.map((section) => {
+          const active = activeHeading === section.heading;
+          return (
+            <li
+              className={cn(
+                "border-l-2 pl-4 transition-colors duration-300",
+                active
+                  ? "border-[#8B5CF6] dark:border-[#C8B2EE]"
+                  : "border-[#1E1E1E1F] dark:border-white/10"
+              )}
+              key={section.heading}
+            >
+              <button
+                className="flex w-full cursor-pointer flex-col gap-1.5 text-left"
+                onClick={() => scrollToHeading(section.heading)}
+                type="button"
+              >
+                <span className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                  <span
+                    className={cn(
+                      "font-mono text-[0.8125rem] font-medium transition-colors duration-300",
+                      active
+                        ? "text-[#1E1E1E] dark:text-white"
+                        : "text-[#1E1E1E99] dark:text-white/50"
+                    )}
+                  >
+                    ## {section.heading}
+                  </span>
+                  <span className="font-sans text-xs text-[#1E1E1E80] dark:text-white/50">
+                    {section.required ? "required" : "optional"}
+                  </span>
+                </span>
+                <span
+                  className={cn(
+                    "font-sans text-[0.8125rem] leading-[1.5] transition-colors duration-300",
+                    active
+                      ? "text-[#1E1E1EA6] dark:text-white/60"
+                      : "text-[#1E1E1E66] dark:text-white/35"
+                  )}
+                >
+                  {section.description}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-command-tabs.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-command-tabs.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { CommandLineIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { CommandTabs } from "@notra/ui/components/ui/command-tabs";
+import { ExpandableTabs } from "@notra/ui/components/ui/expandable-tabs";
+import { cn } from "@notra/ui/lib/utils";
+import Image from "next/image";
+import { useState } from "react";
+
+import { FEEDBACK_MD_CLIENTS } from "@/lib/feedback-md/constants";
+import type {
+  FeedbackMdClient,
+  FeedbackMdCommandTabsProps,
+} from "@/types/feedback-md";
+
+function clientIcon(client: FeedbackMdClient) {
+  if (!client.iconSrc) {
+    return (
+      <HugeiconsIcon
+        className="text-foreground size-4 shrink-0"
+        icon={CommandLineIcon}
+      />
+    );
+  }
+  return (
+    <Image
+      alt={`${client.label} logo`}
+      className={cn("size-4 shrink-0", client.invertInDark && "dark:invert")}
+      height={16}
+      src={client.iconSrc}
+      width={16}
+    />
+  );
+}
+
+const CLIENT_ITEMS = FEEDBACK_MD_CLIENTS.map((client) => ({
+  value: client.id,
+  label: client.label,
+  command: client.command,
+  icon: clientIcon(client),
+}));
+
+export function FeedbackMdCommandTabs({
+  className,
+}: FeedbackMdCommandTabsProps) {
+  const [activeClientId, setActiveClientId] = useState<string | undefined>(
+    FEEDBACK_MD_CLIENTS[0]?.id
+  );
+
+  return (
+    <div className={cn("flex w-full flex-col", className)}>
+      <CommandTabs
+        highlight
+        items={CLIENT_ITEMS}
+        onValueChange={setActiveClientId}
+        tabsPosition="none"
+        value={activeClientId}
+      />
+      <ExpandableTabs
+        className="-mt-px rounded-t-none border-t-0"
+        items={CLIENT_ITEMS}
+        label="Choose how to read feedback.md"
+        onValueChange={setActiveClientId}
+        value={activeClientId}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-copy-button.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-copy-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Copy01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@notra/ui/components/ui/button";
+
+import type { FeedbackMdCopyButtonProps } from "@/types/feedback-md";
+import { copyToClipboard } from "@/utils/copy-to-clipboard";
+
+export function FeedbackMdCopyButton({
+  text,
+  successMessage,
+  children,
+}: FeedbackMdCopyButtonProps) {
+  return (
+    <Button
+      className="bg-white/10 text-white hover:bg-white/15 dark:bg-white/10 dark:hover:bg-white/15"
+      onClick={() => copyToClipboard(text, successMessage)}
+      size="sm"
+      variant="secondary"
+    >
+      <HugeiconsIcon icon={Copy01Icon} />
+      {children}
+    </Button>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-faq.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-faq.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+import { useState } from "react";
+
+import { FEEDBACK_MD_QUESTIONS } from "@/lib/feedback-md/constants";
+import type { FeedbackMdFaqRowProps } from "@/types/feedback-md";
+
+function FaqToggleIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M19.992 12H3.992"
+        fill="none"
+        stroke="#8B5CF6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+      <path
+        className={cn(
+          "origin-center transition-transform duration-300 ease-out motion-reduce:transition-none",
+          open ? "scale-y-0" : "scale-y-100"
+        )}
+        d="M11.992 4V20"
+        fill="none"
+        stroke="#8B5CF6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+function FeedbackMdFaqRow({ item, open, onToggle }: FeedbackMdFaqRowProps) {
+  const panelId = `feedback-md-faq-panel-${item.id}`;
+  const triggerId = `feedback-md-faq-trigger-${item.id}`;
+
+  return (
+    <div className="flex flex-col border-t border-[#1E1E1E1F] py-6 dark:border-white/10">
+      <button
+        aria-controls={panelId}
+        aria-expanded={open}
+        className="flex w-full cursor-pointer items-center gap-4 text-left sm:gap-6"
+        id={triggerId}
+        onClick={onToggle}
+        type="button"
+      >
+        <span className="flex shrink-0 items-center justify-center">
+          <FaqToggleIcon open={open} />
+        </span>
+        <span className="grow font-sans text-lg leading-7 font-medium tracking-[-0.01em] text-[#1E1E1E] dark:text-white">
+          {item.question}
+        </span>
+      </button>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        )}
+        id={panelId}
+      >
+        <div className="overflow-hidden">
+          <p className="pt-3.5 pl-10 font-sans text-base leading-6 tracking-[-0.01em] text-[#1E1E1E99] sm:pl-12 dark:text-white/60">
+            {item.answer}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FeedbackMdFaq() {
+  const [openId, setOpenId] = useState<string | null>(
+    FEEDBACK_MD_QUESTIONS[0]?.id ?? null
+  );
+
+  return (
+    <div className="flex w-full flex-col border-b border-[#1E1E1E1F] dark:border-white/10">
+      {FEEDBACK_MD_QUESTIONS.map((item) => (
+        <FeedbackMdFaqRow
+          item={item}
+          key={item.id}
+          onToggle={() =>
+            setOpenId((current) => (current === item.id ? null : item.id))
+          }
+          open={openId === item.id}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-file-preview.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-file-preview.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@notra/ui/lib/utils";
+
+import { FeedbackMdCopyButton } from "@/components/feedback-md/feedback-md-copy-button";
+import {
+  feedbackMdLineId,
+  parseFeedbackMdLines,
+} from "@/lib/feedback-md/lines";
+import type {
+  FeedbackMdFilePreviewProps,
+  FeedbackMdLineKind,
+} from "@/types/feedback-md";
+
+const LINE_CLASSNAME: Record<FeedbackMdLineKind, string> = {
+  title: "font-semibold text-white",
+  heading: "pt-2 font-medium text-[#C8B2EE]",
+  list: "text-white/80",
+  text: "text-white/60",
+  blank: "h-6",
+};
+
+export function FeedbackMdFilePreview({
+  source,
+  filename,
+  activeHeading,
+}: FeedbackMdFilePreviewProps) {
+  const lines = parseFeedbackMdLines(source);
+
+  return (
+    <div className="flex w-full flex-col overflow-clip rounded-[1.25rem] bg-[#1E1E1E] [box-shadow:#28282833_0rem_1.5rem_3.5rem_-1rem]">
+      <div className="flex items-center justify-between gap-3 bg-[#282828] px-4.5 py-2.5">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <div className="size-2.5 shrink-0 rounded-full bg-[#4A4A4A]" />
+            <div className="size-2.5 shrink-0 rounded-full bg-[#4A4A4A]" />
+            <div className="size-2.5 shrink-0 rounded-full bg-[#4A4A4A]" />
+          </div>
+          <span className="font-mono text-[0.75rem] leading-4 text-[#FFFFFF66]">
+            {filename}
+          </span>
+        </div>
+        <FeedbackMdCopyButton
+          successMessage="Copied feedback.md template"
+          text={source}
+        >
+          Copy
+        </FeedbackMdCopyButton>
+      </div>
+      <pre className="overflow-x-auto p-5 font-mono text-[0.8125rem] leading-6 whitespace-pre-wrap sm:p-6">
+        {lines.map((line, index) => (
+          <span
+            className={cn(
+              "block scroll-mt-40 transition-opacity duration-300",
+              LINE_CLASSNAME[line.kind],
+              activeHeading !== null &&
+                line.section !== null &&
+                line.section !== activeHeading &&
+                "opacity-40"
+            )}
+            id={feedbackMdLineId(line)}
+            key={`${index}-${line.kind}`}
+          >
+            {line.text}
+          </span>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-hero.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-hero.tsx
@@ -1,0 +1,28 @@
+import { FeedbackMdCommandTabs } from "@/components/feedback-md/feedback-md-command-tabs";
+import { HeroDither } from "@/components/landing/hero-dither";
+import { FEEDBACK_MD_HERO_LEAD } from "@/lib/feedback-md/constants";
+
+export function FeedbackMdHero() {
+  return (
+    <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
+      <div className="relative isolate overflow-clip rounded-3xl bg-[#EFEAFA] dark:bg-[#2a2140]">
+        <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
+          <HeroDither className="absolute -top-1.25 -left-10.75 h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />
+        </div>
+
+        <div className="relative flex w-full flex-col items-center gap-10 px-6 pt-20 pb-20 lg:pt-24">
+          <div className="flex flex-col items-center gap-6">
+            <h1 className="font-display max-w-[51.25rem] text-center text-[2.5rem] leading-[1.12] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:text-[3.25rem] lg:text-[4rem] dark:text-white">
+              Are you talking to their{" "}
+              <span className="text-primary">agents</span>?
+            </h1>
+            <p className="max-w-[38.75rem] text-center font-sans text-[1.0625rem] leading-[1.42] font-medium tracking-[-0.005em] text-[#1E1E1EBF] sm:text-[1.1875rem] dark:text-white/70">
+              {FEEDBACK_MD_HERO_LEAD}
+            </p>
+          </div>
+          <FeedbackMdCommandTabs className="max-w-[45rem]" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-principles.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-principles.tsx
@@ -1,0 +1,18 @@
+import { FEEDBACK_MD_PRINCIPLES } from "@/lib/feedback-md/constants";
+
+export function FeedbackMdPrinciples() {
+  return (
+    <dl className="grid gap-8 md:grid-cols-3 md:gap-6">
+      {FEEDBACK_MD_PRINCIPLES.map((principle) => (
+        <div className="flex flex-col gap-1.5" key={principle.title}>
+          <dt className="font-sans text-[0.9375rem] leading-[1.36] font-medium text-[#1E1E1E] dark:text-white">
+            {principle.title}
+          </dt>
+          <dd className="font-sans text-[0.875rem] leading-[1.5] text-[#1E1E1EA6] dark:text-white/60">
+            {principle.description}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-section.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-section.tsx
@@ -1,0 +1,21 @@
+import type { FeedbackMdSectionProps } from "@/types/feedback-md";
+
+export function FeedbackMdSection({
+  title,
+  description,
+  children,
+}: FeedbackMdSectionProps) {
+  return (
+    <section className="flex w-full flex-col gap-5">
+      <div className="flex flex-col gap-1.5">
+        <h2 className="font-display text-[1.75rem] leading-[1.21] font-medium tracking-[-0.02em] text-[#1E1E1E] dark:text-white">
+          {title}
+        </h2>
+        <p className="max-w-[42rem] font-sans text-[0.9375rem] leading-[1.5] text-[#1E1E1EA6] dark:text-white/60">
+          {description}
+        </p>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-siblings-table.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-siblings-table.tsx
@@ -1,0 +1,61 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@notra/ui/components/ui/table";
+import { cn } from "@notra/ui/lib/utils";
+import Link from "next/link";
+
+import { FEEDBACK_MD_SIBLINGS } from "@/lib/feedback-md/constants";
+
+export function FeedbackMdSiblingsTable() {
+  return (
+    <div className="border-border/70 overflow-x-auto rounded-2xl border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="px-5">File</TableHead>
+            <TableHead>Answers</TableHead>
+            <TableHead className="pr-5">Direction</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {FEEDBACK_MD_SIBLINGS.map((sibling) => {
+            const isFeedback = sibling.direction === "agent to site";
+            return (
+              <TableRow
+                className={cn(isFeedback && "bg-primary/5 hover:bg-primary/5")}
+                key={sibling.file}
+              >
+                <TableCell className="px-5 font-mono text-[0.8125rem]">
+                  <Link
+                    className="text-foreground underline-offset-4 hover:underline"
+                    href={sibling.href}
+                  >
+                    /{sibling.file}
+                  </Link>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {sibling.answers}
+                </TableCell>
+                <TableCell
+                  className={cn(
+                    "pr-5",
+                    isFeedback
+                      ? "text-primary font-medium"
+                      : "text-muted-foreground"
+                  )}
+                >
+                  {sibling.direction}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-steps.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-steps.tsx
@@ -1,0 +1,23 @@
+import { FeedbackMdCopyButton } from "@/components/feedback-md/feedback-md-copy-button";
+import { FEEDBACK_MD_SETUP_PROMPT } from "@/lib/feedback-md/constants";
+
+export function FeedbackMdSteps() {
+  return (
+    <div className="flex w-full flex-col overflow-clip rounded-[1.25rem] bg-[#1E1E1E] [box-shadow:#28282833_0rem_1.5rem_3.5rem_-1rem]">
+      <div className="flex items-center justify-between gap-3 bg-[#282828] px-4.5 py-2.5">
+        <span className="font-mono text-[0.75rem] leading-4 text-[#FFFFFF66]">
+          prompt
+        </span>
+        <FeedbackMdCopyButton
+          successMessage="Copied prompt"
+          text={FEEDBACK_MD_SETUP_PROMPT}
+        >
+          Copy
+        </FeedbackMdCopyButton>
+      </div>
+      <p className="p-5 font-mono text-[0.8125rem] leading-6 text-white/80 sm:p-6">
+        {FEEDBACK_MD_SETUP_PROMPT}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-terminal-demo.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-terminal-demo.tsx
@@ -1,0 +1,67 @@
+import { ClaudeHeader } from "@notra/ui/components/brainless/claude/claude-header";
+import { ClaudeMessage } from "@notra/ui/components/brainless/claude/claude-message";
+import { ClaudePrompt } from "@notra/ui/components/brainless/claude/claude-prompt";
+import { ClaudeTodoList } from "@notra/ui/components/brainless/claude/claude-todo-list";
+import { ClaudeToolCall } from "@notra/ui/components/brainless/claude/claude-tool-call";
+
+import {
+  FEEDBACK_MD_TERMINAL_ASSISTANT_MESSAGE,
+  FEEDBACK_MD_TERMINAL_HEADER,
+  FEEDBACK_MD_TERMINAL_PROMPT_PLACEHOLDER,
+  FEEDBACK_MD_TERMINAL_RESULT_MESSAGE,
+  FEEDBACK_MD_TERMINAL_TITLE,
+  FEEDBACK_MD_TERMINAL_TODOS,
+  FEEDBACK_MD_TERMINAL_TOOL_CALLS,
+  FEEDBACK_MD_TERMINAL_USER_MESSAGE,
+} from "@/lib/feedback-md/constants";
+
+export function FeedbackMdTerminalDemo() {
+  return (
+    <div className="flex w-full flex-col overflow-clip rounded-[1.25rem] bg-[#1E1E1E] [box-shadow:#28282833_0rem_1.5rem_3.5rem_-1rem]">
+      <div className="flex items-center gap-3 bg-[#282828] px-4.5 py-3">
+        <div className="flex items-center gap-1.5">
+          <div className="size-2.5 shrink-0 rounded-full bg-[#4A4A4A]" />
+          <div className="size-2.5 shrink-0 rounded-full bg-[#4A4A4A]" />
+          <div className="size-2.5 shrink-0 rounded-full bg-[#4A4A4A]" />
+        </div>
+        <span className="font-mono text-[0.75rem] leading-4 text-[#FFFFFF66]">
+          {FEEDBACK_MD_TERMINAL_TITLE}
+        </span>
+      </div>
+      <div className="flex flex-col gap-3.5 p-4 sm:p-6">
+        <ClaudeHeader
+          cwd={FEEDBACK_MD_TERMINAL_HEADER.cwd}
+          model={FEEDBACK_MD_TERMINAL_HEADER.model}
+          org={FEEDBACK_MD_TERMINAL_HEADER.org}
+          tips={FEEDBACK_MD_TERMINAL_HEADER.tips}
+          user={FEEDBACK_MD_TERMINAL_HEADER.user}
+          version={FEEDBACK_MD_TERMINAL_HEADER.version}
+          whatsNew={FEEDBACK_MD_TERMINAL_HEADER.whatsNew}
+        />
+        <ClaudeMessage className="mt-1 rounded-sm px-2.5 py-1.5" from="user">
+          {FEEDBACK_MD_TERMINAL_USER_MESSAGE}
+        </ClaudeMessage>
+        <ClaudeMessage>{FEEDBACK_MD_TERMINAL_ASSISTANT_MESSAGE}</ClaudeMessage>
+        <ClaudeTodoList todos={FEEDBACK_MD_TERMINAL_TODOS} />
+        <div className="flex flex-col gap-2">
+          {FEEDBACK_MD_TERMINAL_TOOL_CALLS.map((call) => (
+            <ClaudeToolCall
+              arg={call.arg}
+              key={call.tool}
+              result={call.result}
+              status={call.status}
+              tool={call.tool}
+            />
+          ))}
+        </div>
+        <ClaudeMessage>{FEEDBACK_MD_TERMINAL_RESULT_MESSAGE}</ClaudeMessage>
+        <ClaudePrompt
+          className="mt-1"
+          effort={false}
+          mode="bypass"
+          placeholder={FEEDBACK_MD_TERMINAL_PROMPT_PLACEHOLDER}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-upsell.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-upsell.tsx
@@ -1,0 +1,60 @@
+import { CtaButton } from "@notra/ui/components/shared/cta-button";
+import Link from "next/link";
+
+import { DeferredDithering } from "@/components/deferred-dithering";
+import { TrackedSignupLink } from "@/components/tracked-signup-link";
+import {
+  FEEDBACK_MD_DOCS_URL,
+  FEEDBACK_MD_UPSELL_HEADING,
+  FEEDBACK_MD_UPSELL_PRIMARY_LABEL,
+  FEEDBACK_MD_UPSELL_SECONDARY_LABEL,
+  FEEDBACK_MD_UPSELL_SIGNUP_SOURCE,
+  FEEDBACK_MD_UPSELL_SUBCOPY,
+} from "@/lib/feedback-md/constants";
+
+export function FeedbackMdUpsell() {
+  return (
+    <section className="w-full px-6">
+      <div className="relative mx-auto flex w-full max-w-[87rem] flex-col items-center gap-10 overflow-clip rounded-[1.5625rem] bg-[#C8B2EE40] px-6 py-16 antialiased md:py-20 dark:bg-[#231d3a]">
+        <DeferredDithering
+          className="absolute -top-66.25 left-[-5.368rem] h-264.5 w-403.25"
+          colorBack="#00000000"
+          colorFront="#8B5CF62D"
+          scale={0.53}
+          shape="wave"
+          size={2.9}
+          speed={0.7}
+          type="4x4"
+        />
+        <div className="relative flex w-full max-w-[53.3125rem] flex-col items-center gap-4.5">
+          <h2 className="font-display max-w-[46.625rem] text-center text-[2.25rem] leading-[114%] font-medium tracking-[-0.1rem] text-balance text-[#1E1E1E] sm:text-[3rem] lg:text-[3.5rem] dark:text-white">
+            {FEEDBACK_MD_UPSELL_HEADING}
+          </h2>
+          <p className="max-w-[36rem] text-center font-sans text-lg/6 font-medium tracking-[-0.03125rem] text-balance text-[#1E1E1EE6] dark:text-white/85">
+            {FEEDBACK_MD_UPSELL_SUBCOPY}
+          </p>
+        </div>
+        <div className="relative grid w-full grid-cols-2 items-center gap-4 sm:flex sm:w-auto sm:gap-7">
+          <CtaButton
+            className="w-full min-w-0 px-3 text-lg sm:w-auto sm:px-6"
+            nativeButton={false}
+            render={
+              <TrackedSignupLink source={FEEDBACK_MD_UPSELL_SIGNUP_SOURCE} />
+            }
+            variant="primary"
+          >
+            {FEEDBACK_MD_UPSELL_PRIMARY_LABEL}
+          </CtaButton>
+          <CtaButton
+            className="w-full min-w-0 px-3 text-lg sm:w-auto sm:px-6"
+            nativeButton={false}
+            render={<Link href={FEEDBACK_MD_DOCS_URL} />}
+            variant="light"
+          >
+            {FEEDBACK_MD_UPSELL_SECONDARY_LABEL}
+          </CtaButton>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/feedback-md/constants.ts
+++ b/apps/web/src/lib/feedback-md/constants.ts
@@ -227,6 +227,12 @@ export const FEEDBACK_MD_QUESTIONS: FeedbackMdQuestion[] = [
       "llms.txt, auth.md and design.md all live at the root and agents already look there. Markdown under .well-known is unusual, and a file a person can open in a browser is the point. Serving a copy at /.well-known/feedback.md costs nothing if you want both.",
   },
   {
+    id: "discovery",
+    question: "How do agents find it?",
+    answer:
+      "The same way they find everything else on your site. Link it from llms.txt, add it to your agent card or api-catalog under .well-known and mention it in auth.md. Agents follow links they are given. They do not go looking for file names.",
+  },
+  {
     id: "no-endpoint",
     question: "What if I do not have a feedback endpoint?",
     answer:

--- a/apps/web/src/lib/feedback-md/constants.ts
+++ b/apps/web/src/lib/feedback-md/constants.ts
@@ -1,0 +1,254 @@
+import type { ClaudeTodo } from "@notra/ui/components/brainless/claude/claude-todo-list";
+
+import type {
+  FeedbackMdClient,
+  FeedbackMdPrinciple,
+  FeedbackMdQuestion,
+  FeedbackMdSection,
+  FeedbackMdSibling,
+  FeedbackMdTerminalHeader,
+  FeedbackMdTerminalToolCall,
+} from "@/types/feedback-md";
+import { DOCS_URL, SITE_URL } from "@/utils/urls";
+
+export const FEEDBACK_MD_PATH = "/feedback.md";
+
+export const FEEDBACK_MD_PAGE_PATH = "/feedback-md";
+
+const FEEDBACK_MD_URL = `${SITE_URL}${FEEDBACK_MD_PATH}`;
+
+export const FEEDBACK_MD_DOCS_URL = `${DOCS_URL}/api/agent-feedback`;
+
+export const FEEDBACK_MD_TITLE = "feedback.md";
+
+export const FEEDBACK_MD_DESCRIPTION =
+  "feedback.md is a Markdown file at the root of your site. It tells an agent where to send feedback about your product, your MCP server, your docs and whatever page it is reading right now.";
+
+export const FEEDBACK_MD_HERO_LEAD =
+  "You already talk to your users. Their agents hit dead ends and find bugs nobody reports, then quietly move on. feedback.md gives them a place to say so.";
+
+export const FEEDBACK_MD_CLIENTS: FeedbackMdClient[] = [
+  {
+    id: "curl",
+    label: "curl",
+    invertInDark: false,
+    command: `curl -s ${FEEDBACK_MD_URL}`,
+  },
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    iconSrc: "/mcp/claude-code.svg",
+    invertInDark: false,
+    command: `claude "read ${FEEDBACK_MD_URL} and send feedback about the last tool call that failed"`,
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    iconSrc: "/mcp/codex.svg",
+    invertInDark: true,
+    command: `codex "read ${FEEDBACK_MD_URL} and send feedback about the last tool call that failed"`,
+  },
+];
+
+export const FEEDBACK_MD_EXAMPLE_DISCLAIMER =
+  "Fall and usefall.com are made up for this example. The URLs do not resolve.";
+
+export const FEEDBACK_MD_TEMPLATE = `# Fall Feedback
+
+Fall wants to hear from the agents using it. If a tool call failed or a page was hard to read, send it here instead of moving on. Praise is welcome too.
+
+## Where to send it
+
+- MCP: call \`submit_feedback\` on https://mcp.usefall.com/mcp
+- HTTP: POST https://api.usefall.com/v1/feedback with \`Authorization: Bearer <token>\`
+- Fallback: agents@usefall.com
+
+## What we want to hear about
+
+- The product: https://usefall.com
+- The MCP server: https://mcp.usefall.com/mcp
+- The API: https://api.usefall.com (spec at /openapi.json)
+- The docs: https://docs.usefall.com
+- This page: whatever URL you are reading right now
+
+## What to include
+
+- What you were trying to do and what happened instead
+- The URL, tool name or endpoint involved
+- Your client and model, if you are allowed to share them
+
+## What happens next
+
+Feedback lands in the Fall team's inbox and is triaged within a week. We do not reply to agents. Fixes show up at https://usefall.com/changelog.
+`;
+
+export const FEEDBACK_MD_TERMINAL_TITLE = "claude — ~/storefront";
+
+export const FEEDBACK_MD_TERMINAL_HEADER: FeedbackMdTerminalHeader = {
+  version: "v2.1.206",
+  user: "Dominik",
+  model: "Fable 5 with xhigh effort · Claude Max",
+  org: "dominik@usefall.com's Organization",
+  cwd: "~/storefront",
+  tips: ["Sites with a /feedback.md accept bug reports from agents"],
+  whatsNew: [
+    "feedback.md discovered on usefall.com",
+    "Failed tool calls can be reported without stopping the task",
+  ],
+};
+
+export const FEEDBACK_MD_TERMINAL_USER_MESSAGE =
+  "add Fall checkout to the pricing page and test a $49 charge";
+
+export const FEEDBACK_MD_TERMINAL_ASSISTANT_MESSAGE =
+  "create_checkout rejected the request. Checking where Fall wants feedback before I retry.";
+
+export const FEEDBACK_MD_TERMINAL_TODOS: ClaudeTodo[] = [
+  { label: "Install @usefall/checkout and add the keys", status: "done" },
+  { label: "Wire the pricing page to create_checkout", status: "done" },
+  { label: "Report the failed charge via feedback.md", status: "active" },
+  { label: "Retry with the amount in cents", status: "todo" },
+];
+
+export const FEEDBACK_MD_TERMINAL_TOOL_CALLS: FeedbackMdTerminalToolCall[] = [
+  {
+    tool: "fall · create_checkout",
+    arg: "amount: 49",
+    result: "422 amount must be an integer in cents, docs say dollars",
+    status: "error",
+  },
+  {
+    tool: "fetch",
+    arg: "usefall.com/feedback.md",
+    result: "3 channels, MCP preferred",
+    status: "success",
+  },
+  {
+    tool: "fall · submit_feedback",
+    arg: "bug",
+    result: "202 accepted · fb_x8k2q · docs and API disagree on amount units",
+    status: "success",
+  },
+];
+
+export const FEEDBACK_MD_TERMINAL_RESULT_MESSAGE =
+  "Filed the docs mismatch with the exact request that failed and moved on. Retrying with amount: 4900.";
+
+export const FEEDBACK_MD_TERMINAL_PROMPT_PLACEHOLDER =
+  'Try "send feedback about the last tool call that failed"';
+
+export const FEEDBACK_MD_PRINCIPLES: FeedbackMdPrinciple[] = [
+  {
+    title: "A file, not a protocol",
+    description:
+      "Plain Markdown at /feedback.md. No handshake and no schema to validate against. If an agent can read llms.txt it can read this.",
+  },
+  {
+    title: "Where, not how",
+    description:
+      "auth.md explains how to sign in. feedback.md only says where feedback goes and what to put in it. Bring your own endpoint, MCP tool or inbox.",
+  },
+  {
+    title: "Scoped to what the agent touched",
+    description:
+      "One line each for the product, the MCP server, the docs and the current page, so a report about a broken tool reaches whoever owns that tool.",
+  },
+];
+
+export const FEEDBACK_MD_SECTIONS: FeedbackMdSection[] = [
+  {
+    heading: "Where to send it",
+    required: true,
+    description:
+      "The one section every file needs. Channels in order of preference: an MCP tool, an HTTP endpoint or just an email address. Link to auth.md if the channel needs a credential.",
+  },
+  {
+    heading: "What we want to hear about",
+    required: false,
+    description:
+      "The surfaces an agent might be using. Listing them tells the agent that a broken MCP tool and a confusing docs page both belong here, and so does the page it is reading right now.",
+  },
+  {
+    heading: "What to include",
+    required: false,
+    description:
+      "Shapes the report without a schema. What the agent tried, what happened and the URL or tool involved is enough for a human to act on.",
+  },
+  {
+    heading: "What happens next",
+    required: false,
+    description:
+      "Sets expectations. Say who reads it and roughly when. Tell the agent not to wait for a reply.",
+  },
+];
+
+export const FEEDBACK_MD_SIBLINGS: FeedbackMdSibling[] = [
+  {
+    file: "llms.txt",
+    answers: "What should I read?",
+    direction: "site to agent",
+    href: "https://llmstxt.org",
+  },
+  {
+    file: "auth.md",
+    answers: "How do I sign in?",
+    direction: "site to agent",
+    href: "https://workos.com/auth-md",
+  },
+  {
+    file: "design.md",
+    answers: "How should it look?",
+    direction: "site to agent",
+    href: "/design.md",
+  },
+  {
+    file: "feedback.md",
+    answers: "Where do I say what went wrong?",
+    direction: "agent to site",
+    href: FEEDBACK_MD_PATH,
+  },
+];
+
+const FEEDBACK_MD_PAGE_URL = `${SITE_URL}${FEEDBACK_MD_PAGE_PATH}`;
+
+export const FEEDBACK_MD_SETUP_PROMPT = `Read ${FEEDBACK_MD_PAGE_URL} and add a feedback.md to this site at /feedback.md, following the template on that page. Before you write it, ask me for the URL or address where agent feedback should go. Serve the file as text/markdown and link it from llms.txt.`;
+
+export const FEEDBACK_MD_QUESTIONS: FeedbackMdQuestion[] = [
+  {
+    id: "standard",
+    question: "Is this a standard?",
+    answer:
+      "No. It is a convention we use and think other teams should copy, in the same spirit as llms.txt and auth.md. If enough people pick it up we will write it down properly. Until then the whole spec is the template above.",
+  },
+  {
+    id: "well-known",
+    question: "Why the root and not /.well-known?",
+    answer:
+      "llms.txt, auth.md and design.md all live at the root and agents already look there. Markdown under .well-known is unusual, and a file a person can open in a browser is the point. Serving a copy at /.well-known/feedback.md costs nothing if you want both.",
+  },
+  {
+    id: "no-endpoint",
+    question: "What if I do not have a feedback endpoint?",
+    answer:
+      "An email address or a link to your issue tracker is a valid channel. The file gives agents an address. It does not ask you to run infrastructure. You can upgrade the channel later without changing anything an agent has already learned.",
+  },
+  {
+    id: "need-notra",
+    question: "Do I need Notra for this?",
+    answer:
+      "No. Notra is one place the feedback can land, with a write-only token, an MCP helper and an inbox that sorts what comes in. The file itself works with anything.",
+  },
+];
+
+export const FEEDBACK_MD_UPSELL_HEADING =
+  "Give the feedback somewhere to land.";
+
+export const FEEDBACK_MD_UPSELL_SUBCOPY =
+  "Notra is the backend on the other end of the file. Agents post to it over HTTP or MCP, and your team reads it in one inbox.";
+
+export const FEEDBACK_MD_UPSELL_PRIMARY_LABEL =
+  "Start collecting agent feedback";
+
+export const FEEDBACK_MD_UPSELL_SECONDARY_LABEL = "Read the API docs";
+
+export const FEEDBACK_MD_UPSELL_SIGNUP_SOURCE = "feedback_md_upsell";

--- a/apps/web/src/lib/feedback-md/lines.ts
+++ b/apps/web/src/lib/feedback-md/lines.ts
@@ -1,0 +1,48 @@
+import type { FeedbackMdLine, FeedbackMdLineKind } from "@/types/feedback-md";
+
+const TITLE_PREFIX = "# ";
+const HEADING_PREFIX = "## ";
+const LIST_PREFIX = "- ";
+
+function classifyLine(line: string): FeedbackMdLineKind {
+  if (line.length === 0) {
+    return "blank";
+  }
+  if (line.startsWith(HEADING_PREFIX)) {
+    return "heading";
+  }
+  if (line.startsWith(TITLE_PREFIX)) {
+    return "title";
+  }
+  if (line.startsWith(LIST_PREFIX)) {
+    return "list";
+  }
+  return "text";
+}
+
+export function parseFeedbackMdLines(source: string): FeedbackMdLine[] {
+  let section: string | null = null;
+  return source
+    .trimEnd()
+    .split("\n")
+    .map((line) => {
+      const kind = classifyLine(line);
+      if (kind === "heading") {
+        section = line.slice(HEADING_PREFIX.length);
+      }
+      return { kind, text: line, section };
+    });
+}
+
+const NON_ALPHANUMERIC = /[^a-z0-9]+/g;
+
+export function feedbackMdHeadingId(heading: string): string {
+  return `feedback-md-${heading.toLowerCase().replace(NON_ALPHANUMERIC, "-")}`;
+}
+
+export function feedbackMdLineId(line: FeedbackMdLine): string | undefined {
+  if (line.kind !== "heading") {
+    return undefined;
+  }
+  return feedbackMdHeadingId(line.text.slice(HEADING_PREFIX.length));
+}

--- a/apps/web/src/lib/feedback-md/markdown.ts
+++ b/apps/web/src/lib/feedback-md/markdown.ts
@@ -1,0 +1,126 @@
+import {
+  FEEDBACK_MD_DESCRIPTION,
+  FEEDBACK_MD_EXAMPLE_DISCLAIMER,
+  FEEDBACK_MD_HERO_LEAD,
+  FEEDBACK_MD_PAGE_PATH,
+  FEEDBACK_MD_PATH,
+  FEEDBACK_MD_PRINCIPLES,
+  FEEDBACK_MD_QUESTIONS,
+  FEEDBACK_MD_SECTIONS,
+  FEEDBACK_MD_SIBLINGS,
+  FEEDBACK_MD_SETUP_PROMPT,
+  FEEDBACK_MD_TEMPLATE,
+  FEEDBACK_MD_UPSELL_HEADING,
+  FEEDBACK_MD_UPSELL_SUBCOPY,
+} from "@/lib/feedback-md/constants";
+import { NOTRA_SUPPORT_EMAIL } from "@/utils/agent-metadata";
+import { markdownSection } from "@/utils/markdown";
+import { SOCIAL_LINKS } from "@/utils/social-links";
+import { API_URL, APP_URL, DOCS_URL, MCP_URL, SITE_URL } from "@/utils/urls";
+
+const NOTRA_CHANGELOG_URL = `${SITE_URL}/changelog/notra`;
+const NOTRA_FEEDBACK_ENDPOINT = `${API_URL}/v1/feedback/notra`;
+
+const NOTRA_FEEDBACK_CURL = [
+  `curl -X POST ${NOTRA_FEEDBACK_ENDPOINT} \\`,
+  '  -H "Content-Type: application/json" \\',
+  "  -d '{",
+  '    "message": "The search tool times out when the query has quotes.",',
+  '    "contextUrl": "https://docs.usenotra.com/search"',
+  "  }'",
+].join("\n");
+
+export function buildNotraFeedbackMarkdown() {
+  return [
+    "# Notra Feedback",
+    "",
+    "Notra wants to hear from the agents using it. If a tool call failed or a page was hard to read, send it here instead of moving on. Praise is welcome too.",
+    "",
+    markdownSection("Where to send it", [
+      `- HTTP: POST ${NOTRA_FEEDBACK_ENDPOINT} with a JSON body. No auth needed.`,
+      `- Email: ${NOTRA_SUPPORT_EMAIL}`,
+      `- Discord: ${SOCIAL_LINKS.discord}`,
+      "",
+      "```bash",
+      NOTRA_FEEDBACK_CURL,
+      "```",
+      "",
+      `Request body reference: ${DOCS_URL}/api/agent-feedback`,
+    ]),
+    markdownSection("What we want to hear about", [
+      `- The product: ${APP_URL}`,
+      `- The MCP server: ${MCP_URL}`,
+      `- The API: ${API_URL} (spec at ${API_URL}/openapi.json)`,
+      `- The docs: ${DOCS_URL}`,
+      `- This site: any page on ${SITE_URL}, including its Markdown twin (append .md to the path)`,
+    ]),
+    markdownSection("What to include", [
+      "- What you were trying to do and what happened instead",
+      "- The URL, tool name or endpoint involved",
+      "- Your client and model, if you are allowed to share them",
+      "",
+      "Fields: `message` (required), `title`, `kind` (bug, feature, praise, question, other), `sentiment`, `contextUrl`, `agentClient`, `agentModel`, `idempotencyKey`.",
+    ]),
+    markdownSection("What happens next", [
+      "Feedback lands in the Notra team's inbox, gets classified and is triaged within a week. We do not reply to agents.",
+      `Fixes show up at ${NOTRA_CHANGELOG_URL}.`,
+      "",
+      `About this file: ${SITE_URL}${FEEDBACK_MD_PAGE_PATH}`,
+    ]),
+  ].join("\n");
+}
+
+export function buildFeedbackMdPageMarkdown() {
+  const principles = FEEDBACK_MD_PRINCIPLES.flatMap((principle) => [
+    `### ${principle.title}`,
+    principle.description,
+    "",
+  ]);
+  const sections = FEEDBACK_MD_SECTIONS.map(
+    (section) =>
+      `- ${section.heading}${section.required ? " (required)" : ""}: ${section.description}`
+  );
+  const siblings = FEEDBACK_MD_SIBLINGS.map(
+    (sibling) => `- ${sibling.file}: ${sibling.answers} (${sibling.direction})`
+  );
+  const questions = FEEDBACK_MD_QUESTIONS.flatMap((item) => [
+    `### ${item.question}`,
+    item.answer,
+    "",
+  ]);
+
+  return [
+    "# feedback.md",
+    "",
+    FEEDBACK_MD_HERO_LEAD,
+    "",
+    FEEDBACK_MD_DESCRIPTION,
+    "",
+    `Notra's own file: ${SITE_URL}${FEEDBACK_MD_PATH}`,
+    "",
+    markdownSection("What it is", principles),
+    markdownSection("Template", [
+      "```markdown",
+      FEEDBACK_MD_TEMPLATE,
+      "```",
+      "",
+      FEEDBACK_MD_EXAMPLE_DISCLAIMER,
+    ]),
+    markdownSection("Sections", sections),
+    markdownSection("Where it sits", siblings),
+    markdownSection("Add it to your site", [
+      "Paste this into your agent:",
+      "",
+      "```",
+      FEEDBACK_MD_SETUP_PROMPT,
+      "```",
+    ]),
+    markdownSection("FAQ", questions),
+    markdownSection(FEEDBACK_MD_UPSELL_HEADING, [
+      FEEDBACK_MD_UPSELL_SUBCOPY,
+      "",
+      `Docs: ${DOCS_URL}/api/agent-feedback`,
+      `Sign up: ${APP_URL}/signup`,
+    ]),
+  ].join("\n");
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -22,6 +22,7 @@ const dualmarkProxy = createDualmarkMiddleware({
       "/demo.webp",
       "/design.md",
       "/favicon.ico",
+      "/feedback.md",
       "/icon.svg",
       "/llms-full.txt",
       "/llms.txt",

--- a/apps/web/src/types/feedback-md.ts
+++ b/apps/web/src/types/feedback-md.ts
@@ -1,0 +1,92 @@
+import type { ClaudeToolCallStatus } from "@notra/ui/components/brainless/claude/claude-tool-call";
+import type { ReactNode } from "react";
+
+export interface FeedbackMdPrinciple {
+  title: string;
+  description: string;
+}
+
+export interface FeedbackMdSection {
+  heading: string;
+  required: boolean;
+  description: string;
+}
+
+export interface FeedbackMdSibling {
+  file: string;
+  answers: string;
+  direction: "site to agent" | "agent to site";
+  href: string;
+}
+
+export interface FeedbackMdQuestion {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+export interface FeedbackMdFaqRowProps {
+  item: FeedbackMdQuestion;
+  open: boolean;
+  onToggle: () => void;
+}
+
+export interface FeedbackMdClient {
+  id: "curl" | "claude-code" | "codex";
+  label: string;
+  iconSrc?: string;
+  invertInDark: boolean;
+  command: string;
+}
+
+export interface FeedbackMdCommandTabsProps {
+  className?: string;
+}
+
+export interface FeedbackMdTerminalHeader {
+  version: string;
+  user: string;
+  model: string;
+  org: string;
+  cwd: string;
+  tips: string[];
+  whatsNew: string[];
+}
+
+export interface FeedbackMdTerminalToolCall {
+  tool: string;
+  arg: string;
+  result: string;
+  status: ClaudeToolCallStatus;
+}
+
+export type FeedbackMdLineKind =
+  | "title"
+  | "heading"
+  | "list"
+  | "text"
+  | "blank";
+
+export interface FeedbackMdLine {
+  kind: FeedbackMdLineKind;
+  text: string;
+  section: string | null;
+}
+
+export interface FeedbackMdFilePreviewProps {
+  source: string;
+  filename: string;
+  activeHeading: string | null;
+}
+
+export interface FeedbackMdCopyButtonProps {
+  text: string;
+  successMessage: string;
+  children: string;
+}
+
+export interface FeedbackMdSectionProps {
+  title: ReactNode;
+  description: string;
+  children: ReactNode;
+}

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -117,7 +117,7 @@ export function buildAgentJson() {
     auth: buildAgentAuthMetadata(),
     feedback: {
       markdown: siteUrl(AGENT_DISCOVERY_PATHS.feedbackMarkdown),
-      endpoint: apiUrl("/v1/feedback"),
+      endpoint: apiUrl("/v1/feedback/notra"),
       docs: `${DOCS_URL}/api/agent-feedback`,
     },
     contact: {

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -8,6 +8,7 @@ const AGENT_DISCOVERY_PATHS = {
   apiCatalog: "/.well-known/api-catalog",
   authMarkdown: "/auth.md",
   botAuthDirectory: "/.well-known/http-message-signatures-directory",
+  feedbackMarkdown: "/feedback.md",
   mcp: "/.well-known/mcp",
   oauthProtectedResource: "/.well-known/oauth-protected-resource",
   schemaMap: "/schema-map.xml",
@@ -114,6 +115,11 @@ export function buildAgentJson() {
     },
     capabilities: NOTRA_CAPABILITIES,
     auth: buildAgentAuthMetadata(),
+    feedback: {
+      markdown: siteUrl(AGENT_DISCOVERY_PATHS.feedbackMarkdown),
+      endpoint: apiUrl("/v1/feedback"),
+      docs: `${DOCS_URL}/api/agent-feedback`,
+    },
     contact: {
       email: NOTRA_CONTACT_EMAIL,
       support: NOTRA_SUPPORT_EMAIL,

--- a/apps/web/src/utils/llms.ts
+++ b/apps/web/src/utils/llms.ts
@@ -94,6 +94,7 @@ export async function buildLlmsText() {
     ),
     formatLink("API Resources", "/api/llms.txt", "OpenAPI, auth, and MCP"),
     formatLink("Agent Auth", "/auth.md", "Credential discovery and usage"),
+    formatLink("Agent Feedback", "/feedback.md", "Where agents send feedback"),
     formatLink(
       "Agent Discovery",
       "/.well-known/agent.json",

--- a/apps/web/src/utils/markdown-twins.ts
+++ b/apps/web/src/utils/markdown-twins.ts
@@ -5,6 +5,7 @@ import type { CollectionEntry } from "@dualmark/converters";
 import type { CollectionConfig, StaticPageConfig } from "@dualmark/nextjs";
 
 import { changelog } from "@/../.source/server";
+import { buildFeedbackMdPageMarkdown } from "@/lib/feedback-md/markdown";
 import { listNotraBlogPosts } from "@/utils/blog";
 import {
   getChangelogPostHref,
@@ -274,6 +275,7 @@ export function buildDualmarkStaticPages(): StaticPageConfig[] {
     { pattern: "/features", render: () => buildFeaturesMarkdown() },
     { pattern: "/pricing", render: () => buildPricingMarkdown() },
     { pattern: "/brand", render: () => buildBrandMarkdown() },
+    { pattern: "/feedback-md", render: () => buildFeedbackMdPageMarkdown() },
     { pattern: "/blog", render: () => buildBlogIndexMarkdown() },
     { pattern: "/changelog", render: () => buildChangelogHubMarkdown() },
     {


### PR DESCRIPTION
## Summary

Proposes `feedback.md`: a Markdown file at the root of a site that tells an agent where to send feedback about the product, the MCP server, the docs and the page it is reading. Same spirit as `llms.txt` / `auth.md`, but pointing the other way (agent to site).

### New routes (`apps/web`)
- `/feedback-md`: explainer page in the style of `/mcp`. Hero with curl / Claude Code / Codex commands, Claude Code terminal demo (a dev integrating a fictional "Fall" checkout API hits a docs/API mismatch, reads `usefall.com/feedback.md`, files the bug via `submit_feedback` and moves on), "What is feedback.md", annotated anatomy of the file (click an annotation to scroll to that section; the section under the reading line is highlighted), sibling-files table, a copyable setup prompt, accordion FAQ and a Notra upsell banner.
- `/feedback.md`: Notra's own file. Channels: `POST https://api.usenotra.com/v1/feedback/notra` (no auth, curl example inline), support email, Discord.
- `/feedback-md.md`: Markdown twin of the page via dualmark.

### Wiring
- `/.well-known/agent.json` gets a `feedback` block; `/.well-known/api-catalog` links the file; sitemap entry; `/feedback.md` added to the dualmark `skipPaths`.

### Notes
- Fictional company in the example is "Fall" (`usefall.com`); a disclaimer under the file window says so.
- Copy has no Oxford commas and was passed through the humanizer guide.
- No token anywhere: the file points at the public per-org endpoint from #765.

## Test plan
- [x] `tsc`, oxlint, oxfmt clean; knip clean (pre-commit hook)
- [x] `/feedback-md`, `/feedback.md`, `/feedback-md.md` return 200 locally with the expected content types
- [x] Checked light + dark, desktop + 390px, no horizontal overflow
- [ ] Vercel preview

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proposes `feedback.md`, a Markdown file at the root of a site that tells agents where to send feedback about the product, the MCP server, the docs, and the page being read. It's the same spirit as `llms.txt` / `auth.md`, but pointed the other way — agent to site. The PR adds an explainer page, serves Notra's own file, and wires both into agent discovery.

- `/feedback-md`: an explainer page in the style of `/mcp` with command tabs for curl, Claude Code, and Codex, an annotated file anatomy with scroll-linked highlighting, a sibling-files table, a copyable setup prompt, FAQ, and a Notra upsell banner.
- `/feedback.md`: Notra's own file served as `text/markdown`; channels are `POST https://api.usenotra.com/v1/feedback/notra` (no auth), support email, and Discord.
- `/.well-known/agent.json` gains a `feedback` block, `/.well-known/api-catalog` and `llms.txt` link the file, the sitemap includes both new pages, and `/feedback.md` is excluded from dualmark proxying.
- `/feedback-md.md` is the Markdown twin of the explainer page via dualmark.
- The worked example uses a fictional company "Fall" (`usefall.com`); a disclaimer under the file preview says the URLs do not resolve.

<sup>Written for commit 37194adb2602f4640c9d99cb3c96966f3b655f20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

