### PR TITLE
fix(api,web): point OAuth discovery at oauth.usenotra.com AuthKit domain

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -39,7 +39,7 @@ interface AuthOptions {
 }
 
 const BEARER_HEADER_REGEX = /^Bearer\s+(.+)$/i;
-const DEFAULT_AUTHKIT_DOMAIN = "auth.usenotra.com";
+const DEFAULT_AUTHKIT_DOMAIN = "oauth.usenotra.com";
 const OAUTH_AUDIENCES = [
   API_URL,
   "https://mcp.usenotra.com",

--- a/apps/api/src/utils/agent-discovery.ts
+++ b/apps/api/src/utils/agent-discovery.ts
@@ -1,7 +1,7 @@
 import { PUBLIC_API_SCOPES } from "@notra/utils/api-scopes";
 
 export const API_URL = "https://api.usenotra.com";
-const DEFAULT_AUTHKIT_DOMAIN = "auth.usenotra.com";
+const DEFAULT_AUTHKIT_DOMAIN = "oauth.usenotra.com";
 const AUTH_SERVER_URL = `https://${DEFAULT_AUTHKIT_DOMAIN}`;
 const AUTH_ISSUER_URL = AUTH_SERVER_URL;
 const MCP_ORIGIN_URL = "https://mcp.usenotra.com";

--- a/apps/web/src/app/(site)/agent/auth/authorize/route.ts
+++ b/apps/web/src/app/(site)/agent/auth/authorize/route.ts
@@ -9,6 +9,6 @@ export function OPTIONS() {
 export function GET(request: NextRequest) {
   return redirectToAuthServer(
     request,
-    "https://auth.usenotra.com/oauth2/authorize"
+    "https://oauth.usenotra.com/oauth2/authorize"
   );
 }

--- a/apps/web/src/app/(site)/agent/auth/register/route.ts
+++ b/apps/web/src/app/(site)/agent/auth/register/route.ts
@@ -9,6 +9,6 @@ export function OPTIONS() {
 export function POST(request: NextRequest) {
   return redirectToAuthServer(
     request,
-    "https://auth.usenotra.com/oauth2/register"
+    "https://oauth.usenotra.com/oauth2/register"
   );
 }

--- a/apps/web/src/app/(site)/agent/auth/revoke/route.ts
+++ b/apps/web/src/app/(site)/agent/auth/revoke/route.ts
@@ -9,6 +9,6 @@ export function OPTIONS() {
 export function POST(request: NextRequest) {
   return redirectToAuthServer(
     request,
-    "https://auth.usenotra.com/oauth2/revoke"
+    "https://oauth.usenotra.com/oauth2/revoke"
   );
 }

--- a/apps/web/src/app/(site)/agent/auth/token/route.ts
+++ b/apps/web/src/app/(site)/agent/auth/token/route.ts
@@ -9,6 +9,6 @@ export function OPTIONS() {
 export function POST(request: NextRequest) {
   return redirectToAuthServer(
     request,
-    "https://auth.usenotra.com/oauth2/token"
+    "https://oauth.usenotra.com/oauth2/token"
   );
 }

--- a/apps/web/src/app/auth.md/route.ts
+++ b/apps/web/src/app/auth.md/route.ts
@@ -10,15 +10,15 @@ Start at \`/.well-known/agent.json\`, \`/.well-known/agent-card.json\`, and \`/.
 
 ## Pick a method
 
-OAuth-capable clients should follow the authorization server advertised by the protected resource metadata. The production authorization server is \`https://auth.usenotra.com\`, with standard endpoints at \`/oauth2/authorize\`, \`/oauth2/token\`, \`/oauth2/register\`, and \`/oauth2/revoke\`, and signing keys at \`/oauth2/jwks\`. Manual clients can use API keys created in the Notra dashboard.
+OAuth-capable clients should follow the authorization server advertised by the protected resource metadata. The production authorization server is \`https://oauth.usenotra.com\`, with standard endpoints at \`/oauth2/authorize\`, \`/oauth2/token\`, \`/oauth2/register\`, and \`/oauth2/revoke\`, and signing keys at \`/oauth2/jwks\`. Manual clients can use API keys created in the Notra dashboard.
 
 ## Register
 
-Call \`POST https://auth.usenotra.com/oauth2/register\` for dynamic OAuth client registration, or identify with a Client ID Metadata Document if your client supports it. Agents should request the least privileged resource scopes, such as \`posts.read\`, \`posts.write\`, \`skills.read\`, \`skills.write\`, \`integrations.read\`, and \`integrations.write\`. Include \`offline_access\` when a refresh token is needed.
+Call \`POST https://oauth.usenotra.com/oauth2/register\` for dynamic OAuth client registration, or identify with a Client ID Metadata Document if your client supports it. Agents should request the least privileged resource scopes, such as \`posts.read\`, \`posts.write\`, \`skills.read\`, \`skills.write\`, \`integrations.read\`, and \`integrations.write\`. Include \`offline_access\` when a refresh token is needed.
 
 ## Authorize
 
-Use the authorization code flow with PKCE (\`S256\`). Headless clients without a redirect target can use the device authorization grant at \`https://auth.usenotra.com/oauth2/device_authorization\`, then poll \`/oauth2/token\` with the returned device code while the user approves in a browser.
+Use the authorization code flow with PKCE (\`S256\`). Headless clients without a redirect target can use the device authorization grant at \`https://oauth.usenotra.com/oauth2/device_authorization\`, then poll \`/oauth2/token\` with the returned device code while the user approves in a browser.
 
 ## Use the credential
 
@@ -30,7 +30,7 @@ Send the credential as \`Authorization: Bearer <TOKEN>\`. For MCP clients that s
 
 ## Revocation
 
-Call \`POST https://auth.usenotra.com/oauth2/revoke\` for OAuth tokens, or revoke API keys in the Notra dashboard. Agents should discard revoked credentials immediately and repeat discovery before requesting a replacement.
+Call \`POST https://oauth.usenotra.com/oauth2/revoke\` for OAuth tokens, or revoke API keys in the Notra dashboard. Agents should discard revoked credentials immediately and repeat discovery before requesting a replacement.
 `;
 
 export function GET() {

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -43,7 +43,7 @@ export function apiUrl(path = "") {
 }
 
 function authIssuerUrl() {
-  return "https://auth.usenotra.com";
+  return "https://oauth.usenotra.com";
 }
 
 function buildAgentAuthMetadata() {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points OAuth discovery and endpoints at the `oauth.usenotra.com` AuthKit domain instead of `auth.usenotra.com`, fixing authorization server metadata, redirects, and documentation.

<sup>Written for commit 9f6d0ee5b2becfb73480ca693a23b5e4e4440593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

