### PR TITLE
feat(api-keys): add permission presets and improve dialog layout

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/loading.tsx
@@ -30,7 +30,7 @@ export default function Loading() {
             </Button>
           </div>
         </div>
-        <div className="border-border/80 border-b-border/40 bg-muted/80 overflow-hidden rounded-lg border shadow-2xs">
+        <div className="smooth-shadow-ring-xs bg-muted/80 overflow-hidden rounded-lg">
           <div className="bg-background space-y-3 rounded-t-lg p-4">
             {SKELETON_ROW_KEYS.map((key) => (
               <div className="flex items-center gap-4 py-2" key={key}>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -94,44 +94,35 @@ import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
-  API_KEY_ACCESS_MODE_VALUES,
   API_KEY_DEFAULT_SCOPES,
   API_KEY_EXPIRATION_OPTIONS,
   API_KEY_EXPIRATION_VALUES,
   API_KEY_PERMISSION_SUMMARY,
 } from "@/constants/api-keys";
 import { API_KEY_CARD_ITEMS, API_KEY_PRESETS } from "@/lib/api-keys/presets";
-import {
-  expandLegacyApiKeyScopes,
-  getApiKeyAccessMode,
-  getApiKeyScopesForAccessMode,
-} from "@/lib/api-keys/scopes";
+import { expandLegacyApiKeyScopes } from "@/lib/api-keys/scopes";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { CreateApiKeyInput, UpdateApiKeyInput } from "@/schemas/api-keys";
 import { createApiKeySchema, updateApiKeySchema } from "@/schemas/api-keys";
 import type {
-  ApiKeyAccessMode,
   ApiKeyCreateConfig,
   ApiKeyExpiration,
   ApiKeyFormValues,
 } from "@/types/api-keys";
 
 const NEW_KEY_CONFIG_PARSERS = {
-  accessMode: parseAsStringLiteral(API_KEY_ACCESS_MODE_VALUES),
   name: parseAsString,
   scopes: parseAsArrayOf(parseAsString),
   expiration: parseAsStringLiteral(API_KEY_EXPIRATION_VALUES),
 };
 
 const DEFAULT_NEW_KEY_CONFIG: ApiKeyCreateConfig = {
-  accessMode: "restricted",
   name: "",
   scopes: [...API_KEY_DEFAULT_SCOPES],
   expiration: "never",
 };
 
 const EDIT_FORM_DEFAULTS: ApiKeyFormValues = {
-  accessMode: "restricted",
   keyId: "",
   name: "",
   scopes: [...API_KEY_DEFAULT_SCOPES],
@@ -524,7 +515,6 @@ function CreateApiKeyDialog({
   createdKey,
   input,
   isPending,
-  onAccessModeChange,
   onExpirationChange,
   onNameChange,
   onOpenChange,
@@ -537,7 +527,6 @@ function CreateApiKeyDialog({
   createdKey: string | null;
   input: ApiKeyCreateConfig;
   isPending: boolean;
-  onAccessModeChange: (mode: ApiKeyAccessMode) => void;
   onExpirationChange: (expiration: ApiKeyExpiration) => void;
   onNameChange: (name: string | null) => void;
   onOpenChange: (open: boolean) => void;
@@ -646,10 +635,8 @@ function CreateApiKeyDialog({
                     <span className="text-destructive -ml-1">*</span>
                   </FieldLabel>
                   <ApiKeyPermissionSelector
-                    accessMode={input.accessMode}
                     className="[&>div]:py-2.5"
                     disabled={isPending}
-                    onAccessModeChange={onAccessModeChange}
                     onValueChange={onScopesChange}
                     value={input.scopes}
                   />
@@ -755,38 +742,20 @@ function EditApiKeyDialog({
               )}
             </editForm.Field>
 
-            <editForm.Field name="accessMode">
-              {(accessModeField) => (
-                <editForm.Field name="scopes">
-                  {(scopesField) => (
-                    <Field className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-                      <FieldLabel>
-                        Permissions
-                        <span className="text-destructive -ml-1">*</span>
-                      </FieldLabel>
-                      <ApiKeyPermissionSelector
-                        accessMode={
-                          accessModeField.state.value as ApiKeyAccessMode
-                        }
-                        className="[&>div]:py-2.5"
-                        disabled={isPending}
-                        onAccessModeChange={(mode) => {
-                          accessModeField.handleChange(mode);
-                          scopesField.handleChange(
-                            getApiKeyScopesForAccessMode(
-                              mode,
-                              scopesField.state.value as string[]
-                            )
-                          );
-                        }}
-                        onValueChange={(scopes) =>
-                          scopesField.handleChange(scopes)
-                        }
-                        value={scopesField.state.value as string[]}
-                      />
-                    </Field>
-                  )}
-                </editForm.Field>
+            <editForm.Field name="scopes">
+              {(field) => (
+                <Field className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                  <FieldLabel>
+                    Permissions
+                    <span className="text-destructive -ml-1">*</span>
+                  </FieldLabel>
+                  <ApiKeyPermissionSelector
+                    className="[&>div]:py-2.5"
+                    disabled={isPending}
+                    onValueChange={(scopes) => field.handleChange(scopes)}
+                    value={field.state.value as string[]}
+                  />
+                </Field>
               )}
             </editForm.Field>
           </div>
@@ -865,7 +834,6 @@ export default function ApiKeysPage() {
     NEW_KEY_CONFIG_PARSERS
   );
   const hasNewKeyConfig =
-    newKeyConfig.accessMode !== null &&
     newKeyConfig.name !== null &&
     newKeyConfig.scopes !== null &&
     newKeyConfig.expiration !== null;
@@ -892,14 +860,11 @@ export default function ApiKeysPage() {
 
   const sortedKeys = sortApiKeys(keys, createdSortOrder);
 
-  const newKeyAccessMode =
-    newKeyConfig.accessMode ?? DEFAULT_NEW_KEY_CONFIG.accessMode;
   const newKeyName = newKeyConfig.name;
   const newKeyScopes = newKeyConfig.scopes ?? DEFAULT_NEW_KEY_CONFIG.scopes;
   const newKeyExpiration =
     newKeyConfig.expiration ?? DEFAULT_NEW_KEY_CONFIG.expiration;
   const createInput = {
-    accessMode: newKeyAccessMode,
     name: newKeyName ?? DEFAULT_NEW_KEY_CONFIG.name,
     scopes: newKeyScopes,
     expiration: newKeyExpiration,
@@ -917,7 +882,6 @@ export default function ApiKeysPage() {
       return;
     }
     const config = {
-      accessMode: getApiKeyAccessMode(preset.scopes),
       name: preset.defaultName,
       scopes: preset.scopes,
       expiration: preset.expiration,
@@ -1074,7 +1038,6 @@ export default function ApiKeysPage() {
     const scopes = expandLegacyApiKeyScopes(key.permissions);
 
     editForm.reset({
-      accessMode: getApiKeyAccessMode(scopes),
       keyId: key.keyId,
       name: key.name,
       scopes,
@@ -1125,12 +1088,6 @@ export default function ApiKeysPage() {
         createError={createError}
         input={createInput}
         isPending={mutation.isPending}
-        onAccessModeChange={(accessMode) =>
-          setNewKeyConfig({
-            accessMode,
-            scopes: getApiKeyScopesForAccessMode(accessMode, newKeyScopes),
-          })
-        }
         onExpirationChange={(expiration) => setNewKeyConfig({ expiration })}
         onNameChange={(name) => {
           dispatchUi({ type: "createErrorChanged", createError: null });

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -462,7 +462,7 @@ function ApiKeysTable({
   onSort: () => void;
 }) {
   return (
-    <div className="border-border/80 border-b-border/40 bg-muted/80 overflow-hidden rounded-lg border shadow-2xs">
+    <div className="smooth-shadow-ring-xs bg-muted/80 overflow-hidden rounded-lg">
       <Table>
         <TableHeader>
           <TableRow>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -94,35 +94,44 @@ import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
+  API_KEY_ACCESS_MODE_VALUES,
   API_KEY_DEFAULT_SCOPES,
   API_KEY_EXPIRATION_OPTIONS,
   API_KEY_EXPIRATION_VALUES,
   API_KEY_PERMISSION_SUMMARY,
 } from "@/constants/api-keys";
 import { API_KEY_CARD_ITEMS, API_KEY_PRESETS } from "@/lib/api-keys/presets";
-import { expandLegacyApiKeyScopes } from "@/lib/api-keys/scopes";
+import {
+  expandLegacyApiKeyScopes,
+  getApiKeyAccessMode,
+  getApiKeyScopesForAccessMode,
+} from "@/lib/api-keys/scopes";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { CreateApiKeyInput, UpdateApiKeyInput } from "@/schemas/api-keys";
 import { createApiKeySchema, updateApiKeySchema } from "@/schemas/api-keys";
 import type {
+  ApiKeyAccessMode,
   ApiKeyCreateConfig,
   ApiKeyExpiration,
   ApiKeyFormValues,
 } from "@/types/api-keys";
 
 const NEW_KEY_CONFIG_PARSERS = {
+  accessMode: parseAsStringLiteral(API_KEY_ACCESS_MODE_VALUES),
   name: parseAsString,
   scopes: parseAsArrayOf(parseAsString),
   expiration: parseAsStringLiteral(API_KEY_EXPIRATION_VALUES),
 };
 
 const DEFAULT_NEW_KEY_CONFIG: ApiKeyCreateConfig = {
+  accessMode: "restricted",
   name: "",
   scopes: [...API_KEY_DEFAULT_SCOPES],
   expiration: "never",
 };
 
 const EDIT_FORM_DEFAULTS: ApiKeyFormValues = {
+  accessMode: "restricted",
   keyId: "",
   name: "",
   scopes: [...API_KEY_DEFAULT_SCOPES],
@@ -515,6 +524,7 @@ function CreateApiKeyDialog({
   createdKey,
   input,
   isPending,
+  onAccessModeChange,
   onExpirationChange,
   onNameChange,
   onOpenChange,
@@ -527,6 +537,7 @@ function CreateApiKeyDialog({
   createdKey: string | null;
   input: ApiKeyCreateConfig;
   isPending: boolean;
+  onAccessModeChange: (mode: ApiKeyAccessMode) => void;
   onExpirationChange: (expiration: ApiKeyExpiration) => void;
   onNameChange: (name: string | null) => void;
   onOpenChange: (open: boolean) => void;
@@ -545,8 +556,9 @@ function CreateApiKeyDialog({
         className={
           createdKey
             ? "sm:max-w-md"
-            : "flex max-h-[90svh] flex-col overflow-hidden sm:max-w-2xl"
+            : "flex max-h-[85svh] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl"
         }
+        drawerClassName="[&>form]:px-0"
       >
         {createdKey ? (
           <>
@@ -574,7 +586,7 @@ function CreateApiKeyDialog({
           </>
         ) : (
           <>
-            <ResponsiveDialogHeader>
+            <ResponsiveDialogHeader className="shrink-0 border-b p-4 pr-14">
               <ResponsiveDialogTitle className="text-2xl">
                 Create API Key
               </ResponsiveDialogTitle>
@@ -582,12 +594,9 @@ function CreateApiKeyDialog({
                 Create a new API key for your organization.
               </ResponsiveDialogDescription>
             </ResponsiveDialogHeader>
-            <form
-              action={onSubmit}
-              className="flex min-h-0 flex-1 flex-col overflow-hidden"
-            >
-              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain py-4 pr-1">
-                <Field>
+            <form action={onSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+                <Field className="shrink-0">
                   <FieldLabel>
                     Name<span className="text-destructive -ml-1">*</span>
                   </FieldLabel>
@@ -604,19 +613,7 @@ function CreateApiKeyDialog({
                   ) : null}
                 </Field>
 
-                <Field>
-                  <FieldLabel>
-                    Permission
-                    <span className="text-destructive -ml-1">*</span>
-                  </FieldLabel>
-                  <ApiKeyPermissionSelector
-                    disabled={isPending}
-                    onValueChange={onScopesChange}
-                    value={input.scopes}
-                  />
-                </Field>
-
-                <Field>
+                <Field className="shrink-0">
                   <FieldLabel>
                     Expiration
                     <span className="text-muted-foreground -ml-1 text-xs">
@@ -642,8 +639,23 @@ function CreateApiKeyDialog({
                     </SelectContent>
                   </Select>
                 </Field>
+
+                <Field className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                  <FieldLabel>
+                    Permissions
+                    <span className="text-destructive -ml-1">*</span>
+                  </FieldLabel>
+                  <ApiKeyPermissionSelector
+                    accessMode={input.accessMode}
+                    className="[&>div]:py-2.5"
+                    disabled={isPending}
+                    onAccessModeChange={onAccessModeChange}
+                    onValueChange={onScopesChange}
+                    value={input.scopes}
+                  />
+                </Field>
               </div>
-              <ResponsiveDialogFooter className="shrink-0">
+              <ResponsiveDialogFooter className="bg-background/95 supports-backdrop-filter:bg-background/80 mx-0 mb-0 shrink-0 rounded-b-xl border-t p-4 sm:justify-between">
                 <ResponsiveDialogClose
                   disabled={isPending}
                   render={<Button variant="outline">Cancel</Button>}
@@ -675,20 +687,23 @@ function EditApiKeyDialog({
 }) {
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
-      <ResponsiveDialogContent className="sm:max-w-2xl">
-        <form action={onSubmit}>
-          <ResponsiveDialogHeader>
+      <ResponsiveDialogContent
+        className="flex max-h-[85svh] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl"
+        drawerClassName="[&>form]:px-0"
+      >
+        <form action={onSubmit} className="flex min-h-0 flex-1 flex-col">
+          <ResponsiveDialogHeader className="shrink-0 border-b p-4 pr-14">
             <ResponsiveDialogTitle className="text-2xl">
               Edit API Key
             </ResponsiveDialogTitle>
           </ResponsiveDialogHeader>
-          <div className="space-y-4 py-4">
+          <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
             <editForm.Field
               name="name"
               validators={{ onChange: updateApiKeySchema.shape.name }}
             >
               {(field) => (
-                <Field>
+                <Field className="shrink-0">
                   <FieldLabel>
                     Name<span className="text-destructive -ml-1">*</span>
                   </FieldLabel>
@@ -714,25 +729,9 @@ function EditApiKeyDialog({
               )}
             </editForm.Field>
 
-            <editForm.Field name="scopes">
-              {(field) => (
-                <Field>
-                  <FieldLabel>
-                    Permission
-                    <span className="text-destructive -ml-1">*</span>
-                  </FieldLabel>
-                  <ApiKeyPermissionSelector
-                    disabled={isPending}
-                    onValueChange={(scopes) => field.handleChange(scopes)}
-                    value={field.state.value as string[]}
-                  />
-                </Field>
-              )}
-            </editForm.Field>
-
             <editForm.Field name="expiration">
               {(field) => (
-                <Field>
+                <Field className="shrink-0">
                   <FieldLabel>Expiration</FieldLabel>
                   <Select
                     disabled={isPending}
@@ -755,8 +754,43 @@ function EditApiKeyDialog({
                 </Field>
               )}
             </editForm.Field>
+
+            <editForm.Field name="accessMode">
+              {(accessModeField) => (
+                <editForm.Field name="scopes">
+                  {(scopesField) => (
+                    <Field className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                      <FieldLabel>
+                        Permissions
+                        <span className="text-destructive -ml-1">*</span>
+                      </FieldLabel>
+                      <ApiKeyPermissionSelector
+                        accessMode={
+                          accessModeField.state.value as ApiKeyAccessMode
+                        }
+                        className="[&>div]:py-2.5"
+                        disabled={isPending}
+                        onAccessModeChange={(mode) => {
+                          accessModeField.handleChange(mode);
+                          scopesField.handleChange(
+                            getApiKeyScopesForAccessMode(
+                              mode,
+                              scopesField.state.value as string[]
+                            )
+                          );
+                        }}
+                        onValueChange={(scopes) =>
+                          scopesField.handleChange(scopes)
+                        }
+                        value={scopesField.state.value as string[]}
+                      />
+                    </Field>
+                  )}
+                </editForm.Field>
+              )}
+            </editForm.Field>
           </div>
-          <ResponsiveDialogFooter>
+          <ResponsiveDialogFooter className="bg-background/95 supports-backdrop-filter:bg-background/80 mx-0 mb-0 shrink-0 rounded-b-xl border-t p-4">
             <ResponsiveDialogClose
               disabled={isPending}
               render={<Button variant="outline">Cancel</Button>}
@@ -831,6 +865,7 @@ export default function ApiKeysPage() {
     NEW_KEY_CONFIG_PARSERS
   );
   const hasNewKeyConfig =
+    newKeyConfig.accessMode !== null &&
     newKeyConfig.name !== null &&
     newKeyConfig.scopes !== null &&
     newKeyConfig.expiration !== null;
@@ -857,11 +892,14 @@ export default function ApiKeysPage() {
 
   const sortedKeys = sortApiKeys(keys, createdSortOrder);
 
+  const newKeyAccessMode =
+    newKeyConfig.accessMode ?? DEFAULT_NEW_KEY_CONFIG.accessMode;
   const newKeyName = newKeyConfig.name;
   const newKeyScopes = newKeyConfig.scopes ?? DEFAULT_NEW_KEY_CONFIG.scopes;
   const newKeyExpiration =
     newKeyConfig.expiration ?? DEFAULT_NEW_KEY_CONFIG.expiration;
   const createInput = {
+    accessMode: newKeyAccessMode,
     name: newKeyName ?? DEFAULT_NEW_KEY_CONFIG.name,
     scopes: newKeyScopes,
     expiration: newKeyExpiration,
@@ -879,6 +917,7 @@ export default function ApiKeysPage() {
       return;
     }
     const config = {
+      accessMode: getApiKeyAccessMode(preset.scopes),
       name: preset.defaultName,
       scopes: preset.scopes,
       expiration: preset.expiration,
@@ -1035,6 +1074,7 @@ export default function ApiKeysPage() {
     const scopes = expandLegacyApiKeyScopes(key.permissions);
 
     editForm.reset({
+      accessMode: getApiKeyAccessMode(scopes),
       keyId: key.keyId,
       name: key.name,
       scopes,
@@ -1085,6 +1125,12 @@ export default function ApiKeysPage() {
         createError={createError}
         input={createInput}
         isPending={mutation.isPending}
+        onAccessModeChange={(accessMode) =>
+          setNewKeyConfig({
+            accessMode,
+            scopes: getApiKeyScopesForAccessMode(accessMode, newKeyScopes),
+          })
+        }
         onExpirationChange={(expiration) => setNewKeyConfig({ expiration })}
         onNameChange={(name) => {
           dispatchUi({ type: "createErrorChanged", createError: null });

--- a/apps/dashboard/src/components/api-keys/permission-selector.tsx
+++ b/apps/dashboard/src/components/api-keys/permission-selector.tsx
@@ -18,6 +18,8 @@ import {
   API_KEY_SCOPE_GROUPS,
   applyScopeLevel,
   deriveScopeLevel,
+  getApiKeyAccessMode,
+  getApiKeyScopesForAccessMode,
   sortApiKeyScopes,
 } from "@/lib/api-keys/scopes";
 import type {
@@ -27,14 +29,13 @@ import type {
 } from "@/types/api-keys";
 
 export function ApiKeyPermissionSelector({
-  accessMode,
   value,
-  onAccessModeChange,
   onValueChange,
   disabled,
   className,
 }: ApiKeyPermissionSelectorProps) {
   const selected = new Set(value);
+  const accessMode = getApiKeyAccessMode(value);
   const selectedMode = API_KEY_ACCESS_MODE_OPTIONS.find(
     (option) => option.value === accessMode
   );
@@ -53,7 +54,11 @@ export function ApiKeyPermissionSelector({
         indicatorMotion="smooth"
         label="API key access"
         layout="compact"
-        onValueChange={(mode) => onAccessModeChange(mode as ApiKeyAccessMode)}
+        onValueChange={(mode) =>
+          onValueChange(
+            getApiKeyScopesForAccessMode(mode as ApiKeyAccessMode, value)
+          )
+        }
         value={accessMode}
       >
         {API_KEY_ACCESS_MODE_OPTIONS.map((option) => (

--- a/apps/dashboard/src/components/api-keys/permission-selector.tsx
+++ b/apps/dashboard/src/components/api-keys/permission-selector.tsx
@@ -1,11 +1,19 @@
 "use client";
 
+import { InformationCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@notra/ui/components/ui/alert";
 import {
   PermissionOption,
   PermissionRow,
   PermissionSelector,
 } from "@notra/ui/components/ui/permission-selector";
 
+import { API_KEY_ACCESS_MODE_OPTIONS } from "@/constants/api-keys";
 import {
   API_KEY_SCOPE_GROUPS,
   applyScopeLevel,
@@ -13,17 +21,23 @@ import {
   sortApiKeyScopes,
 } from "@/lib/api-keys/scopes";
 import type {
+  ApiKeyAccessMode,
   ApiKeyPermissionSelectorProps,
   ApiKeyScopeGroup,
 } from "@/types/api-keys";
 
 export function ApiKeyPermissionSelector({
+  accessMode,
   value,
+  onAccessModeChange,
   onValueChange,
   disabled,
   className,
 }: ApiKeyPermissionSelectorProps) {
   const selected = new Set(value);
+  const selectedMode = API_KEY_ACCESS_MODE_OPTIONS.find(
+    (option) => option.value === accessMode
+  );
 
   const handleLevelChange = (group: ApiKeyScopeGroup, levelValue: string) => {
     onValueChange(
@@ -32,27 +46,79 @@ export function ApiKeyPermissionSelector({
   };
 
   return (
-    <PermissionSelector className={className} label="API key permissions">
-      {API_KEY_SCOPE_GROUPS.map((group) => (
-        <PermissionRow
-          description={group.description}
-          disabled={disabled}
-          key={group.id}
-          label={group.label}
-          onValueChange={(levelValue) => handleLevelChange(group, levelValue)}
-          value={deriveScopeLevel(selected, group)}
-        >
-          {group.levels.map((level) => (
-            <PermissionOption
-              key={level.value}
-              tone={level.tone}
-              value={level.value}
+    <div className="space-y-3">
+      <PermissionRow
+        className="w-full"
+        disabled={disabled}
+        indicatorMotion="smooth"
+        label="API key access"
+        layout="compact"
+        onValueChange={(mode) => onAccessModeChange(mode as ApiKeyAccessMode)}
+        value={accessMode}
+      >
+        {API_KEY_ACCESS_MODE_OPTIONS.map((option) => (
+          <PermissionOption
+            className="flex-1 text-xs"
+            key={option.value}
+            value={option.value}
+          >
+            {option.label}
+          </PermissionOption>
+        ))}
+      </PermissionRow>
+
+      {accessMode !== "restricted" && selectedMode ? (
+        <Alert className="grid-cols-[auto_1fr] gap-x-3 rounded-xl border-blue-500/25 bg-blue-500/8 p-4 text-blue-500 dark:border-blue-400/25 dark:bg-blue-400/10 dark:text-blue-400">
+          <HugeiconsIcon
+            className="mt-0.5 size-5"
+            icon={InformationCircleIcon}
+          />
+          <AlertTitle className="text-sm font-medium">
+            {selectedMode.title}
+          </AlertTitle>
+          <AlertDescription className="text-muted-foreground mt-1 text-xs leading-relaxed">
+            {selectedMode.description}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {accessMode === "restricted" ? (
+        <div>
+          <p className="text-sm font-medium">Resource access</p>
+          <p className="text-muted-foreground text-xs">
+            {API_KEY_ACCESS_MODE_OPTIONS[2].description}
+          </p>
+          <div className="mt-3">
+            <PermissionSelector
+              className={className}
+              label="API key permissions"
             >
-              {level.label}
-            </PermissionOption>
-          ))}
-        </PermissionRow>
-      ))}
-    </PermissionSelector>
+              {API_KEY_SCOPE_GROUPS.map((group) => (
+                <PermissionRow
+                  description={group.description}
+                  disabled={disabled}
+                  key={group.id}
+                  label={group.label}
+                  onValueChange={(levelValue) =>
+                    handleLevelChange(group, levelValue)
+                  }
+                  value={deriveScopeLevel(selected, group)}
+                >
+                  {group.levels.map((level) => (
+                    <PermissionOption
+                      key={level.value}
+                      tone={level.tone}
+                      value={level.value}
+                    >
+                      {level.label}
+                    </PermissionOption>
+                  ))}
+                </PermissionRow>
+              ))}
+            </PermissionSelector>
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/dashboard/src/constants/api-keys.ts
+++ b/apps/dashboard/src/constants/api-keys.ts
@@ -27,12 +27,11 @@ export const API_KEY_ACCEPTED_PERMISSIONS = API_ACCEPTED_SCOPES;
 
 export const API_KEY_DEFAULT_SCOPES = API_READ_SCOPES;
 
-export const API_KEY_GEO_SCOPES = API_SCOPE_RESOURCES.filter(
-  (resource) => resource.openApiTag === "GEO"
-).flatMap((resource) => [
-  getApiScopeId(resource.id, "read"),
-  getApiScopeId(resource.id, "write"),
-]);
+export const API_KEY_GEO_SCOPES = API_SCOPE_RESOURCES.flatMap((resource) =>
+  resource.openApiTag === "GEO"
+    ? [getApiScopeId(resource.id, "read"), getApiScopeId(resource.id, "write")]
+    : []
+);
 
 export const API_KEY_ACCESS_MODE_VALUES = [
   "full",

--- a/apps/dashboard/src/constants/api-keys.ts
+++ b/apps/dashboard/src/constants/api-keys.ts
@@ -27,6 +27,43 @@ export const API_KEY_ACCEPTED_PERMISSIONS = API_ACCEPTED_SCOPES;
 
 export const API_KEY_DEFAULT_SCOPES = API_READ_SCOPES;
 
+export const API_KEY_GEO_SCOPES = API_SCOPE_RESOURCES.filter(
+  (resource) => resource.openApiTag === "GEO"
+).flatMap((resource) => [
+  getApiScopeId(resource.id, "read"),
+  getApiScopeId(resource.id, "write"),
+]);
+
+export const API_KEY_ACCESS_MODE_VALUES = [
+  "full",
+  "geo",
+  "restricted",
+] as const;
+
+export const API_KEY_ACCESS_MODE_OPTIONS = [
+  {
+    value: "full",
+    label: "Full Access",
+    title: "Full Access",
+    description:
+      "This key grants full access to all API resources. For better security, we recommend creating a restricted key.",
+  },
+  {
+    value: "geo",
+    label: "GEO Access",
+    title: "GEO Access",
+    description:
+      "This key grants read and write access to GEO resources only. All other API resources remain restricted.",
+  },
+  {
+    value: "restricted",
+    label: "Restricted",
+    title: "Resource access",
+    description:
+      "Set read and write access individually for every API resource.",
+  },
+] as const;
+
 export const API_KEY_SCOPE_LEVEL = {
   none: "none",
   read: "read",
@@ -68,6 +105,7 @@ export const API_KEY_PERMISSION_SUMMARY = {
   none: "No access",
   read: "Read only",
   write: "Read & write",
+  geo: "GEO access",
   custom: "Custom",
 } as const;
 

--- a/apps/dashboard/src/lib/api-keys/scopes.ts
+++ b/apps/dashboard/src/lib/api-keys/scopes.ts
@@ -6,7 +6,6 @@ import {
 
 import {
   API_KEY_ACCESS_MODE_VALUES,
-  API_KEY_DEFAULT_SCOPES,
   API_KEY_GEO_SCOPES,
   API_KEY_GRANULAR_PERMISSIONS,
   API_KEY_GRANULAR_READ_PERMISSIONS,
@@ -19,6 +18,10 @@ import type {
   ApiKeyGranularScope,
   ApiKeyScopeGroup,
 } from "@/types/api-keys";
+
+const READ_SCOPE_SET: ReadonlySet<string> = new Set(
+  API_KEY_GRANULAR_READ_PERMISSIONS
+);
 
 export const API_KEY_SCOPE_GROUPS: ApiKeyScopeGroup[] =
   API_KEY_SCOPE_RESOURCES.map((resource) => ({
@@ -123,7 +126,9 @@ export function getApiKeyScopesForAccessMode(
   if (getApiKeyAccessMode(currentScopes) === "restricted") {
     return sortApiKeyScopes([...currentScopes]);
   }
-  return [...API_KEY_DEFAULT_SCOPES];
+  return sortApiKeyScopes(
+    currentScopes.filter((scope) => READ_SCOPE_SET.has(scope))
+  );
 }
 
 export function summarizeApiKeyScopes(scopes: readonly string[]) {

--- a/apps/dashboard/src/lib/api-keys/scopes.ts
+++ b/apps/dashboard/src/lib/api-keys/scopes.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   API_KEY_ACCESS_MODE_VALUES,
+  API_KEY_DEFAULT_SCOPES,
   API_KEY_GEO_SCOPES,
   API_KEY_GRANULAR_PERMISSIONS,
   API_KEY_GRANULAR_READ_PERMISSIONS,
@@ -111,7 +112,7 @@ export function getApiKeyAccessMode(
 
 export function getApiKeyScopesForAccessMode(
   mode: ApiKeyAccessMode,
-  restrictedScopes: readonly string[]
+  currentScopes: readonly string[]
 ): ApiKeyGranularScope[] {
   if (mode === "full") {
     return [...API_KEY_GRANULAR_PERMISSIONS];
@@ -119,7 +120,10 @@ export function getApiKeyScopesForAccessMode(
   if (mode === "geo") {
     return [...API_KEY_GEO_SCOPES];
   }
-  return sortApiKeyScopes([...restrictedScopes]);
+  if (getApiKeyAccessMode(currentScopes) === "restricted") {
+    return sortApiKeyScopes([...currentScopes]);
+  }
+  return [...API_KEY_DEFAULT_SCOPES];
 }
 
 export function summarizeApiKeyScopes(scopes: readonly string[]) {

--- a/apps/dashboard/src/lib/api-keys/scopes.ts
+++ b/apps/dashboard/src/lib/api-keys/scopes.ts
@@ -5,11 +5,19 @@ import {
 } from "@notra/utils/api-scopes";
 
 import {
+  API_KEY_ACCESS_MODE_VALUES,
+  API_KEY_GEO_SCOPES,
+  API_KEY_GRANULAR_PERMISSIONS,
+  API_KEY_GRANULAR_READ_PERMISSIONS,
   API_KEY_SCOPE_LEVEL,
   API_KEY_SCOPE_LEVEL_LABELS,
   API_KEY_SCOPE_RESOURCES,
 } from "@/constants/api-keys";
-import type { ApiKeyScopeGroup } from "@/types/api-keys";
+import type {
+  ApiKeyAccessMode,
+  ApiKeyGranularScope,
+  ApiKeyScopeGroup,
+} from "@/types/api-keys";
 
 export const API_KEY_SCOPE_GROUPS: ApiKeyScopeGroup[] =
   API_KEY_SCOPE_RESOURCES.map((resource) => ({
@@ -78,6 +86,42 @@ export const sortApiKeyScopes = sortApiScopes;
 
 export const getUnknownApiKeyPermissions = getUnknownApiScopes;
 
+function hasExactScopes(
+  scopes: readonly string[],
+  expected: readonly string[]
+) {
+  const selected = new Set(scopes);
+  return (
+    selected.size === expected.length &&
+    expected.every((scope) => selected.has(scope))
+  );
+}
+
+export function getApiKeyAccessMode(
+  scopes: readonly string[]
+): ApiKeyAccessMode {
+  if (hasExactScopes(scopes, API_KEY_GRANULAR_PERMISSIONS)) {
+    return API_KEY_ACCESS_MODE_VALUES[0];
+  }
+  if (hasExactScopes(scopes, API_KEY_GEO_SCOPES)) {
+    return API_KEY_ACCESS_MODE_VALUES[1];
+  }
+  return API_KEY_ACCESS_MODE_VALUES[2];
+}
+
+export function getApiKeyScopesForAccessMode(
+  mode: ApiKeyAccessMode,
+  restrictedScopes: readonly string[]
+): ApiKeyGranularScope[] {
+  if (mode === "full") {
+    return [...API_KEY_GRANULAR_PERMISSIONS];
+  }
+  if (mode === "geo") {
+    return [...API_KEY_GEO_SCOPES];
+  }
+  return sortApiKeyScopes([...restrictedScopes]);
+}
+
 export function summarizeApiKeyScopes(scopes: readonly string[]) {
   const selected = new Set(scopes);
   if (selected.size === 0) {
@@ -89,6 +133,10 @@ export function summarizeApiKeyScopes(scopes: readonly string[]) {
   );
   if (everyWrite) {
     return "write" as const;
+  }
+
+  if (hasExactScopes(scopes, API_KEY_GEO_SCOPES)) {
+    return "geo" as const;
   }
 
   const everyReadOnly = API_KEY_SCOPE_GROUPS.every(

--- a/apps/dashboard/src/types/api-keys.ts
+++ b/apps/dashboard/src/types/api-keys.ts
@@ -52,16 +52,13 @@ export interface ApiKeyRevealFieldProps {
 }
 
 export interface ApiKeyPermissionSelectorProps {
-  accessMode: ApiKeyAccessMode;
   value: string[];
-  onAccessModeChange: (mode: ApiKeyAccessMode) => void;
   onValueChange: (scopes: string[]) => void;
   disabled?: boolean;
   className?: string;
 }
 
 export interface ApiKeyFormValues {
-  accessMode: ApiKeyAccessMode;
   keyId: string;
   name: string;
   scopes: string[];

--- a/apps/dashboard/src/types/api-keys.ts
+++ b/apps/dashboard/src/types/api-keys.ts
@@ -2,6 +2,7 @@ import type { IconSvgElement } from "@hugeicons/react";
 import type { PermissionTone } from "@notra/ui/components/ui/permission-selector";
 
 import type {
+  API_KEY_ACCESS_MODE_VALUES,
   API_KEY_EXPIRATION_VALUES,
   API_KEY_GRANULAR_PERMISSIONS,
   API_KEY_PERMISSIONS,
@@ -12,6 +13,7 @@ export type ApiKeyPermission = (typeof API_KEY_PERMISSIONS)[number];
 export type ApiKeyGranularScope = (typeof API_KEY_GRANULAR_PERMISSIONS)[number];
 export type ApiKeyPresetId = (typeof API_KEY_PRESET_IDS)[number];
 export type ApiKeyExpiration = (typeof API_KEY_EXPIRATION_VALUES)[number];
+export type ApiKeyAccessMode = (typeof API_KEY_ACCESS_MODE_VALUES)[number];
 
 export interface ApiKeyPreset {
   id: ApiKeyPresetId;
@@ -50,13 +52,16 @@ export interface ApiKeyRevealFieldProps {
 }
 
 export interface ApiKeyPermissionSelectorProps {
+  accessMode: ApiKeyAccessMode;
   value: string[];
+  onAccessModeChange: (mode: ApiKeyAccessMode) => void;
   onValueChange: (scopes: string[]) => void;
   disabled?: boolean;
   className?: string;
 }
 
 export interface ApiKeyFormValues {
+  accessMode: ApiKeyAccessMode;
   keyId: string;
   name: string;
   scopes: string[];

--- a/packages/ui/src/components/ui/permission-option.tsx
+++ b/packages/ui/src/components/ui/permission-option.tsx
@@ -9,6 +9,7 @@ import {
 } from "./permission-selector-context";
 
 const SPRING = { type: "spring", bounce: 0.2, duration: 0.4 } as const;
+const SMOOTH = { type: "tween", duration: 0.18, ease: "easeOut" } as const;
 
 const TONE_TEXT: Record<PermissionTone, string> = {
   neutral: "text-foreground",
@@ -45,6 +46,7 @@ export function PermissionOption({
     value: selected,
     select,
     layoutId,
+    indicatorMotion,
     disabled: rowDisabled,
   } = usePermissionRow();
   const active = selected === value;
@@ -74,8 +76,8 @@ export function PermissionOption({
             "absolute inset-0 rounded-md shadow-sm ring-1",
             TONE_PILL[tone]
           )}
-          layoutId={layoutId}
-          transition={SPRING}
+          layoutId={indicatorMotion === "none" ? undefined : layoutId}
+          transition={indicatorMotion === "smooth" ? SMOOTH : SPRING}
         />
       )}
       <span className="relative z-10 flex items-center gap-1.5">

--- a/packages/ui/src/components/ui/permission-row.tsx
+++ b/packages/ui/src/components/ui/permission-row.tsx
@@ -5,6 +5,7 @@ import type { KeyboardEvent, ReactNode } from "react";
 import { useId, useState } from "react";
 import { cn } from "@notra/ui/lib/utils";
 import {
+  type PermissionIndicatorMotion,
   PermissionRowContext,
   type PermissionRowContextValue,
 } from "./permission-selector-context";
@@ -63,6 +64,7 @@ export interface PermissionRowProps {
   disabled?: boolean;
   className?: string;
   layout?: "row" | "compact";
+  indicatorMotion?: PermissionIndicatorMotion;
 }
 
 export function PermissionRow({
@@ -75,6 +77,7 @@ export function PermissionRow({
   disabled = false,
   className,
   layout = "row",
+  indicatorMotion = "spring",
 }: PermissionRowProps) {
   const layoutId = useId();
   const [internalValue, setInternalValue] = useState(defaultValue);
@@ -89,6 +92,7 @@ export function PermissionRow({
     value: activeValue,
     select,
     layoutId,
+    indicatorMotion,
     disabled,
   };
 

--- a/packages/ui/src/components/ui/permission-selector-context.ts
+++ b/packages/ui/src/components/ui/permission-selector-context.ts
@@ -3,11 +3,13 @@
 import { createContext, use } from "react";
 
 export type PermissionTone = "neutral" | "success" | "danger" | "warning";
+export type PermissionIndicatorMotion = "spring" | "smooth" | "none";
 
 export interface PermissionRowContextValue {
   value: string | undefined;
   select: (value: string) => void;
   layoutId: string;
+  indicatorMotion: PermissionIndicatorMotion;
   disabled: boolean;
 }
 

--- a/packages/ui/src/components/ui/permission-selector.tsx
+++ b/packages/ui/src/components/ui/permission-selector.tsx
@@ -7,7 +7,10 @@ import {
   type PermissionOptionProps,
 } from "./permission-option";
 import { PermissionRow, type PermissionRowProps } from "./permission-row";
-import type { PermissionTone } from "./permission-selector-context";
+import type {
+  PermissionIndicatorMotion,
+  PermissionTone,
+} from "./permission-selector-context";
 
 export interface PermissionSelectorProps {
   children: ReactNode;
@@ -34,4 +37,9 @@ function PermissionSelector({
 }
 
 export { PermissionSelector, PermissionRow, PermissionOption };
-export type { PermissionRowProps, PermissionOptionProps, PermissionTone };
+export type {
+  PermissionIndicatorMotion,
+  PermissionOptionProps,
+  PermissionRowProps,
+  PermissionTone,
+};


### PR DESCRIPTION
### Description
Improves the API key dialogs with Full Access, GEO Access, and Restricted permission presets. Also fixes the modal layout at smaller viewport heights by keeping Name and Expiration visible while making the permissions section scrollable.

### Screenshot/Recording (if applicable)
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/dc5ad40e-4ad4-431a-ada1-1468539bc406" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds permission presets to the API key selector. Full Access selects all granular scopes, GEO Access selects GEO read/write scopes, and Restricted reveals the per-resource selector. The create/edit dialog now keeps Name and Expiration pinned while the permissions section scrolls, so it stays usable on short screens.

<sup>Written for commit 26d83e84b065ba954e4a39df5fbb5373fd4ee176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

