### PR TITLE
fix(dashboard): improve brand voice selector

### DIFF
--- a/apps/dashboard/src/components/automation/events/event-trigger-rules-section.tsx
+++ b/apps/dashboard/src/components/automation/events/event-trigger-rules-section.tsx
@@ -14,11 +14,9 @@ export function EventTriggerRulesSection({
   const outputType = useStore(form.store, (s) => s.values.outputType);
 
   const nonDefaultBrandVoices = brandVoices.filter((voice) => !voice.isDefault);
-  const defaultBrandVoiceName = brandVoices.find(
-    (voice) => voice.isDefault
-  )?.name;
-  const defaultBrandVoiceLabel = defaultBrandVoiceName
-    ? `${defaultBrandVoiceName} (Default)`
+  const defaultBrandVoice = brandVoices.find((voice) => voice.isDefault);
+  const defaultBrandVoiceLabel = defaultBrandVoice
+    ? `${defaultBrandVoice.name} (Default)`
     : "Default brand voice";
 
   if (!(brandVoices.length > 1 || supportsAutoPublish(outputType))) {
@@ -44,6 +42,7 @@ export function EventTriggerRulesSection({
               emptyOption={{
                 label: defaultBrandVoiceLabel,
                 description: "Use your default brand voice.",
+                voice: defaultBrandVoice,
               }}
               id={field.name}
               label="Brand voice"

--- a/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
+++ b/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
@@ -227,11 +227,9 @@ export function CreateScheduleDialog({
 
   const brandVoices = brandResponse?.voices ?? [];
   const nonDefaultBrandVoices = brandVoices.filter((voice) => !voice.isDefault);
-  const defaultBrandVoiceName = brandVoices.find(
-    (voice) => voice.isDefault
-  )?.name;
-  const defaultBrandVoiceLabel = defaultBrandVoiceName
-    ? `${defaultBrandVoiceName} (Default)`
+  const defaultBrandVoice = brandVoices.find((voice) => voice.isDefault);
+  const defaultBrandVoiceLabel = defaultBrandVoice
+    ? `${defaultBrandVoice.name} (Default)`
     : "Default brand voice";
 
   const { integrationOptions, githubIntegrationId } = useMemo(() => {
@@ -584,6 +582,7 @@ export function CreateScheduleDialog({
                           emptyOption={{
                             label: defaultBrandVoiceLabel,
                             description: "Use your default brand voice.",
+                            voice: defaultBrandVoice,
                           }}
                           id={field.name}
                           label="Brand voice"

--- a/apps/dashboard/src/components/brand-identity-radio-group.tsx
+++ b/apps/dashboard/src/components/brand-identity-radio-group.tsx
@@ -22,7 +22,7 @@ interface BrandIdentityOptionCardProps {
   itemId: string;
   itemValue: string;
   title: string;
-  subtitle: string;
+  subtitle?: string;
   isSelected: boolean;
   faviconUrl?: string;
   fallback?: string;
@@ -40,7 +40,7 @@ function BrandIdentityOptionCard({
   return (
     <Label
       className={cn(
-        "bg-card hover:border-foreground/20 flex w-full cursor-pointer items-center gap-3 rounded-lg border px-3 py-3 font-normal transition-colors",
+        "bg-card hover:border-foreground/20 flex w-full min-w-0 cursor-pointer items-center gap-3 overflow-hidden rounded-lg border px-3 py-3 font-normal transition-colors",
         isSelected
           ? "border-foreground/40 ring-foreground/10 ring-2"
           : "border-border"
@@ -56,7 +56,9 @@ function BrandIdentityOptionCard({
       )}
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium">{title}</p>
-        <p className="text-muted-foreground truncate text-xs">{subtitle}</p>
+        {subtitle && (
+          <p className="text-muted-foreground truncate text-xs">{subtitle}</p>
+        )}
       </div>
     </Label>
   );
@@ -81,7 +83,7 @@ export function BrandIdentityRadioGroup({
   };
 
   return (
-    <div className="space-y-2">
+    <div className="min-w-0 space-y-2">
       {label && (
         <p className="text-sm font-medium" id={labelId}>
           {label}
@@ -89,12 +91,16 @@ export function BrandIdentityRadioGroup({
       )}
       <RadioGroup
         aria-labelledby={label ? labelId : undefined}
-        className="gap-2"
+        className="min-w-0 gap-2"
         onValueChange={handleValueChange}
         value={groupValue}
       >
         {emptyOption && (
           <BrandIdentityOptionCard
+            fallback={emptyOption.voice?.name.slice(0, 2).toUpperCase()}
+            faviconUrl={getBrandFaviconUrl(
+              emptyOption.voice?.websiteUrl ?? null
+            )}
             isSelected={value === ""}
             itemId={`${groupId}-none`}
             itemValue={EMPTY_SENTINEL}
@@ -110,9 +116,6 @@ export function BrandIdentityRadioGroup({
             itemId={`${groupId}-${voice.id}`}
             itemValue={voice.id}
             key={voice.id}
-            subtitle={
-              voice.isDefault ? "Default brand identity" : "Brand identity"
-            }
             title={voice.name}
           />
         ))}

--- a/apps/dashboard/src/types/components/brand-identity.ts
+++ b/apps/dashboard/src/types/components/brand-identity.ts
@@ -3,6 +3,7 @@ import type { BrandSettings } from "@/types/hooks/brand-analysis";
 export interface BrandIdentityEmptyOption {
   label: string;
   description: string;
+  voice?: BrandSettings;
 }
 
 export interface BrandIdentityRadioGroupProps {


### PR DESCRIPTION
### Description
Fixes the brand voice selector in event trigger and schedule dialogs:

- Truncates long brand voice names and prevents horizontal overflow
- Shows the default brand voice favicon or initials
- Removes the redundant “Brand identity” subtitles
- Preserves the explanatory text for the default option

### Screenshot/Recording (if applicable)
<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/cab5b754-2ec0-42a2-8e76-c0a8b502ac26" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the brand voice selector in event trigger and schedule dialogs so long names no longer overflow and the default option shows its favicon or initials.

- Removes redundant “Brand identity” subtitles from non-default options.
- Keeps the explanatory text for the default option.

<sup>Written for commit 6e7a539c50ac3ddb3bc3d061d56514fecabc00df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

