### PR TITLE
fix(geo): use native Gemini search grounding

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -428,6 +428,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.84",
+        "@ai-sdk/google": "3.0.82",
         "@ai-sdk/openai": "3.0.71",
         "@ai-sdk/perplexity": "3.0.35",
         "@cursor/sdk": "^1.0.28",
@@ -594,6 +595,8 @@
     "@ai-sdk/devtools": ["@ai-sdk/devtools@1.0.1", "", { "dependencies": { "@ai-sdk/provider": "4.0.1", "@hono/node-server": "^1.19.13", "hono": "^4.12.25" }, "bin": { "devtools": "bin/cli.js" } }, "sha512-Yak6fCfooo+4/DhPGlMlhte89swJtw4OKI7epX3tFs/0/CDDQ/fw2FyaoP2Xv1TQaAqy7lbaVfJbghAI5sJ3hA=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.132", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.29", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-sFZFGk6aVSNKmgDrb14efaAbvM71AB3UUvaTsU+bvhWP9jrkRrwix/jFX8IoOAJk0/X7Xf7p3m0J2O2G6ljZbA=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.82", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.29" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-md+M92ZJuPIMU2p4v1rGLpJJWTmTh/vpJPkMnQbEdcLaPTZxRaroIKSnmL/9UGJV0BORJlHNDJegkcnhVpTmDA=="],
 
     "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.51", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.29", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-03JEdJtB+K/I7a85GWJjrB+ypYY++ZFDTp2YJ5Wd0e0raZdFpBLvvX9LJIxPF1LRbs7PMtx6TIS1YMP0Dece+w=="],
 

--- a/packages/geo-core/package.json
+++ b/packages/geo-core/package.json
@@ -13,10 +13,12 @@
     "./csv/*": "./src/csv/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test src"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.84",
+    "@ai-sdk/google": "3.0.82",
     "@ai-sdk/openai": "3.0.71",
     "@ai-sdk/perplexity": "3.0.35",
     "@cursor/sdk": "^1.0.28",

--- a/packages/geo-core/src/geo/engines.test.ts
+++ b/packages/geo-core/src/geo/engines.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { GEO_GROUNDED_ENGINES } from "../constants/geo";
+import type { GeoGroundedProvider } from "../types/geo";
+import { buildGroundedInvocation } from "./engines";
+
+function getGatewayEngine(provider: GeoGroundedProvider) {
+  const engine = GEO_GROUNDED_ENGINES.find(
+    (candidate) => candidate.provider === provider
+  );
+  assert.ok(engine, `Missing grounded engine for ${provider}`);
+  return engine;
+}
+
+function getProviderTool(provider: GeoGroundedProvider, toolName: string) {
+  const invocation = buildGroundedInvocation(getGatewayEngine(provider));
+  const providerTool = invocation.tools[toolName];
+  assert.ok(providerTool, `Missing ${toolName} for ${provider}`);
+  assert.equal(providerTool.type, "provider");
+  return providerTool;
+}
+
+describe("grounded GEO engine tools", () => {
+  test("uses OpenAI's native web search tool", () => {
+    const providerTool = getProviderTool("gateway-openai", "web_search");
+    assert.equal(providerTool.id, "openai.web_search");
+  });
+
+  test("uses Anthropic's native web search tool with the GEO search limit", () => {
+    const providerTool = getProviderTool("gateway-anthropic", "web_search");
+    assert.equal(providerTool.id, "anthropic.web_search_20250305");
+    assert.deepEqual(providerTool.args, { maxUses: 3 });
+  });
+
+  test("uses Google's native search grounding tool", () => {
+    const providerTool = getProviderTool("gateway-google", "google_search");
+    assert.equal(providerTool.id, "google.google_search");
+    assert.deepEqual(providerTool.args, {});
+  });
+});

