### PR TITLE
fix(geo): unify Search Console prompts

### DIFF
--- a/packages/geo-core/src/geo/search-console.ts
+++ b/packages/geo-core/src/geo/search-console.ts
@@ -17,6 +17,7 @@ import { generateText, Output } from "ai";
 import { and, eq, ne } from "drizzle-orm";
 
 import {
+  GEO_DISCOVERY_SYSTEM_PROMPT,
   GEO_GAP_TITLE_MAX_LENGTH,
   GEO_PROMPT_MAX_LENGTH,
   GEO_PROMPT_MIN_LENGTH,
@@ -39,16 +40,13 @@ import {
   resolveSourceKeywords,
   selectKeywordsForModel,
 } from "./suggestion-keywords";
-import {
-  buildGscSuggestionPrompt,
-  GSC_SUGGESTION_SYSTEM_PROMPT,
-} from "./suggestion-prompt";
+import { buildGscSuggestionPrompt } from "./suggestion-prompt";
 
 async function generateSuggestions(params: GscSuggestionGenerationParams) {
   const result = await generateText({
     model: gateway(GSC_SUGGESTION_MODEL, {}),
     output: Output.object({ schema: geoSearchConsoleSuggestionSchema }),
-    system: GSC_SUGGESTION_SYSTEM_PROMPT,
+    system: GEO_DISCOVERY_SYSTEM_PROMPT,
     prompt: buildGscSuggestionPrompt(params),
     maxOutputTokens: GSC_SUGGESTION_MAX_TOKENS,
   });

--- a/packages/geo-core/src/geo/suggestion-prompt.ts
+++ b/packages/geo-core/src/geo/suggestion-prompt.ts
@@ -13,8 +13,6 @@ import {
 } from "../constants/google-search-console";
 import type { GscSuggestionGenerationParams } from "../types/google-search-console";
 
-export const GSC_SUGGESTION_SYSTEM_PROMPT = `You are a search visibility analyst. You turn the Google Search queries a website already ranks for into the questions people type into ChatGPT about the same topics, plus the article headline that would win each question. ${GEO_TRACKED_PROMPT_VOICE} Never mention the tracked company or product by name. Never copy a product description or tagline. Stay in one language. Respond only with the requested structured data.`;
-
 function formatKeywordLine(row: GscQueryRow): string {
   return `- "${row.query}" (impressions ${row.impressions}, clicks ${row.clicks}, avg position ${row.position.toFixed(1)})`;
 }
@@ -45,11 +43,11 @@ ${formatExistingPrompts(params.existingPrompts)}
 Write up to ${GSC_SUGGESTIONS_MAX_PER_SYNC} entries. Each entry has a "prompt", a "title", and "keywords".
 
 Prompt rules:
-- A prompt is the exact text a real person would type into ChatGPT about these topics. ${GEO_TRACKED_PROMPT_VOICE}
-- Do not copy keyword phrasing verbatim; rewrite the underlying intent in your own words. Never concatenate keywords, never mix languages within a prompt, and never write anything you would not plausibly type yourself.
+- A prompt is the exact text a real buyer would type into ChatGPT while researching this category - before they know this company exists. ${GEO_TRACKED_PROMPT_VOICE}
+- Treat the source queries as evidence of topics and buyer intent, not as copy. Rewrite the underlying intent in natural language. Never concatenate keywords, never mix languages within a prompt, and never write anything you would not plausibly type yourself.
 - Group related queries into one prompt; do not write one prompt per keyword.
-- Never mention "${brand}" or any brand name owned by ${brand} in the prompt. Never copy what ${brand} is or does into the question. Frame each question around the topic, problem, or buying decision so the answer reveals whether an assistant recommends ${brand} unprompted. Competitor brand names are allowed only in alternatives or comparison prompts, still in the same lowercase voice ("what's a good buffer alternative").
-- Prefer topics with high impressions and commercial or comparison intent. Do not append "${year}".
+- Never mention "${brand}", its domain, or any brand name owned by ${brand} in the prompt. Never describe what ${brand} is or does. Frame each question around the topic, problem, or buying decision so the answer reveals whether an assistant recommends ${brand} unprompted. Competitor names are allowed only in alternatives or comparison prompts, still in the same lowercase voice ("what's a good hootsuite alternative").
+- Cover different intents across the set in that same voice: what tools to use, how to do a task, what to compare, and what a competitor alternative is. Use impressions to prioritize topics only after producing this balanced set. Do not append "${year}".
 - Each prompt must be between ${GEO_PROMPT_MIN_LENGTH} and ${GEO_PROMPT_MAX_LENGTH} characters, in the same language as the underlying queries.
 
 Title rules:

--- a/packages/geo-core/src/geo/suggestion-prompt.ts
+++ b/packages/geo-core/src/geo/suggestion-prompt.ts
@@ -46,8 +46,9 @@ Prompt rules:
 - A prompt is the exact text a real buyer would type into ChatGPT while researching this category - before they know this company exists. ${GEO_TRACKED_PROMPT_VOICE}
 - Treat the source queries as evidence of topics and buyer intent, not as copy. Rewrite the underlying intent in natural language. Never concatenate keywords, never mix languages within a prompt, and never write anything you would not plausibly type yourself.
 - Group related queries into one prompt; do not write one prompt per keyword.
-- Never mention "${brand}", its domain, or any brand name owned by ${brand} in the prompt. Never describe what ${brand} is or does. Frame each question around the topic, problem, or buying decision so the answer reveals whether an assistant recommends ${brand} unprompted. Competitor names are allowed only in alternatives or comparison prompts, still in the same lowercase voice ("what's a good hootsuite alternative").
-- Cover different intents across the set in that same voice: what tools to use, how to do a task, what to compare, and what a competitor alternative is. Use impressions to prioritize topics only after producing this balanced set. Do not append "${year}".
+- Never mention "${brand}", its domain, or any brand name owned by ${brand} in the prompt. Never describe what ${brand} is or does. Frame each question around the topic, problem, or buying decision so the answer reveals whether an assistant recommends ${brand} unprompted.
+- Only mention a competitor when its name appears verbatim in an exact source query attributed to that entry, and only in an alternative or comparison prompt. Never infer or invent a competitor.
+- Cover different intents supported by the source queries in that same voice, such as what tools to use, how to do a task, or what to compare. Do not force an intent that the source queries do not support. Use impressions to prioritize topics only after producing a balanced set. Do not append "${year}".
 - Each prompt must be between ${GEO_PROMPT_MIN_LENGTH} and ${GEO_PROMPT_MAX_LENGTH} characters, in the same language as the underlying queries.
 
 Title rules:


### PR DESCRIPTION
### Description
Unifies Google Search Console prompt suggestions with the existing GEO discovery prompt style. GSC queries are now treated as signals for buyer intent rather than copied as SEO-style prompts, while maintaining balanced intent coverage and using the shared GEO system prompt.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Google Search Console suggestions with the GEO discovery flow so GSC queries are treated as buyer-intent signals instead of being copied as SEO-style prompts.

Suggestions now use the shared GEO system prompt, and competitor names may only appear when they show up verbatim in an exact source query for that entry. Prompts keep a balanced set of intents supported by the source queries without forcing unsupported ones.

<sup>Written for commit b03d7ad25c106f50a31252f460fed0e365776c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

