### PR TITLE
fix(dashboard): baseline-align GEO tab counts with labels

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
@@ -107,12 +107,16 @@ export function GeoTabs({
       >
         <PermissionOption value="visibility">Visibility</PermissionOption>
         <PermissionOption value="prompts">
-          Prompts
-          <TriggerCount count={promptCount} />
+          <span className="flex items-baseline gap-1.5">
+            Prompts
+            <TriggerCount count={promptCount} />
+          </span>
         </PermissionOption>
         <PermissionOption value="journeys">
-          Journeys
-          <TriggerCount count={journeys.length} />
+          <span className="flex items-baseline gap-1.5">
+            Journeys
+            <TriggerCount count={journeys.length} />
+          </span>
         </PermissionOption>
       </PermissionRow>
 


### PR DESCRIPTION
The Prompts/Journeys counts in the GEO section tabs sat slightly high relative to the labels: `PermissionOption` lays its children out with `flex items-center`, which center-aligns the `text-sm` label against the `text-xs` count instead of matching their baselines.

Wraps each label + `TriggerCount` pair in an `items-baseline` flex span inside `geo-tabs.tsx` (the primitive in `packages/ui` stays untouched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Prompts and Journeys counts with their labels in the GEO tabs instead of vertically centering the different text sizes.

<sup>Written for commit ffbc9401c7889b9d59701783cdb9deae299400c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

