### PR TITLE
fix: render persisted GEO answers statically

### DIFF
--- a/apps/dashboard/src/components/geo/conversation-replay-thread.tsx
+++ b/apps/dashboard/src/components/geo/conversation-replay-thread.tsx
@@ -215,7 +215,11 @@ function ReplayTurn({
             <ThinkingIndicator skin={skin} />
           ) : (
             <>
-              <AnswerMarkdown skin={skin} text={answerText} />
+              <AnswerMarkdown
+                mode={answerDone ? "static" : "streaming"}
+                skin={skin}
+                text={answerText}
+              />
               {answerDone && skin !== "perplexity" && (
                 <SourcePills sources={sources} />
               )}

--- a/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
+++ b/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
@@ -75,9 +75,11 @@ function emptyAnswerClassName(skin: GeoChatSkin): string {
 export function AnswerMarkdown({
   text,
   skin,
+  mode = "static",
 }: {
   text: string;
   skin: GeoChatSkin;
+  mode?: "static" | "streaming";
 }) {
   return (
     <MessageResponse
@@ -88,6 +90,7 @@ export function AnswerMarkdown({
         skin === "perplexity" &&
           "font-serif [&_h1]:font-serif [&_h2]:font-serif [&_h3]:font-serif"
       )}
+      mode={mode}
     >
       {text}
     </MessageResponse>

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -719,7 +719,8 @@ export const MessageResponse = memo(
       {...props}
     />
   ),
-  (prevProps, nextProps) => prevProps.children === nextProps.children
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children && prevProps.mode === nextProps.mode
 );
 
 MessageResponse.displayName = "MessageResponse";


### PR DESCRIPTION
### Description
Render completed, persisted GEO answers using Streamdown’s static mode. This prevents incomplete-Markdown recovery from modifying stored responses.

The conversation replay continues using streaming mode while simulating typed output and switches to static mode when the answer is complete. The `MessageResponse` memo comparator now includes `mode`, ensuring this transition is rendered even when the text remains unchanged.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed persisted GEO answers rendering statically so incomplete-Markdown recovery no longer modifies stored responses.

- Conversation replay keeps streaming while simulating typed output, then switches to static mode when the answer completes.
- `MessageResponse` memo now compares `mode`, so the static-mode switch renders even when the text is unchanged.

<sup>Written for commit 01e7093a287045230484c59075f8fd48b72f2b0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

