### PR TITLE
feat(dashboard): add resizable sidebar

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/layout.tsx
@@ -5,7 +5,9 @@ import {
 import { cookies } from "next/headers";
 
 import { DashboardClientWrapper } from "@/components/dashboard/dashboard-client-wrapper";
+import { SIDEBAR_WIDTH_COOKIE_NAME } from "@/constants/nav";
 import { validateOrganizationAccess } from "@/lib/auth/actions";
+import { getSidebarWidthFromCookie } from "@/utils/sidebar-width";
 
 export const instant = false;
 
@@ -25,6 +27,9 @@ export default async function OrganizationLayout({
   const initialSidebarOpen = getSidebarOpenFromCookie(
     cookieStore.get(SIDEBAR_COOKIE_NAME)?.value
   );
+  const initialSidebarWidth = getSidebarWidthFromCookie(
+    cookieStore.get(SIDEBAR_WIDTH_COOKIE_NAME)?.value
+  );
 
   const { organization } = await validateOrganizationAccess(slug);
 
@@ -32,6 +37,7 @@ export default async function OrganizationLayout({
     <DashboardClientWrapper
       initialActiveOrganization={organization}
       initialSidebarOpen={initialSidebarOpen}
+      initialSidebarWidth={initialSidebarWidth}
       modal={modal}
     >
       {children}

--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -13,10 +13,10 @@ import {
 } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import type * as React from "react";
 import { useEffect, useRef } from "react";
 
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import type { DashboardSidebarProps } from "@/types/components/sidebar-resize-handle";
 
 import { ChatHistoryNav } from "./chat-history-nav";
 import { NavBrandIdentity } from "./nav-brand-identity";
@@ -27,6 +27,7 @@ import { OrgSelector } from "./org-selector";
 import { SidebarLabel } from "./sidebar-label";
 import { SidebarOnboarding } from "./sidebar-onboarding";
 import { SidebarProjectSwitcher } from "./sidebar-project-switcher";
+import { SidebarResizeHandle } from "./sidebar-resize-handle";
 import { SidebarSwap } from "./sidebar-swap";
 import { SidebarTrialExpired } from "./sidebar-trial-expired";
 import { SidebarUpgrade } from "./sidebar-upgrade";
@@ -50,8 +51,13 @@ function SidebarBackButton({ onBack }: { onBack: () => void }) {
 
 export function DashboardSidebar({
   className,
+  onWidthChange,
+  onWidthChangeEnd,
+  onWidthChangeStart,
+  resizing,
+  width,
   ...props
-}: React.ComponentProps<typeof Sidebar>) {
+}: DashboardSidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -95,7 +101,11 @@ export function DashboardSidebar({
     <Sidebar
       collapsible="icon"
       {...props}
-      className={cn("overflow-hidden overscroll-none border-none", className)}
+      className={cn(
+        "overflow-hidden overscroll-none border-none",
+        resizing && "transition-none!",
+        className
+      )}
     >
       <SidebarHeader>
         <SidebarProjectSwitcher />
@@ -156,6 +166,12 @@ export function DashboardSidebar({
       <SidebarFooter>
         <OrgSelector />
       </SidebarFooter>
+      <SidebarResizeHandle
+        onWidthChange={onWidthChange}
+        onWidthChangeEnd={onWidthChangeEnd}
+        onWidthChangeStart={onWidthChangeStart}
+        width={width}
+      />
     </Sidebar>
   );
 }

--- a/apps/dashboard/src/components/dashboard/dashboard-client-wrapper.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-client-wrapper.tsx
@@ -14,6 +14,7 @@ interface DashboardClientWrapperProps {
   children: React.ReactNode;
   initialActiveOrganization?: InitialActiveOrganization | null;
   initialSidebarOpen?: boolean;
+  initialSidebarWidth: number;
   modal?: React.ReactNode;
 }
 
@@ -21,6 +22,7 @@ export function DashboardClientWrapper({
   children,
   initialActiveOrganization,
   initialSidebarOpen = true,
+  initialSidebarWidth,
   modal,
 }: DashboardClientWrapperProps) {
   return (
@@ -30,7 +32,10 @@ export function DashboardClientWrapper({
       <DatabuddyFlagsProvider>
         <FeedbackProvider>
           <CommandPaletteProvider>
-            <DashboardShell initialSidebarOpen={initialSidebarOpen}>
+            <DashboardShell
+              initialSidebarOpen={initialSidebarOpen}
+              initialSidebarWidth={initialSidebarWidth}
+            >
               {children}
             </DashboardShell>
             <CommandPalette />

--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -20,8 +20,10 @@ import {
   useOnboardingAgentRun,
   useRunOnboardingAgent,
 } from "@/lib/hooks/use-onboarding";
+import { useSidebarWidth } from "@/lib/hooks/use-sidebar-width";
 import type {
   DashboardShellProps,
+  DashboardSidebarStyle,
   DashboardShellStyle,
 } from "@/types/components/dashboard-shell";
 
@@ -52,6 +54,13 @@ export function DashboardShell({
   const pathname = usePathname();
   const mainScrollRef = useRef<HTMLDivElement>(null);
   const [mainScrolled, setMainScrolled] = useState(false);
+  const {
+    finishSidebarResize,
+    setSidebarWidth,
+    sidebarResizing,
+    sidebarWidth,
+    startSidebarResize,
+  } = useSidebarWidth();
 
   useEffect(() => {
     setDismissingOrganizationId(null);
@@ -106,6 +115,10 @@ export function DashboardShell({
     dismiss();
   };
 
+  const sidebarStyle: DashboardSidebarStyle = {
+    "--sidebar-width": `${sidebarWidth}px`,
+  };
+
   return (
     <div
       className="flex h-svh flex-col overflow-hidden overscroll-none"
@@ -138,15 +151,25 @@ export function DashboardShell({
         </div>
       ) : null}
       <SidebarProvider
-        className="min-h-0! flex-1 overflow-hidden overscroll-none"
+        className={cn(
+          "min-h-0! flex-1 overflow-hidden overscroll-none",
+          sidebarResizing &&
+            "[&_[data-slot=sidebar-gap]]:transition-none! [&_[data-slot=sidebar-inset]]:transition-none!"
+        )}
         defaultOpen={initialSidebarOpen}
+        style={sidebarStyle}
       >
         <DashboardSidebar
           className={cn(
             "transition-[left,right,width,top,height] [transition-duration:var(--sidebar-duration),var(--sidebar-duration),var(--sidebar-duration),200ms,200ms] [transition-timing-function:var(--sidebar-ease),var(--sidebar-ease),var(--sidebar-ease),ease-out,ease-out] motion-reduce:transition-none md:top-(--eve-banner-height) md:h-[calc(100svh-var(--eve-banner-height))]",
             visible && "md:pt-0!"
           )}
+          onWidthChange={setSidebarWidth}
+          onWidthChangeEnd={finishSidebarResize}
+          onWidthChangeStart={startSidebarResize}
+          resizing={sidebarResizing}
           variant="inset"
+          width={sidebarWidth}
         />
         <SidebarInset
           className={cn(

--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -30,6 +30,7 @@ import type {
 export function DashboardShell({
   children,
   initialSidebarOpen,
+  initialSidebarWidth,
 }: DashboardShellProps) {
   const { activeOrganization } = useOrganizationsContext();
   const organizationId = activeOrganization?.id ?? "";
@@ -60,7 +61,7 @@ export function DashboardShell({
     sidebarResizing,
     sidebarWidth,
     startSidebarResize,
-  } = useSidebarWidth();
+  } = useSidebarWidth(initialSidebarWidth);
 
   useEffect(() => {
     setDismissingOrganizationId(null);

--- a/apps/dashboard/src/components/dashboard/sidebar-resize-handle.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-resize-handle.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useSidebar } from "@notra/ui/components/ui/sidebar";
+import { type KeyboardEvent, type PointerEvent, useRef } from "react";
+
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_RESIZE_STEP,
+} from "@/constants/nav";
+import type { SidebarResizeHandleProps } from "@/types/components/sidebar-resize-handle";
+
+function clampSidebarWidth(width: number) {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+}
+
+export function SidebarResizeHandle({
+  onWidthChange,
+  onWidthChangeEnd,
+  onWidthChangeStart,
+  width,
+}: SidebarResizeHandleProps) {
+  const { state } = useSidebar();
+  const currentWidthRef = useRef<number | null>(null);
+  const startWidthRef = useRef(0);
+  const startXRef = useRef(0);
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || state === "collapsed") {
+      return;
+    }
+
+    event.preventDefault();
+    currentWidthRef.current = width;
+    startWidthRef.current = width;
+    startXRef.current = event.clientX;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    onWidthChangeStart();
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (currentWidthRef.current === null) {
+      return;
+    }
+
+    const nextWidth = clampSidebarWidth(
+      startWidthRef.current + event.clientX - startXRef.current
+    );
+    currentWidthRef.current = nextWidth;
+    onWidthChange(nextWidth);
+  };
+
+  const finishResize = (event: PointerEvent<HTMLDivElement>) => {
+    const currentWidth = currentWidthRef.current;
+    if (currentWidth === null) {
+      return;
+    }
+
+    currentWidthRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    onWidthChangeEnd(currentWidth);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    let nextWidth: number | undefined;
+
+    if (event.key === "ArrowLeft") {
+      nextWidth = clampSidebarWidth(width - SIDEBAR_RESIZE_STEP);
+    } else if (event.key === "ArrowRight") {
+      nextWidth = clampSidebarWidth(width + SIDEBAR_RESIZE_STEP);
+    } else if (event.key === "Home") {
+      nextWidth = SIDEBAR_MIN_WIDTH;
+    } else if (event.key === "End") {
+      nextWidth = SIDEBAR_MAX_WIDTH;
+    }
+
+    if (nextWidth === undefined) {
+      return;
+    }
+
+    event.preventDefault();
+    onWidthChange(nextWidth);
+    onWidthChangeEnd(nextWidth);
+  };
+
+  return (
+    <div
+      aria-label="Resize sidebar"
+      aria-orientation="vertical"
+      aria-valuemax={SIDEBAR_MAX_WIDTH}
+      aria-valuemin={SIDEBAR_MIN_WIDTH}
+      aria-valuenow={width}
+      className="absolute inset-y-2 right-0 z-20 hidden w-2 cursor-col-resize touch-none outline-none group-data-[collapsible=icon]:hidden md:block"
+      onDoubleClick={() => {
+        onWidthChange(SIDEBAR_DEFAULT_WIDTH);
+        onWidthChangeEnd(SIDEBAR_DEFAULT_WIDTH);
+      }}
+      onKeyDown={handleKeyDown}
+      onPointerCancel={finishResize}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishResize}
+      role="separator"
+      tabIndex={state === "collapsed" ? -1 : 0}
+      title="Drag to resize sidebar. Double-click to reset."
+    />
+  );
+}

--- a/apps/dashboard/src/components/dashboard/sidebar-resize-handle.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-resize-handle.tsx
@@ -10,10 +10,7 @@ import {
   SIDEBAR_RESIZE_STEP,
 } from "@/constants/nav";
 import type { SidebarResizeHandleProps } from "@/types/components/sidebar-resize-handle";
-
-function clampSidebarWidth(width: number) {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
-}
+import { clampSidebarWidth } from "@/utils/sidebar-width";
 
 export function SidebarResizeHandle({
   onWidthChange,
@@ -99,6 +96,7 @@ export function SidebarResizeHandle({
         onWidthChangeEnd(SIDEBAR_DEFAULT_WIDTH);
       }}
       onKeyDown={handleKeyDown}
+      onLostPointerCapture={finishResize}
       onPointerCancel={finishResize}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}

--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -63,6 +63,11 @@ export const GEO_COMPETITORS_NAV_LINK = "/geo/competitors";
 export const GEO_SETTINGS_NAV_LINK = "/geo/settings";
 
 export const SIDEBAR_DEFAULT_MODE: SidebarMode = "geo";
+export const SIDEBAR_DEFAULT_WIDTH = 256;
+export const SIDEBAR_MIN_WIDTH = 240;
+export const SIDEBAR_MAX_WIDTH = 400;
+export const SIDEBAR_RESIZE_STEP = 8;
+export const SIDEBAR_WIDTH_EVENT = "notra:sidebar-width-change";
 
 export const SIDEBAR_MODES: SidebarModeOption[] = [
   { id: "geo", label: "GEO", icon: AiBrowserIcon },

--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -67,7 +67,7 @@ export const SIDEBAR_DEFAULT_WIDTH = 256;
 export const SIDEBAR_MIN_WIDTH = 240;
 export const SIDEBAR_MAX_WIDTH = 400;
 export const SIDEBAR_RESIZE_STEP = 8;
-export const SIDEBAR_WIDTH_EVENT = "notra:sidebar-width-change";
+export const SIDEBAR_WIDTH_COOKIE_NAME = "sidebar_width";
 
 export const SIDEBAR_MODES: SidebarModeOption[] = [
   { id: "geo", label: "GEO", icon: AiBrowserIcon },

--- a/apps/dashboard/src/constants/storage.ts
+++ b/apps/dashboard/src/constants/storage.ts
@@ -8,7 +8,6 @@ export const localStorageKeys = {
   imageExportTarget: "notra:image-export-target",
   contentView: "notra:content-view",
   sidebarMode: "notra:sidebar-mode:v1",
-  sidebarWidth: "notra:sidebar-width:v1",
   sidebarOnboardingCollapsed: (organizationId?: string) =>
     organizationId
       ? `onboarding-collapsed:${organizationId}`

--- a/apps/dashboard/src/constants/storage.ts
+++ b/apps/dashboard/src/constants/storage.ts
@@ -8,6 +8,7 @@ export const localStorageKeys = {
   imageExportTarget: "notra:image-export-target",
   contentView: "notra:content-view",
   sidebarMode: "notra:sidebar-mode:v1",
+  sidebarWidth: "notra:sidebar-width:v1",
   sidebarOnboardingCollapsed: (organizationId?: string) =>
     organizationId
       ? `onboarding-collapsed:${organizationId}`

--- a/apps/dashboard/src/lib/hooks/use-sidebar-width.ts
+++ b/apps/dashboard/src/lib/hooks/use-sidebar-width.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback, useState, useSyncExternalStore } from "react";
+
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_WIDTH_EVENT,
+} from "@/constants/nav";
+import { localStorageKeys } from "@/constants/storage";
+import type { UseSidebarWidthResult } from "@/types/components/sidebar-resize-handle";
+
+function getStoredSidebarWidth() {
+  try {
+    const storedWidth = Number(
+      window.localStorage.getItem(localStorageKeys.sidebarWidth)
+    );
+    return Number.isFinite(storedWidth) &&
+      storedWidth >= SIDEBAR_MIN_WIDTH &&
+      storedWidth <= SIDEBAR_MAX_WIDTH
+      ? storedWidth
+      : SIDEBAR_DEFAULT_WIDTH;
+  } catch {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+}
+
+function getServerSidebarWidth() {
+  return SIDEBAR_DEFAULT_WIDTH;
+}
+
+function subscribeToSidebarWidth(onChange: () => void) {
+  window.addEventListener("storage", onChange);
+  window.addEventListener(SIDEBAR_WIDTH_EVENT, onChange);
+  return () => {
+    window.removeEventListener("storage", onChange);
+    window.removeEventListener(SIDEBAR_WIDTH_EVENT, onChange);
+  };
+}
+
+export function useSidebarWidth(): UseSidebarWidthResult {
+  const storedWidth = useSyncExternalStore(
+    subscribeToSidebarWidth,
+    getStoredSidebarWidth,
+    getServerSidebarWidth
+  );
+  const [pendingWidth, setPendingWidth] = useState<number | null>(null);
+  const [sidebarResizing, setSidebarResizing] = useState(false);
+  const sidebarWidth = pendingWidth ?? storedWidth;
+
+  const startSidebarResize = useCallback(() => {
+    setSidebarResizing(true);
+  }, []);
+
+  const finishSidebarResize = useCallback((width: number) => {
+    let persisted = false;
+    try {
+      window.localStorage.setItem(localStorageKeys.sidebarWidth, String(width));
+      persisted = true;
+    } catch {
+      // Resizing still works for the current session without persistence.
+    }
+    if (persisted) {
+      window.dispatchEvent(new Event(SIDEBAR_WIDTH_EVENT));
+      setPendingWidth(null);
+    } else {
+      setPendingWidth(width);
+    }
+    setSidebarResizing(false);
+  }, []);
+
+  return {
+    finishSidebarResize,
+    setSidebarWidth: setPendingWidth,
+    sidebarResizing,
+    sidebarWidth,
+    startSidebarResize,
+  };
+}

--- a/apps/dashboard/src/lib/hooks/use-sidebar-width.ts
+++ b/apps/dashboard/src/lib/hooks/use-sidebar-width.ts
@@ -1,78 +1,28 @@
 "use client";
 
-import { useCallback, useState, useSyncExternalStore } from "react";
+import { SIDEBAR_COOKIE_MAX_AGE } from "@notra/ui/lib/sidebar-state";
+import { useCallback, useState } from "react";
 
-import {
-  SIDEBAR_DEFAULT_WIDTH,
-  SIDEBAR_MAX_WIDTH,
-  SIDEBAR_MIN_WIDTH,
-  SIDEBAR_WIDTH_EVENT,
-} from "@/constants/nav";
-import { localStorageKeys } from "@/constants/storage";
+import { SIDEBAR_WIDTH_COOKIE_NAME } from "@/constants/nav";
 import type { UseSidebarWidthResult } from "@/types/components/sidebar-resize-handle";
 
-function getStoredSidebarWidth() {
-  try {
-    const storedWidth = Number(
-      window.localStorage.getItem(localStorageKeys.sidebarWidth)
-    );
-    return Number.isFinite(storedWidth) &&
-      storedWidth >= SIDEBAR_MIN_WIDTH &&
-      storedWidth <= SIDEBAR_MAX_WIDTH
-      ? storedWidth
-      : SIDEBAR_DEFAULT_WIDTH;
-  } catch {
-    return SIDEBAR_DEFAULT_WIDTH;
-  }
-}
-
-function getServerSidebarWidth() {
-  return SIDEBAR_DEFAULT_WIDTH;
-}
-
-function subscribeToSidebarWidth(onChange: () => void) {
-  window.addEventListener("storage", onChange);
-  window.addEventListener(SIDEBAR_WIDTH_EVENT, onChange);
-  return () => {
-    window.removeEventListener("storage", onChange);
-    window.removeEventListener(SIDEBAR_WIDTH_EVENT, onChange);
-  };
-}
-
-export function useSidebarWidth(): UseSidebarWidthResult {
-  const storedWidth = useSyncExternalStore(
-    subscribeToSidebarWidth,
-    getStoredSidebarWidth,
-    getServerSidebarWidth
-  );
-  const [pendingWidth, setPendingWidth] = useState<number | null>(null);
+export function useSidebarWidth(initialWidth: number): UseSidebarWidthResult {
+  const [sidebarWidth, setSidebarWidth] = useState(initialWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
-  const sidebarWidth = pendingWidth ?? storedWidth;
 
   const startSidebarResize = useCallback(() => {
     setSidebarResizing(true);
   }, []);
 
   const finishSidebarResize = useCallback((width: number) => {
-    let persisted = false;
-    try {
-      window.localStorage.setItem(localStorageKeys.sidebarWidth, String(width));
-      persisted = true;
-    } catch {
-      // Resizing still works for the current session without persistence.
-    }
-    if (persisted) {
-      window.dispatchEvent(new Event(SIDEBAR_WIDTH_EVENT));
-      setPendingWidth(null);
-    } else {
-      setPendingWidth(width);
-    }
+    setSidebarWidth(width);
+    document.cookie = `${SIDEBAR_WIDTH_COOKIE_NAME}=${width}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     setSidebarResizing(false);
   }, []);
 
   return {
     finishSidebarResize,
-    setSidebarWidth: setPendingWidth,
+    setSidebarWidth,
     sidebarResizing,
     sidebarWidth,
     startSidebarResize,

--- a/apps/dashboard/src/types/components/dashboard-shell.ts
+++ b/apps/dashboard/src/types/components/dashboard-shell.ts
@@ -8,3 +8,7 @@ export interface DashboardShellProps {
 export interface DashboardShellStyle extends CSSProperties {
   "--eve-banner-height": string;
 }
+
+export interface DashboardSidebarStyle extends CSSProperties {
+  "--sidebar-width": string;
+}

--- a/apps/dashboard/src/types/components/dashboard-shell.ts
+++ b/apps/dashboard/src/types/components/dashboard-shell.ts
@@ -3,6 +3,7 @@ import type { CSSProperties, ReactNode } from "react";
 export interface DashboardShellProps {
   children: ReactNode;
   initialSidebarOpen: boolean;
+  initialSidebarWidth: number;
 }
 
 export interface DashboardShellStyle extends CSSProperties {

--- a/apps/dashboard/src/types/components/sidebar-resize-handle.ts
+++ b/apps/dashboard/src/types/components/sidebar-resize-handle.ts
@@ -1,0 +1,22 @@
+import type { Sidebar } from "@notra/ui/components/ui/sidebar";
+import type { ComponentProps } from "react";
+
+export interface SidebarResizeHandleProps {
+  onWidthChange: (width: number) => void;
+  onWidthChangeEnd: (width: number) => void;
+  onWidthChangeStart: () => void;
+  width: number;
+}
+
+export interface DashboardSidebarProps
+  extends ComponentProps<typeof Sidebar>, SidebarResizeHandleProps {
+  resizing: boolean;
+}
+
+export interface UseSidebarWidthResult {
+  finishSidebarResize: (width: number) => void;
+  setSidebarWidth: (width: number) => void;
+  sidebarResizing: boolean;
+  sidebarWidth: number;
+  startSidebarResize: () => void;
+}

--- a/apps/dashboard/src/utils/sidebar-width.ts
+++ b/apps/dashboard/src/utils/sidebar-width.ts
@@ -1,0 +1,22 @@
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+} from "@/constants/nav";
+
+export function clampSidebarWidth(width: number) {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+}
+
+export function getSidebarWidthFromCookie(cookieValue?: string) {
+  if (!cookieValue) {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+
+  const width = Number(cookieValue);
+  return Number.isFinite(width) &&
+    width >= SIDEBAR_MIN_WIDTH &&
+    width <= SIDEBAR_MAX_WIDTH
+    ? width
+    : SIDEBAR_DEFAULT_WIDTH;
+}


### PR DESCRIPTION
### Description
Adds a resizable desktop dashboard sidebar using the existing border as the drag handle. The width is constrained between 240–400 px and persisted across sessions. Keyboard resizing and double-click reset are supported, while mobile and collapsed sidebar behavior remain unchanged.

### Screenshot/Recording (if applicable)
https://cap.so/s/jf463ehh353n7f1

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the desktop dashboard sidebar resizable by dragging its edge, with the width persisted across sessions. The sidebar previously had a fixed width; now it can be adjusted between 240–400 px via drag, keyboard, or double-click reset to the default 256 px.

**Notes**
- Arrow keys resize in 8 px steps; Home and End jump to the min and max width.
- Width changes sync across open browser tabs.
- Transitions are disabled while dragging so the sidebar follows the cursor without lag.

<sup>Written for commit 9d525b398cafc63e5c9046b57e0abe31aa804ffa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

