### PR TITLE
feat(dashboard): add GEO settings to sidebar

### DIFF
--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -156,6 +156,7 @@ export const NAV_GEO_IMPROVE_LINKS: readonly string[] = [
   GEO_WRITER_NAV_LINK,
   CONTENT_NAV_LINK,
   SCHEDULES_NAV_LINK,
+  GEO_SETTINGS_NAV_LINK,
 ];
 
 export const NAV_GEO_LINKS: readonly string[] = [


### PR DESCRIPTION
GEO settings (`/geo/settings`) had a nav item defined but was only reachable via the project switcher dropdown — it was never wired into the GEO sidebar groups after the project-first sidebar rework (#709).

Adds `GEO_SETTINGS_NAV_LINK` to `NAV_GEO_IMPROVE_LINKS`, so "GEO settings" now renders at the bottom of the Improve group in the GEO sidebar. Active-state highlighting works automatically since `NAV_GEO_LINKS` is composed from that array.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GEO settings link to the Improve group in the GEO sidebar, making `/geo/settings` directly accessible after the project-first sidebar rework.

- Active-state highlighting is inherited from the existing GEO navigation links.

<sup>Written for commit ee24e80ce732b223f6d5d399f103e455f16802df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

