### PR TITLE
fix(geo): time out provider calls

### DIFF
--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -36,6 +36,8 @@ export const GEO_CURSOR_API_KEY_ENV = "CURSOR_API_KEY";
 /** Catalog id of the Cursor engine; the SDK model id is the slug part. */
 export const GEO_CURSOR_ENGINE_ID = "cursor/composer-2.5";
 export const GEO_CURSOR_MODEL_ID = "composer-2.5";
+/** Maximum wall-clock time for a single answer, judge, or translation call. */
+export const GEO_PROVIDER_TIMEOUT_MS = 90_000;
 /** Local Cursor runs took ~8s in testing; cold starts can be slower. */
 export const GEO_CURSOR_TIMEOUT_MS = 90_000;
 /** Databuddy flag that exposes the Cursor engine to an organization. */

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -36,6 +36,7 @@ import {
   GEO_MAX_LANGUAGES,
   GEO_MAX_PROMPTS,
   GEO_MAX_SEQUENCES,
+  GEO_PROVIDER_TIMEOUT_MS,
   GEO_SCAN_CONCURRENCY,
   GEO_SCAN_LEASE_HEARTBEAT_MS,
   GEO_SEQUENCE_MAX_TURNS,
@@ -246,7 +247,7 @@ const askGatewayEngine = Effect.fn("geo.askGatewayEngine")(function* (
   gatewayPin: Exclude<GeoModelGateway, "cursor"> | undefined
 ) {
   const result = yield* Effect.tryPromise({
-    try: () =>
+    try: (signal) =>
       generateText({
         model: gateway(engine, {
           organizationId,
@@ -256,13 +257,24 @@ const askGatewayEngine = Effect.fn("geo.askGatewayEngine")(function* (
         prompt: promptText,
         system: GEO_ANSWER_SYSTEM_PROMPT,
         maxOutputTokens: GEO_ANSWER_MAX_TOKENS,
+        abortSignal: signal,
       }),
     catch: (cause) =>
       new GeoScanError({
         message: `Engine ${engine} failed to answer`,
         cause,
       }),
-  });
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: GEO_PROVIDER_TIMEOUT_MS,
+      orElse: () =>
+        Effect.fail(
+          new GeoScanError({
+            message: `Engine ${engine} timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+          })
+        ),
+    })
+  );
   const answer: GeoEngineAnswer = {
     text: result.text,
     grounding: extractGrounding(result),
@@ -351,7 +363,7 @@ const askGroundedConversation = Effect.fn("geo.askGroundedConversation")(
     zdr: GeoZdrMode
   ) {
     const result = yield* Effect.tryPromise({
-      try: () => {
+      try: (signal) => {
         const invocation = buildGroundedInvocation(engine, {
           organizationId,
           zdr,
@@ -363,6 +375,7 @@ const askGroundedConversation = Effect.fn("geo.askGroundedConversation")(
           messages,
           system: GEO_ANSWER_SYSTEM_PROMPT,
           maxOutputTokens: GEO_GROUNDED_ANSWER_MAX_TOKENS,
+          abortSignal: signal,
         });
       },
       catch: (cause) =>
@@ -370,7 +383,17 @@ const askGroundedConversation = Effect.fn("geo.askGroundedConversation")(
           message: `Grounded engine ${engine.key} failed to answer`,
           cause,
         }),
-    });
+    }).pipe(
+      Effect.timeoutOrElse({
+        duration: GEO_PROVIDER_TIMEOUT_MS,
+        orElse: () =>
+          Effect.fail(
+            new GeoScanError({
+              message: `Grounded engine ${engine.key} timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+            })
+          ),
+      })
+    );
     const answer: GeoGroundedAnswer = {
       text: result.text,
       grounding: extractGrounding(result),
@@ -391,7 +414,7 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
   answer: string
 ) {
   const result = yield* Effect.tryPromise({
-    try: () =>
+    try: (signal) =>
       generateText({
         model: gateway(GEO_JUDGE_MODEL, {
           organizationId: context.organizationId,
@@ -401,10 +424,22 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
         system:
           "You analyze AI assistant answers for brand mentions. Respond only with the requested structured data.",
         maxOutputTokens: GEO_JUDGE_MAX_TOKENS,
+        abortSignal: signal,
       }),
     catch: (cause) =>
       new GeoJudgeError({ message: "Judge model failed", cause }),
-  });
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: GEO_PROVIDER_TIMEOUT_MS,
+      orElse: () =>
+        Effect.fail(
+          new GeoJudgeError({
+            message: `Judge model timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+            cause: new Error("Judge model request timed out"),
+          })
+        ),
+    })
+  );
   const judged: GeoJudgeResult = result.output;
   return judged;
 });
@@ -415,7 +450,7 @@ const translatePrompts = Effect.fn("geo.translatePrompts")(function* (
   prompts: GeoPromptDefinition[]
 ) {
   const result = yield* Effect.tryPromise({
-    try: () =>
+    try: (signal) =>
       generateText({
         model: gateway(GEO_JUDGE_MODEL, { organizationId }),
         output: Output.object({ schema: geoTranslationResultSchema }),
@@ -423,6 +458,7 @@ const translatePrompts = Effect.fn("geo.translatePrompts")(function* (
         system:
           "You translate user prompts faithfully, preserving intent and named entities. Respond only with the requested structured data.",
         maxOutputTokens: GEO_TRANSLATION_MAX_TOKENS,
+        abortSignal: signal,
       }),
     catch: (cause) =>
       new GeoTranslationError({
@@ -430,7 +466,18 @@ const translatePrompts = Effect.fn("geo.translatePrompts")(function* (
         language,
         cause,
       }),
-  });
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: GEO_PROVIDER_TIMEOUT_MS,
+      orElse: () =>
+        Effect.fail(
+          new GeoTranslationError({
+            message: `Translation to ${language} timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+            language,
+          })
+        ),
+    })
+  );
   const translations = result.output.translations;
   if (translations.length !== prompts.length) {
     return yield* Effect.fail(


### PR DESCRIPTION
### Description
Adds a 90-second timeout to GEO answer, grounded answer, judge, and translation provider calls. Effect cancellation is propagated to the AI SDK request, preventing a hanging provider from blocking an entire scan indefinitely.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Time out GEO answer, grounded answer, judge, and translation provider calls at 90 seconds, and abort the underlying AI SDK request on timeout so a hanging provider can't block a scan indefinitely.

<sup>Written for commit 0f4b04a6da6d8e4d071d214cbe7b9c72ecf70772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

