### PR TITLE
perf(ui): move text shimmer to compositor

### DIFF
--- a/apps/console/src/components/integrations/tool-chat-preview.tsx
+++ b/apps/console/src/components/integrations/tool-chat-preview.tsx
@@ -4,7 +4,6 @@ import { ArrowDown01Icon, CpuIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Shimmer } from "@notra/ui/components/ai-elements/shimmer";
 import { cn } from "cnfast";
-import { domAnimation, LazyMotion } from "motion/react";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 
@@ -106,18 +105,15 @@ export function ToolChatPreview({
       <p className="text-muted-foreground/70 text-[0.65rem] font-medium tracking-wider uppercase">
         In chat
       </p>
-      <LazyMotion features={domAnimation}>
-        <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
-          {icon}
-          <Shimmer
-            as="span"
-            className="min-w-0 truncate text-sm leading-5"
-            duration={1.8}
-          >
-            {runningText}
-          </Shimmer>
-        </div>
-      </LazyMotion>
+      <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
+        {icon}
+        <Shimmer
+          as="span"
+          className="min-w-0 truncate text-sm leading-5"
+        >
+          {runningText}
+        </Shimmer>
+      </div>
       <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
         {icon}
         <span className="inline-block min-w-0 truncate leading-5">

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@notra/ui/cta-button.css";
+@import "@notra/ui/text-shimmer.css";
 
 @source "../../../../packages/ui/src/**/*.{ts,tsx}";
 
@@ -332,12 +333,6 @@
 
 .thinking-letter {
   animation: thinking-letter 1.35s ease-in-out infinite;
-}
-
-@keyframes shimmer {
-  100% {
-    transform: translateX(100%);
-  }
 }
 
 @keyframes chat-input-slide-down {

--- a/apps/dashboard/src/components/ai/chat-tool-block.tsx
+++ b/apps/dashboard/src/components/ai/chat-tool-block.tsx
@@ -780,7 +780,6 @@ export function ChatToolBlock({
           <Shimmer
             as="span"
             className="min-w-0 truncate text-sm leading-5"
-            duration={1.8}
           >
             {subtitle}
           </Shimmer>

--- a/apps/dashboard/src/components/command-palette/command-palette.tsx
+++ b/apps/dashboard/src/components/command-palette/command-palette.tsx
@@ -28,7 +28,6 @@ import { Kbd } from "@notra/ui/components/ui/kbd";
 import { cn } from "@notra/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { Command as CommandPrimitive } from "cmdk";
-import { domAnimation, LazyMotion } from "motion/react";
 import { useRouter } from "next/navigation";
 import {
   useEffect,
@@ -494,18 +493,14 @@ export function CommandPalette() {
               <div className="flex h-[14rem] flex-col items-center justify-center px-6 text-center">
                 <div className="text-foreground grid grid-cols-[1.125rem_auto_1.125rem] items-center gap-2 text-sm">
                   <BrailleSpinner className="text-[18px] leading-none" />
-                  <LazyMotion features={domAnimation}>
-                    <Shimmer
-                      as="span"
-                      className="font-medium"
-                      duration={1.6}
-                      spread={1.4}
-                    >
-                      {isNavigatingAi
-                        ? `${(aiState as { status: "navigating"; label: string }).label}…`
-                        : "Thinking…"}
-                    </Shimmer>
-                  </LazyMotion>
+                  <Shimmer
+                    as="span"
+                    className="font-medium"
+                  >
+                    {isNavigatingAi
+                      ? `${(aiState as { status: "navigating"; label: string }).label}…`
+                      : "Thinking…"}
+                  </Shimmer>
                   <span aria-hidden="true" />
                 </div>
                 <p className="text-muted-foreground mt-3 max-w-xs text-xs">

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -216,12 +216,6 @@
   animation: thinking-letter 1.35s ease-in-out infinite;
 }
 
-@keyframes shimmer {
-  100% {
-    transform: translateX(100%);
-  }
-}
-
 @keyframes agent-readiness-progress {
   from {
     transform: translateX(-100%);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
   "exports": {
     "./globals.css": "./src/styles/globals.css",
     "./cta-button.css": "./src/styles/cta-button.css",
+    "./text-shimmer.css": "./src/styles/text-shimmer.css",
     "./postcss.config": "./postcss.config.mjs",
     "./lib/*": "./src/lib/*.ts",
     "./constants/*": "./src/constants/*.ts",

--- a/packages/ui/src/components/ai-elements/shimmer.tsx
+++ b/packages/ui/src/components/ai-elements/shimmer.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import { m } from "motion/react";
-import {
-  type CSSProperties,
-  type ElementType,
-  type JSX,
-  memo,
-  useMemo,
-} from "react";
+import { type CSSProperties, type ElementType, memo, useId } from "react";
 import { cn } from "@notra/ui/lib/utils";
 
 export interface TextShimmerProps {
@@ -22,42 +15,33 @@ const ShimmerComponent = ({
   children,
   as: Component = "p",
   className,
-  duration = 2,
-  spread = 2,
+  duration = 1.7,
+  spread = 4,
 }: TextShimmerProps) => {
-  const MotionComponent = m.create(
-    Component as keyof JSX.IntrinsicElements
-  );
-
-  const dynamicSpread = useMemo(
-    () => (children?.length ?? 0) * spread,
-    [children, spread]
-  );
+  const textId = `text-shimmer-${useId().replaceAll(":", "")}`;
 
   return (
-    <MotionComponent
-      animate={{ backgroundPosition: "0% center" }}
-      className={cn(
-        "relative inline-block bg-size-[250%_100%,auto] bg-clip-text text-transparent",
-        "[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--color-background),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]",
-        className
-      )}
-      initial={{ backgroundPosition: "100% center" }}
+    <Component
+      className={cn("text-shimmer", className)}
       style={
         {
-          "--spread": `${dynamicSpread}px`,
-          backgroundImage:
-            "var(--bg), linear-gradient(var(--color-muted-foreground), var(--color-muted-foreground))",
+          "--text-shimmer-duration": `${duration}s`,
+          "--text-shimmer-firefox-mask": `-moz-element(#${textId})`,
+          "--text-shimmer-spread": `${spread}ch`,
         } as CSSProperties
       }
-      transition={{
-        repeat: Number.POSITIVE_INFINITY,
-        duration,
-        ease: "linear",
-      }}
     >
-      {children}
-    </MotionComponent>
+      <span className="text-shimmer__text" id={textId}>
+        {children}
+      </span>
+      <span
+        aria-hidden="true"
+        className="text-shimmer__mask"
+        inert
+      >
+        {children}
+      </span>
+    </Component>
   );
 };
 

--- a/packages/ui/src/components/brainless/chatgpt/chatgpt-thinking.tsx
+++ b/packages/ui/src/components/brainless/chatgpt/chatgpt-thinking.tsx
@@ -20,9 +20,7 @@ export function ChatgptThinking({
       {reducedMotion ? (
         "Thinking"
       ) : (
-        <Shimmer className="font-medium" duration={1.6} spread={1.4}>
-          Thinking
-        </Shimmer>
+        <Shimmer className="font-medium">Thinking</Shimmer>
       )}
     </div>
   );

--- a/packages/ui/src/components/brainless/perplexity/perplexity-thinking.tsx
+++ b/packages/ui/src/components/brainless/perplexity/perplexity-thinking.tsx
@@ -23,9 +23,7 @@ export function PerplexityThinking({
       {reducedMotion ? (
         label
       ) : (
-        <Shimmer className="font-medium" duration={1.6} spread={1.4}>
-          {label}
-        </Shimmer>
+        <Shimmer className="font-medium">{label}</Shimmer>
       )}
     </div>
   );

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "./cta-button.css";
+@import "./text-shimmer.css";
 
 @source "../../node_modules/streamdown/dist/*.js";
 

--- a/packages/ui/src/styles/text-shimmer.css
+++ b/packages/ui/src/styles/text-shimmer.css
@@ -1,0 +1,65 @@
+@layer components {
+  .text-shimmer {
+    position: relative;
+    display: inline-block;
+    color: var(--muted-foreground);
+  }
+
+  .text-shimmer__text {
+    display: inline-block;
+  }
+
+  .text-shimmer__mask {
+    position: absolute;
+    inset: 0;
+    contain: strict;
+    overflow: clip;
+    color: transparent;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  @supports (-webkit-mask-clip: text) {
+    .text-shimmer__mask {
+      mask-image: linear-gradient(white, white);
+      -webkit-mask-clip: text;
+    }
+  }
+
+  @supports (mask-image: -moz-element(#text)) {
+    .text-shimmer__mask {
+      mask-image: var(--text-shimmer-firefox-mask);
+    }
+  }
+
+  .text-shimmer__mask::after {
+    position: absolute;
+    inset: 0;
+    content: "";
+    background: linear-gradient(
+      90deg,
+      transparent calc(50% - var(--text-shimmer-spread)),
+      var(--foreground) 50%,
+      transparent calc(50% + var(--text-shimmer-spread))
+    );
+    pointer-events: none;
+    will-change: transform;
+    animation: text-shimmer var(--text-shimmer-duration) linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .text-shimmer__mask {
+      display: none;
+    }
+  }
+}
+
+@keyframes text-shimmer {
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}


### PR DESCRIPTION
### Description
Replace the Motion-based text shimmer with a CSS clone-and-mask implementation that animates on the compositor. This unifies shimmer timing across the app, supports reduced motion, and removes obsolete Motion wrappers and legacy keyframes.

| Szenario | Vorher | Nachher |
|---|---:|---:|
| **1 Shimmer: Paint-Events** | 362 | **0** |
| Paint-Zeit | 15,49 ms | **0 ms** |
| Style-Updates | 14,01 ms | **0,54 ms** |
| JS-Animation | 14,50 ms | **0,14 ms** |
| Gemessener Main-Thread-Proxy | 41,62 ms | **0,77 ms** |
| **Reduktion** |  | **−98,2 %** |

### Screenshot/Recording (if applicable)

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the text shimmer from Motion to a CSS clone-and-mask technique that animates on the compositor, cutting main-thread work by ~98% in tool-chat and command-palette previews. Removes now-unused `LazyMotion`/`domAnimation` wrappers and the legacy `@keyframes shimmer` from both app stylesheets.

**Migration**

- Apps using `Shimmer` must import `@notra/ui/text-shimmer.css` in their global stylesheet; console, dashboard, and `packages/ui` globals now do.
- The `duration` and `spread` props still exist but default to `1.7s` and `4ch`; call sites that passed custom values now use the defaults, slightly changing timing and highlight width.
- Shimmer now honors `prefers-reduced-motion` by hiding the animated mask.

<sup>Written for commit 7a3d774516e1352d81fd6d2ef36c1fd94abf28e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

