### PR TITLE
fix(web): make the llms.txt step explicit in the feedback.md setup prompt

### DIFF
--- a/apps/web/src/lib/feedback-md/constants.ts
+++ b/apps/web/src/lib/feedback-md/constants.ts
@@ -211,7 +211,7 @@ export const FEEDBACK_MD_SIBLINGS: FeedbackMdSibling[] = [
 
 const FEEDBACK_MD_PAGE_URL = `${SITE_URL}${FEEDBACK_MD_PAGE_PATH}`;
 
-export const FEEDBACK_MD_SETUP_PROMPT = `Read ${FEEDBACK_MD_PAGE_URL} and add a feedback.md to this site at /feedback.md, following the template on that page. Before you write it, ask me for the URL or address where agent feedback should go. Serve the file as text/markdown and link it from llms.txt.`;
+export const FEEDBACK_MD_SETUP_PROMPT = `Read ${FEEDBACK_MD_PAGE_URL} and add a feedback.md to this site at /feedback.md, following the template on that page. Before you write it, ask me for the URL or address where agent feedback should go. Serve the file as text/markdown. Then add it to the site's llms.txt so agents can find it, creating llms.txt if it does not exist yet.`;
 
 export const FEEDBACK_MD_QUESTIONS: FeedbackMdQuestion[] = [
   {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the feedback.md setup prompt so agents explicitly update `llms.txt`, creating it when missing, instead of just being told to link the file from it.

<sup>Written for commit b2fb1c6a9a8d71947c7fe5842119687f1253057b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

