### PR TITLE
fix(web): stretch feature mock frames to card width

### DIFF
--- a/apps/web/src/components/landing/features-section.tsx
+++ b/apps/web/src/components/landing/features-section.tsx
@@ -38,7 +38,7 @@ function FeaturesCard({
           {copy.description}
         </p>
       </div>
-      <div className="relative z-10 -mx-6 mt-2 h-[24.5rem] min-w-0 overflow-hidden [mask-image:linear-gradient(to_bottom,black_78%,transparent)] px-6 pt-6">
+      <div className="relative z-10 -mx-6 mt-2 h-[24.5rem] min-w-0 self-stretch overflow-hidden [mask-image:linear-gradient(to_bottom,black_78%,transparent)] px-6 pt-6">
         {children}
       </div>
       {footnote ? (


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


https://claude.ai/code/session_015fKXzo3CL89o5Bd1iHM3Xm


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the landing page feature mock frames so they stretch to the full card width instead of only the content width.

<sup>Written for commit 74d29e46cb52e1ea50fc419b471464c668dd57c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

