### PR TITLE
style(dashboard): align font with website

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist_Mono, Noto_Sans } from "next/font/google";
+import { Geist_Mono, Inter } from "next/font/google";
 
 import "@/styles/globals.css";
 
@@ -9,8 +9,8 @@ import { SITE_CONFIG } from "../utils/site";
 
 export const instant = false;
 
-const notoSans = Noto_Sans({
-  variable: "--font-noto-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
@@ -45,7 +45,7 @@ export default function RootLayout({
 }>) {
   return (
     <html
-      className={`${notoSans.variable} ${geistMono.variable} dark:scheme-dark`}
+      className={`${inter.variable} ${geistMono.variable} dark:scheme-dark`}
       lang="en"
       suppressHydrationWarning
     >

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -24,7 +24,7 @@
 }
 
 @theme inline {
-  --font-sans: var(--font-noto-sans);
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-geist-mono);
   --color-geo-search: var(--geo-search);
   --color-geo-memory: var(--geo-memory);


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps the dashboard font from Noto Sans to Inter so the dashboard matches the website's typography. Updates the font variable name and the CSS theme reference accordingly.

<sup>Written for commit 53d510f9b5410ba702dcfe5c6f8fed5f8c888c1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

