### PR TITLE
fix(web): sync hero provider with traffic feed

### DIFF
--- a/apps/web/src/components/landing/citation-rows.tsx
+++ b/apps/web/src/components/landing/citation-rows.tsx
@@ -2,6 +2,7 @@
 
 import { EngineIcon } from "@notra/ui/components/geo/engine-icon";
 import { PurposeBadge } from "@notra/ui/components/geo/purpose-badge";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import {
   Table,
   TableBody,
@@ -13,7 +14,6 @@ import {
 import { cn } from "@notra/ui/lib/utils";
 import { AnimatePresence, domAnimation, LazyMotion, m } from "motion/react";
 
-import { LIVE_TRAFFIC_TIMESTAMP_PLACEHOLDER } from "@/constants/landing/live-traffic";
 import { formatCapturedAt } from "@/lib/landing/live-traffic";
 import type { CitationRowsProps, LiveCitationRow } from "@/types/landing/geo";
 
@@ -37,11 +37,15 @@ function CitationCells({
     <>
       <TableCell className="text-muted-foreground py-3.5 text-sm whitespace-nowrap tabular-nums">
         {base === null ? (
-          <span className="invisible">
-            {LIVE_TRAFFIC_TIMESTAMP_PLACEHOLDER}
-          </span>
+          <Skeleton aria-hidden className="h-4 w-32" />
         ) : (
-          formatCapturedAt(row, base)
+          <m.span
+            animate={{ opacity: 1 }}
+            initial={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            {formatCapturedAt(row, base)}
+          </m.span>
         )}
       </TableCell>
       <TableCell className="py-3.5">

--- a/apps/web/src/components/landing/hero-collage.tsx
+++ b/apps/web/src/components/landing/hero-collage.tsx
@@ -1,9 +1,10 @@
 import { LiveTrafficLog } from "@/components/landing/live-traffic-log";
+import type { HeroCollageProps } from "@/types/landing/hero";
 
-export function HeroCollage() {
+export function HeroCollage({ engine }: HeroCollageProps) {
   return (
     <div className="border-border bg-card h-[36rem] w-full max-w-[64rem] overflow-hidden rounded-2xl border">
-      <LiveTrafficLog />
+      <LiveTrafficLog engine={engine} />
     </div>
   );
 }

--- a/apps/web/src/components/landing/hero-headline.tsx
+++ b/apps/web/src/components/landing/hero-headline.tsx
@@ -2,26 +2,19 @@
 
 import { EngineIcon } from "@notra/ui/components/geo/engine-icon";
 import { cn } from "@notra/ui/lib/utils";
-import {
-  AnimatePresence,
-  domAnimation,
-  LazyMotion,
-  m,
-  useReducedMotion,
-} from "motion/react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { AnimatePresence, domAnimation, LazyMotion, m } from "motion/react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import { GEO_ENGINE_NAMES } from "@/constants/landing/geo-engines";
 import {
   HERO_HEADLINE_CYCLE,
-  HERO_HEADLINE_CYCLE_MS,
   HERO_HEADLINE_LINE_ONE,
   HERO_HEADLINE_LINE_TWO_PREFIX,
   HERO_HEADLINE_SUFFIX,
   HERO_WORD_SIZE_DESCENDER_EM,
   HERO_WORD_SIZE_EM,
 } from "@/constants/landing/hero";
-import type { HeroCycleWord } from "@/types/landing/hero";
+import type { HeroCycleWord, HeroHeadlineProps } from "@/types/landing/hero";
 
 const WORD_TRANSITION = { duration: 0.5, ease: [0.22, 1, 0.36, 1] } as const;
 
@@ -58,12 +51,9 @@ function WordContent({ word }: { word: HeroCycleWord }) {
   );
 }
 
-export function HeroHeadline() {
-  const reduceMotion = useReducedMotion();
-  const [index, setIndex] = useState(0);
+export function HeroHeadline({ word }: HeroHeadlineProps) {
   const [widths, setWidths] = useState<Record<string, number>>({});
   const measureRefs = useRef(new Map<string, HTMLSpanElement>());
-  const word = HERO_HEADLINE_CYCLE[index] ?? HERO_HEADLINE_CYCLE[0];
 
   useLayoutEffect(() => {
     const measure = () => {
@@ -81,20 +71,6 @@ export function HeroHeadline() {
     }
     return () => observer.disconnect();
   }, []);
-
-  useEffect(() => {
-    if (reduceMotion) {
-      return;
-    }
-    const interval = window.setInterval(() => {
-      setIndex((current) => (current + 1) % HERO_HEADLINE_CYCLE.length);
-    }, HERO_HEADLINE_CYCLE_MS);
-    return () => window.clearInterval(interval);
-  }, [reduceMotion]);
-
-  if (!word) {
-    return null;
-  }
 
   const width = widths[word.text];
 

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import { CtaButton } from "@notra/ui/components/shared/cta-button";
+import { useReducedMotion } from "motion/react";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 import { HeroCollage } from "@/components/landing/hero-collage";
 import { HeroDither } from "@/components/landing/hero-dither";
@@ -7,6 +11,8 @@ import { HeroHeadline } from "@/components/landing/hero-headline";
 import { TrackedSignupLink } from "@/components/tracked-signup-link";
 import {
   HERO_BOOK_A_CALL_HREF,
+  HERO_HEADLINE_CYCLE,
+  HERO_HEADLINE_CYCLE_MS,
   HERO_SIGNUP_SOURCE,
   HERO_SUBHEAD,
 } from "@/constants/landing/hero";
@@ -15,6 +21,24 @@ const CTA_BUTTON_CLASSNAME =
   "h-auto rounded-[2.5625rem] px-6 py-3 font-display font-medium text-[1.125rem] leading-[1.14] tracking-[-0.015em]";
 
 export function HeroSection() {
+  const reduceMotion = useReducedMotion();
+  const [index, setIndex] = useState(0);
+  const word = HERO_HEADLINE_CYCLE[index] ?? HERO_HEADLINE_CYCLE[0];
+
+  useEffect(() => {
+    if (reduceMotion) {
+      return;
+    }
+    const interval = window.setInterval(() => {
+      setIndex((current) => (current + 1) % HERO_HEADLINE_CYCLE.length);
+    }, HERO_HEADLINE_CYCLE_MS);
+    return () => window.clearInterval(interval);
+  }, [reduceMotion]);
+
+  if (!word) {
+    return null;
+  }
+
   return (
     <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
       <div className="relative isolate overflow-clip rounded-3xl bg-[#C8B2EE40] lg:h-[59.9375rem] dark:bg-[#2a2140]">
@@ -25,7 +49,7 @@ export function HeroSection() {
         <div className="relative flex h-full w-full flex-col items-center">
           <div className="flex flex-col items-center gap-8 px-6 pt-20 pb-2 sm:gap-10 sm:pt-24 lg:pt-[7.5rem]">
             <div className="flex flex-col items-center gap-7">
-              <HeroHeadline />
+              <HeroHeadline word={word} />
               <p className="max-w-[42.875rem] text-center font-sans text-[1.0625rem] leading-[1.14] font-medium tracking-[-0.005em] text-pretty text-[#1E1E1EBF] sm:text-[1.25rem] dark:text-white/70">
                 {HERO_SUBHEAD}
               </p>
@@ -53,7 +77,7 @@ export function HeroSection() {
 
           <div className="mt-9 flex w-full flex-1 flex-col items-center overflow-clip py-3.75 sm:mt-16.25">
             <div className="flex w-full flex-col items-center">
-              <HeroCollage />
+              <HeroCollage engine={word.engine} />
             </div>
           </div>
         </div>

--- a/apps/web/src/components/landing/live-traffic-log.tsx
+++ b/apps/web/src/components/landing/live-traffic-log.tsx
@@ -2,7 +2,7 @@
 
 import { ScrollArea } from "@notra/ui/components/ui/scroll-area";
 import { useReducedMotion } from "motion/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { CitationRows } from "@/components/landing/citation-rows";
 import {
@@ -10,38 +10,27 @@ import {
   HERO_COLLAGE_CITATION_ROWS,
 } from "@/constants/landing/hero-collage";
 import { LIVE_TRAFFIC_MAX_ROWS } from "@/constants/landing/live-traffic";
-import {
-  randomLiveDelayMs,
-  randomLiveRow,
-  seedLiveRows,
-} from "@/lib/landing/live-traffic";
+import { randomLiveRow, seedLiveRows } from "@/lib/landing/live-traffic";
 import { pageClockElapsedMs, usePageClockBase } from "@/lib/landing/page-clock";
+import type { HeroCollageProps } from "@/types/landing/hero";
 
-export function LiveTrafficLog() {
+export function LiveTrafficLog({ engine }: HeroCollageProps) {
   const reduceMotion = useReducedMotion();
   const base = usePageClockBase();
+  const previousEngine = useRef(engine);
   const [rows, setRows] = useState(() =>
     seedLiveRows(HERO_COLLAGE_CITATION_ROWS)
   );
   const live = !reduceMotion;
 
   useEffect(() => {
-    if (!live) {
+    if (!live || previousEngine.current === engine) {
       return;
     }
-    let timer = 0;
-    const schedule = () => {
-      timer = window.setTimeout(() => {
-        const row = randomLiveRow(pageClockElapsedMs());
-        setRows((previous) =>
-          [row, ...previous].slice(0, LIVE_TRAFFIC_MAX_ROWS)
-        );
-        schedule();
-      }, randomLiveDelayMs());
-    };
-    schedule();
-    return () => window.clearTimeout(timer);
-  }, [live]);
+    previousEngine.current = engine;
+    const row = randomLiveRow(pageClockElapsedMs(), engine);
+    setRows((previous) => [row, ...previous].slice(0, LIVE_TRAFFIC_MAX_ROWS));
+  }, [engine, live]);
 
   return (
     <ScrollArea className="h-full [&_[data-slot=table-container]]:overflow-visible">

--- a/apps/web/src/constants/landing/live-traffic.ts
+++ b/apps/web/src/constants/landing/live-traffic.ts
@@ -67,7 +67,4 @@ export const LIVE_TRAFFIC_MARKDOWN_PATHS = new Set([
   "/docs/mcp",
 ]);
 
-export const LIVE_TRAFFIC_MIN_DELAY_MS = 1800;
-export const LIVE_TRAFFIC_MAX_DELAY_MS = 4200;
 export const LIVE_TRAFFIC_MAX_ROWS = 20;
-export const LIVE_TRAFFIC_TIMESTAMP_PLACEHOLDER = "00/00/0000 00:00:00";

--- a/apps/web/src/lib/landing/live-traffic.ts
+++ b/apps/web/src/lib/landing/live-traffic.ts
@@ -1,11 +1,13 @@
 import {
   LIVE_TRAFFIC_MARKDOWN_PATHS,
-  LIVE_TRAFFIC_MAX_DELAY_MS,
-  LIVE_TRAFFIC_MIN_DELAY_MS,
   LIVE_TRAFFIC_PATHS,
   LIVE_TRAFFIC_PROVIDERS,
 } from "@/constants/landing/live-traffic";
-import type { CitationRow, LiveCitationRow } from "@/types/landing/geo";
+import type {
+  CitationRow,
+  EngineId,
+  LiveCitationRow,
+} from "@/types/landing/geo";
 
 const MS_PER_SECOND = 1000;
 const PAD_LENGTH = 2;
@@ -30,8 +32,13 @@ export function seedLiveRows(rows: CitationRow[]): LiveCitationRow[] {
   }));
 }
 
-export function randomLiveRow(offsetMs: number): LiveCitationRow {
-  const source = pick(LIVE_TRAFFIC_PROVIDERS);
+export function randomLiveRow(
+  offsetMs: number,
+  engine: EngineId
+): LiveCitationRow {
+  const source = pick(
+    LIVE_TRAFFIC_PROVIDERS.filter((provider) => provider.engine === engine)
+  );
   const path = pick(LIVE_TRAFFIC_PATHS);
   return {
     id: `live-${offsetMs}-${Math.random().toString(36).slice(2, 8)}`,
@@ -43,11 +50,6 @@ export function randomLiveRow(offsetMs: number): LiveCitationRow {
     markdown: LIVE_TRAFFIC_MARKDOWN_PATHS.has(path) ? true : undefined,
     offsetMs,
   };
-}
-
-export function randomLiveDelayMs(): number {
-  const span = LIVE_TRAFFIC_MAX_DELAY_MS - LIVE_TRAFFIC_MIN_DELAY_MS;
-  return LIVE_TRAFFIC_MIN_DELAY_MS + Math.random() * span;
 }
 
 export function formatCapturedAt(row: LiveCitationRow, base: number): string {

--- a/apps/web/src/types/landing/hero.ts
+++ b/apps/web/src/types/landing/hero.ts
@@ -8,3 +8,11 @@ export interface HeroCycleWord {
   text: string;
   engine: EngineId;
 }
+
+export interface HeroHeadlineProps {
+  word: HeroCycleWord;
+}
+
+export interface HeroCollageProps {
+  engine: EngineId;
+}


### PR DESCRIPTION
### Description
Synchronizes the rotating hero provider with the incoming traffic feed so each headline transition inserts a matching provider row. It also replaces blank “When” cells during hydration with skeletons and a smooth timestamp fade-in.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The rotating hero headline now drives the traffic feed, so each headline change inserts a matching provider row instead of the feed cycling on its own timer.

- Moved headline cycling from `HeroHeadline` up to `HeroSection` and passes the selected engine down to the collage and traffic log.
- Traffic rows are now generated only when the headline engine changes, filtered to that engine's providers.
- Blank "When" cells during hydration now show a skeleton instead of invisible placeholder text, and timestamps fade in.

<sup>Written for commit 336d4f171127d6d129ca278086d1c80707c320ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

