### PR TITLE
feat(dashboard): use CTA button for sidebar primary action

### DIFF
--- a/apps/dashboard/src/components/dashboard/nav-mode-primary-action.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-mode-primary-action.tsx
@@ -2,13 +2,13 @@
 
 import { HugeiconsIcon } from "@hugeicons/react";
 import { GEO_WRITER_NAV_LINK } from "@notra/geo-core/constants/geo";
-import { Button } from "@notra/ui/components/ui/button";
 import { SidebarGroup } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useState } from "react";
 
+import { Button } from "@/components/button";
 import {
   NAV_PRIMARY_ACTIONS,
   SIDEBAR_MODE_ENTER_CLASS,

--- a/apps/dashboard/src/constants/nav.ts
+++ b/apps/dashboard/src/constants/nav.ts
@@ -137,7 +137,7 @@ export const NAV_MAIN_ITEMS: NavMainItem[] = [
     label: "Competitors",
   },
   { link: GEO_WRITER_NAV_LINK, icon: PencilEdit01Icon, label: "Write" },
-  { link: GEO_SETTINGS_NAV_LINK, icon: Settings01Icon, label: "GEO settings" },
+  { link: GEO_SETTINGS_NAV_LINK, icon: Settings01Icon, label: "Settings" },
   { link: SKILLS_NAV_LINK, icon: MagicWand01Icon, label: "Skills" },
   { link: API_KEYS_NAV_LINK, icon: Key01Icon, label: "API Keys" },
 ];


### PR DESCRIPTION
The sidebar Write button used the plain `@notra/ui` Button while page-level primary actions like Run Scan use the dashboard `@/components/button` wrapper, which layers the `CTA_PRIMARY` squircle + inset-highlight styling onto the default variant.

Swaps the import in `nav-mode-primary-action.tsx` so the Write button (GEO mode) gets the same treatment. The Studio-mode "New post" button shares the component, so it picks up the styling too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps the sidebar primary action to the dashboard CTA button so the Write button matches page-level primary actions like Run Scan, and renames the GEO settings nav label to Settings.

The GEO-mode Write button and Studio-mode New post button now use `@/components/button` instead of the plain `@notra/ui` Button, gaining the CTA_PRIMARY squircle and inset-highlight styling.

<sup>Written for commit 63d8bc05777cfb589d88ac4aa9e6e5e9ead4c2e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

