### PR TITLE
feat(geo): always list tracked models in the mentions card

### DIFF
--- a/apps/dashboard/src/app/design-system/geo-demo/page.tsx
+++ b/apps/dashboard/src/app/design-system/geo-demo/page.tsx
@@ -3,6 +3,7 @@ import { MentionTrendCard } from "@/components/geo/mention-trend-card";
 import {
   DESIGN_SYSTEM_GEO_OVERVIEW,
   DESIGN_SYSTEM_GEO_POINTS,
+  DESIGN_SYSTEM_GEO_TRACKED_ENGINES,
 } from "@/constants/design-system-geo";
 
 export default function GeoDemoPage() {
@@ -13,6 +14,7 @@ export default function GeoDemoPage() {
           <MentionRateCard
             engines={DESIGN_SYSTEM_GEO_OVERVIEW}
             timeseriesPoints={DESIGN_SYSTEM_GEO_POINTS}
+            trackedEngines={DESIGN_SYSTEM_GEO_TRACKED_ENGINES}
           />
         </div>
         <div className="h-[430px] lg:col-span-7">

--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -6,17 +6,20 @@ import {
   GEO_EMPTY_PROMPT_RESULTS,
   GEO_EMPTY_TIMESERIES,
   GEO_FAMILY_STAT_TREND_HINT,
-  GEO_MENTION_SUMMARY_LESS,
+  GEO_MENTION_HINT_HEIGHT_REM,
+  GEO_MENTION_ROW_HEIGHT_REM,
   GEO_MENTION_SUMMARY_VISIBLE,
+  GEO_MENTION_UNTRACKED_HINT,
+  GEO_MENTION_UNTRACKED_LABEL,
   GEO_MENTIONS_LABEL,
 } from "@notra/geo-core/constants/geo";
-import type {
-  GeoEngineFamily,
-  GeoEngineFamilyTotals,
-  MentionProviderRow,
-} from "@notra/geo-core/types/geo";
+import type { GeoEngineFamily } from "@notra/geo-core/types/geo";
 import { engineFamilyLabel } from "@notra/geo-core/utils/geo-engine-family";
 import { geoScanEmptyMessage } from "@notra/geo-core/utils/geo-scan";
+import {
+  HoverCard,
+  HoverCardTrigger,
+} from "@notra/ui/components/ui/hover-card";
 import {
   AnimatePresence,
   domAnimation,
@@ -24,70 +27,69 @@ import {
   m,
   useReducedMotion,
 } from "motion/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { EngineFamilySheet } from "@/components/geo/engine-family-sheet";
 import { EngineIcon } from "@/components/geo/engine-icon";
 import { GeoStatDelta } from "@/components/geo/geo-stat-delta";
+import { TrafficBreakdownCard } from "@/components/geo/traffic-breakdown-card";
 import {
   InstrumentEmpty,
   InstrumentModule,
 } from "@/components/instrument/instrument-module";
+import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
 import { EASE_OUT } from "@/lib/ease";
+import { useScrollOverflow } from "@/lib/hooks/use-scroll-overflow";
 import { cn } from "@/lib/utils";
-import type { MentionRateCardProps } from "@/types/geo";
+import type {
+  MentionMoreModelsHintProps,
+  MentionProviderRowProps,
+  MentionRateCardProps,
+} from "@/types/geo";
 import {
   buildMentionProviderRows,
+  mentionMoreModelsLabel,
   mentionOverviewTotals,
   mentionStatTrends,
   withTrackedMentionEngines,
 } from "@/utils/geo-charts";
 
-const REVEAL_SPRING = { type: "spring", duration: 0.3, bounce: 0 } as const;
-const REVEAL_STAGGER = 0.08;
-const OVERLAY_HIDDEN = {
-  opacity: 0,
-  y: -4,
-  filter: "blur(4px)",
+const HINT_TRANSITION = { duration: 0.2, ease: EASE_OUT } as const;
+const HINT_HIDDEN = { opacity: 0 } as const;
+const HINT_VISIBLE = { opacity: 1 } as const;
+const HINT_ROW_CLASS =
+  "group border-border bg-card focus-visible:ring-ring absolute inset-x-0 bottom-0 grid w-full cursor-pointer grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-1.5 border-t text-left outline-none focus-visible:ring-2";
+const HINT_ROW_HOVER_CLASS =
+  "group-hover:bg-muted/50 pointer-events-none absolute inset-0 transition-colors";
+const ROW_STYLE = { height: `${GEO_MENTION_ROW_HEIGHT_REM}rem` } as const;
+const HINT_ROW_STYLE = {
+  height: `calc(${GEO_MENTION_HINT_HEIGHT_REM}rem + 1px)`,
 } as const;
-const OVERLAY_VISIBLE = {
-  opacity: 1,
-  y: 0,
-  filter: "blur(0px)",
+const LIST_STYLE = {
+  maxHeight: `${GEO_MENTION_SUMMARY_VISIBLE * GEO_MENTION_ROW_HEIGHT_REM + GEO_MENTION_HINT_HEIGHT_REM}rem`,
 } as const;
-const OVERLAY_CLASS =
-  "absolute top-full -right-4 -left-4 z-20 rounded-b-xl bg-card px-4 pb-4 shadow-[0_12px_24px_-8px_oklch(0_0_0/0.14)]";
 
-function ProviderRow({
-  rank,
-  family,
-  totals,
-  mentionDelta,
-  onOpen,
-}: {
-  rank: number;
-  family: GeoEngineFamily;
-  totals: GeoEngineFamilyTotals;
-  mentionDelta: number | null;
-  onOpen: () => void;
-}) {
+function ProviderRow({ rank, row, onOpen }: MentionProviderRowProps) {
+  const { family, totals, mentionDelta, tracked } = row;
   const name = engineFamilyLabel(family.family);
   const clickable = totals.mentions > 0;
-
-  return (
-    <button
-      aria-disabled={!clickable}
-      aria-label={
-        clickable ? `Open ${name} mention breakdown` : `${name}, no mentions`
-      }
-      className={cn(
-        "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-1.5 border-b py-2 text-left transition-colors",
-        clickable ? "hover:bg-muted/50 cursor-pointer" : "cursor-default"
-      )}
-      disabled={!clickable}
-      onClick={clickable ? onOpen : undefined}
-      type="button"
-    >
+  const buttonProps = {
+    "aria-disabled": !clickable,
+    "aria-label": clickable
+      ? `Open ${name} mention breakdown`
+      : `${name}, no mentions`,
+    className: cn(
+      "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-1.5 border-b text-left transition-colors",
+      clickable ? "hover:bg-muted/50 cursor-pointer" : "cursor-default",
+      !tracked && "opacity-50 hover:opacity-100"
+    ),
+    disabled: !clickable,
+    onClick: clickable ? () => onOpen(family) : undefined,
+    style: ROW_STYLE,
+    type: "button",
+  } as const;
+  const content = (
+    <>
       <span className="text-muted-foreground w-4 shrink-0 text-right text-xs tabular-nums">
         {rank}
       </span>
@@ -112,134 +114,78 @@ function ProviderRow({
           variant="plain"
         />
       </span>
-    </button>
-  );
-}
-
-function ProviderList({
-  rows,
-  startRank,
-  onOpen,
-}: {
-  rows: readonly MentionProviderRow[];
-  startRank: number;
-  onOpen: (family: GeoEngineFamily) => void;
-}) {
-  return (
-    <>
-      {rows.map((row, index) => (
-        <ProviderRow
-          family={row.family}
-          key={row.family.family}
-          mentionDelta={row.mentionDelta}
-          onOpen={() => onOpen(row.family)}
-          rank={startRank + index}
-          totals={row.totals}
-        />
-      ))}
     </>
   );
-}
 
-function ProviderToggle({
-  expanded,
-  hiddenCount,
-  onToggle,
-}: {
-  expanded: boolean;
-  hiddenCount: number;
-  onToggle: () => void;
-}) {
+  if (tracked) {
+    return <button {...buttonProps}>{content}</button>;
+  }
+
   return (
-    <button
-      aria-expanded={expanded}
-      className="text-muted-foreground hover:text-foreground focus-visible:ring-ring -mx-4 -mb-4 flex min-h-10 w-[calc(100%+2rem)] items-center justify-between pr-6 pl-9 text-sm transition-colors outline-none focus-visible:ring-2"
-      onClick={onToggle}
-      type="button"
-    >
-      {expanded
-        ? GEO_MENTION_SUMMARY_LESS
-        : `Tracking ${hiddenCount.toLocaleString()} more`}
-      <HugeiconsIcon
-        className={cn(
-          "transition-transform duration-200 ease-out",
-          expanded && "rotate-180"
-        )}
-        icon={ArrowDown01Icon}
-        size={12}
-      />
-    </button>
+    <HoverCard>
+      <HoverCardTrigger
+        delay={GEO_TRAFFIC_HOVER_DELAY_MS}
+        render={<button {...buttonProps} />}
+      >
+        {content}
+      </HoverCardTrigger>
+      <TrafficBreakdownCard
+        aside={GEO_MENTION_UNTRACKED_LABEL}
+        icon={<EngineIcon className="size-4" engine={family.family} />}
+        title={name}
+      >
+        <p className="text-muted-foreground px-3 py-1.5 text-xs text-pretty">
+          {GEO_MENTION_UNTRACKED_HINT}
+        </p>
+      </TrafficBreakdownCard>
+    </HoverCard>
   );
 }
 
-function ProviderOverlay({
-  rows,
-  startRank,
-  expanded,
-  onOpen,
-  onToggle,
-}: {
-  rows: readonly MentionProviderRow[];
-  startRank: number;
-  expanded: boolean;
-  onOpen: (family: GeoEngineFamily) => void;
-  onToggle: () => void;
-}) {
+function MoreModelsHint({
+  count,
+  visible,
+  onClick,
+}: MentionMoreModelsHintProps) {
   const reduceMotion = useReducedMotion();
+  const row = (
+    <button
+      aria-label={`Show ${mentionMoreModelsLabel(count)}`}
+      className={HINT_ROW_CLASS}
+      onClick={onClick}
+      style={HINT_ROW_STYLE}
+      type="button"
+    >
+      <span aria-hidden="true" className={HINT_ROW_HOVER_CLASS} />
+      <span className="w-4 shrink-0" />
+      <span className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="text-muted-foreground flex w-7 shrink-0 items-center justify-center">
+          <HugeiconsIcon icon={ArrowDown01Icon} size={12} />
+        </span>
+        <span className="text-muted-foreground truncate text-xs">
+          {mentionMoreModelsLabel(count)}
+        </span>
+      </span>
+      <span className="shrink-0" />
+    </button>
+  );
 
   if (reduceMotion) {
-    return expanded ? (
-      <div className={OVERLAY_CLASS}>
-        <ProviderList onOpen={onOpen} rows={rows} startRank={startRank} />
-        <ProviderToggle
-          expanded
-          hiddenCount={rows.length}
-          onToggle={onToggle}
-        />
-      </div>
-    ) : null;
+    return visible ? row : null;
   }
 
   return (
     <LazyMotion features={domAnimation}>
       <AnimatePresence initial={false}>
-        {expanded ? (
+        {visible ? (
           <m.div
-            animate={OVERLAY_VISIBLE}
-            className={OVERLAY_CLASS}
-            exit={OVERLAY_HIDDEN}
-            initial={OVERLAY_HIDDEN}
-            key="mention-providers"
-            transition={REVEAL_SPRING}
+            animate={HINT_VISIBLE}
+            exit={HINT_HIDDEN}
+            initial={HINT_HIDDEN}
+            key="more-models"
+            transition={HINT_TRANSITION}
           >
-            {rows.map((row, index) => (
-              <m.div
-                animate={OVERLAY_VISIBLE}
-                exit={{
-                  ...OVERLAY_HIDDEN,
-                  transition: { duration: 0.15, ease: EASE_OUT },
-                }}
-                initial={OVERLAY_HIDDEN}
-                key={row.family.family}
-                transition={{
-                  ...REVEAL_SPRING,
-                  delay: index * REVEAL_STAGGER,
-                }}
-              >
-                <ProviderRow
-                  family={row.family}
-                  mentionDelta={row.mentionDelta}
-                  onOpen={() => onOpen(row.family)}
-                  rank={startRank + index}
-                  totals={row.totals}
-                />
-              </m.div>
-            ))}
-            <ProviderToggle
-              expanded
-              hiddenCount={rows.length}
-              onToggle={onToggle}
-            />
+            {row}
           </m.div>
         ) : null}
       </AnimatePresence>
@@ -263,46 +209,22 @@ export function MentionRateCard({
       }),
     [engines, trackedEngines, timeseriesPoints]
   );
-  const visible = ranked.slice(0, GEO_MENTION_SUMMARY_VISIBLE);
-  const hidden = ranked.slice(GEO_MENTION_SUMMARY_VISIBLE);
   const totals = mentionOverviewTotals(
     withTrackedMentionEngines(engines, trackedEngines)
   );
   const overviewDelta = mentionStatTrends(timeseriesPoints).mentionDelta;
   const [selected, setSelected] = useState<GeoEngineFamily | null>(null);
-  const [expanded, setExpanded] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!expanded) {
-      return;
-    }
-
-    const onPointerDown = (event: PointerEvent) => {
-      const node = rootRef.current;
-      if (node && !node.contains(event.target as Node)) {
-        setExpanded(false);
-      }
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setExpanded(false);
-      }
-    };
-
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [expanded]);
+  const reduceMotion = useReducedMotion();
+  const { ref, hiddenBelow, atEnd, scrollToEnd } =
+    useScrollOverflow<HTMLDivElement>(
+      ranked.length,
+      GEO_MENTION_HINT_HEIGHT_REM
+    );
 
   return (
-    <div className="relative h-full" ref={rootRef}>
+    <div className="relative h-full">
       <InstrumentModule
-        bodyClassName={cn(expanded && "rounded-b-none")}
-        className={cn("h-full overflow-visible", expanded && "rounded-b-none")}
+        className="h-full"
         eyebrow={GEO_MENTIONS_LABEL}
         variant="table"
       >
@@ -333,30 +255,26 @@ export function MentionRateCard({
                 <span>Provider</span>
                 <span>Mentions</span>
               </div>
-              <div className="border-border relative [&>button:last-of-type]:border-b-0">
-                <ProviderList
-                  onOpen={setSelected}
-                  rows={visible}
-                  startRank={1}
-                />
-                {hidden.length > 0 ? (
-                  <>
-                    {expanded ? null : (
-                      <ProviderToggle
-                        expanded={false}
-                        hiddenCount={hidden.length}
-                        onToggle={() => setExpanded(true)}
-                      />
-                    )}
-                    <ProviderOverlay
-                      expanded={expanded}
+              <div className="relative">
+                <div
+                  className="border-border relative overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button:last-of-type]:border-b-0"
+                  ref={ref}
+                  style={LIST_STYLE}
+                >
+                  {ranked.map((row, index) => (
+                    <ProviderRow
+                      key={row.family.family}
                       onOpen={setSelected}
-                      onToggle={() => setExpanded(false)}
-                      rows={hidden}
-                      startRank={GEO_MENTION_SUMMARY_VISIBLE + 1}
+                      rank={index + 1}
+                      row={row}
                     />
-                  </>
-                ) : null}
+                  ))}
+                </div>
+                <MoreModelsHint
+                  count={hiddenBelow}
+                  onClick={() => scrollToEnd(!reduceMotion)}
+                  visible={!atEnd && hiddenBelow > 0}
+                />
               </div>
             </div>
           </div>

--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -83,7 +83,7 @@ function ProviderRow({ rank, row, onOpen }: MentionProviderRowProps) {
       clickable ? "hover:bg-muted/50 cursor-pointer" : "cursor-default",
       !tracked && "opacity-50 hover:opacity-100"
     ),
-    disabled: !clickable,
+    disabled: tracked && !clickable,
     onClick: clickable ? () => onOpen(family) : undefined,
     style: ROW_STYLE,
     type: "button",

--- a/apps/dashboard/src/constants/design-system-geo.ts
+++ b/apps/dashboard/src/constants/design-system-geo.ts
@@ -67,3 +67,10 @@ export const DESIGN_SYSTEM_GEO_OVERVIEW: GeoOverviewEngine[] = PROVIDERS.map(
     };
   }
 );
+
+export const DESIGN_SYSTEM_GEO_TRACKED_ENGINES: readonly string[] = [
+  ...PROVIDERS.filter(
+    (provider) => !provider.engine.startsWith("mistral/")
+  ).map((provider) => provider.engine),
+  "deepseek/deepseek-v4-pro",
+];

--- a/apps/dashboard/src/lib/hooks/use-scroll-overflow.ts
+++ b/apps/dashboard/src/lib/hooks/use-scroll-overflow.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  ScrollOverflow,
+  ScrollOverflowState,
+} from "@/types/scroll-overflow";
+
+const EDGE_TOLERANCE_PX = 1;
+const DEFAULT_ROOT_FONT_PX = 16;
+const INITIAL_STATE: ScrollOverflowState = { hiddenBelow: 0, atEnd: true };
+
+function remToPx(rem: number): number {
+  const rootSize = Number.parseFloat(
+    getComputedStyle(document.documentElement).fontSize
+  );
+  return rem * (Number.isFinite(rootSize) ? rootSize : DEFAULT_ROOT_FONT_PX);
+}
+
+function measureOverflow(
+  node: HTMLElement,
+  insetRem: number
+): ScrollOverflowState {
+  const atEnd =
+    node.scrollTop + node.clientHeight + EDGE_TOLERANCE_PX >= node.scrollHeight;
+  const visibleBottom = node.scrollTop + node.clientHeight - remToPx(insetRem);
+  let hiddenBelow = 0;
+  for (const child of node.children) {
+    if (!(child instanceof HTMLElement)) {
+      continue;
+    }
+    if (
+      child.offsetTop + child.offsetHeight >
+      visibleBottom + EDGE_TOLERANCE_PX
+    ) {
+      hiddenBelow += 1;
+    }
+  }
+  return { hiddenBelow, atEnd };
+}
+
+export function useScrollOverflow<T extends HTMLElement>(
+  itemCount: number,
+  insetRem = 0
+): ScrollOverflow<T> {
+  const ref = useRef<T>(null);
+  const [state, setState] = useState<ScrollOverflowState>(INITIAL_STATE);
+
+  const measure = useCallback(() => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    setState(measureOverflow(node, insetRem));
+  }, [insetRem]);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    measure();
+    node.addEventListener("scroll", measure, { passive: true });
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => {
+      node.removeEventListener("scroll", measure);
+      observer.disconnect();
+    };
+  }, [measure, itemCount]);
+
+  const scrollToEnd = useCallback((smooth: boolean) => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    node.scrollTo({
+      top: node.scrollHeight,
+      behavior: smooth ? "smooth" : "auto",
+    });
+  }, []);
+
+  return { ref, ...state, scrollToEnd };
+}

--- a/apps/dashboard/src/lib/hooks/use-scroll-overflow.ts
+++ b/apps/dashboard/src/lib/hooks/use-scroll-overflow.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type {
   ScrollOverflow,
@@ -47,19 +47,14 @@ export function useScrollOverflow<T extends HTMLElement>(
   const ref = useRef<T>(null);
   const [state, setState] = useState<ScrollOverflowState>(INITIAL_STATE);
 
-  const measure = useCallback(() => {
-    const node = ref.current;
-    if (!node) {
-      return;
-    }
-    setState(measureOverflow(node, insetRem));
-  }, [insetRem]);
-
   useEffect(() => {
     const node = ref.current;
     if (!node) {
       return;
     }
+    const measure = () => {
+      setState(measureOverflow(node, insetRem));
+    };
     measure();
     node.addEventListener("scroll", measure, { passive: true });
     const observer = new ResizeObserver(measure);
@@ -68,9 +63,9 @@ export function useScrollOverflow<T extends HTMLElement>(
       node.removeEventListener("scroll", measure);
       observer.disconnect();
     };
-  }, [measure, itemCount]);
+  }, [insetRem, itemCount]);
 
-  const scrollToEnd = useCallback((smooth: boolean) => {
+  const scrollToEnd = (smooth: boolean) => {
     const node = ref.current;
     if (!node) {
       return;
@@ -79,7 +74,7 @@ export function useScrollOverflow<T extends HTMLElement>(
       top: node.scrollHeight,
       behavior: smooth ? "smooth" : "auto",
     });
-  }, []);
+  };
 
   return { ref, ...state, scrollToEnd };
 }

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -6,6 +6,7 @@ import type {
   GeoCompetitorSharePoint,
   GeoCompetitorShareTimeseriesPoint,
   GeoEngineFamily,
+  MentionProviderRow,
   GeoIngestFramework,
   GeoIngestPackageManager,
   GeoIngestSetupResponse,
@@ -398,6 +399,18 @@ export interface LanguagePerformanceCardProps {
   organizationId: string;
   settings: GeoSettings;
   isScanning?: boolean;
+}
+
+export interface MentionProviderRowProps {
+  rank: number;
+  row: MentionProviderRow;
+  onOpen: (family: GeoEngineFamily) => void;
+}
+
+export interface MentionMoreModelsHintProps {
+  count: number;
+  visible: boolean;
+  onClick: () => void;
 }
 
 export interface MentionRateCardProps {

--- a/apps/dashboard/src/types/scroll-overflow.ts
+++ b/apps/dashboard/src/types/scroll-overflow.ts
@@ -1,0 +1,13 @@
+import type { RefObject } from "react";
+
+export interface ScrollOverflowState {
+  hiddenBelow: number;
+  atEnd: boolean;
+}
+
+export interface ScrollOverflow<
+  T extends HTMLElement,
+> extends ScrollOverflowState {
+  ref: RefObject<T | null>;
+  scrollToEnd: (smooth: boolean) => void;
+}

--- a/apps/dashboard/src/utils/geo-charts.ts
+++ b/apps/dashboard/src/utils/geo-charts.ts
@@ -651,13 +651,21 @@ export function buildMentionProviderRows(
     withTrackedMentionEngines(scanned, options?.trackedEngines)
   );
   const points = options?.timeseriesPoints ?? [];
+  const trackedFamilies = new Set(
+    (options?.trackedEngines ?? []).map((engine) => engineFamilyOf(engine))
+  );
   return families
     .map((family) => ({
       family,
       totals: engineFamilyTotals(family) ?? EMPTY_FAMILY_TOTALS,
       mentionDelta: engineFamilyStatTrends(points, family.family).mentionDelta,
+      tracked: trackedFamilies.size === 0 || trackedFamilies.has(family.family),
     }))
     .sort(compareMentionProviderRows);
+}
+
+export function mentionMoreModelsLabel(count: number): string {
+  return count === 1 ? "1 more model" : `${count.toLocaleString()} more models`;
 }
 
 function sumFamilyWindow(

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -671,7 +671,11 @@ export const GEO_MENTION_TREND_AGENT_ICON_LIMIT = 4;
 export const GEO_MENTION_TREND_ALL_PROVIDERS_LABEL = "All providers";
 export const GEO_MENTION_ACTIVITY_LABEL = "Mention activity";
 export const GEO_MENTION_SUMMARY_VISIBLE = 5;
-export const GEO_MENTION_SUMMARY_LESS = "Show less";
+export const GEO_MENTION_ROW_HEIGHT_REM = 2.75;
+export const GEO_MENTION_HINT_HEIGHT_REM = 2;
+export const GEO_MENTION_UNTRACKED_LABEL = "Not tracked";
+export const GEO_MENTION_UNTRACKED_HINT =
+  "These mentions come from earlier scans. Add the model back in GEO settings to keep tracking it.";
 export const GEO_RANGE_PRESETS = [
   { value: "today", label: "Today" },
   { value: "yesterday", label: "Yesterday" },

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -764,6 +764,7 @@ export interface MentionProviderRow {
   family: GeoEngineFamily;
   totals: GeoEngineFamilyTotals;
   mentionDelta: number | null;
+  tracked: boolean;
 }
 
 export interface GeoLanguageSharePoint {

--- a/packages/geo-core/src/utils/geo-engine-icon.ts
+++ b/packages/geo-core/src/utils/geo-engine-icon.ts
@@ -49,6 +49,7 @@ const ENGINE_ICON_RULES: readonly EngineIconRule[] = [
   {
     key: "amazon",
     patterns: ["amazonbot", "amzn-"],
+    exact: ["amazon"],
   },
   {
     key: "duckduckgo",
@@ -148,6 +149,7 @@ const ENGINE_ICON_RULES: readonly EngineIconRule[] = [
   {
     key: "meta",
     patterns: ["meta-", "meta/", "llama", "facebook", "muse-spark"],
+    exact: ["meta"],
   },
   {
     key: "grok",


### PR DESCRIPTION
## Summary
- Every tracked engine family now appears in the Mentions provider list, showing `0` when a model has no data yet.
- Models that still have data but were removed from tracking stay in the list at their normal rank, greyed out, with a hover card (same HoverCard + breakdown-card style as the traffic cells) explaining that the mentions come from earlier scans.
- The expand overlay is gone. The list is a scroll container capped at five rows with a compact, row-styled "N more models" hint pinned at the bottom. The count updates as you scroll, the hint fades out at the end, and clicking it scrolls to the end.
- `resolveEngineIconKey` now matches the bare `meta` and `amazon` family keys, so the Meta logo renders in the list.

## Details
- `use-scroll-overflow` hook (`lib/hooks`) measures rows hidden below the fold minus a rem inset for the hint strip and exposes `atEnd`.
- `MentionProviderRow.tracked` added in `@notra/geo-core`; `buildMentionProviderRows` sets it from `trackedEngines`.
- New constants: `GEO_MENTION_ROW_HEIGHT_REM`, `GEO_MENTION_HINT_HEIGHT_REM`, `GEO_MENTION_UNTRACKED_LABEL`, `GEO_MENTION_UNTRACKED_HINT`. `GEO_MENTION_SUMMARY_LESS` removed.
- `/design-system/geo-demo` passes `trackedEngines` so the untracked and zero-mention states are visible on the public demo page.

## Test plan
- [ ] `/design-system/geo-demo`: 5 rows visible, "2 more models" strip, click scrolls to end and hides the strip, Mistral greyed with hover card, DeepSeek at 0
- [ ] `/{org}/geo` with more than 5 tracked engines: strip count matches hidden rows, scroll counts down
- [ ] Org with an engine removed from tracking that still has checks: row stays ranked by mentions, greyed, hover card opens
- [ ] Meta shows its logo
- [ ] Reduced motion: strip appears/disappears without animation, click scrolls instantly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the GEO mentions card to always show every tracked model (displaying 0 when there's no data yet) and replaces the expand overlay with a scrollable list plus a row-styled "N more models" hint that counts down as you scroll.

- Models with data that were removed from tracking stay in the list at their normal rank, greyed out, with a hover card explaining the mentions come from earlier scans; untracked rows stay focusable so the hover card opens even with zero mentions.
- The hint fades once you reach the end, and clicking it scrolls to the end.
- With reduced motion, the hint appears and disappears without animation and clicking scrolls instantly.
- `resolveEngineIconKey` now matches bare `meta` and `amazon` family keys so the Meta logo renders.
- `/design-system/geo-demo` passes `trackedEngines` so the zero-mention and untracked states are visible on the demo page.

<sup>Written for commit d395afa80dba6dd038b0433dfa6e71dbae6cf125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

