### PR TITLE
fix(web): lock hero headline to two lines and balance subhead

### DIFF
--- a/apps/web/src/components/landing/hero-headline.tsx
+++ b/apps/web/src/components/landing/hero-headline.tsx
@@ -100,10 +100,8 @@ export function HeroHeadline() {
 
   return (
     <h1 className="font-display max-w-[20.5rem] text-center text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:max-w-[56.875rem] sm:text-[3.25rem] sm:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
-      <span className="block whitespace-nowrap sm:inline sm:whitespace-normal">
-        {HERO_HEADLINE_LINE_ONE}{" "}
-      </span>
-      <span className="block whitespace-nowrap sm:inline sm:whitespace-normal">
+      <span className="block whitespace-nowrap">{HERO_HEADLINE_LINE_ONE} </span>
+      <span className="block whitespace-nowrap">
         {HERO_HEADLINE_LINE_TWO_PREFIX}{" "}
         <span className="sr-only">{listEngineNames()}</span>
         <span

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -26,7 +26,7 @@ export function HeroSection() {
           <div className="flex flex-col items-center gap-8 px-6 pt-20 pb-2 sm:gap-10 sm:pt-24 lg:pt-[7.5rem]">
             <div className="flex flex-col items-center gap-7">
               <HeroHeadline />
-              <p className="max-w-[42.875rem] text-center font-sans text-[1.0625rem] leading-[1.14] font-medium tracking-[-0.005em] text-[#1E1E1EBF] sm:text-[1.25rem] dark:text-white/70">
+              <p className="max-w-[42.875rem] text-center font-sans text-[1.0625rem] leading-[1.14] font-medium tracking-[-0.005em] text-pretty text-[#1E1E1EBF] sm:text-[1.25rem] dark:text-white/70">
                 {HERO_SUBHEAD}
               </p>
             </div>


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

https://claude.ai/code/session_015fKXzo3CL89o5Bd1iHM3Xm


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the hero headline to exactly two lines and applies balanced text to the subhead, so the landing hero layout no longer shifts between viewport sizes.

<sup>Written for commit 37d04c0f8fa3fa518a8e9b3c7033baa27830dd47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

