### PR TITLE
fix(web): align feedback mobile nav padding

### DIFF
--- a/apps/web/src/components/feedback-md/feedback-md-hero.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-hero.tsx
@@ -4,7 +4,7 @@ import { FEEDBACK_MD_HERO_LEAD } from "@/lib/feedback-md/constants";
 
 export function FeedbackMdHero() {
   return (
-    <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
+    <section className="w-full px-6 pt-2 antialiased [font-synthesis:none] sm:pt-6">
       <div className="relative isolate overflow-clip rounded-3xl bg-[#EFEAFA] dark:bg-[#2a2140]">
         <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
           <HeroDither className="absolute -top-1.25 -left-10.75 h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />


### PR DESCRIPTION
### Description
Fixes the missing top spacing above the mobile navigation on `/feedback-md`, matching the main landing page while preserving the existing tablet and desktop spacing.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing top spacing above the mobile navigation on `/feedback-md` by reducing the hero's top padding on small screens, while keeping the existing tablet and desktop spacing unchanged.

<sup>Written for commit c30dc9ee7b75896b49af93dd23d09662c54c50f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

