### PR TITLE
fix(api-keys): preserve modal content during close

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -518,6 +518,7 @@ function CreateApiKeyDialog({
   onExpirationChange,
   onNameChange,
   onOpenChange,
+  onOpenChangeComplete,
   onScopesChange,
   onSubmit,
   open,
@@ -529,12 +530,17 @@ function CreateApiKeyDialog({
   onExpirationChange: (expiration: ApiKeyExpiration) => void;
   onNameChange: (name: string | null) => void;
   onOpenChange: (open: boolean) => void;
+  onOpenChangeComplete: (open: boolean) => void;
   onScopesChange: (scopes: string[]) => void;
   onSubmit: () => void;
   open: boolean;
 }) {
   return (
-    <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
+    <ResponsiveDialog
+      onOpenChange={onOpenChange}
+      onOpenChangeComplete={onOpenChangeComplete}
+      open={open}
+    >
       <ResponsiveDialogContent
         className={createdKey ? "sm:max-w-md" : "sm:max-w-2xl"}
       >
@@ -985,13 +991,17 @@ export default function ApiKeysPage() {
       return;
     }
 
-    if (!open) {
-      dispatchUi({ type: "createErrorChanged", createError: null });
-      mutation.reset();
-      dispatchUi({ type: "createdKeyChanged", createdKey: null });
-      setNewKeyConfig(null);
-    }
     dispatchUi({ type: "createDialogChanged", open });
+  };
+
+  const handleDialogOpenChangeComplete = (open: boolean) => {
+    if (open) {
+      return;
+    }
+
+    mutation.reset();
+    setNewKeyConfig(null);
+    dispatchUi({ type: "createDialogReset" });
   };
 
   const handleEditDialogClose = (open: boolean) => {
@@ -1074,6 +1084,7 @@ export default function ApiKeysPage() {
           setNewKeyConfig({ name });
         }}
         onOpenChange={handleDialogClose}
+        onOpenChangeComplete={handleDialogOpenChangeComplete}
         onScopesChange={(scopes) => setNewKeyConfig({ scopes })}
         onSubmit={handleCreateSubmit}
         open={dialogOpen}


### PR DESCRIPTION
### Description
Fixes the API key success modal briefly switching back to the create form while closing. The success state is now reset only after the dialog’s exit animation completes.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the API key success modal briefly flashing the create form while closing. The success state is now reset only after the dialog's exit animation finishes via a new `onOpenChangeComplete` callback.

<sup>Written for commit 65e8b0e4255d451eefd9c8aa995666b1864a8126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

