### PR TITLE
fix(dashboard): preserve sidebar mode on content

### DIFF
--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -84,9 +84,11 @@ export const GEO_ROUTE_SECTIONS: ReadonlySet<string> = new Set([
   "feedback",
 ]);
 
+// Only mode-exclusive routes belong here. Shared destinations such as Content
+// keep the currently stored mode so navigating there from GEO does not swap
+// the sidebar to Studio.
 export const STUDIO_ROUTE_SECTIONS: ReadonlySet<string> = new Set([
   "chat",
-  "content",
   "collection",
   "analytics",
   "brand",

--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -84,9 +84,8 @@ export const GEO_ROUTE_SECTIONS: ReadonlySet<string> = new Set([
   "feedback",
 ]);
 
-// Only mode-exclusive routes belong here. Shared destinations such as Content
-// keep the currently stored mode so navigating there from GEO does not swap
-// the sidebar to Studio.
+export const SHARED_ROUTE_SECTIONS: ReadonlySet<string> = new Set(["content"]);
+
 export const STUDIO_ROUTE_SECTIONS: ReadonlySet<string> = new Set([
   "chat",
   "collection",

--- a/apps/dashboard/src/utils/nav.ts
+++ b/apps/dashboard/src/utils/nav.ts
@@ -7,6 +7,7 @@ import {
   GEO_ROUTE_SECTIONS,
   NAV_GEO_IMPROVE_LINKS,
   NAV_MAIN_ITEMS,
+  SHARED_ROUTE_SECTIONS,
   SIDEBAR_DEFAULT_MODE,
   STUDIO_ROUTE_SECTIONS,
 } from "@/constants/nav";
@@ -35,6 +36,11 @@ export function resolveSidebarMode(
   // GEO pick so opening `/{slug}` can restore that mode instead of writing
   // studio over it.
   if (section === undefined) {
+    return storedMode ?? "studio";
+  }
+  // Shared destinations keep the current mode. Without a stored choice, match
+  // the org root's visible Studio default instead of switching on navigation.
+  if (SHARED_ROUTE_SECTIONS.has(section)) {
     return storedMode ?? "studio";
   }
   if (GEO_ROUTE_SECTIONS.has(section)) {


### PR DESCRIPTION
### Description
Keep the current sidebar mode when navigating to the shared Content destination. GEO users now remain in GEO, while Studio users remain in Studio.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the active sidebar mode on the shared Content destination, and defaults it to Studio when no mode has been stored.

- Moves `content` out of Studio-only sections into shared route sections.
- Shared routes now keep the current mode instead of switching to Studio on navigation.

<sup>Written for commit 1712d7a981d09ad7fc07e3b542d808d4475ed61d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

