### PR TITLE
fix(api): restore Docker build with geo-core, posthog and bunfig

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -8,7 +8,7 @@ FROM oven/bun:1.4.0-alpine@sha256:07235578f79ef8c6f97d94aee7938e76f5cdba5f21ae5d
 WORKDIR /app
 
 # Copy workspace manifests needed to resolve the full dependency graph
-COPY package.json bun.lock ./
+COPY package.json bun.lock bunfig.toml ./
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/dashboard/package.json ./apps/dashboard/package.json
 COPY apps/docs/package.json ./apps/docs/package.json
@@ -19,7 +19,9 @@ COPY packages/content-generation/package.json ./packages/content-generation/pack
 COPY packages/db/package.json ./packages/db/package.json
 COPY packages/email/package.json ./packages/email/package.json
 COPY packages/geo/package.json ./packages/geo/package.json
+COPY packages/geo-core/package.json ./packages/geo-core/package.json
 COPY packages/kiwi/package.json ./packages/kiwi/package.json
+COPY packages/posthog/package.json ./packages/posthog/package.json
 COPY packages/typescript-config/package.json ./packages/typescript-config/package.json
 COPY packages/ui/package.json ./packages/ui/package.json
 COPY packages/utils/package.json ./packages/utils/package.json
@@ -36,6 +38,8 @@ COPY packages/analytics ./packages/analytics
 COPY packages/content-generation ./packages/content-generation
 COPY packages/typescript-config ./packages/typescript-config
 COPY packages/db ./packages/db
+COPY packages/geo-core ./packages/geo-core
+COPY packages/posthog ./packages/posthog
 COPY packages/utils ./packages/utils
 COPY apps/api ./apps/api
 


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the API Docker build by copying the missing workspace files and packages into the image. The build previously failed because `bunfig.toml`, `packages/geo-core`, and `packages/posthog` were not included in the Docker context.

<sup>Written for commit 64cf40f332e67117a711883e825298cac9865dc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

