### PR TITLE
perf(dashboard): remove healthcheck rate limit

### DIFF
--- a/apps/dashboard/src/app/api/healthcheck/route.ts
+++ b/apps/dashboard/src/app/api/healthcheck/route.ts
@@ -1,18 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-import { getClientIp, ratelimit } from "@/utils/ratelimit";
-
-export async function GET(request: NextRequest) {
+export function GET() {
   const cacheControlHeaders = { "Cache-Control": "no-store" };
-
-  const { success, reset } = await ratelimit.free.limit(getClientIp(request));
-
-  if (!success) {
-    return NextResponse.json(
-      { error: "Rate limit exceeded", reset },
-      { status: 429, headers: cacheControlHeaders }
-    );
-  }
 
   return NextResponse.json(
     {

--- a/apps/dashboard/src/utils/ratelimit.ts
+++ b/apps/dashboard/src/utils/ratelimit.ts
@@ -7,12 +7,6 @@ import { COMPANY_LOGO_RATE_LIMIT_PER_QUERY_PER_MINUTE } from "@/constants/compan
 const redis = Redis.fromEnv();
 
 export const ratelimit = {
-  free: new Ratelimit({
-    redis,
-    analytics: true,
-    prefix: "ratelimit:healthcheck",
-    limiter: Ratelimit.slidingWindow(2, "1m"),
-  }),
   fetchTweet: new Ratelimit({
     redis,
     analytics: true,


### PR DESCRIPTION
### Description
Removes the Upstash Redis rate-limit call from `/api/healthcheck` and deletes its unused limiter configuration. The lightweight healthcheck now avoids unnecessary Redis latency and false `429` responses.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Upstash Redis rate limit from the healthcheck endpoint so health checks no longer incur Redis latency or false 429 responses, and deletes the unused `ratelimit.free` configuration.

<sup>Written for commit 0fe3aa600cc1ffc9d5ca12de143a83a3e5a346b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

