### PR TITLE
fix(dashboard): smooth setup banner dismissal

### DIFF
--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -93,7 +93,6 @@ export function DashboardShell({
       return;
     }
 
-    dismiss();
     setDismissingOrganizationId(null);
   };
 
@@ -104,6 +103,7 @@ export function DashboardShell({
     }
 
     setDismissingOrganizationId(organizationId);
+    dismiss();
   };
 
   return (
@@ -111,7 +111,7 @@ export function DashboardShell({
       className="flex h-svh flex-col overflow-hidden overscroll-none"
       style={shellStyle}
     >
-      {bannerAvailable ? (
+      {bannerAvailable || dismissing ? (
         <div
           className={cn(
             "w-full shrink-0 overflow-hidden transition-[max-height,opacity] duration-200 ease-out motion-reduce:transition-none",

--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -2,6 +2,7 @@
 
 import { SidebarInset, SidebarProvider } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
+import { useReducedMotion } from "motion/react";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -36,7 +37,13 @@ export function DashboardShell({
     useOnboardingAgentBannerDismissal(organizationId);
   const running = data?.running ?? false;
   const canStart = !!data && !data.ran && !running && !dismissed;
-  const visible = running || canStart;
+  const bannerAvailable = running || canStart;
+  const [dismissingOrganizationId, setDismissingOrganizationId] = useState<
+    string | null
+  >(null);
+  const dismissing = dismissingOrganizationId === organizationId;
+  const visible = bannerAvailable && !dismissing;
+  const shouldReduceMotion = useReducedMotion();
   const starting =
     runAgent.isPending && runAgent.variables?.organizationId === organizationId;
   const shellStyle: DashboardShellStyle = {
@@ -45,6 +52,10 @@ export function DashboardShell({
   const pathname = usePathname();
   const mainScrollRef = useRef<HTMLDivElement>(null);
   const [mainScrolled, setMainScrolled] = useState(false);
+
+  useEffect(() => {
+    setDismissingOrganizationId(null);
+  }, [organizationId]);
 
   useEffect(() => {
     const el = mainScrollRef.current;
@@ -77,18 +88,54 @@ export function DashboardShell({
     );
   };
 
+  const handleBannerExitComplete = () => {
+    if (!dismissing) {
+      return;
+    }
+
+    dismiss();
+    setDismissingOrganizationId(null);
+  };
+
+  const handleDismiss = () => {
+    if (shouldReduceMotion) {
+      dismiss();
+      return;
+    }
+
+    setDismissingOrganizationId(organizationId);
+  };
+
   return (
     <div
       className="flex h-svh flex-col overflow-hidden overscroll-none"
       style={shellStyle}
     >
-      {visible ? (
-        <OnboardingAgentBanner
-          onDismiss={dismiss}
-          onStart={handleStart}
-          starting={starting}
-          state={running ? "running" : "idle"}
-        />
+      {bannerAvailable ? (
+        <div
+          className={cn(
+            "w-full shrink-0 overflow-hidden transition-[max-height,opacity] duration-200 ease-out motion-reduce:transition-none",
+            visible ? "opacity-100" : "opacity-0"
+          )}
+          onTransitionEnd={(event) => {
+            if (
+              event.target === event.currentTarget &&
+              event.propertyName === "max-height"
+            ) {
+              handleBannerExitComplete();
+            }
+          }}
+          style={{ maxHeight: visible ? EVE_BANNER_HEIGHT : "0rem" }}
+        >
+          <div style={{ height: EVE_BANNER_HEIGHT }}>
+            <OnboardingAgentBanner
+              onDismiss={handleDismiss}
+              onStart={handleStart}
+              starting={starting}
+              state={running ? "running" : "idle"}
+            />
+          </div>
+        </div>
       ) : null}
       <SidebarProvider
         className="min-h-0! flex-1 overflow-hidden overscroll-none"
@@ -96,7 +143,7 @@ export function DashboardShell({
       >
         <DashboardSidebar
           className={cn(
-            "md:top-(--eve-banner-height) md:h-[calc(100svh-var(--eve-banner-height))]",
+            "transition-[left,right,width,top,height] [transition-duration:var(--sidebar-duration),var(--sidebar-duration),var(--sidebar-duration),200ms,200ms] [transition-timing-function:var(--sidebar-ease),var(--sidebar-ease),var(--sidebar-ease),ease-out,ease-out] motion-reduce:transition-none md:top-(--eve-banner-height) md:h-[calc(100svh-var(--eve-banner-height))]",
             visible && "md:pt-0!"
           )}
           variant="inset"

--- a/apps/dashboard/src/components/dashboard/onboarding-agent-banner.tsx
+++ b/apps/dashboard/src/components/dashboard/onboarding-agent-banner.tsx
@@ -55,7 +55,7 @@ export function OnboardingAgentBanner({
 
   return (
     <div
-      className="relative isolate flex h-(--eve-banner-height) w-full shrink-0 items-center justify-center overflow-hidden"
+      className="relative isolate flex h-full w-full items-center justify-center overflow-hidden"
       style={{ backgroundColor: colors.colorBack }}
     >
       <Dithering


### PR DESCRIPTION
### Description
Smoothly collapses the workspace setup banner when dismissed, keeping the dashboard and sidebar transitions synchronized while preserving reduced-motion behavior and existing sidebar animations.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smoothly collapses the workspace setup banner on dismissal so the dashboard and sidebar transition together instead of the banner vanishing instantly. The dismissal is persisted immediately, so the banner won't reappear if the user navigates away during the collapse.

- Animates the banner exit with max-height and opacity; reduced-motion users skip the animation.
- Clears the dismissing state when the collapse finishes or the organization changes.
- Syncs the sidebar top/height transitions with the banner collapse duration and easing.

<sup>Written for commit b3abf8acbd98d08cbab4f6dd20eb56e93c88bdd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

