### PR TITLE
fix(geo): drop test step from prepublishOnly

### DIFF
--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -75,8 +75,7 @@
   "scripts": {
     "build": "tsup",
     "check-types": "tsc --noEmit",
-    "test": "bun test test",
-    "prepublishOnly": "bun run build && bun run test"
+    "prepublishOnly": "bun run build"
   },
   "devDependencies": {
     "@notra/typescript-config": "workspace:*",


### PR DESCRIPTION
The `test` dir in `packages/geo` was removed in f13018363, but `prepublishOnly` still ran `bun run test` (`bun test test`), which matches no files and exits 1, aborting `npm publish`.

Removes the `test` script and makes `prepublishOnly` just `bun run build`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `npm publish` for `packages/geo`, which previously aborted because `prepublishOnly` ran a `test` script that matched no files and exited 1. The `prepublishOnly` step now only runs `bun run build`, and the unused `test` script is removed.

<sup>Written for commit 0b210ba7fa100b23fdf70d3b889c0f903602f6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

