### PR TITLE
refactor(dashboard): move zod schemas into schemas folder, bump zod to 4.5

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,7 @@
     "nanoid": "^5.1.11",
     "sanitize-html": "^2.17.0",
     "tsup": "^8.5.1",
-    "zod": "^4.4.3"
+    "zod": "^4.5.0"
   },
   "devDependencies": {
     "@notra/typescript-config": "workspace:*",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,5 @@
 import "./tcc";
-import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { createDb } from "@notra/db/drizzle";
 import { shutdownPostHogServer } from "@notra/posthog/server";
 import {
@@ -42,6 +42,7 @@ import { legacyRedirectRoutes } from "./routes/legacy-redirects";
 import { postsRoutes } from "./routes/posts";
 import { schedulesRoutes } from "./routes/schedules";
 import { skillsRoutes } from "./routes/skills";
+import { publicStatusResponseSchema } from "./schemas/status";
 import type { ApiEnv } from "./types/env";
 import {
   API_URL,
@@ -65,20 +66,6 @@ const FRAMER_PLUGIN_ORIGIN_PATTERN = new RegExp(
 const LOCAL_DEV_ORIGIN_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
-
-const publicStatusResponseSchema = z
-  .object({
-    status: z.literal("ok"),
-    service: z.literal("Notra API"),
-    version: z.string(),
-    public: z.literal(true),
-    authentication: z.object({
-      type: z.literal("bearer"),
-      resource_metadata: z.string().url(),
-      guide: z.string().url(),
-    }),
-  })
-  .openapi("PublicStatusResponse");
 
 const publicStatusRoute = createRoute({
   method: "get",

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -13,6 +13,7 @@ import * as z from "zod";
 
 import {
   createScheduleRequestSchema,
+  scheduleTargetsRepositoryIdsSchema,
   deleteScheduleResponseSchema,
   getSchedulesQuerySchema,
   getSchedulesResponseSchema,
@@ -198,9 +199,9 @@ function filterByRepositoryIds<T extends ScheduleTriggerRow>(
   const repositoryIdSet = new Set(repositoryIds);
 
   return triggers.filter((trigger) => {
-    const parsed = z
-      .object({ repositoryIds: z.array(z.string()) })
-      .safeParse(trigger.targets);
+    const parsed = scheduleTargetsRepositoryIdsSchema.safeParse(
+      trigger.targets
+    );
 
     if (!parsed.success) {
       return false;

--- a/apps/api/src/schemas/agent-chats.ts
+++ b/apps/api/src/schemas/agent-chats.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 const AGENT_MESSAGE_MAX_LENGTH = 200_000;

--- a/apps/api/src/schemas/chats.ts
+++ b/apps/api/src/schemas/chats.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import {
   chatModelSchema,

--- a/apps/api/src/schemas/content.ts
+++ b/apps/api/src/schemas/content.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import { supportedLanguageSchema } from "@notra/ai/schemas/language";
 import {

--- a/apps/api/src/schemas/event-triggers.ts
+++ b/apps/api/src/schemas/event-triggers.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import { SUPPORTED_CONTENT_GENERATION_TYPES } from "@notra/content-generation/schemas";
 

--- a/apps/api/src/schemas/feedback.ts
+++ b/apps/api/src/schemas/feedback.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import {
   AGENT_FEEDBACK_IDEMPOTENCY_KEY_MAX_LENGTH,

--- a/apps/api/src/schemas/geo-agent-readiness.ts
+++ b/apps/api/src/schemas/geo-agent-readiness.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 import { organizationResponseSchema } from "./content";

--- a/apps/api/src/schemas/geo-competitors.ts
+++ b/apps/api/src/schemas/geo-competitors.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import {
   GEO_COMPETITOR_MAX_SYNONYMS,

--- a/apps/api/src/schemas/geo-content.ts
+++ b/apps/api/src/schemas/geo-content.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import { BLOG_POST_SUBTYPES } from "@notra/db/constants/content";
 import {

--- a/apps/api/src/schemas/geo-fields.ts
+++ b/apps/api/src/schemas/geo-fields.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import {
   GEO_PROMPT_MAX_LENGTH,

--- a/apps/api/src/schemas/geo-import.ts
+++ b/apps/api/src/schemas/geo-import.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 export const geoImportIssueSchema = z.object({

--- a/apps/api/src/schemas/geo-params.ts
+++ b/apps/api/src/schemas/geo-params.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 import { createGeoShortTextSchema } from "./geo-fields";

--- a/apps/api/src/schemas/geo-projects.ts
+++ b/apps/api/src/schemas/geo-projects.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 import { organizationResponseSchema } from "./content";

--- a/apps/api/src/schemas/geo-prompts.ts
+++ b/apps/api/src/schemas/geo-prompts.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import {
   GEO_CSV_IMPORT_MAX_BYTES,

--- a/apps/api/src/schemas/geo-scans.ts
+++ b/apps/api/src/schemas/geo-scans.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 import {

--- a/apps/api/src/schemas/geo-sequences.ts
+++ b/apps/api/src/schemas/geo-sequences.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import { GEO_SEQUENCE_MAX_TURNS } from "@notra/geo-core/constants/geo";
 

--- a/apps/api/src/schemas/geo-settings.ts
+++ b/apps/api/src/schemas/geo-settings.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import {
   GEO_MAX_ALIASES,

--- a/apps/api/src/schemas/geo-traffic.ts
+++ b/apps/api/src/schemas/geo-traffic.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import { GEO_SHORT_FIELD_MAX_LENGTH } from "@notra/geo-core/constants/geo";
 

--- a/apps/api/src/schemas/geo-visibility.ts
+++ b/apps/api/src/schemas/geo-visibility.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import { GEO_SHORT_FIELD_MAX_LENGTH } from "@notra/geo-core/constants/geo";
 

--- a/apps/api/src/schemas/ids.ts
+++ b/apps/api/src/schemas/ids.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 const RESOURCE_ID_REGEX = /^[A-Za-z0-9_-]{1,100}$/;

--- a/apps/api/src/schemas/internal-geo.ts
+++ b/apps/api/src/schemas/internal-geo.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 import { planBriefResponseSchema } from "./geo-content";

--- a/apps/api/src/schemas/internal-workflow.ts
+++ b/apps/api/src/schemas/internal-workflow.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "zod";
 
 export const internalWorkflowStartResponseSchema = z.object({

--- a/apps/api/src/schemas/responses.ts
+++ b/apps/api/src/schemas/responses.ts
@@ -1,0 +1,11 @@
+import "zod/compile";
+import { z } from "@hono/zod-openapi";
+
+export const rateLimitResponseSchema = z
+  .object({
+    error: z.string(),
+    limit: z.number().int().min(1),
+    remaining: z.number().int().min(0),
+    reset: z.number().int(),
+  })
+  .openapi("RateLimitErrorResponse");

--- a/apps/api/src/schemas/schedules.ts
+++ b/apps/api/src/schemas/schedules.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 import { SUPPORTED_CONTENT_GENERATION_TYPES } from "@notra/content-generation/schemas";
 import { lookbackWindowEnum } from "@notra/db/schema";
@@ -123,4 +124,8 @@ export const scheduleResponseSchema = z.object({
 export const deleteScheduleResponseSchema = z.object({
   id: z.string(),
   organization: organizationSchema,
+});
+
+export const scheduleTargetsRepositoryIdsSchema = z.object({
+  repositoryIds: z.array(z.string()),
 });

--- a/apps/api/src/schemas/skills.ts
+++ b/apps/api/src/schemas/skills.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "@hono/zod-openapi";
 
 import {

--- a/apps/api/src/schemas/status.ts
+++ b/apps/api/src/schemas/status.ts
@@ -1,0 +1,16 @@
+import "zod/compile";
+import { z } from "@hono/zod-openapi";
+
+export const publicStatusResponseSchema = z
+  .object({
+    status: z.literal("ok"),
+    service: z.literal("Notra API"),
+    version: z.string(),
+    public: z.literal(true),
+    authentication: z.object({
+      type: z.literal("bearer"),
+      resource_metadata: z.string().url(),
+      guide: z.string().url(),
+    }),
+  })
+  .openapi("PublicStatusResponse");

--- a/apps/api/src/utils/openapi-responses.ts
+++ b/apps/api/src/utils/openapi-responses.ts
@@ -1,6 +1,5 @@
-import { z } from "@hono/zod-openapi";
-
 import { errorResponseSchema } from "../schemas/content";
+import { rateLimitResponseSchema } from "../schemas/responses";
 
 export function errorResponse(description: string) {
   return {
@@ -12,15 +11,6 @@ export function errorResponse(description: string) {
     },
   };
 }
-
-const rateLimitResponseSchema = z
-  .object({
-    error: z.string(),
-    limit: z.number().int().min(1),
-    remaining: z.number().int().min(0),
-    reset: z.number().int(),
-  })
-  .openapi("RateLimitErrorResponse");
 
 const rateLimitHeaderDescriptors = {
   "RateLimit-Limit": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -107,7 +107,7 @@
     "sugar-high": "^1.2.1",
     "three": "^0.167.1",
     "workflow": "^4.6.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.0"
   },
   "devDependencies": {
     "@notra/typescript-config": "workspace:*",

--- a/apps/dashboard/src/app/api/command-palette/navigate/route.ts
+++ b/apps/dashboard/src/app/api/command-palette/navigate/route.ts
@@ -16,25 +16,17 @@ import { generateObject } from "ai";
 import { and, desc, eq, ilike, or } from "drizzle-orm";
 import { createRequestLogger } from "evlog";
 import { type NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 import { commandRoutesForAI } from "@/components/command-palette/registry";
 import { getServerSession } from "@/lib/auth/session";
 import { hasAiCreditsGrant } from "@/lib/billing/subscription";
+import {
+  commandPaletteNavigateRequestSchema,
+  commandPaletteNavigateResultSchema,
+} from "@/schemas/command-palette";
 import { getClientIp, ratelimit } from "@/utils/ratelimit";
 
 export const maxDuration = 15;
-
-const requestSchema = z.object({
-  query: z.string().min(1).max(500),
-  slug: z.string().min(1).max(100),
-});
-
-const resultSchema = z.object({
-  action: z.enum(["navigate", "chat"]),
-  path: z.string().nullish(),
-  reason: z.string().max(160).default(""),
-});
 
 const LIKE_ESCAPE_PATTERN = /[\\%_]/g;
 
@@ -241,7 +233,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const parsed = requestSchema.safeParse(
+  const parsed = commandPaletteNavigateRequestSchema.safeParse(
     await request.json().catch(() => null)
   );
   if (!parsed.success) {
@@ -281,7 +273,7 @@ export async function POST(request: NextRequest) {
       model: gateway("anthropic/claude-sonnet-4.6", {
         organizationId,
       }),
-      schema: resultSchema,
+      schema: commandPaletteNavigateResultSchema,
       system: [
         "You are a navigation router for the Notra dashboard command palette.",
         "Given a natural language query, decide whether to navigate to an existing route or fall back to the AI chat.",

--- a/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
+++ b/apps/dashboard/src/app/onboarding/workspace/workspace-form.tsx
@@ -17,8 +17,6 @@ import { useDebouncedValue } from "@tanstack/react-pacer";
 import { Loader2Icon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
-import * as z from "zod";
 
 import { OrgLogoField } from "@/components/onboarding/org-logo-field";
 import { OnboardingProgress } from "@/components/onboarding/progress";
@@ -40,6 +38,7 @@ import {
   onboardingWorkspaceFormFieldsSchema,
   onboardingWorkspaceFormSchema,
 } from "@/schemas/onboarding/workspace";
+import { slugSchema } from "@/schemas/organization";
 import type { WorkspaceFormProps } from "@/types/onboarding";
 import {
   getHeardAboutNotraLabel,
@@ -47,7 +46,6 @@ import {
 } from "@/utils/onboarding";
 
 const WEBSITE_PREFIX_REGEX = /^https?:\/\//i;
-const slugSchema = z.string().slugify();
 
 function slugify(value: string): string {
   return slugSchema.safeParse(value).data ?? "";

--- a/apps/dashboard/src/components/dashboard/create-org-modal.tsx
+++ b/apps/dashboard/src/components/dashboard/create-org-modal.tsx
@@ -15,17 +15,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
-import * as z from "zod";
 
 import { Button } from "@/components/button";
 import { authClient } from "@/lib/auth/client";
 import { errorMessageOr, generateOrganizationAvatar } from "@/lib/utils";
-import { createOrganizationSchema } from "@/schemas/organization";
+import { createOrganizationSchema, slugSchema } from "@/schemas/organization";
 import { setLastVisitedOrganization } from "@/utils/cookies";
 import { QUERY_KEYS } from "@/utils/query-keys";
-
-const slugSchema = z.string().slugify();
 
 function slugify(value: string): string {
   return slugSchema.safeParse(value).data ?? "";

--- a/apps/dashboard/src/components/settings/profile-section.tsx
+++ b/apps/dashboard/src/components/settings/profile-section.tsx
@@ -14,17 +14,14 @@ import { useForm } from "@tanstack/react-form";
 import { Loader2Icon } from "lucide-react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
-import * as z from "zod";
 
 import { Button } from "@/components/button";
 import { authClient } from "@/lib/auth/client";
 import { uploadFile } from "@/lib/upload/client";
 import { errorMessageOr } from "@/lib/utils";
+import { userNameSchema } from "@/schemas/auth/user-actions";
 import type { ProfileSectionProps } from "@/types/settings/account";
 import { getUserAvatarUrl } from "@/utils/avatar";
-
-const nameSchema = z.string().trim().min(1, "Name cannot be empty");
 
 export function ProfileSection({
   user,
@@ -77,7 +74,7 @@ export function ProfileSection({
       name: user.name,
     },
     onSubmit: async ({ value }) => {
-      const validated = nameSchema.safeParse(value.name);
+      const validated = userNameSchema.safeParse(value.name);
 
       if (!validated.success) {
         const issue = validated.error?.issues[0];

--- a/apps/dashboard/src/lib/auth/workos-error.ts
+++ b/apps/dashboard/src/lib/auth/workos-error.ts
@@ -1,19 +1,4 @@
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
-import * as z from "zod";
-
-const workosErrorSchema = z.looseObject({
-  code: z.string().optional(),
-  message: z.string().optional(),
-  rawData: z
-    .looseObject({
-      code: z.string().optional(),
-      message: z.string().optional(),
-      email: z.string().optional(),
-      pending_authentication_token: z.string().optional(),
-      organizations: z.array(z.looseObject({ id: z.string() })).optional(),
-    })
-    .optional(),
-});
+import { workosErrorSchema } from "@/schemas/auth/workos-error";
 
 export interface WorkOSErrorInfo {
   code: string | null;

--- a/apps/dashboard/src/lib/orpc/routers/api-keys.ts
+++ b/apps/dashboard/src/lib/orpc/routers/api-keys.ts
@@ -3,7 +3,6 @@ import type {
   KeyResponseData,
   V2ApisListKeysResponseBody,
 } from "@unkey/api/models/components";
-import { z } from "zod";
 
 import { API_KEY_EXPIRATION_MS } from "@/constants/api-keys";
 import { trackServerEvent } from "@/lib/analytics/posthog-server";
@@ -18,10 +17,10 @@ import { assertActiveSubscription } from "@/lib/billing/subscription";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import {
   createApiKeySchema,
-  deleteApiKeySchema,
-  updateApiKeySchema,
+  deleteKeyInputSchema,
+  updateKeyInputSchema,
 } from "@/schemas/api-keys";
-import { organizationIdSchema } from "@/schemas/auth/organization";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 
 import {
   badRequest,
@@ -29,22 +28,6 @@ import {
   notFound,
   serviceUnavailable,
 } from "../utils/errors";
-
-const organizationInputSchema = z.object({
-  organizationId: organizationIdSchema,
-});
-
-const updateKeyInputSchema = z.object({
-  keyIdParam: z.string().min(1),
-  organizationId: organizationIdSchema,
-  payload: updateApiKeySchema,
-});
-
-const deleteKeyInputSchema = z.object({
-  keyIdParam: z.string().min(1),
-  organizationId: organizationIdSchema,
-  payload: deleteApiKeySchema,
-});
 
 function inferExpirationOption(createdAt: number, expires: number | null) {
   if (expires === null) {
@@ -129,7 +112,7 @@ async function findOrganizationKey(
 
 export const apiKeysRouter = {
   list: authorizedProcedure
-    .input(organizationInputSchema)
+    .input(organizationIdInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -169,7 +152,7 @@ export const apiKeysRouter = {
       });
     }),
   create: authorizedProcedure
-    .input(organizationInputSchema.extend(createApiKeySchema.shape))
+    .input(organizationIdInputSchema.extend(createApiKeySchema.shape))
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,

--- a/apps/dashboard/src/lib/orpc/routers/attachments.ts
+++ b/apps/dashboard/src/lib/orpc/routers/attachments.ts
@@ -3,11 +3,14 @@ import { db } from "@notra/db/drizzle";
 import { chatAttachments, members } from "@notra/db/schema";
 import { ORPCError } from "@orpc/server";
 import { and, desc, eq, inArray, lt, notInArray, or } from "drizzle-orm";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import { authorizedProcedure } from "@/lib/orpc/base";
 import { getR2Config, getR2PublicUrl } from "@/lib/upload/r2";
+import {
+  type AttachmentFilter,
+  deleteManyAttachmentsInputSchema,
+  listAttachmentsInputSchema,
+} from "@/schemas/attachments";
 
 const TRAILING_SLASH_REGEX = /\/$/;
 
@@ -26,26 +29,7 @@ const KNOWN_MIME_TYPES = [
   ...TEXT_MIME_TYPES,
 ] as const;
 
-const ATTACHMENT_FILTER = ["all", "image", "pdf", "text", "other"] as const;
-type AttachmentFilter = (typeof ATTACHMENT_FILTER)[number];
-
 const LIST_PAGE_SIZE = 100;
-
-const listInputSchema = z.object({
-  organizationId: z.string().min(1),
-  filter: z.enum(ATTACHMENT_FILTER).default("all"),
-  cursor: z
-    .object({
-      createdAt: z.string().datetime(),
-      id: z.string(),
-    })
-    .optional(),
-});
-
-const deleteManyInputSchema = z.object({
-  organizationId: z.string().min(1),
-  keys: z.array(z.string().min(1)).min(1).max(500),
-});
 
 function buildFilterCondition(
   organizationId: string,
@@ -131,7 +115,7 @@ async function requireOrganizationAccess(
 
 export const attachmentsRouter = {
   list: authorizedProcedure
-    .input(listInputSchema)
+    .input(listAttachmentsInputSchema)
     .handler(async ({ context, input }) => {
       const organizationId = await requireOrganizationAccess(
         context.user.id,
@@ -185,7 +169,7 @@ export const attachmentsRouter = {
       };
     }),
   deleteMany: authorizedProcedure
-    .input(deleteManyInputSchema)
+    .input(deleteManyAttachmentsInputSchema)
     .handler(async ({ context, input }) => {
       const organizationId = await requireOrganizationAccess(
         context.user.id,

--- a/apps/dashboard/src/lib/orpc/routers/automation.ts
+++ b/apps/dashboard/src/lib/orpc/routers/automation.ts
@@ -16,8 +16,6 @@ import {
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { and, eq, inArray, ne } from "drizzle-orm";
 import { customAlphabet } from "nanoid";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import { DEFAULT_LOOKBACK_WINDOW } from "@/constants/workflows";
 import { trackServerEvent } from "@/lib/analytics/posthog-server";
@@ -28,11 +26,13 @@ import {
   ManualTriggerRunError,
   triggerManualAutomationRun,
 } from "@/lib/triggers/manual-run";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 import {
   configureEventTriggerBodySchema,
   configureScheduleBodySchema,
-  getSchedulesQuerySchema,
   type LookbackWindow,
+  schedulesListInputSchema,
+  triggerInputSchema,
   triggerTargetsSchema,
 } from "@/schemas/integrations";
 import type { Trigger } from "@/types/triggers/triggers";
@@ -46,18 +46,6 @@ import {
 
 const nanoid = customAlphabet("abcdefghijklmnopqrstuvwxyz0123456789", 16);
 const DEFAULT_SCHEDULE_NAME = "Untitled Schedule";
-
-const organizationIdInputSchema = z.object({
-  organizationId: z.string().min(1, "Organization ID is required"),
-});
-
-const triggerInputSchema = organizationIdInputSchema.extend({
-  triggerId: z.string().min(1, "Trigger ID is required"),
-});
-
-const schedulesListInputSchema = organizationIdInputSchema.and(
-  getSchedulesQuerySchema
-);
 
 function toEffectiveLookbackWindow(
   lookbackWindow?: LookbackWindow | null

--- a/apps/dashboard/src/lib/orpc/routers/brand.ts
+++ b/apps/dashboard/src/lib/orpc/routers/brand.ts
@@ -25,8 +25,6 @@ import { publicWebsiteUrlSchema } from "@notra/geo-core/schemas/url";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { Effect } from "effect";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import {
   BRAND_REFERENCE_SOURCES,
@@ -47,13 +45,19 @@ import {
   startBrandAnalysisRun,
   startBrandGuidelinesRun,
 } from "@/lib/workflows/start";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 import {
+  analyzeInputSchema,
   createReferenceSchema,
   fetchTweetSchema,
   importTweetsSchema,
+  referenceInputSchema,
   referenceSourceUrlSchema,
-  updateBrandSettingsSchema,
+  setDefaultVoiceInputSchema,
   updateReferenceSchema,
+  voiceCreateInputSchema,
+  voiceInputSchema,
+  voiceUpdateInputSchema,
 } from "@/schemas/brand";
 import {
   createGuidelineAssetSchema,
@@ -99,41 +103,7 @@ import {
   tooManyRequests,
 } from "../utils/errors";
 
-const organizationIdInputSchema = z.object({
-  organizationId: z.string().min(1, "Organization ID is required"),
-});
-
-const voiceInputSchema = organizationIdInputSchema.extend({
-  voiceId: z.string().min(1, "Voice ID is required"),
-});
-
-const voiceCreateInputSchema = organizationIdInputSchema.extend({
-  name: z.string().optional(),
-  websiteUrl: z.string().min(1, "Website URL is required"),
-});
-
 const FREE_IMPORTED_TWEET_REFERENCE_LIMIT = 10;
-
-const voiceUpdateInputSchema = organizationIdInputSchema
-  .extend({
-    voiceId: z.string().min(1, "Voice ID is required"),
-  })
-  .and(updateBrandSettingsSchema.omit({ id: true }));
-
-const referenceInputSchema = voiceInputSchema.extend({
-  referenceId: z.string().min(1, "Reference ID is required"),
-});
-
-const analyzeInputSchema = organizationIdInputSchema.extend({
-  voiceId: z.string().optional(),
-  url: publicWebsiteUrlSchema,
-});
-
-const setDefaultVoiceInputSchema = organizationIdInputSchema.extend({
-  voiceId: z.string().min(1, "Voice ID is required"),
-});
-
-const guidelineInputSchema = voiceInputSchema;
 
 const typeDefaults: Record<string, ApplicablePlatform[]> = {
   twitter_post: ["twitter"],
@@ -681,7 +651,7 @@ export const brandRouter = {
   },
   guidelines: {
     get: baseProcedure
-      .input(guidelineInputSchema)
+      .input(voiceInputSchema)
       .handler(async ({ context, input }) => {
         await assertOrganizationAccess({
           headers: context.headers,
@@ -693,7 +663,7 @@ export const brandRouter = {
         return getBrandGuidelines(input.voiceId);
       }),
     refresh: baseProcedure
-      .input(guidelineInputSchema)
+      .input(voiceInputSchema)
       .handler(async ({ context, input }) => {
         const auth = await assertOrganizationAccess({
           headers: context.headers,

--- a/apps/dashboard/src/lib/orpc/routers/github.ts
+++ b/apps/dashboard/src/lib/orpc/routers/github.ts
@@ -12,8 +12,6 @@ import { createOctokit } from "@notra/ai/utils/octokit";
 import { redis } from "@notra/ai/utils/redis";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { Data, Effect } from "effect";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import { GITHUB_INSTALL_STATE_TTL_SECONDS } from "@/constants/github";
 import {
@@ -29,31 +27,16 @@ import {
   notFound,
   tooManyRequests,
 } from "@/lib/orpc/utils/errors";
-import { githubPersonalAccessTokenSchema } from "@/schemas/integrations";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
+import {
+  disconnectGitHubAppInputSchema,
+  type PrepareInstallUrlInput,
+  prepareInstallUrlInputSchema,
+  probeRepositoryInputSchema,
+  saveGitHubAppRepositoriesInputSchema,
+} from "@/schemas/github";
 import type { GitHubAccountType } from "@/types/integrations/github";
 import { ratelimit } from "@/utils/ratelimit";
-
-const probeRepositoryInputSchema = z.object({
-  owner: z.string().trim().min(1, "owner is required"),
-  repo: z.string().trim().min(1, "repo is required"),
-  token: githubPersonalAccessTokenSchema.optional(),
-});
-
-const organizationIdInputSchema = z.object({
-  organizationId: z.string().min(1, "Organization ID is required"),
-});
-
-const saveGitHubAppRepositoriesInputSchema = organizationIdInputSchema.extend({
-  repositoryIds: z.array(z.string().min(1)).default([]),
-});
-
-const disconnectGitHubAppInputSchema = organizationIdInputSchema.extend({
-  accountId: z.string().min(1).optional(),
-});
-
-const prepareInstallUrlInputSchema = organizationIdInputSchema.extend({
-  callbackPath: z.string().trim().min(1, "Callback path is required"),
-});
 
 class GitHubAppInstallPreparationError extends Data.TaggedError(
   "GitHubAppInstallPreparationError"
@@ -134,7 +117,7 @@ function toGitHubAccountType(accountType: string): GitHubAccountType {
 }
 
 const prepareGitHubAppInstall = Effect.fn("prepareGitHubAppInstall")(function* (
-  input: z.infer<typeof prepareInstallUrlInputSchema> & {
+  input: PrepareInstallUrlInput & {
     userId: string;
   }
 ) {

--- a/apps/dashboard/src/lib/orpc/routers/integrations.ts
+++ b/apps/dashboard/src/lib/orpc/routers/integrations.ts
@@ -70,8 +70,6 @@ import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { PublicUrlValidationError } from "@notra/utils/url";
 import { and, eq } from "drizzle-orm";
 import { Effect } from "effect";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import {
   INTEGRATION_AUTH_KINDS,
@@ -90,6 +88,7 @@ import {
 } from "@/lib/integrations/slack/channel-cache";
 import { baseProcedure } from "@/lib/orpc/base";
 import { getIntegrationsByOrganization } from "@/lib/services/integrations";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 import {
   createGranolaIntegrationRequestSchema,
   updateGranolaIntegrationBodySchema,
@@ -101,11 +100,11 @@ import {
   createGitHubIntegrationRequestSchema,
   createMcpServerRequestSchema,
   type IntegrationType,
-  integrationIdParamSchema,
-  mcpServerIdParamSchema,
-  outputIdParamSchema,
+  integrationInputSchema,
+  mcpServerInputSchema,
+  outputInputSchema,
   reauthorizeMcpOAuthRequestSchema,
-  repositoryIdParamSchema,
+  repositoryInputSchema,
   testMcpServerRequestSchema,
   triggerTargetsSchema,
   updateIntegrationBodySchema,
@@ -135,26 +134,6 @@ import {
   notFound,
   tooManyRequests,
 } from "../utils/errors";
-
-const organizationIdInputSchema = z.object({
-  organizationId: z.string().min(1, "Organization ID is required"),
-});
-
-const integrationInputSchema = organizationIdInputSchema.extend({
-  integrationId: integrationIdParamSchema.shape.integrationId,
-});
-
-const repositoryInputSchema = organizationIdInputSchema.extend({
-  repositoryId: repositoryIdParamSchema.shape.repositoryId,
-});
-
-const outputInputSchema = organizationIdInputSchema.extend({
-  outputId: outputIdParamSchema.shape.outputId,
-});
-
-const mcpServerInputSchema = organizationIdInputSchema.extend({
-  serverId: mcpServerIdParamSchema.shape.serverId,
-});
 
 async function assertMcpConnectionRateLimit(organizationId: string) {
   const { success } = await ratelimit.mcpConnection.limit(organizationId);

--- a/apps/dashboard/src/lib/orpc/routers/logs.ts
+++ b/apps/dashboard/src/lib/orpc/routers/logs.ts
@@ -5,7 +5,7 @@ import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import { listWebhookLogs } from "@/lib/webhooks/logging";
 import { webhookLogsQuerySchema } from "@/schemas/api-params";
-import { organizationIdSchema } from "@/schemas/auth/organization";
+import { listWebhookLogsInputSchema } from "@/schemas/logs";
 import type { Log, LogsResponse } from "@/types/webhooks/webhooks";
 
 function paginateLogs(logs: Log[], page: number, pageSize: number) {
@@ -40,17 +40,6 @@ function filterLogs(
     return true;
   });
 }
-
-const listWebhookLogsInputSchema = z.object({
-  organizationId: organizationIdSchema,
-  page: webhookLogsQuerySchema.shape.page,
-  pageSize: webhookLogsQuerySchema.shape.pageSize,
-  integrationType: webhookLogsQuerySchema.shape.integrationType,
-  integrationId: z.string().nullish(),
-  source: webhookLogsQuerySchema.shape.source,
-  status: webhookLogsQuerySchema.shape.status,
-  search: webhookLogsQuerySchema.shape.search,
-});
 
 export const logsRouter = {
   webhooks: {

--- a/apps/dashboard/src/lib/orpc/routers/notifications.ts
+++ b/apps/dashboard/src/lib/orpc/routers/notifications.ts
@@ -1,29 +1,18 @@
 import { db } from "@notra/db/drizzle";
 import { organizationNotificationSettings } from "@notra/db/schema";
 import { eq } from "drizzle-orm";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { assertActiveSubscription } from "@/lib/billing/subscription";
 import { authorizedProcedure } from "@/lib/orpc/base";
-import { organizationIdSchema } from "@/schemas/auth/organization";
-import { updateNotificationSettingsSchema } from "@/schemas/notification-settings";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
+import { updateNotificationSettingsInputSchema } from "@/schemas/notification-settings";
 
 import { forbidden } from "../utils/errors";
 
-const notificationSettingsInputSchema = z.object({
-  organizationId: organizationIdSchema,
-});
-
-const updateNotificationSettingsInputSchema =
-  notificationSettingsInputSchema.extend(
-    updateNotificationSettingsSchema.shape
-  );
-
 export const notificationsRouter = {
   get: authorizedProcedure
-    .input(notificationSettingsInputSchema)
+    .input(organizationIdInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,

--- a/apps/dashboard/src/lib/orpc/routers/onboarding.ts
+++ b/apps/dashboard/src/lib/orpc/routers/onboarding.ts
@@ -10,7 +10,6 @@ import {
 } from "@notra/db/schema";
 import { ORPCError } from "@orpc/server";
 import { and, desc, eq } from "drizzle-orm";
-import { z } from "zod";
 
 import {
   AGENT_RUN_HARD_LIMIT_MS,
@@ -23,17 +22,13 @@ import {
 } from "@/lib/onboarding-agent";
 import { pickCompanyLogoUrl } from "@/lib/onboarding/company-logo";
 import { authorizedProcedure } from "@/lib/orpc/base";
-import { organizationIdSchema } from "@/schemas/auth/organization";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 import {
   dismissSuggestionInputSchema,
   listSuggestionsInputSchema,
 } from "@/schemas/onboarding-agent";
 import { companyLogoInputSchema } from "@/schemas/onboarding/company-logo";
 import { ratelimit } from "@/utils/ratelimit";
-
-const onboardingInputSchema = z.object({
-  organizationId: organizationIdSchema,
-});
 
 export const onboardingRouter = {
   companyLogo: authorizedProcedure
@@ -78,7 +73,7 @@ export const onboardingRouter = {
       }
     }),
   get: authorizedProcedure
-    .input(onboardingInputSchema)
+    .input(organizationIdInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -144,7 +139,7 @@ export const onboardingRouter = {
       };
     }),
   agentRun: authorizedProcedure
-    .input(onboardingInputSchema)
+    .input(organizationIdInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -163,7 +158,7 @@ export const onboardingRouter = {
       return { ran, running, startedAt };
     }),
   runAgent: authorizedProcedure
-    .input(onboardingInputSchema)
+    .input(organizationIdInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,

--- a/apps/dashboard/src/lib/orpc/routers/search.ts
+++ b/apps/dashboard/src/lib/orpc/routers/search.ts
@@ -8,23 +8,16 @@ import {
   posts,
 } from "@notra/db/schema";
 import { and, desc, eq, ilike, or } from "drizzle-orm";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { baseProcedure } from "@/lib/orpc/base";
+import { globalSearchInputSchema } from "@/schemas/search";
 
 const LIKE_ESCAPE_PATTERN = /[\\%_]/g;
 
 function toLikePattern(input: string): string {
   return `%${input.replace(LIKE_ESCAPE_PATTERN, (char) => `\\${char}`)}%`;
 }
-
-const globalSearchInputSchema = z.object({
-  organizationId: z.string().min(1, "Organization ID is required"),
-  query: z.string().trim().min(1).max(200),
-  limit: z.number().int().min(1).max(20).default(5),
-});
 
 export const searchRouter = {
   global: baseProcedure

--- a/apps/dashboard/src/lib/orpc/routers/skills.ts
+++ b/apps/dashboard/src/lib/orpc/routers/skills.ts
@@ -3,19 +3,18 @@ import { skills } from "@notra/db/schema";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
 import { trackServerEvent } from "@/lib/analytics/posthog-server";
 import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import { parseSkillFrontmatter } from "@/lib/skills/parse-frontmatter";
-import { organizationIdSchema } from "@/schemas/auth/organization";
 import {
-  createSkillSchema,
-  skillImportUrlSchema,
-  skillNameSchema,
-  updateSkillSchema,
+  createSkillInputSchema,
+  deleteSkillInputSchema,
+  getSkillInputSchema,
+  importSkillFromUrlInputSchema,
+  listSkillsInputSchema,
+  updateSkillInputSchema,
 } from "@/schemas/skills";
 
 import {
@@ -25,35 +24,6 @@ import {
   notFound,
   serviceUnavailable,
 } from "../utils/errors";
-
-const listSkillsInput = z.object({
-  organizationId: organizationIdSchema,
-});
-
-const getSkillInput = z.object({
-  organizationId: organizationIdSchema,
-  name: skillNameSchema,
-});
-
-const createSkillInput = z.object({
-  organizationId: organizationIdSchema,
-  payload: createSkillSchema,
-});
-
-const updateSkillInput = z.object({
-  organizationId: organizationIdSchema,
-  name: skillNameSchema,
-  payload: updateSkillSchema,
-});
-
-const deleteSkillInput = z.object({
-  organizationId: organizationIdSchema,
-  name: skillNameSchema,
-});
-
-const importSkillFromUrlInput = z.object({
-  url: skillImportUrlSchema,
-});
 
 const SKILLS_SH_API_BASE = "https://skills.sh/api/v1/skills";
 
@@ -82,7 +52,7 @@ function pickPrimarySkillFile(files: SkillsShFile[]): SkillsShFile | null {
 
 export const skillsRouter = {
   list: authorizedProcedure
-    .input(listSkillsInput)
+    .input(listSkillsInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -105,7 +75,7 @@ export const skillsRouter = {
     }),
 
   getByName: authorizedProcedure
-    .input(getSkillInput)
+    .input(getSkillInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -128,7 +98,7 @@ export const skillsRouter = {
     }),
 
   create: authorizedProcedure
-    .input(createSkillInput)
+    .input(createSkillInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -177,7 +147,7 @@ export const skillsRouter = {
     }),
 
   update: authorizedProcedure
-    .input(updateSkillInput)
+    .input(updateSkillInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -249,7 +219,7 @@ export const skillsRouter = {
     }),
 
   delete: authorizedProcedure
-    .input(deleteSkillInput)
+    .input(deleteSkillInputSchema)
     .handler(async ({ context, input }) => {
       await assertOrganizationAccess({
         headers: context.headers,
@@ -293,7 +263,7 @@ export const skillsRouter = {
     }),
 
   importFromUrl: authorizedProcedure
-    .input(importSkillFromUrlInput)
+    .input(importSkillFromUrlInputSchema)
     .handler(async ({ context, input }) => {
       let pathname: string;
       let sourceHost: string;

--- a/apps/dashboard/src/schemas/agent-feedback.ts
+++ b/apps/dashboard/src/schemas/agent-feedback.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import {
   AGENT_FEEDBACK_KINDS,
   AGENT_FEEDBACK_STATUSES,

--- a/apps/dashboard/src/schemas/agent-proxy.ts
+++ b/apps/dashboard/src/schemas/agent-proxy.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "zod";
 
 const AGENT_MESSAGE_MAX_LENGTH = 200_000;

--- a/apps/dashboard/src/schemas/agent.ts
+++ b/apps/dashboard/src/schemas/agent.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "zod";
 
 export const agentCreateSessionResponseSchema = z.object({

--- a/apps/dashboard/src/schemas/ai/chat-tool-block.ts
+++ b/apps/dashboard/src/schemas/ai/chat-tool-block.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "zod";
 
 const optionalStringSchema = z.preprocess(

--- a/apps/dashboard/src/schemas/analytics.ts
+++ b/apps/dashboard/src/schemas/analytics.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { literal, number, object, string, union } from "zod";
 
 const LEADERBOARD_USERNAME_MAX_LENGTH = 30;

--- a/apps/dashboard/src/schemas/api-keys.ts
+++ b/apps/dashboard/src/schemas/api-keys.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 
@@ -5,6 +6,7 @@ import {
   API_KEY_EXPIRATION_VALUES,
   API_KEY_GRANULAR_PERMISSIONS,
 } from "@/constants/api-keys";
+import { organizationIdSchema } from "@/schemas/auth/organization";
 
 const scopesSchema = z
   .array(z.enum(API_KEY_GRANULAR_PERMISSIONS))
@@ -25,6 +27,18 @@ export const updateApiKeySchema = z.object({
 
 export const deleteApiKeySchema = z.object({
   keyId: z.string().min(1, "Key ID is required"),
+});
+
+export const updateKeyInputSchema = z.object({
+  keyIdParam: z.string().min(1),
+  organizationId: organizationIdSchema,
+  payload: updateApiKeySchema,
+});
+
+export const deleteKeyInputSchema = z.object({
+  keyIdParam: z.string().min(1),
+  organizationId: organizationIdSchema,
+  payload: deleteApiKeySchema,
 });
 
 export type CreateApiKeyInput = z.infer<typeof createApiKeySchema>;

--- a/apps/dashboard/src/schemas/api-params.ts
+++ b/apps/dashboard/src/schemas/api-params.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/attachments.ts
+++ b/apps/dashboard/src/schemas/attachments.ts
@@ -1,0 +1,30 @@
+import "zod/compile";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+import { organizationIdSchema } from "@/schemas/auth/organization";
+
+export const ATTACHMENT_FILTER = [
+  "all",
+  "image",
+  "pdf",
+  "text",
+  "other",
+] as const;
+export type AttachmentFilter = (typeof ATTACHMENT_FILTER)[number];
+
+export const listAttachmentsInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  filter: z.enum(ATTACHMENT_FILTER).default("all"),
+  cursor: z
+    .object({
+      createdAt: z.string().datetime(),
+      id: z.string(),
+    })
+    .optional(),
+});
+
+export const deleteManyAttachmentsInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  keys: z.array(z.string().min(1)).min(1).max(500),
+});

--- a/apps/dashboard/src/schemas/auth/credentials.ts
+++ b/apps/dashboard/src/schemas/auth/credentials.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/auth/external-login.ts
+++ b/apps/dashboard/src/schemas/auth/external-login.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/auth/organization.ts
+++ b/apps/dashboard/src/schemas/auth/organization.ts
@@ -1,6 +1,11 @@
+import "zod/compile";
 import z from "zod";
 
 export const organizationIdSchema = z.string().min(1);
+
+export const organizationIdInputSchema = z.object({
+  organizationId: organizationIdSchema,
+});
 
 const ORGANIZATION_SLUG_MAX_LENGTH = 63;
 

--- a/apps/dashboard/src/schemas/auth/return-to.ts
+++ b/apps/dashboard/src/schemas/auth/return-to.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/auth/social.ts
+++ b/apps/dashboard/src/schemas/auth/social.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/auth/user-actions.ts
+++ b/apps/dashboard/src/schemas/auth/user-actions.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 
@@ -6,6 +7,8 @@ import { RETURN_TO_MAX_LENGTH } from "@/schemas/auth/return-to";
 const USER_NAME_MAX_LENGTH = 100;
 const USER_IMAGE_URL_MAX_LENGTH = 2048;
 const PROVIDER_ID_MAX_LENGTH = 64;
+
+export const userNameSchema = z.string().trim().min(1, "Name cannot be empty");
 
 export const updateUserInputSchema = z.object({
   name: z

--- a/apps/dashboard/src/schemas/auth/workos-error.ts
+++ b/apps/dashboard/src/schemas/auth/workos-error.ts
@@ -1,0 +1,17 @@
+import "zod/compile";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
+import * as z from "zod";
+
+export const workosErrorSchema = z.looseObject({
+  code: z.string().optional(),
+  message: z.string().optional(),
+  rawData: z
+    .looseObject({
+      code: z.string().optional(),
+      message: z.string().optional(),
+      email: z.string().optional(),
+      pending_authentication_token: z.string().optional(),
+      organizations: z.array(z.looseObject({ id: z.string() })).optional(),
+    })
+    .optional(),
+});

--- a/apps/dashboard/src/schemas/automation/event-trigger-form.ts
+++ b/apps/dashboard/src/schemas/automation/event-trigger-form.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/automation/schedule-form.ts
+++ b/apps/dashboard/src/schemas/automation/schedule-form.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/brand-analysis.ts
+++ b/apps/dashboard/src/schemas/brand-analysis.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { publicWebsiteUrlSchema } from "@notra/geo-core/schemas/url";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";

--- a/apps/dashboard/src/schemas/brand-guidelines.ts
+++ b/apps/dashboard/src/schemas/brand-guidelines.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/brand.ts
+++ b/apps/dashboard/src/schemas/brand.ts
@@ -170,4 +170,3 @@ export const analyzeInputSchema = organizationIdInputSchema.extend({
 export const setDefaultVoiceInputSchema = organizationIdInputSchema.extend({
   voiceId: z.string().min(1, "Voice ID is required"),
 });
-

--- a/apps/dashboard/src/schemas/brand.ts
+++ b/apps/dashboard/src/schemas/brand.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import {
   DEFAULT_LANGUAGE,
   type SupportedLanguage,
@@ -12,8 +13,11 @@ import {
   brandNameSchema,
 } from "@notra/ai/schemas/limits";
 import { toneProfileSchema } from "@notra/ai/schemas/tone";
+import { publicWebsiteUrlSchema } from "@notra/geo-core/schemas/url";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
+
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 
 export function getValidLanguage(value: unknown): SupportedLanguage {
   const parsed = supportedLanguageSchema.safeParse(value);
@@ -138,3 +142,32 @@ export const brandIdentityToolOutputSchema = z
     brandIdentities: z.array(brandIdentityWithWebsiteSchema).optional(),
   })
   .partial();
+
+export const voiceInputSchema = organizationIdInputSchema.extend({
+  voiceId: z.string().min(1, "Voice ID is required"),
+});
+
+export const voiceCreateInputSchema = organizationIdInputSchema.extend({
+  name: z.string().optional(),
+  websiteUrl: z.string().min(1, "Website URL is required"),
+});
+
+export const voiceUpdateInputSchema = organizationIdInputSchema
+  .extend({
+    voiceId: z.string().min(1, "Voice ID is required"),
+  })
+  .and(updateBrandSettingsSchema.omit({ id: true }));
+
+export const referenceInputSchema = voiceInputSchema.extend({
+  referenceId: z.string().min(1, "Reference ID is required"),
+});
+
+export const analyzeInputSchema = organizationIdInputSchema.extend({
+  voiceId: z.string().optional(),
+  url: publicWebsiteUrlSchema,
+});
+
+export const setDefaultVoiceInputSchema = organizationIdInputSchema.extend({
+  voiceId: z.string().min(1, "Voice ID is required"),
+});
+

--- a/apps/dashboard/src/schemas/command-palette.ts
+++ b/apps/dashboard/src/schemas/command-palette.ts
@@ -1,0 +1,14 @@
+import "zod/compile";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+export const commandPaletteNavigateRequestSchema = z.object({
+  query: z.string().min(1).max(500),
+  slug: z.string().min(1).max(100),
+});
+
+export const commandPaletteNavigateResultSchema = z.object({
+  action: z.enum(["navigate", "chat"]),
+  path: z.string().nullish(),
+  reason: z.string().max(160).default(""),
+});

--- a/apps/dashboard/src/schemas/content.ts
+++ b/apps/dashboard/src/schemas/content.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import {
   chatIdSchema,
   UI_MESSAGES_MAX,

--- a/apps/dashboard/src/schemas/content/create-content-form.ts
+++ b/apps/dashboard/src/schemas/content/create-content-form.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/feedback.ts
+++ b/apps/dashboard/src/schemas/feedback.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/generations.ts
+++ b/apps/dashboard/src/schemas/generations.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/geo-analytics.ts
+++ b/apps/dashboard/src/schemas/geo-analytics.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { geoOrganizationInputSchema } from "@notra/geo-core/schemas/geo";
 import { z } from "zod";
 

--- a/apps/dashboard/src/schemas/github-webhook.ts
+++ b/apps/dashboard/src/schemas/github-webhook.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/github.ts
+++ b/apps/dashboard/src/schemas/github.ts
@@ -1,0 +1,29 @@
+import "zod/compile";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
+import { githubPersonalAccessTokenSchema } from "@/schemas/integrations";
+
+export const probeRepositoryInputSchema = z.object({
+  owner: z.string().trim().min(1, "owner is required"),
+  repo: z.string().trim().min(1, "repo is required"),
+  token: githubPersonalAccessTokenSchema.optional(),
+});
+
+export const saveGitHubAppRepositoriesInputSchema =
+  organizationIdInputSchema.extend({
+    repositoryIds: z.array(z.string().min(1)).default([]),
+  });
+
+export const disconnectGitHubAppInputSchema = organizationIdInputSchema.extend({
+  accountId: z.string().min(1).optional(),
+});
+
+export const prepareInstallUrlInputSchema = organizationIdInputSchema.extend({
+  callbackPath: z.string().trim().min(1, "Callback path is required"),
+});
+
+export type PrepareInstallUrlInput = z.infer<
+  typeof prepareInstallUrlInputSchema
+>;

--- a/apps/dashboard/src/schemas/granola.ts
+++ b/apps/dashboard/src/schemas/granola.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { GRANOLA_API_KEY_PREFIX } from "@notra/ai/constants/granola";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";

--- a/apps/dashboard/src/schemas/integrations.ts
+++ b/apps/dashboard/src/schemas/integrations.ts
@@ -1,7 +1,9 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 
 import { GITHUB_URL_PATTERNS } from "@/constants/github";
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 
 export const INTEGRATION_CATEGORIES = ["input", "output"] as const;
 export type IntegrationCategory = (typeof INTEGRATION_CATEGORIES)[number];
@@ -155,15 +157,27 @@ export const integrationIdParamSchema = z.object({
 });
 export type IntegrationIdParam = z.infer<typeof integrationIdParamSchema>;
 
+export const integrationInputSchema = organizationIdInputSchema.extend({
+  integrationId: integrationIdParamSchema.shape.integrationId,
+});
+
 export const repositoryIdParamSchema = z.object({
   repositoryId: z.string().min(1, "Repository ID is required"),
 });
 export type RepositoryIdParam = z.infer<typeof repositoryIdParamSchema>;
 
+export const repositoryInputSchema = organizationIdInputSchema.extend({
+  repositoryId: repositoryIdParamSchema.shape.repositoryId,
+});
+
 export const outputIdParamSchema = z.object({
   outputId: z.string().min(1, "Output ID is required"),
 });
 export type OutputIdParam = z.infer<typeof outputIdParamSchema>;
+
+export const outputInputSchema = organizationIdInputSchema.extend({
+  outputId: outputIdParamSchema.shape.outputId,
+});
 
 const repoIdentifierSchema = z
   .string()
@@ -344,6 +358,14 @@ export const getSchedulesQuerySchema = z.object({
   repositoryIds: z.array(z.string().min(1)).optional(),
 });
 export type GetSchedulesQuery = z.infer<typeof getSchedulesQuerySchema>;
+
+export const triggerInputSchema = organizationIdInputSchema.extend({
+  triggerId: z.string().min(1, "Trigger ID is required"),
+});
+
+export const schedulesListInputSchema = organizationIdInputSchema.and(
+  getSchedulesQuerySchema
+);
 
 export const affectedTriggerSchema = z.object({
   id: z.string(),
@@ -570,6 +592,10 @@ export type UpdateMcpServerBody = z.infer<typeof updateMcpServerBodySchema>;
 
 export const mcpServerIdParamSchema = z.object({
   serverId: z.string().min(1, "MCP server ID is required"),
+});
+
+export const mcpServerInputSchema = organizationIdInputSchema.extend({
+  serverId: mcpServerIdParamSchema.shape.serverId,
 });
 
 export const testMcpServerRequestSchema =

--- a/apps/dashboard/src/schemas/iris.ts
+++ b/apps/dashboard/src/schemas/iris.ts
@@ -1,3 +1,5 @@
+import "zod/compile";
+import { irisOutboxArtifactSchema } from "@notra/ai/schemas/autonomy/outbox";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 
@@ -33,3 +35,9 @@ export const irisListSignalsInputSchema = irisOrganizationInputSchema.extend({
     .default(IRIS_SIGNALS_PAGE_SIZE),
 });
 export type IrisListSignalsInput = z.infer<typeof irisListSignalsInputSchema>;
+
+export const irisArtifactListSchema = z.array(irisOutboxArtifactSchema);
+
+export const irisArtifactContainerSchema = z.object({
+  artifacts: irisArtifactListSchema.optional(),
+});

--- a/apps/dashboard/src/schemas/linear.ts
+++ b/apps/dashboard/src/schemas/linear.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/logs.ts
+++ b/apps/dashboard/src/schemas/logs.ts
@@ -1,0 +1,17 @@
+import "zod/compile";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+import { webhookLogsQuerySchema } from "@/schemas/api-params";
+import { organizationIdSchema } from "@/schemas/auth/organization";
+
+export const listWebhookLogsInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  page: webhookLogsQuerySchema.shape.page,
+  pageSize: webhookLogsQuerySchema.shape.pageSize,
+  integrationType: webhookLogsQuerySchema.shape.integrationType,
+  integrationId: z.string().nullish(),
+  source: webhookLogsQuerySchema.shape.source,
+  status: webhookLogsQuerySchema.shape.status,
+  search: webhookLogsQuerySchema.shape.search,
+});

--- a/apps/dashboard/src/schemas/notification-settings.ts
+++ b/apps/dashboard/src/schemas/notification-settings.ts
@@ -1,5 +1,8 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
+
+import { organizationIdInputSchema } from "@/schemas/auth/organization";
 
 export const updateNotificationSettingsSchema = z.object({
   scheduledContentCreation: z.boolean().optional(),
@@ -11,3 +14,6 @@ export const updateNotificationSettingsSchema = z.object({
 export type UpdateNotificationSettings = z.infer<
   typeof updateNotificationSettingsSchema
 >;
+
+export const updateNotificationSettingsInputSchema =
+  organizationIdInputSchema.extend(updateNotificationSettingsSchema.shape);

--- a/apps/dashboard/src/schemas/onboarding-agent.ts
+++ b/apps/dashboard/src/schemas/onboarding-agent.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { Schema } from "effect";
 import { z } from "zod";
 

--- a/apps/dashboard/src/schemas/onboarding/company-logo.ts
+++ b/apps/dashboard/src/schemas/onboarding/company-logo.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "zod";
 
 export const companyLogoInputSchema = z.object({

--- a/apps/dashboard/src/schemas/onboarding/workspace.ts
+++ b/apps/dashboard/src/schemas/onboarding/workspace.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { optionalPublicWebsiteUrlSchema } from "@notra/geo-core/schemas/url";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";

--- a/apps/dashboard/src/schemas/organization.ts
+++ b/apps/dashboard/src/schemas/organization.ts
@@ -1,7 +1,10 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 
 import { RESERVED_ORGANIZATION_SLUGS } from "@/constants/organization";
+
+export const slugSchema = z.string().slugify();
 
 export const organizationSlugSchema = z
   .string()

--- a/apps/dashboard/src/schemas/organizations/actions.ts
+++ b/apps/dashboard/src/schemas/organizations/actions.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/search.ts
+++ b/apps/dashboard/src/schemas/search.ts
@@ -1,0 +1,9 @@
+import "zod/compile";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+export const globalSearchInputSchema = z.object({
+  organizationId: z.string().min(1, "Organization ID is required"),
+  query: z.string().trim().min(1).max(200),
+  limit: z.number().int().min(1).max(20).default(5),
+});

--- a/apps/dashboard/src/schemas/sitemap.ts
+++ b/apps/dashboard/src/schemas/sitemap.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/skills.ts
+++ b/apps/dashboard/src/schemas/skills.ts
@@ -1,5 +1,8 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
+
+import { organizationIdSchema } from "@/schemas/auth/organization";
 
 export const skillNameSchema = z
   .string()
@@ -49,3 +52,32 @@ export const updateSkillSchema = z.object({
 
 export type CreateSkillInput = z.infer<typeof createSkillSchema>;
 export type UpdateSkillInput = z.infer<typeof updateSkillSchema>;
+
+export const listSkillsInputSchema = z.object({
+  organizationId: organizationIdSchema,
+});
+
+export const getSkillInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  name: skillNameSchema,
+});
+
+export const createSkillInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  payload: createSkillSchema,
+});
+
+export const updateSkillInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  name: skillNameSchema,
+  payload: updateSkillSchema,
+});
+
+export const deleteSkillInputSchema = z.object({
+  organizationId: organizationIdSchema,
+  name: skillNameSchema,
+});
+
+export const importSkillFromUrlInputSchema = z.object({
+  url: skillImportUrlSchema,
+});

--- a/apps/dashboard/src/schemas/slack-integration.ts
+++ b/apps/dashboard/src/schemas/slack-integration.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/slack-relay.ts
+++ b/apps/dashboard/src/schemas/slack-relay.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { z } from "zod";
 
 export const slackPostMessageResponseSchema = z.looseObject({

--- a/apps/dashboard/src/schemas/social-accounts.ts
+++ b/apps/dashboard/src/schemas/social-accounts.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/upload.ts
+++ b/apps/dashboard/src/schemas/upload.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import { ORPCError } from "@orpc/server";
 import z from "zod";
 

--- a/apps/dashboard/src/schemas/webhooks.ts
+++ b/apps/dashboard/src/schemas/webhooks.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/workflows.ts
+++ b/apps/dashboard/src/schemas/workflows.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 import {
   contentGenerationWorkflowPayloadSchema,
   LOOKBACK_WINDOWS,

--- a/apps/dashboard/src/schemas/workflows/iris.ts
+++ b/apps/dashboard/src/schemas/workflows/iris.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/workflows/onboarding-agent-payload.ts
+++ b/apps/dashboard/src/schemas/workflows/onboarding-agent-payload.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 

--- a/apps/dashboard/src/schemas/workos-webhook.ts
+++ b/apps/dashboard/src/schemas/workos-webhook.ts
@@ -1,3 +1,4 @@
+import "zod/compile";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way to import
 import * as z from "zod";
 

--- a/apps/dashboard/src/utils/iris-artifacts.ts
+++ b/apps/dashboard/src/utils/iris-artifacts.ts
@@ -1,22 +1,16 @@
+import type { IrisOutboxArtifact } from "@notra/ai/schemas/autonomy/outbox";
+
 import {
-  type IrisOutboxArtifact,
-  irisOutboxArtifactSchema,
-} from "@notra/ai/schemas/autonomy/outbox";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
-
-const artifactListSchema = z.array(irisOutboxArtifactSchema);
-
-const artifactContainerSchema = z.object({
-  artifacts: artifactListSchema.optional(),
-});
+  irisArtifactContainerSchema,
+  irisArtifactListSchema,
+} from "@/schemas/iris";
 
 export const extractIrisArtifacts = (value: unknown): IrisOutboxArtifact[] => {
-  const container = artifactContainerSchema.safeParse(value);
+  const container = irisArtifactContainerSchema.safeParse(value);
   if (container.success) {
     return container.data.artifacts ?? [];
   }
 
-  const list = artifactListSchema.safeParse(value);
+  const list = irisArtifactListSchema.safeParse(value);
   return list.success ? list.data : [];
 };

--- a/bun.lock
+++ b/bun.lock
@@ -188,7 +188,7 @@
         "sugar-high": "^1.2.1",
         "three": "^0.167.1",
         "workflow": "^4.6.0",
-        "zod": "^4.4.3",
+        "zod": "^4.5.0",
       },
       "devDependencies": {
         "@notra/typescript-config": "workspace:*",
@@ -4956,7 +4956,7 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,7 @@
         "nanoid": "^5.1.11",
         "sanitize-html": "^2.17.0",
         "tsup": "^8.5.1",
-        "zod": "^4.4.3",
+        "zod": "^4.5.0",
       },
       "devDependencies": {
         "@notra/typescript-config": "workspace:*",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -33,4 +33,5 @@ minimumReleaseAgeExcludes = [
   "@ai-sdk/provider-utils",
   "@tanstack/db-ivm",
   "@usenotra/geo",
+  "zod",
 ]


### PR DESCRIPTION
## What

### Dashboard
- Moves every inline Zod schema in the dashboard into `src/schemas/` — oRPC router input schemas (api-keys, attachments, automation, brand, github, integrations, logs, notifications, onboarding, search, skills), the command-palette navigate route, the workspace/create-org slug schema, the profile name schema, the WorkOS error schema, and the iris artifact schemas.
- Adds a shared `organizationIdInputSchema` in `schemas/auth/organization.ts` and replaces the five identical per-router copies with it.
- Drops the `guidelineInputSchema` alias in favor of `voiceInputSchema` (knip duplicate-export).

### API
- Moves the remaining inline schemas into `src/schemas/`: the public status response schema (`index.ts` → `schemas/status.ts`), the rate-limit response schema (`utils/openapi-responses.ts` → `schemas/responses.ts`), and the inline schedule-targets parse in `routes/schedules.ts` → `schemas/schedules.ts`.

### Zod 4.5 + z.compile
- Bumps dashboard and API zod to `^4.5.0` (resolves 4.5.4) and adds `zod` to the bunfig `minimumReleaseAgeExcludes` since 4.5.x shipped within the 7-day window.
- Adds `import "zod/compile"` at the top of every schema file in both apps so schemas constructed in them are JIT-compiled on first parse (per https://zod.dev/blog/introducing-z-compile).

## Notes

- Routers that previously used a local org-id schema with the message "Organization ID is required" now share the plain `min(1)` schema, so that validation message falls back to the default.
- `bun run check-types` passes for all 15 packages; `bun run format` applied.