### PR TITLE
fix(billing): resolve the Autumn customer from the org in the URL

### DIFF
--- a/apps/dashboard/src/app/api/autumn/[...all]/route.ts
+++ b/apps/dashboard/src/app/api/autumn/[...all]/route.ts
@@ -1,19 +1,26 @@
 import { autumnHandler } from "autumn-js/next";
 
 import { getAuthSession } from "@/lib/auth/server";
+import { resolveBillingOrganizationId } from "@/lib/billing/resolve-billing-organization";
 
 type RouteHandler = (request: Request) => Response | Promise<Response>;
 
 const handlers: { GET: RouteHandler; POST: RouteHandler } = autumnHandler({
-  identify: async () => {
+  identify: async (request) => {
     const session = await getAuthSession();
 
-    if (!(session?.user && session?.session?.activeOrganizationId)) {
+    if (!session?.user) {
+      return null;
+    }
+
+    const customerId = await resolveBillingOrganizationId(request, session);
+
+    if (!customerId) {
       return null;
     }
 
     return {
-      customerId: session.session.activeOrganizationId,
+      customerId,
       customerData: {
         name: session.user.name,
         email: session.user.email,

--- a/apps/dashboard/src/components/providers/autumn-org-provider.tsx
+++ b/apps/dashboard/src/components/providers/autumn-org-provider.tsx
@@ -2,7 +2,7 @@
 
 import { AutumnProvider } from "autumn-js/react";
 import { usePathname } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 import { AUTUMN_ORGANIZATION_HEADER } from "@/constants/billing";
 import { authClient } from "@/lib/auth/client";
@@ -49,10 +49,9 @@ export function AutumnOrgProvider({ children }: AutumnOrgProviderProps) {
     : INITIAL_PROVIDER_KEY;
   const providerKey = pathSlug ? `slug:${pathSlug}` : sessionProviderKey;
 
-  const headers = useMemo(
-    () => (pathSlug ? { [AUTUMN_ORGANIZATION_HEADER]: pathSlug } : undefined),
-    [pathSlug]
-  );
+  const headers = pathSlug
+    ? { [AUTUMN_ORGANIZATION_HEADER]: pathSlug }
+    : undefined;
 
   return (
     <AutumnProvider headers={headers} includeCredentials key={providerKey}>

--- a/apps/dashboard/src/components/providers/autumn-org-provider.tsx
+++ b/apps/dashboard/src/components/providers/autumn-org-provider.tsx
@@ -1,15 +1,20 @@
 "use client";
 
 import { AutumnProvider } from "autumn-js/react";
-import { useState } from "react";
+import { usePathname } from "next/navigation";
+import { useMemo, useState } from "react";
 
+import { AUTUMN_ORGANIZATION_HEADER } from "@/constants/billing";
 import { authClient } from "@/lib/auth/client";
 import type { AutumnOrgProviderProps } from "@/types/components/providers";
+import { getOrganizationSlugFromPathname } from "@/utils/organization-pathname";
 
 const INITIAL_PROVIDER_KEY = "initial-organization";
 const NO_ORGANIZATION_BASELINE = "no-organization";
 
 export function AutumnOrgProvider({ children }: AutumnOrgProviderProps) {
+  const pathname = usePathname();
+  const pathSlug = getOrganizationSlugFromPathname(pathname);
   const { data: session, isPending } = authClient.useSession();
   const sessionOrganizationId = session?.session.activeOrganizationId ?? null;
 
@@ -39,12 +44,18 @@ export function AutumnOrgProvider({ children }: AutumnOrgProviderProps) {
     effectiveOrganizationId !== null &&
     baselineOrganizationId !== null &&
     effectiveOrganizationId !== baselineOrganizationId;
-  const providerKey = hasSwitchedOrganization
+  const sessionProviderKey = hasSwitchedOrganization
     ? effectiveOrganizationId
     : INITIAL_PROVIDER_KEY;
+  const providerKey = pathSlug ? `slug:${pathSlug}` : sessionProviderKey;
+
+  const headers = useMemo(
+    () => (pathSlug ? { [AUTUMN_ORGANIZATION_HEADER]: pathSlug } : undefined),
+    [pathSlug]
+  );
 
   return (
-    <AutumnProvider includeCredentials key={providerKey}>
+    <AutumnProvider headers={headers} includeCredentials key={providerKey}>
       {children}
     </AutumnProvider>
   );

--- a/apps/dashboard/src/constants/billing.ts
+++ b/apps/dashboard/src/constants/billing.ts
@@ -82,3 +82,5 @@ export const ZDR_CONSENT_FOOTNOTE =
   "By enabling, you acknowledge that zero data retention is provided under third-party gateway agreements and applies only to models covered by one at the time of each request.";
 export const ZDR_CONSENT_CONFIRM = "Enable";
 export const ZDR_CONSENT_CANCEL = "Not now";
+
+export const AUTUMN_ORGANIZATION_HEADER = "x-notra-organization";

--- a/apps/dashboard/src/constants/cookies.ts
+++ b/apps/dashboard/src/constants/cookies.ts
@@ -1,3 +1,4 @@
 export const LAST_VISITED_ORGANIZATION_COOKIE = "notra_last_organization";
 export const SIDEBAR_MODE_COOKIE = "notra_sidebar_mode";
 export const SIDEBAR_MODE_COOKIE_MAX_AGE = 365 * 86_400;
+export const LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE = 30 * 86_400;

--- a/apps/dashboard/src/constants/organization-routes.ts
+++ b/apps/dashboard/src/constants/organization-routes.ts
@@ -1,0 +1,13 @@
+export const NON_ORGANIZATION_ROUTE_SEGMENTS: ReadonlySet<string> = new Set([
+  "account",
+  "api",
+  "auth",
+  "callback",
+  "connect",
+  "design-system",
+  "integrations",
+  "login",
+  "onboarding",
+  "rpc",
+  "signup",
+]);

--- a/apps/dashboard/src/lib/billing/resolve-billing-organization.ts
+++ b/apps/dashboard/src/lib/billing/resolve-billing-organization.ts
@@ -34,17 +34,22 @@ export async function resolveBillingOrganizationId(
   request: Request,
   session: AuthSessionData
 ): Promise<string | null> {
-  const requestedSlug = organizationSlugParamSchema.safeParse(
-    request.headers.get(AUTUMN_ORGANIZATION_HEADER)
-  );
+  const requestedSlugHeader = request.headers.get(AUTUMN_ORGANIZATION_HEADER);
 
-  if (requestedSlug.success) {
-    return await Effect.runPromise(
-      findMemberOrganizationIdBySlug(requestedSlug.data, session.user.id).pipe(
-        Effect.catch(() => Effect.succeed(null))
-      )
-    );
+  if (requestedSlugHeader === null) {
+    return session.session.activeOrganizationId ?? null;
   }
 
-  return session.session.activeOrganizationId ?? null;
+  const requestedSlug =
+    organizationSlugParamSchema.safeParse(requestedSlugHeader);
+
+  if (!requestedSlug.success) {
+    return null;
+  }
+
+  return await Effect.runPromise(
+    findMemberOrganizationIdBySlug(requestedSlug.data, session.user.id).pipe(
+      Effect.catch(() => Effect.succeed(null))
+    )
+  );
 }

--- a/apps/dashboard/src/lib/billing/resolve-billing-organization.ts
+++ b/apps/dashboard/src/lib/billing/resolve-billing-organization.ts
@@ -1,0 +1,53 @@
+import { db } from "@notra/db/drizzle";
+import { members, organizations } from "@notra/db/schema";
+import { eq } from "drizzle-orm";
+import { Effect } from "effect";
+
+import { AUTUMN_ORGANIZATION_HEADER } from "@/constants/billing";
+import { organizationSlugParamSchema } from "@/schemas/auth/organization";
+import type { AuthSessionData } from "@/types/auth/session";
+
+const findMemberOrganizationIdBySlug = Effect.fn(
+  "billing.resolveOrganization.bySlug"
+)(function* (slug: string, userId: string) {
+  const organization = yield* Effect.tryPromise(() =>
+    db.query.organizations.findFirst({
+      where: eq(organizations.slug, slug),
+      columns: { id: true },
+      with: {
+        members: {
+          where: eq(members.userId, userId),
+          columns: { id: true },
+        },
+      },
+    })
+  );
+
+  if (!organization || organization.members.length === 0) {
+    return null;
+  }
+
+  return organization.id;
+});
+
+export async function resolveBillingOrganizationId(
+  request: Request,
+  session: AuthSessionData
+): Promise<string | null> {
+  const requestedSlug = organizationSlugParamSchema.safeParse(
+    request.headers.get(AUTUMN_ORGANIZATION_HEADER)
+  );
+
+  if (requestedSlug.success) {
+    const organizationId = await Effect.runPromise(
+      findMemberOrganizationIdBySlug(requestedSlug.data, session.user.id).pipe(
+        Effect.catch(() => Effect.succeed(null))
+      )
+    );
+    if (organizationId) {
+      return organizationId;
+    }
+  }
+
+  return session.session.activeOrganizationId ?? null;
+}

--- a/apps/dashboard/src/lib/billing/resolve-billing-organization.ts
+++ b/apps/dashboard/src/lib/billing/resolve-billing-organization.ts
@@ -39,14 +39,11 @@ export async function resolveBillingOrganizationId(
   );
 
   if (requestedSlug.success) {
-    const organizationId = await Effect.runPromise(
+    return await Effect.runPromise(
       findMemberOrganizationIdBySlug(requestedSlug.data, session.user.id).pipe(
         Effect.catch(() => Effect.succeed(null))
       )
     );
-    if (organizationId) {
-      return organizationId;
-    }
   }
 
   return session.session.activeOrganizationId ?? null;

--- a/apps/dashboard/src/lib/organizations/actions.ts
+++ b/apps/dashboard/src/lib/organizations/actions.ts
@@ -16,7 +16,10 @@ import { Effect } from "effect";
 import { isValid as isNotDisposableEmail } from "mailchecker";
 import { cookies } from "next/headers";
 
-import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
+import {
+  LAST_VISITED_ORGANIZATION_COOKIE,
+  LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE,
+} from "@/constants/cookies";
 import { readWorkOSError } from "@/lib/auth/workos-error";
 import { OrganizationActionError } from "@/lib/organizations/errors";
 import {
@@ -476,6 +479,7 @@ export async function setActiveOrganizationAction(
       );
       cookieStore.set(LAST_VISITED_ORGANIZATION_COOKIE, organization.slug, {
         path: "/",
+        maxAge: LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE,
       });
 
       return organization;

--- a/apps/dashboard/src/utils/cookies.ts
+++ b/apps/dashboard/src/utils/cookies.ts
@@ -3,6 +3,7 @@ import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension
 
 import {
   LAST_VISITED_ORGANIZATION_COOKIE,
+  LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE,
   SIDEBAR_MODE_COOKIE,
   SIDEBAR_MODE_COOKIE_MAX_AGE,
 } from "@/constants/cookies";
@@ -49,7 +50,7 @@ async function setClientCookie(
 
 export const setLastVisitedOrganization = async (
   organizationSlug: string,
-  maxAge: number = 30 * 86_400
+  maxAge: number = LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE
 ) => {
   await setClientCookie(
     LAST_VISITED_ORGANIZATION_COOKIE,

--- a/apps/dashboard/src/utils/organization-pathname.ts
+++ b/apps/dashboard/src/utils/organization-pathname.ts
@@ -1,0 +1,14 @@
+import { NON_ORGANIZATION_ROUTE_SEGMENTS } from "@/constants/organization-routes";
+
+export function getOrganizationSlugFromPathname(
+  pathname: string | null
+): string | null {
+  if (!pathname) {
+    return null;
+  }
+  const [firstSegment] = pathname.split("/").filter(Boolean);
+  if (!firstSegment || NON_ORGANIZATION_ROUTE_SEGMENTS.has(firstSegment)) {
+    return null;
+  }
+  return firstSegment;
+}


### PR DESCRIPTION
## Why

Visiting `/notra/geo` on an org with an active Scale plan still showed the GEO upgrade dialog.

The GEO gate (`GeoUpgradeGate` → `useHasGeoFeature`) locks when the Autumn customer has no `ai_answers` balance. The Autumn route's `identify` never looked at the org in the URL: it used `session.activeOrganizationId`, which is resolved from the `notra_last_organization` cookie, falling back to the user's most recently created membership. That cookie was set without a `maxAge` (a session cookie), so on any fresh browser session Autumn was asked about the wrong org (an empty one), the gate rendered the dialog on first paint, and closing it pushed the user out of GEO.

## What

- `AutumnOrgProvider` derives the org slug from the pathname, sends it as `x-notra-organization` on every Autumn request, and keys the provider on the slug so the cached customer never leaks across orgs.
- The Autumn route resolves the customer through `resolveBillingOrganizationId`: it uses the header slug when the user is a member of that org, and falls back to the session's active org otherwise.
- `setActiveOrganizationAction` now sets the last-visited-org cookie with a 30 day `maxAge` (shared constant with the client helper).

No behaviour change for routes without an org slug (onboarding, account) which keep the session fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Autumn billing checks so the GEO gate no longer shows an upgrade dialog for orgs with active Scale plans. Visiting an org route like `/notra/geo` previously identified the Autumn customer from `session.activeOrganizationId`, which was resolved from a session cookie set without a `maxAge`. On a fresh browser session, Autumn was asked about the wrong org, the gate locked, and closing the dialog pushed users out. Now Autumn resolves the customer from the org slug in the URL when the user is a member of that org, and fails closed with no customer when the lookup fails or the org header is malformed; routes without an org slug keep the session fallback.

- Sends the org slug as an `x-notra-organization` header on all Autumn requests from org routes and keys the provider on that slug so cached customers don't leak across orgs.
- Adds `resolveBillingOrganizationId` to validate the requested slug against membership, returning null when the lookup fails or the header is malformed instead of falling back to the session org.
- Sets the last-visited-org cookie with a 30-day `maxAge` via a shared constant with the client helper.

<sup>Written for commit 0f4ee20fd8d9eb49739016fc624f58af8007bb76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

