### PR TITLE
feat(geo): track models from mention card

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
@@ -129,6 +129,7 @@ export function GeoTabs({
                 isScanning={isScanning}
                 organizationSlug={organizationSlug}
                 promptResults={promptResults}
+                settings={settings}
                 timeseriesPoints={timeseriesPoints}
                 trackedEngines={settings.engines}
               />

--- a/apps/dashboard/src/components/geo/language-performance-card.tsx
+++ b/apps/dashboard/src/components/geo/language-performance-card.tsx
@@ -11,7 +11,6 @@ import type { LanguagePerformanceRow } from "@notra/geo-core/types/geo";
 import {
   buildLanguagePerformanceRows,
   trackedGeoLanguages,
-  withAddedGeoLanguage,
 } from "@notra/geo-core/utils/geo-language-rows";
 import {
   ResponsiveAlertDialog,
@@ -28,7 +27,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/button";
 import { GeoBar } from "@/components/geo/geo-bar";
@@ -39,7 +39,7 @@ import { InstrumentSection } from "@/components/instrument/instrument-module";
 import { Table, type TableColumn } from "@/components/motion/table";
 import { LANGUAGE_FLAGS } from "@/constants/language-flags";
 import { TABLE_ROW_HEIGHT } from "@/constants/table";
-import { useGeoSettingsUpsert } from "@/lib/hooks/use-geo";
+import { useGeoSettingsLanguageAdd } from "@/lib/hooks/use-geo";
 import { cn } from "@/lib/utils";
 import type { LanguagePerformanceCardProps } from "@/types/geo";
 import { formatMentionRate } from "@/utils/geo-charts";
@@ -212,17 +212,15 @@ export function LanguagePerformanceCard({
   settings,
 }: LanguagePerformanceCardProps) {
   const [languageToAdd, setLanguageToAdd] = useState<string>();
-  const upsert = useGeoSettingsUpsert(organizationId);
+  const addLanguage = useGeoSettingsLanguageAdd(organizationId);
   const savedExtras = trackedGeoLanguages(settings.languages);
-  const savedExtraSet = new Set(savedExtras);
+  const pendingLanguage = addLanguage.isPending
+    ? addLanguage.variables
+    : undefined;
   const configuredLanguages =
-    upsert.isPending && upsert.variables
-      ? trackedGeoLanguages(upsert.variables.languages)
+    pendingLanguage !== undefined
+      ? trackedGeoLanguages([...savedExtras, pendingLanguage])
       : savedExtras;
-  const configuredLanguageSet = new Set(configuredLanguages);
-  const pendingLanguage =
-    configuredLanguages.find((language) => !savedExtraSet.has(language)) ??
-    savedExtras.find((language) => !configuredLanguageSet.has(language));
   const atLimit = configuredLanguages.length >= GEO_MAX_LANGUAGES;
 
   const rows = buildLanguagePerformanceRows({
@@ -231,59 +229,25 @@ export function LanguagePerformanceCard({
     slotCount: GEO_VISIBILITY_TABLE_ROWS,
   });
 
-  const persistLanguages = useCallback(
-    (next: string[] | null) => {
-      if (upsert.isPending) {
-        return;
-      }
-      const companyName = settings.companyName.trim();
-      if (next === null || companyName.length === 0) {
-        return;
-      }
-      upsert.mutate({
-        aliases: settings.aliases,
-        companyName,
-        competitors: settings.competitors,
-        enabled: settings.enabled,
-        enforceZdr: settings.enforceZdr,
-        engines: settings.engines,
-        languages: next,
-        nonZdrApprovedEngines: settings.nonZdrApprovedEngines,
-        organizationId,
-        scanIntervalHours: settings.scanIntervalHours,
-      });
-    },
-    [
-      organizationId,
-      settings.aliases,
-      settings.companyName,
-      settings.competitors,
-      settings.enabled,
-      settings.enforceZdr,
-      settings.engines,
-      settings.nonZdrApprovedEngines,
-      settings.scanIntervalHours,
-      upsert,
-    ]
-  );
-
-  const handleConfirmAddLanguage = useCallback(() => {
+  const handleConfirmAddLanguage = () => {
     if (!languageToAdd) {
       return;
     }
-    persistLanguages(withAddedGeoLanguage(configuredLanguages, languageToAdd));
+    addLanguage.mutate(languageToAdd, {
+      onSuccess: () => toast.success(`${languageToAdd} added to tracking`),
+    });
     setLanguageToAdd(undefined);
-  }, [configuredLanguages, languageToAdd, persistLanguages]);
+  };
 
   const columns = useMemo(
     () =>
       languagePerformanceColumns({
-        adding: upsert.isPending,
+        adding: addLanguage.isPending,
         atLimit,
         onAddLanguage: setLanguageToAdd,
         pendingLanguage,
       }),
-    [atLimit, pendingLanguage, upsert.isPending]
+    [addLanguage.isPending, atLimit, pendingLanguage]
   );
 
   return (

--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -90,6 +90,7 @@ function ProviderRow({
   onOpen,
   onTrack,
   trackEngine,
+  trackingDisabled,
   tracking,
 }: MentionProviderRowProps) {
   const { family, totals, mentionDelta, tracked } = row;
@@ -156,7 +157,7 @@ function ProviderRow({
           trackEngine ? (
             <Button
               aria-label={`Track ${name}`}
-              disabled={tracking}
+              disabled={trackingDisabled}
               onClick={() => onTrack(trackEngine, name)}
               size="xs"
               type="button"
@@ -368,6 +369,7 @@ export function MentionRateCard({
                       rank={index + 1}
                       row={row}
                       trackEngine={trackableEngines.get(row.family.family)}
+                      trackingDisabled={addEngine.isPending}
                       tracking={pendingFamily === row.family.family}
                     />
                   ))}

--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -19,10 +19,7 @@ import {
   engineFamilyLabel,
   engineFamilyOf,
 } from "@notra/geo-core/utils/geo-engine-family";
-import {
-  resolveGeoZdrMode,
-  sortKnownEngines,
-} from "@notra/geo-core/utils/geo-engines";
+import { resolveGeoZdrMode } from "@notra/geo-core/utils/geo-engines";
 import { geoScanEmptyMessage } from "@notra/geo-core/utils/geo-scan";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import {
@@ -52,7 +49,10 @@ import {
 import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import { EASE_OUT } from "@/lib/ease";
-import { useGeoModelCatalog, useGeoSettingsUpsert } from "@/lib/hooks/use-geo";
+import {
+  useGeoModelCatalog,
+  useGeoSettingsEngineAdd,
+} from "@/lib/hooks/use-geo";
 import { useScrollOverflow } from "@/lib/hooks/use-scroll-overflow";
 import { cn } from "@/lib/utils";
 import type {
@@ -240,7 +240,7 @@ export function MentionRateCard({
 }: MentionRateCardProps) {
   const organizationId = settings?.organizationId ?? "";
   const { data: catalog } = useGeoModelCatalog(organizationId);
-  const upsert = useGeoSettingsUpsert(organizationId, { silentSuccess: true });
+  const addEngine = useGeoSettingsEngineAdd(organizationId);
   const ranked = useMemo(
     () =>
       buildMentionProviderRows(engines, {
@@ -286,14 +286,10 @@ export function MentionRateCard({
     }
     return result;
   }, [catalog, ranked, settings]);
-  const savedEngineSet = new Set(settings?.engines);
-  const pendingEngine =
-    upsert.isPending && upsert.variables
-      ? upsert.variables.engines.find((engine) => !savedEngineSet.has(engine))
+  const pendingFamily =
+    addEngine.isPending && addEngine.variables
+      ? engineFamilyOf(addEngine.variables)
       : undefined;
-  const pendingFamily = pendingEngine
-    ? engineFamilyOf(pendingEngine)
-    : undefined;
   const totals = mentionOverviewTotals(
     withTrackedMentionEngines(engines, trackedEngines)
   );
@@ -311,26 +307,12 @@ export function MentionRateCard({
     setSelected(family);
   };
   const trackEngine = (engine: string, name: string) => {
-    if (!catalog || !settings || upsert.isPending) {
+    if (addEngine.isPending) {
       return;
     }
-    upsert.mutate(
-      {
-        aliases: settings.aliases,
-        companyName: settings.companyName,
-        competitors: settings.competitors,
-        enabled: settings.enabled,
-        enforceZdr: settings.enforceZdr,
-        engines: sortKnownEngines(catalog, [...settings.engines, engine]),
-        languages: settings.languages,
-        nonZdrApprovedEngines: settings.nonZdrApprovedEngines,
-        organizationId,
-        scanIntervalHours: settings.scanIntervalHours,
-      },
-      {
-        onSuccess: () => toast.success(`${name} added to tracking`),
-      }
-    );
+    addEngine.mutate(engine, {
+      onSuccess: () => toast.success(`${name} added to tracking`),
+    });
   };
   const { ref, hiddenBelow, atEnd, scrollToEnd } =
     useScrollOverflow<HTMLDivElement>(

--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -1,21 +1,28 @@
 "use client";
 
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { ArrowDown01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   GEO_EMPTY_PROMPT_RESULTS,
   GEO_EMPTY_TIMESERIES,
   GEO_FAMILY_STAT_TREND_HINT,
+  GEO_MAX_ENGINES,
   GEO_MENTION_HINT_BLEED_REM,
   GEO_MENTION_HINT_HEIGHT_REM,
   GEO_MENTION_ROW_HEIGHT_REM,
   GEO_MENTION_SUMMARY_VISIBLE,
   GEO_MENTION_UNTRACKED_HINT,
-  GEO_MENTION_UNTRACKED_LABEL,
   GEO_MENTIONS_LABEL,
 } from "@notra/geo-core/constants/geo";
 import type { GeoEngineFamily } from "@notra/geo-core/types/geo";
-import { engineFamilyLabel } from "@notra/geo-core/utils/geo-engine-family";
+import {
+  engineFamilyLabel,
+  engineFamilyOf,
+} from "@notra/geo-core/utils/geo-engine-family";
+import {
+  resolveGeoZdrMode,
+  sortKnownEngines,
+} from "@notra/geo-core/utils/geo-engines";
 import { geoScanEmptyMessage } from "@notra/geo-core/utils/geo-scan";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import {
@@ -30,10 +37,13 @@ import {
   useReducedMotion,
 } from "motion/react";
 import { useMemo, useState } from "react";
+import { toast } from "sonner";
 
+import { Button } from "@/components/button";
 import { EngineFamilySheet } from "@/components/geo/engine-family-sheet";
 import { EngineIcon } from "@/components/geo/engine-icon";
 import { GeoStatDelta } from "@/components/geo/geo-stat-delta";
+import { StatusSpinner } from "@/components/geo/status-spinner";
 import { TrafficBreakdownCard } from "@/components/geo/traffic-breakdown-card";
 import {
   InstrumentEmpty,
@@ -42,6 +52,7 @@ import {
 import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import { EASE_OUT } from "@/lib/ease";
+import { useGeoModelCatalog, useGeoSettingsUpsert } from "@/lib/hooks/use-geo";
 import { useScrollOverflow } from "@/lib/hooks/use-scroll-overflow";
 import { cn } from "@/lib/utils";
 import type {
@@ -73,7 +84,14 @@ const LIST_STYLE = {
   maxHeight: `${GEO_MENTION_SUMMARY_VISIBLE * GEO_MENTION_ROW_HEIGHT_REM + GEO_MENTION_HINT_HEIGHT_REM}rem`,
 } as const;
 
-function ProviderRow({ rank, row, onOpen }: MentionProviderRowProps) {
+function ProviderRow({
+  rank,
+  row,
+  onOpen,
+  onTrack,
+  trackEngine,
+  tracking,
+}: MentionProviderRowProps) {
   const { family, totals, mentionDelta, tracked } = row;
   const name = engineFamilyLabel(family.family);
   const clickable = totals.mentions > 0;
@@ -134,7 +152,29 @@ function ProviderRow({ rank, row, onOpen }: MentionProviderRowProps) {
         {content}
       </HoverCardTrigger>
       <TrafficBreakdownCard
-        aside={GEO_MENTION_UNTRACKED_LABEL}
+        aside={
+          trackEngine ? (
+            <Button
+              aria-label={`Track ${name}`}
+              disabled={tracking}
+              onClick={() => onTrack(trackEngine, name)}
+              size="xs"
+              type="button"
+              variant="outline"
+            >
+              {tracking ? (
+                <StatusSpinner />
+              ) : (
+                <HugeiconsIcon
+                  data-icon="inline-start"
+                  icon={PlusSignIcon}
+                  strokeWidth={2}
+                />
+              )}
+              Track
+            </Button>
+          ) : null
+        }
         icon={<EngineIcon className="size-4" engine={family.family} />}
         title={name}
       >
@@ -191,12 +231,16 @@ function MoreModelsHint({
 
 export function MentionRateCard({
   engines,
+  settings,
   trackedEngines,
   timeseriesPoints = GEO_EMPTY_TIMESERIES,
   promptResults = GEO_EMPTY_PROMPT_RESULTS,
   isScanning = false,
   organizationSlug,
 }: MentionRateCardProps) {
+  const organizationId = settings?.organizationId ?? "";
+  const { data: catalog } = useGeoModelCatalog(organizationId);
+  const upsert = useGeoSettingsUpsert(organizationId, { silentSuccess: true });
   const ranked = useMemo(
     () =>
       buildMentionProviderRows(engines, {
@@ -205,6 +249,51 @@ export function MentionRateCard({
       }),
     [engines, trackedEngines, timeseriesPoints]
   );
+  const trackableEngines = useMemo(() => {
+    const result = new Map<string, string>();
+    if (!catalog || !settings || settings.engines.length >= GEO_MAX_ENGINES) {
+      return result;
+    }
+
+    const knownEngines = new Set<string>();
+    const currentModelsByFamily = new Map<string, string[]>();
+    for (const model of catalog.models) {
+      knownEngines.add(model.id);
+      const family = engineFamilyOf(model.id);
+      const models = currentModelsByFamily.get(family) ?? [];
+      models.push(model.id);
+      currentModelsByFamily.set(family, models);
+    }
+    for (const row of ranked) {
+      if (row.tracked) {
+        continue;
+      }
+      const historicModels = row.family.variants.map(
+        (variant) => variant.model
+      );
+      const currentModels = currentModelsByFamily.get(row.family.family) ?? [];
+      const engine = [...historicModels, ...currentModels].find(
+        (candidate) =>
+          knownEngines.has(candidate) &&
+          resolveGeoZdrMode(catalog, candidate, {
+            enforceZdr: settings.enforceZdr,
+            nonZdrApprovedEngines: settings.nonZdrApprovedEngines,
+          }) !== null
+      );
+      if (engine) {
+        result.set(row.family.family, engine);
+      }
+    }
+    return result;
+  }, [catalog, ranked, settings]);
+  const savedEngineSet = new Set(settings?.engines);
+  const pendingEngine =
+    upsert.isPending && upsert.variables
+      ? upsert.variables.engines.find((engine) => !savedEngineSet.has(engine))
+      : undefined;
+  const pendingFamily = pendingEngine
+    ? engineFamilyOf(pendingEngine)
+    : undefined;
   const totals = mentionOverviewTotals(
     withTrackedMentionEngines(engines, trackedEngines)
   );
@@ -220,6 +309,28 @@ export function MentionRateCard({
       tracked: row?.tracked ?? null,
     });
     setSelected(family);
+  };
+  const trackEngine = (engine: string, name: string) => {
+    if (!catalog || !settings || upsert.isPending) {
+      return;
+    }
+    upsert.mutate(
+      {
+        aliases: settings.aliases,
+        companyName: settings.companyName,
+        competitors: settings.competitors,
+        enabled: settings.enabled,
+        enforceZdr: settings.enforceZdr,
+        engines: sortKnownEngines(catalog, [...settings.engines, engine]),
+        languages: settings.languages,
+        nonZdrApprovedEngines: settings.nonZdrApprovedEngines,
+        organizationId,
+        scanIntervalHours: settings.scanIntervalHours,
+      },
+      {
+        onSuccess: () => toast.success(`${name} added to tracking`),
+      }
+    );
   };
   const { ref, hiddenBelow, atEnd, scrollToEnd } =
     useScrollOverflow<HTMLDivElement>(
@@ -271,8 +382,11 @@ export function MentionRateCard({
                     <ProviderRow
                       key={row.family.family}
                       onOpen={openFamily}
+                      onTrack={trackEngine}
                       rank={index + 1}
                       row={row}
+                      trackEngine={trackableEngines.get(row.family.family)}
+                      tracking={pendingFamily === row.family.family}
                     />
                   ))}
                 </div>

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -228,6 +228,44 @@ export function useGeoSettingsUpsert(
   });
 }
 
+export function useGeoSettingsEngineAdd(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (engine: string) =>
+      dashboardOrpc.geo.settingsEngineAdd.call({
+        organizationId,
+        projectId,
+        engine,
+      }),
+    onSuccess: () =>
+      invalidateCompetitorQueries(queryClient, organizationId, projectId),
+    onError: (error) => {
+      trackEvent(POSTHOG_EVENTS.GEO_SETTINGS_SAVE_FAILED);
+      toast.error(toErrorMessage(error, "Failed to add model to tracking"));
+    },
+  });
+}
+
+export function useGeoSettingsLanguageAdd(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (language: string) =>
+      dashboardOrpc.geo.settingsLanguageAdd.call({
+        organizationId,
+        projectId,
+        language,
+      }),
+    onSuccess: () =>
+      invalidateCompetitorQueries(queryClient, organizationId, projectId),
+    onError: (error) => {
+      trackEvent(POSTHOG_EVENTS.GEO_SETTINGS_SAVE_FAILED);
+      toast.error(toErrorMessage(error, "Failed to add language to tracking"));
+    },
+  });
+}
+
 export function useGeoOverview(organizationId: string, range?: GeoRangeQuery) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoOverviewResponse>({

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -50,6 +50,8 @@ import {
   suggestGeoCompetitors,
 } from "@notra/geo-core/geo/onboarding";
 import {
+  addGeoTrackedEngine,
+  addGeoTrackedLanguage,
   createGeoPrompt,
   deleteGeoCompetitor,
   deleteGeoPrompt,
@@ -124,6 +126,8 @@ import {
   geoSequenceResultsInputSchema,
   geoSequenceRunInputSchema,
   geoSequenceUpdateInputSchema,
+  geoSettingsEngineAddInputSchema,
+  geoSettingsLanguageAddInputSchema,
   geoSettingsUpsertInputSchema,
   geoSuggestionIdInputSchema,
   geoTimeseriesInputSchema,
@@ -402,6 +406,12 @@ export const geoRouter = {
   settings: authorizedProcedure
     .input(geoOrganizationInputSchema)
     .handler(geoOpenHandler((input) => loadGeoSettings(input))),
+  settingsEngineAdd: authorizedProcedure
+    .input(geoSettingsEngineAddInputSchema)
+    .handler(geoHandler((input) => addGeoTrackedEngine(input))),
+  settingsLanguageAdd: authorizedProcedure
+    .input(geoSettingsLanguageAddInputSchema)
+    .handler(geoHandler((input) => addGeoTrackedLanguage(input))),
   settingsUpsert: authorizedProcedure
     .input(geoSettingsUpsertInputSchema)
     .handler(

--- a/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
+++ b/apps/dashboard/src/lib/orpc/utils/geo-errors.ts
@@ -40,6 +40,8 @@ export function toGeoOrpcError(failure: GeoRouterError): Error {
       return badRequest("Configure your brand tracking settings first");
     case "GeoSettingsDisabledError":
       return badRequest("Enable brand tracking before starting a scan");
+    case "GeoSettingsTrackingError":
+      return badRequest(failure.message);
     case "GeoSampleDataDisabledError":
       return notFound();
     case "GeoDiscoveryError":

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -419,6 +419,9 @@ export interface MentionProviderRowProps {
   rank: number;
   row: MentionProviderRow;
   onOpen: (family: GeoEngineFamily) => void;
+  onTrack: (engine: string, name: string) => void;
+  trackEngine?: string;
+  tracking: boolean;
 }
 
 export interface MentionMoreModelsHintProps {
@@ -429,6 +432,7 @@ export interface MentionMoreModelsHintProps {
 
 export interface MentionRateCardProps {
   engines: GeoOverviewEngine[];
+  settings?: GeoSettings;
   trackedEngines?: readonly string[];
   timeseriesPoints?: readonly GeoTimeseriesPoint[];
   promptResults?: readonly GeoPromptResult[];

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -421,6 +421,7 @@ export interface MentionProviderRowProps {
   onOpen: (family: GeoEngineFamily) => void;
   onTrack: (engine: string, name: string) => void;
   trackEngine?: string;
+  trackingDisabled: boolean;
   tracking: boolean;
 }
 

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -705,9 +705,8 @@ export const GEO_MENTION_SUMMARY_VISIBLE = 5;
 export const GEO_MENTION_ROW_HEIGHT_REM = 2.75;
 export const GEO_MENTION_HINT_HEIGHT_REM = 2;
 export const GEO_MENTION_HINT_BLEED_REM = 1;
-export const GEO_MENTION_UNTRACKED_LABEL = "Not tracked";
 export const GEO_MENTION_UNTRACKED_HINT =
-  "These mentions come from earlier scans. Add the model back in GEO settings to keep tracking it.";
+  "This model is not tracked. These mentions come from earlier scans.";
 export const GEO_RANGE_PRESETS = [
   { value: "today", label: "Today" },
   { value: "yesterday", label: "Yesterday" },

--- a/packages/geo-core/src/geo/errors.ts
+++ b/packages/geo-core/src/geo/errors.ts
@@ -87,6 +87,12 @@ export class GeoSettingsDisabledError extends Data.TaggedError(
   readonly projectId: string;
 }> {}
 
+export class GeoSettingsTrackingError extends Data.TaggedError(
+  "GeoSettingsTrackingError"
+)<{
+  readonly message: string;
+}> {}
+
 export class GeoScanStartError extends Data.TaggedError("GeoScanStartError")<{
   readonly cause: unknown;
 }> {}
@@ -239,6 +245,7 @@ export type GeoRouterError =
   | GeoSequenceRunUnavailableError
   | GeoSettingsDisabledError
   | GeoSettingsMissingError
+  | GeoSettingsTrackingError
   | GeoTinybirdError
   | GeoWriterCreditsExhaustedError
   | GeoWriterPlanError

--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -39,6 +39,8 @@ import {
   GEO_COMPETITOR_SHARE_LIMIT,
   GEO_JOURNEY_DETAIL_LIMIT,
   GEO_MAX_COMPETITORS,
+  GEO_MAX_ENGINES,
+  GEO_MAX_LANGUAGES,
 } from "../constants/geo";
 import { GEO_MODEL_CATALOG_STATIC } from "../constants/geo-model-catalog";
 import { GeoEntitlementService } from "../deps";
@@ -60,6 +62,8 @@ import type {
   GeoPromptInsert,
   GeoPromptResultsResponse,
   GeoScopeInput,
+  GeoSettingsEngineAddInput,
+  GeoSettingsLanguageAddInput,
   GeoSettingsResponse,
   GeoSettingsUpsertInput,
   GeoTimeseriesResponse,
@@ -78,7 +82,12 @@ import type {
   GeoPromptImportRow,
 } from "../types/geo-import";
 import { toGeoTrafficTotals, toGeoVisitorType } from "../utils/ai-traffic";
-import { getGeoModelCatalogEntry } from "../utils/geo-model-catalog";
+import { trackedGeoLanguages } from "../utils/geo-language-rows";
+import {
+  geoDefaultEngines,
+  getGeoModelCatalogEntry,
+  isGeoEngineZdrCapable,
+} from "../utils/geo-model-catalog";
 import { groupGeoSparklinePoints } from "../utils/geo-sparkline";
 import { competitorKey } from "./domain";
 import { geoDb, geoQuery } from "./effect";
@@ -89,6 +98,7 @@ import {
   GeoScanAlreadyRunningError,
   GeoSettingsDisabledError,
   GeoSettingsMissingError,
+  GeoSettingsTrackingError,
 } from "./errors";
 import { geoHiddenSourceParams } from "./hidden-sources";
 import { lockGeoProject } from "./lock";
@@ -472,6 +482,103 @@ export const importGeoCompetitors = Effect.fn("geo.competitorsImport")(
       competitors,
     };
     return result;
+  }
+);
+
+export const addGeoTrackedEngine = Effect.fn("geo.settingsEngineAdd")(
+  function* (input: GeoSettingsEngineAddInput) {
+    const { projectId } = yield* requireGeoProject(input);
+    const catalog = yield* loadGeoModelCatalog(input.organizationId);
+    if (!getGeoModelCatalogEntry(catalog, input.engine)) {
+      return yield* Effect.fail(
+        new GeoSettingsTrackingError({
+          message: "This model is no longer available for tracking",
+        })
+      );
+    }
+
+    const initialEngines = [
+      ...new Set([...geoDefaultEngines(catalog), input.engine]),
+    ];
+    const updated = yield* geoDb("tracked engine update failed", () =>
+      db
+        .update(geoSettings)
+        .set({
+          engines: sql<string[]>`
+            CASE
+              WHEN ${geoSettings.engines} IS NULL OR cardinality(${geoSettings.engines}) = 0
+                THEN ${initialEngines}::text[]
+              WHEN ${input.engine} = ANY(${geoSettings.engines})
+                THEN ${geoSettings.engines}
+              WHEN cardinality(${geoSettings.engines}) < ${GEO_MAX_ENGINES}
+                THEN array_append(${geoSettings.engines}, ${input.engine})
+              ELSE ${geoSettings.engines}
+            END
+          `,
+        })
+        .where(
+          and(
+            eq(geoSettings.organizationId, input.organizationId),
+            eq(geoSettings.projectId, projectId),
+            sql`(
+              NOT ${geoSettings.enforceZdr}
+              OR ${isGeoEngineZdrCapable(catalog, input.engine)}
+              OR ${input.engine} = ANY(${geoSettings.nonZdrApprovedEngines})
+            )`
+          )
+        )
+        .returning({ engines: geoSettings.engines })
+    );
+
+    if (!updated.at(0)?.engines?.includes(input.engine)) {
+      return yield* Effect.fail(
+        new GeoSettingsTrackingError({
+          message:
+            "This model cannot be added under the current tracking settings",
+        })
+      );
+    }
+  }
+);
+
+export const addGeoTrackedLanguage = Effect.fn("geo.settingsLanguageAdd")(
+  function* (input: GeoSettingsLanguageAddInput) {
+    const { projectId } = yield* requireGeoProject(input);
+    const initialLanguages = [
+      ...new Set([...trackedGeoLanguages([]), input.language]),
+    ];
+    const updated = yield* geoDb("tracked language update failed", () =>
+      db
+        .update(geoSettings)
+        .set({
+          languages: sql<string[]>`
+            CASE
+              WHEN ${geoSettings.languages} IS NULL OR cardinality(${geoSettings.languages}) = 0
+                THEN ${initialLanguages}::text[]
+              WHEN ${input.language} = ANY(${geoSettings.languages})
+                THEN ${geoSettings.languages}
+              WHEN cardinality(${geoSettings.languages}) < ${GEO_MAX_LANGUAGES}
+                THEN array_append(${geoSettings.languages}, ${input.language})
+              ELSE ${geoSettings.languages}
+            END
+          `,
+        })
+        .where(
+          and(
+            eq(geoSettings.organizationId, input.organizationId),
+            eq(geoSettings.projectId, projectId)
+          )
+        )
+        .returning({ languages: geoSettings.languages })
+    );
+
+    if (!updated.at(0)?.languages?.includes(input.language)) {
+      return yield* Effect.fail(
+        new GeoSettingsTrackingError({
+          message: "This language cannot be added to tracking",
+        })
+      );
+    }
   }
 );
 

--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -510,7 +510,10 @@ export const addGeoTrackedEngine = Effect.fn("geo.settingsEngineAdd")(
                 THEN ${initialEngines}::text[]
               WHEN ${input.engine} = ANY(${geoSettings.engines})
                 THEN ${geoSettings.engines}
-              WHEN cardinality(${geoSettings.engines}) < ${GEO_MAX_ENGINES}
+              WHEN (
+                SELECT count(DISTINCT engine)
+                FROM unnest(${geoSettings.engines}) AS tracked_engines(engine)
+              ) < ${GEO_MAX_ENGINES}
                 THEN array_append(${geoSettings.engines}, ${input.engine})
               ELSE ${geoSettings.engines}
             END
@@ -557,7 +560,10 @@ export const addGeoTrackedLanguage = Effect.fn("geo.settingsLanguageAdd")(
                 THEN ${initialLanguages}::text[]
               WHEN ${input.language} = ANY(${geoSettings.languages})
                 THEN ${geoSettings.languages}
-              WHEN cardinality(${geoSettings.languages}) < ${GEO_MAX_LANGUAGES}
+              WHEN (
+                SELECT count(DISTINCT language)
+                FROM unnest(${geoSettings.languages}) AS tracked_languages(language)
+              ) < ${GEO_MAX_LANGUAGES}
                 THEN array_append(${geoSettings.languages}, ${input.language})
               ELSE ${geoSettings.languages}
             END

--- a/packages/geo-core/src/schemas/geo.ts
+++ b/packages/geo-core/src/schemas/geo.ts
@@ -101,6 +101,20 @@ export const geoModelCatalogInputSchema = object({
   organizationId: string().min(1),
 });
 
+export const geoSettingsEngineAddInputSchema =
+  geoOrganizationInputSchema.extend({
+    engine: string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
+  });
+
+export const geoSettingsLanguageAddInputSchema =
+  geoOrganizationInputSchema.extend({
+    language: string()
+      .min(1)
+      .refine((value) => GEO_SUPPORTED_LANGUAGE_SET.has(value), {
+        message: "Unsupported language",
+      }),
+  });
+
 export const geoSettingsUpsertInputSchema = geoOrganizationInputSchema.extend({
   companyName: string().min(1),
   aliases: array(string().min(1)).max(GEO_MAX_ALIASES),

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -289,6 +289,14 @@ export interface GeoSettingsUpsertInput {
   scanIntervalHours: number;
 }
 
+export interface GeoSettingsEngineAddInput extends GeoScopeInput {
+  engine: string;
+}
+
+export interface GeoSettingsLanguageAddInput extends GeoScopeInput {
+  language: string;
+}
+
 export interface SyncGeoScanScheduleInput {
   organizationId: string;
   projectId: string;


### PR DESCRIPTION
### Description
Replaces the passive “Not tracked” label in the GEO mentions card with a direct “+ Track” action. The action adds a compatible model from the same provider family to GEO tracking while respecting ZDR requirements and model limits. It includes loading, success, and error feedback.


### Screenshot/Recording (if applicable)
<img width="338" height="158" alt="image" src="https://github.com/user-attachments/assets/4218fa0a-ec56-40f3-a03a-55bc770eb764" />



<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a direct "+ Track" action to the GEO mentions card so users can resume tracking a model from an untracked provider row, and moves language adds onto the same dedicated endpoint pattern.

- Untracked provider rows now show a "+ Track" button that adds a compatible model, respecting ZDR settings and the engine limit; the button is hidden when no compatible catalog model passes ZDR checks.
- New `settingsEngineAdd` and `settingsLanguageAdd` endpoints update only the engines or languages array and enforce limits against distinct selections, replacing full-settings upserts and avoiding read-modify-write races.
- Tracking actions are disabled while a save is in flight to prevent concurrent adds.
- The language performance card now uses the same dedicated add endpoint instead of re-writing all settings on each add.

<sup>Written for commit 40dd311736dd77578a8492d9c26c7f8f0a1b30a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

