### PR TITLE
fix(dashboard): align mention activity header

### DIFF
--- a/apps/dashboard/src/components/instrument/instrument-module.tsx
+++ b/apps/dashboard/src/components/instrument/instrument-module.tsx
@@ -36,7 +36,7 @@ export function InstrumentModule({
       contentClassName = "flex flex-1 flex-col p-0";
     } else if (tableHeader) {
       headerClassName =
-        "border-border bg-muted h-[4.25rem] content-center rounded-t-2xl border border-b-0 pb-5";
+        "border-border bg-muted h-[4.25rem] content-center items-center rounded-t-2xl border border-b-0 pb-5";
       contentClassName =
         "border-border bg-card relative -mt-5 flex flex-1 flex-col rounded-2xl border p-4";
     }
@@ -55,7 +55,12 @@ export function InstrumentModule({
           </CardTitle>
           {description && <CardDescription>{description}</CardDescription>}
           {(readout || action) && (
-            <CardAction className="flex min-w-0 items-center gap-2">
+            <CardAction
+              className={cn(
+                "flex min-w-0 items-center gap-2",
+                tableHeader && "row-span-1 self-center"
+              )}
+            >
               {readout && (
                 <span className="text-muted-foreground truncate text-xs tabular-nums">
                   {readout}


### PR DESCRIPTION
### Description
Vertically aligns the Mention Activity title with the “All providers” action in table-style instrument headers.

The action now uses a single grid row and both header elements are centered consistently without affecting other card variants.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vertically aligns the Mention Activity title with the “All providers” action in table-style instrument headers. Both elements now sit on a single grid row and are centered consistently without affecting other card variants.

<sup>Written for commit 65e1d599b62d477a0e6e03a619f3196cc0b63493. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