--- a/packages/geo-core/src/geo/engines.ts
+++ b/packages/geo-core/src/geo/engines.ts
@@ -1,9 +1,8 @@
 import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
 import { createOpenAI, openai } from "@ai-sdk/openai";
 import { createPerplexity } from "@ai-sdk/perplexity";
 import { gateway } from "@notra/ai/gateway";
-import { tool } from "ai";
-import { z } from "zod";
 
 import {
   GEO_ANTHROPIC_API_KEY_ENV,
@@ -18,13 +17,6 @@ import type {
   GeoGroundedInvocationOptions,
 } from "../types/geo";
 import { requireApiKey } from "../utils/require-api-key";
-
-const googleSearchTool = tool({
-  type: "provider",
-  id: "google.google_search",
-  args: {},
-  inputSchema: z.object({}),
-});
 
 export function buildGroundedInvocation(
   engine: GeoGroundedEngine,
@@ -55,7 +47,7 @@ export function buildGroundedInvocation(
     case "gateway-google":
       return {
         model: gateway(engine.model, groundedGateway),
-        tools: { google_search: googleSearchTool },
+        tools: { google_search: google.tools.googleSearch({}) },
       };
     case "direct-openai": {
       const provider = createOpenAI({

--- a/packages/geo-core/src/geo/grounding.test.ts
+++ b/packages/geo-core/src/geo/grounding.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { extractGrounding } from "./grounding";
+
+describe("GEO grounding extraction", () => {
+  test("extracts Gemini search queries and sources from gateway metadata", () => {
+    const grounding = extractGrounding({
+      providerMetadata: {
+        googleVertex: {
+          groundingMetadata: {
+            webSearchQueries: ["Notra GEO", "Notra GEO"],
+            groundingChunks: [
+              {
+                web: {
+                  uri: "https://www.usenotra.com/geo",
+                  title: "Notra GEO",
+                },
+              },
+              {
+                retrievedContext: {
+                  uri: "https://vercel.com/docs/ai-gateway/models-and-providers/web-search",
+                  title: "Web Search",
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(grounding, {
+      queries: ["Notra GEO"],
+      sources: [
+        {
+          url: "https://www.usenotra.com/geo",
+          title: "Notra GEO",
+          domain: "usenotra.com",
+        },
+        {
+          url: "https://vercel.com/docs/ai-gateway/models-and-providers/web-search",
+          title: "Web Search",
+          domain: "vercel.com",
+        },
+      ],
+    });
+  });
+
+  test("extracts grounding metadata emitted on generation steps", () => {
+    const grounding = extractGrounding({
+      steps: [
+        {
+          providerMetadata: {
+            vertex: {
+              groundingMetadata: {
+                webSearchQueries: ["current answer engine results"],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    assert.deepEqual(grounding.queries, ["current answer engine results"]);
+  });
+});

--- a/packages/geo-core/src/geo/grounding.ts
+++ b/packages/geo-core/src/geo/grounding.ts
@@ -113,6 +113,61 @@ function collectToolOutputs(
   }
 }
 
+function collectProviderMetadata(
+  providerMetadata: unknown,
+  queries: string[],
+  seenQueries: Set<string>,
+  sources: GeoCheckSource[],
+  seenUrls: Set<string>
+): void {
+  if (!isRecord(providerMetadata)) {
+    return;
+  }
+
+  for (const metadata of Object.values(providerMetadata)) {
+    if (!isRecord(metadata) || !isRecord(metadata.groundingMetadata)) {
+      continue;
+    }
+    const grounding = metadata.groundingMetadata;
+    for (const query of Array.isArray(grounding.webSearchQueries)
+      ? grounding.webSearchQueries
+      : []) {
+      addQuery(queries, seenQueries, query);
+    }
+    for (const chunk of Array.isArray(grounding.groundingChunks)
+      ? grounding.groundingChunks
+      : []) {
+      if (!isRecord(chunk)) {
+        continue;
+      }
+      if (isRecord(chunk.web)) {
+        addSource(sources, seenUrls, {
+          title: chunk.web.title,
+          url: chunk.web.uri,
+        });
+      }
+      if (isRecord(chunk.image)) {
+        addSource(sources, seenUrls, {
+          title: chunk.image.title,
+          url: chunk.image.sourceUri,
+        });
+      }
+      if (isRecord(chunk.retrievedContext)) {
+        addSource(sources, seenUrls, {
+          title: chunk.retrievedContext.title,
+          url: chunk.retrievedContext.uri,
+        });
+      }
+      if (isRecord(chunk.maps)) {
+        addSource(sources, seenUrls, {
+          title: chunk.maps.title,
+          url: chunk.maps.uri,
+        });
+      }
+    }
+  }
+}
+
 function collectTrace(
   trace: GeoGenerateTrace,
   queries: string[],
@@ -126,6 +181,13 @@ function collectTrace(
   collectToolInputs(trace.toolCalls, queries, seenQueries);
   collectToolOutputs(
     trace.toolResults,
+    queries,
+    seenQueries,
+    sources,
+    seenUrls
+  );
+  collectProviderMetadata(
+    trace.providerMetadata,
     queries,
     seenQueries,
     sources,
@@ -152,6 +214,7 @@ export function extractGrounding(result: GeoGenerateTrace): GeoCheckGrounding {
         toolResults: Array.isArray(step.toolResults)
           ? step.toolResults
           : undefined,
+        providerMetadata: step.providerMetadata,
       },
       queries,
       seenQueries,

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -394,11 +394,16 @@ const askGroundedConversation = Effect.fn("geo.askGroundedConversation")(
           ),
       })
     );
+    const grounding = extractGrounding(result);
+    const resultSources = collectGroundedSources(result.sources);
     const answer: GeoGroundedAnswer = {
       text: result.text,
-      grounding: extractGrounding(result),
+      grounding,
       finishReason: result.finishReason,
-      sources: collectGroundedSources(result.sources),
+      sources:
+        resultSources.length > 0
+          ? resultSources
+          : grounding.sources.map(({ title, url }) => ({ title, url })),
       usage: result.usage,
       zdrEnforced: GEO_DIRECT_GROUNDED_PROVIDERS.has(engine.provider)
         ? false

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -138,6 +138,7 @@ export interface GeoGenerateTrace {
   sources?: readonly unknown[];
   toolCalls?: readonly unknown[];
   toolResults?: readonly unknown[];
+  providerMetadata?: unknown;
   steps?: readonly unknown[];
 }
 


### PR DESCRIPTION
Gemini GEO scans should use Google's provider-native Search Grounding and retain the evidence returned by Vertex instead of relying on a hand-authored tool descriptor.

This switches the grounded Gemini engine to `google.tools.googleSearch({})`, extracts Google grounding queries and source chunks from gateway provider metadata, and persists those sources through the existing GEO check fields. OpenAI and Anthropic remain on their already-native search tools.

## Notes
- Scope is limited to `@notra/geo-core`; dashboard chat and Eve agents are unchanged.
- `bun run --filter=@notra/geo-core test`: 5 passed.
- `bun run --filter=@notra/geo-core check-types`: passed.
- Targeted Ultracite check: 0 warnings and 0 errors.
- Live Vercel Gateway smoke tests passed for Gemini, OpenAI, and Anthropic grounded GEO invocations. The complete Gemini run persisted 5 search queries and 2 attributed sources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Gemini GEO scans to Google's provider-native Search Grounding and collects the search queries and citations Vertex returns into the existing GEO check fields, replacing the hand-authored search tool descriptor.

- Extracts grounding metadata (web search queries and source chunks) from gateway provider metadata on traces and generation steps.
- Falls back to grounding-derived sources when the provider returns no direct sources.
- OpenAI and Anthropic grounded engines are unchanged.
- Adds the `@ai-sdk/google` dependency and a `test` script to `@notra/geo-core`.

<sup>Written for commit 9b9cac403330f3b43d053fcb094be533d568c021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

