### PR TITLE
perf(geo): speed up competitors page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
@@ -3,18 +3,18 @@
 import { PlusSignIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Kbd } from "@notra/ui/components/ui/kbd";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { useHotkey } from "@tanstack/react-hotkeys";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useState } from "react";
 
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
 import { EmptyStateTablePreview } from "@/components/empty-state-preview";
-import { CompetitorEditDialog } from "@/components/geo/competitor-edit-dialog";
-import { CompetitorShareCard } from "@/components/geo/competitor-share-card";
 import { CompetitorsTable } from "@/components/geo/competitors-table";
-import { CompetitorsCsvImportDialog } from "@/components/geo/geo-csv-import-dialog";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
+import { GeoSectionSkeleton } from "@/components/geo/skeleton-parts";
 import { PageContainer } from "@/components/layout/container";
 import {
   GeoProjectProvider,
@@ -36,6 +36,34 @@ import { useGeoRange } from "@/lib/hooks/use-geo-range";
 import { withGeoProject } from "@/utils/geo-paths";
 
 import { GeoPageSkeleton } from "../skeleton";
+
+const loadCompetitorEditDialog = () =>
+  import("@/components/geo/competitor-edit-dialog").then(
+    (module) => module.CompetitorEditDialog
+  );
+const loadCompetitorsCsvImportDialog = () =>
+  import("@/components/geo/geo-csv-import-dialog").then(
+    (module) => module.CompetitorsCsvImportDialog
+  );
+
+const CompetitorEditDialog = dynamic(loadCompetitorEditDialog, { ssr: false });
+const CompetitorsCsvImportDialog = dynamic(loadCompetitorsCsvImportDialog, {
+  ssr: false,
+});
+const CompetitorShareCard = dynamic(
+  () =>
+    import("@/components/geo/competitor-share-card").then(
+      (module) => module.CompetitorShareCard
+    ),
+  {
+    loading: () => (
+      <GeoSectionSkeleton eyebrow="Share of voice">
+        <Skeleton className="h-64 w-full rounded-xl" />
+      </GeoSectionSkeleton>
+    ),
+    ssr: false,
+  }
+);
 
 interface PageClientProps {
   organizationSlug: string;
@@ -65,7 +93,8 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
   const { data: settingsData, isPending } = useGeoSettings(organizationId);
   const { data: competitorShare } = useGeoCompetitorShare(
     organizationId,
-    geoRange.query
+    geoRange.query,
+    true
   );
   const { competitors } = useGeoCompetitorsDb(organizationId);
   const isScanning = useIsGeoScanning(organizationId);
@@ -134,12 +163,19 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
             <Button
               className="gap-1.5"
               onClick={() => setImportOpen(true)}
+              onFocus={loadCompetitorsCsvImportDialog}
+              onMouseEnter={loadCompetitorsCsvImportDialog}
               variant="outline"
             >
               <HugeiconsIcon className="size-4" icon={Upload01Icon} />
               Import CSV
             </Button>
-            <Button className="gap-1.5" onClick={() => setManagerOpen(true)}>
+            <Button
+              className="gap-1.5"
+              onClick={() => setManagerOpen(true)}
+              onFocus={loadCompetitorEditDialog}
+              onMouseEnter={loadCompetitorEditDialog}
+            >
               <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
               Add Competitor
               <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
@@ -163,17 +199,21 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
           points={competitorShare?.points ?? []}
         />
       </div>
-      <CompetitorEditDialog
-        competitor={null}
-        onOpenChange={setManagerOpen}
-        open={managerOpen}
-        organizationId={organizationId}
-      />
-      <CompetitorsCsvImportDialog
-        onOpenChange={setImportOpen}
-        open={importOpen}
-        organizationId={organizationId}
-      />
+      {managerOpen ? (
+        <CompetitorEditDialog
+          competitor={null}
+          onOpenChange={setManagerOpen}
+          open
+          organizationId={organizationId}
+        />
+      ) : null}
+      {importOpen ? (
+        <CompetitorsCsvImportDialog
+          onOpenChange={setImportOpen}
+          open
+          organizationId={organizationId}
+        />
+      ) : null}
     </PageContainer>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
@@ -12,7 +12,9 @@ import { useState } from "react";
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
 import { EmptyStateTablePreview } from "@/components/empty-state-preview";
+import { CompetitorEditDialog } from "@/components/geo/competitor-edit-dialog";
 import { CompetitorsTable } from "@/components/geo/competitors-table";
+import { CompetitorsCsvImportDialog } from "@/components/geo/geo-csv-import-dialog";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
 import { GeoSectionSkeleton } from "@/components/geo/skeleton-parts";
 import { PageContainer } from "@/components/layout/container";
@@ -37,19 +39,6 @@ import { withGeoProject } from "@/utils/geo-paths";
 
 import { GeoPageSkeleton } from "../skeleton";
 
-const loadCompetitorEditDialog = () =>
-  import("@/components/geo/competitor-edit-dialog").then(
-    (module) => module.CompetitorEditDialog
-  );
-const loadCompetitorsCsvImportDialog = () =>
-  import("@/components/geo/geo-csv-import-dialog").then(
-    (module) => module.CompetitorsCsvImportDialog
-  );
-
-const CompetitorEditDialog = dynamic(loadCompetitorEditDialog, { ssr: false });
-const CompetitorsCsvImportDialog = dynamic(loadCompetitorsCsvImportDialog, {
-  ssr: false,
-});
 const CompetitorShareCard = dynamic(
   () =>
     import("@/components/geo/competitor-share-card").then(
@@ -163,19 +152,12 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
             <Button
               className="gap-1.5"
               onClick={() => setImportOpen(true)}
-              onFocus={loadCompetitorsCsvImportDialog}
-              onMouseEnter={loadCompetitorsCsvImportDialog}
               variant="outline"
             >
               <HugeiconsIcon className="size-4" icon={Upload01Icon} />
               Import CSV
             </Button>
-            <Button
-              className="gap-1.5"
-              onClick={() => setManagerOpen(true)}
-              onFocus={loadCompetitorEditDialog}
-              onMouseEnter={loadCompetitorEditDialog}
-            >
+            <Button className="gap-1.5" onClick={() => setManagerOpen(true)}>
               <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
               Add Competitor
               <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>
@@ -199,21 +181,17 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
           points={competitorShare?.points ?? []}
         />
       </div>
-      {managerOpen ? (
-        <CompetitorEditDialog
-          competitor={null}
-          onOpenChange={setManagerOpen}
-          open
-          organizationId={organizationId}
-        />
-      ) : null}
-      {importOpen ? (
-        <CompetitorsCsvImportDialog
-          onOpenChange={setImportOpen}
-          open
-          organizationId={organizationId}
-        />
-      ) : null}
+      <CompetitorEditDialog
+        competitor={null}
+        onOpenChange={setManagerOpen}
+        open={managerOpen}
+        organizationId={organizationId}
+      />
+      <CompetitorsCsvImportDialog
+        onOpenChange={setImportOpen}
+        open={importOpen}
+        organizationId={organizationId}
+      />
     </PageContainer>
   );
 }

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -268,12 +268,18 @@ export function useGeoPromptResults(
 
 export function useGeoCompetitorShare(
   organizationId: string,
-  range?: GeoRangeQuery
+  range?: GeoRangeQuery,
+  summaryOnly = false
 ) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoCompetitorShareResponse>({
     ...dashboardOrpc.geo.competitorShare.queryOptions({
-      input: { organizationId, projectId, ...toGeoWindowInput(range) },
+      input: {
+        organizationId,
+        projectId,
+        ...toGeoWindowInput(range),
+        summaryOnly: summaryOnly || undefined,
+      },
     }),
     enabled: !!organizationId,
     placeholderData: keepPreviousData,

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -99,6 +99,7 @@ import {
   aiTrafficInputSchema,
   geoBrandSearchInputSchema,
   geoCompetitorDeleteInputSchema,
+  geoCompetitorShareInputSchema,
   geoCompetitorsImportInputSchema,
   geoCompetitorDetailInputSchema,
   geoCompetitorSuggestionsInputSchema,
@@ -391,9 +392,11 @@ export const geoRouter = {
       geoHandler((input) => loadGeoPromptResults(input, geoWindow(input)))
     ),
   competitorShare: authorizedProcedure
-    .input(geoTimeseriesInputSchema)
+    .input(geoCompetitorShareInputSchema)
     .handler(
-      geoOpenHandler((input) => loadGeoCompetitorShare(input, geoWindow(input)))
+      geoOpenHandler((input) =>
+        loadGeoCompetitorShare(input, geoWindow(input), input.summaryOnly)
+      )
     ),
   competitors: authorizedProcedure
     .input(geoOrganizationInputSchema)

--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -706,10 +706,36 @@ export const loadGeoPromptResults = Effect.fn("geo.promptResults")(function* (
 });
 
 export const loadGeoCompetitorShare = Effect.fn("geo.competitorShare")(
-  function* (input: GeoScopeInput, window: GeoWindowInput) {
+  function* (
+    input: GeoScopeInput,
+    window: GeoWindowInput,
+    summaryOnly = false
+  ) {
     const scope = yield* resolveGeoScope(input);
     const checkScope = geoCheckScope(scope);
     const checkWindow = toGeoCheckWindow(window);
+
+    if (summaryOnly) {
+      // The competitors page only renders aggregate shares. Avoid the two
+      // additional full-range scans used for overview sparklines and charts.
+      const rows = yield* geoDb("competitor share query failed", () =>
+        queryGeoCheckCompetitorShare(
+          checkScope,
+          checkWindow,
+          GEO_COMPETITOR_SHARE_LIMIT
+        )
+      );
+      const response: GeoCompetitorShareResponse = {
+        configured: true,
+        points: rows.map((row) => ({
+          brand: row.brand,
+          mentions: row.mentions,
+        })),
+        timeseries: [],
+      };
+      return response;
+    }
+
     const [rows, timeseries, trendRows] = yield* Effect.all(
       [
         geoDb("competitor share query failed", () =>

--- a/packages/geo-core/src/schemas/geo.ts
+++ b/packages/geo-core/src/schemas/geo.ts
@@ -207,6 +207,10 @@ export const geoTimeseriesInputSchema = geoOrganizationInputSchema.extend({
   ...geoWindowFields,
 });
 
+export const geoCompetitorShareInputSchema = geoTimeseriesInputSchema.extend({
+  summaryOnly: boolean().optional(),
+});
+
 export const geoPromptCreateInputSchema = geoOrganizationInputSchema.extend({
   id: string().uuid().optional(),
   prompt: string().min(MIN_PROMPT_LENGTH).max(MAX_PROMPT_LENGTH),


### PR DESCRIPTION
### Description
Speeds up the GEO Competitors page by introducing a summary-only mode for competitor share data. The page now skips the unused timeseries and trend queries and only loads the aggregate share data it renders.

The Share of Voice chart is also dynamically loaded, keeping the heavy ECharts dependency out of the initial page bundle.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the GEO Competitors page by skipping the unused timeseries and trend queries and loading the Share of Voice chart only when needed.

- Adds an optional `summaryOnly` flag to the competitor share API that returns just the aggregate share rows.
- The competitors page passes `summaryOnly` and now lazy-loads the Share of Voice chart, keeping ECharts out of the initial bundle.
- Summary-only responses return an empty `timeseries` array.

<sup>Written for commit 034f7092ee72137c31df75b2bf9c7fdb43f4dc60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

