### PR TITLE
style(geo): center the more-models hint and lift its text color

### DIFF
--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -6,6 +6,7 @@ import {
   GEO_EMPTY_PROMPT_RESULTS,
   GEO_EMPTY_TIMESERIES,
   GEO_FAMILY_STAT_TREND_HINT,
+  GEO_MENTION_HINT_BLEED_REM,
   GEO_MENTION_HINT_HEIGHT_REM,
   GEO_MENTION_ROW_HEIGHT_REM,
   GEO_MENTION_SUMMARY_VISIBLE,
@@ -58,12 +59,13 @@ const HINT_TRANSITION = { duration: 0.2, ease: EASE_OUT } as const;
 const HINT_HIDDEN = { opacity: 0 } as const;
 const HINT_VISIBLE = { opacity: 1 } as const;
 const HINT_ROW_CLASS =
-  "group border-border bg-card text-foreground/70 hover:text-foreground focus-visible:ring-ring absolute inset-x-0 bottom-0 flex w-full cursor-pointer items-center justify-center gap-1.5 border-t text-xs transition-colors outline-none focus-visible:ring-2";
+  "group border-border bg-card text-foreground/70 hover:text-foreground focus-visible:ring-ring absolute inset-x-0 flex w-full cursor-pointer items-center justify-center gap-1.5 border-t text-xs transition-colors outline-none focus-visible:ring-2";
 const HINT_ROW_HOVER_CLASS =
   "group-hover:bg-muted/50 pointer-events-none absolute inset-0 transition-colors";
 const ROW_STYLE = { height: `${GEO_MENTION_ROW_HEIGHT_REM}rem` } as const;
 const HINT_ROW_STYLE = {
-  height: `calc(${GEO_MENTION_HINT_HEIGHT_REM}rem + 1px)`,
+  top: `calc(${GEO_MENTION_SUMMARY_VISIBLE * GEO_MENTION_ROW_HEIGHT_REM}rem - 1px)`,
+  bottom: `-${GEO_MENTION_HINT_BLEED_REM}rem`,
 } as const;
 const LIST_STYLE = {
   maxHeight: `${GEO_MENTION_SUMMARY_VISIBLE * GEO_MENTION_ROW_HEIGHT_REM + GEO_MENTION_HINT_HEIGHT_REM}rem`,
@@ -228,7 +230,7 @@ export function MentionRateCard({
             seed="Mentions"
           />
         ) : (
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-1 flex-col gap-4">
             <div className="flex items-end gap-2">
               <p className="text-3xl leading-none font-semibold tracking-tight tabular-nums">
                 {totals.mentions.toLocaleString()}
@@ -242,12 +244,12 @@ export function MentionRateCard({
               />
             </div>
 
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-1 flex-col gap-1">
               <div className="flex items-center justify-between gap-3 text-sm font-medium">
                 <span>Provider</span>
                 <span>Mentions</span>
               </div>
-              <div className="relative">
+              <div className="relative flex-1">
                 <div
                   className="border-border relative overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button:last-of-type]:border-b-0"
                   ref={ref}

--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -58,7 +58,7 @@ const HINT_TRANSITION = { duration: 0.2, ease: EASE_OUT } as const;
 const HINT_HIDDEN = { opacity: 0 } as const;
 const HINT_VISIBLE = { opacity: 1 } as const;
 const HINT_ROW_CLASS =
-  "group border-border bg-card focus-visible:ring-ring absolute inset-x-0 bottom-0 grid w-full cursor-pointer grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-1.5 border-t text-left outline-none focus-visible:ring-2";
+  "group border-border bg-card text-foreground/70 hover:text-foreground focus-visible:ring-ring absolute inset-x-0 bottom-0 flex w-full cursor-pointer items-center justify-center gap-1.5 border-t text-xs transition-colors outline-none focus-visible:ring-2";
 const HINT_ROW_HOVER_CLASS =
   "group-hover:bg-muted/50 pointer-events-none absolute inset-0 transition-colors";
 const ROW_STYLE = { height: `${GEO_MENTION_ROW_HEIGHT_REM}rem` } as const;
@@ -157,16 +157,8 @@ function MoreModelsHint({
       type="button"
     >
       <span aria-hidden="true" className={HINT_ROW_HOVER_CLASS} />
-      <span className="w-4 shrink-0" />
-      <span className="flex min-w-0 flex-1 items-center gap-2">
-        <span className="text-muted-foreground flex w-7 shrink-0 items-center justify-center">
-          <HugeiconsIcon icon={ArrowDown01Icon} size={12} />
-        </span>
-        <span className="text-muted-foreground truncate text-xs">
-          {mentionMoreModelsLabel(count)}
-        </span>
-      </span>
-      <span className="shrink-0" />
+      <span className="relative">{mentionMoreModelsLabel(count)}</span>
+      <HugeiconsIcon className="relative" icon={ArrowDown01Icon} size={12} />
     </button>
   );
 

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -673,6 +673,7 @@ export const GEO_MENTION_ACTIVITY_LABEL = "Mention activity";
 export const GEO_MENTION_SUMMARY_VISIBLE = 5;
 export const GEO_MENTION_ROW_HEIGHT_REM = 2.75;
 export const GEO_MENTION_HINT_HEIGHT_REM = 2;
+export const GEO_MENTION_HINT_BLEED_REM = 1;
 export const GEO_MENTION_UNTRACKED_LABEL = "Not tracked";
 export const GEO_MENTION_UNTRACKED_HINT =
   "These mentions come from earlier scans. Add the model back in GEO settings to keep tracking it.";


### PR DESCRIPTION
## Summary
Follow-up to #783 for the "N more models" hint row in the Mentions card.

- Centers the label and chevron in the row instead of aligning them to the provider name column.
- Lifts the text from `text-muted-foreground` to `text-foreground/70`, brightening to full `text-foreground` on hover, so it no longer reads as washed out over the hover tint.

No behavior changes: the scroll counting, fade at end, and click-to-scroll are untouched.

## Test plan
- [ ] `/design-system/geo-demo`: "2 more models" sits centered under the fifth row, readable in light and dark
- [ ] Hover: row tint appears, text goes full foreground, nothing bleeds through from the row beneath
- [ ] Click still scrolls to the end and hides the hint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to the Mentions card hint styling: centers the "N more models" row between the last row and the card edge and lifts its text color so it no longer looks washed out. The hint now bleeds slightly past the card edge, and the text moves from `text-muted-foreground` to `text-foreground/70`, brightening to `text-foreground` on hover. No behavior changes—scroll counting, fade at end, and click-to-scroll are untouched.

**Test plan**
- In `/design-system/geo-demo`, confirm the hint sits centered between the last row and the card edge, is readable in light and dark, and brightens on hover.
- Verify clicking still scrolls to the end and hides the hint.

<sup>Written for commit bc108c50579245930ff5592f140931463cfbd7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

