### PR TITLE
fix(dashboard): use duotone API keys table

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/api-keys/page.tsx
@@ -2,9 +2,6 @@
 
 import {
   Add01Icon,
-  ArrowDown01Icon,
-  ArrowUp01Icon,
-  ArrowUpDownIcon,
   Book01Icon,
   Delete02Icon,
   Dots,
@@ -51,15 +48,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@notra/ui/components/ui/select";
-import { Skeleton } from "@notra/ui/components/ui/skeleton";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@notra/ui/components/ui/table";
 import {
   Tooltip,
   TooltipContent,
@@ -92,6 +80,7 @@ import { ApiKeyPermissionSelector } from "@/components/api-keys/permission-selec
 import { TrackingTokenCard } from "@/components/api-keys/tracking-token-card";
 import { Button } from "@/components/button";
 import { PageContainer } from "@/components/layout/container";
+import { Table, type TableColumn } from "@/components/motion/table";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   API_KEY_DEFAULT_SCOPES,
@@ -128,8 +117,6 @@ const EDIT_FORM_DEFAULTS: ApiKeyFormValues = {
   scopes: [...API_KEY_DEFAULT_SCOPES],
   expiration: "never",
 };
-
-const API_KEY_SKELETON_ROWS = ["row-1", "row-2", "row-3"];
 
 interface ApiKeyEditForm {
   // TanStack Form's Field component carries deep generics that are local to the
@@ -173,15 +160,12 @@ interface ApiKeyMutationResponse {
   success: boolean;
 }
 
-type CreatedSortOrder = false | "asc" | "desc";
-
 interface ApiKeysUiState {
   dialogOpen: boolean;
   createdKey: string | null;
   createError: string | null;
   editDialogOpen: boolean;
   deletingKey: ApiKeyListItem | null;
-  createdSortOrder: CreatedSortOrder;
 }
 
 type ApiKeysUiAction =
@@ -190,7 +174,6 @@ type ApiKeysUiAction =
   | { type: "createErrorChanged"; createError: string | null }
   | { type: "editDialogChanged"; open: boolean }
   | { type: "deletingKeyChanged"; deletingKey: ApiKeyListItem | null }
-  | { type: "createdSortOrderChanged"; sortOrder: CreatedSortOrder }
   | { type: "createDialogReset" };
 
 const initialApiKeysUiState: ApiKeysUiState = {
@@ -199,7 +182,6 @@ const initialApiKeysUiState: ApiKeysUiState = {
   createError: null,
   editDialogOpen: false,
   deletingKey: null,
-  createdSortOrder: false,
 };
 
 function apiKeysUiReducer(
@@ -217,8 +199,6 @@ function apiKeysUiReducer(
       return { ...state, editDialogOpen: action.open };
     case "deletingKeyChanged":
       return { ...state, deletingKey: action.deletingKey };
-    case "createdSortOrderChanged":
-      return { ...state, createdSortOrder: action.sortOrder };
     case "createDialogReset":
       return {
         ...state,
@@ -272,136 +252,6 @@ function getDefaultEditExpiration(
   return "90d";
 }
 
-function getSortIcon(isSorted: false | "asc" | "desc") {
-  if (isSorted === "asc") {
-    return ArrowUp01Icon;
-  }
-  if (isSorted === "desc") {
-    return ArrowDown01Icon;
-  }
-  return ArrowUpDownIcon;
-}
-
-function sortApiKeys(
-  keys: ApiKeyListItem[],
-  createdSortOrder: false | "asc" | "desc"
-) {
-  if (createdSortOrder === false) {
-    return keys;
-  }
-
-  return keys
-    .slice()
-    .sort((a, b) =>
-      createdSortOrder === "desc"
-        ? b.createdAt - a.createdAt
-        : a.createdAt - b.createdAt
-    );
-}
-
-function ApiKeysTableContent({
-  isPending,
-  keys,
-  onDelete,
-  onEdit,
-  actionsDisabled,
-}: {
-  isPending: boolean;
-  keys: ApiKeyListItem[];
-  onDelete: (key: ApiKeyListItem) => void;
-  onEdit: (key: ApiKeyListItem) => void;
-  actionsDisabled: boolean;
-}) {
-  if (isPending) {
-    return (
-      <>
-        {API_KEY_SKELETON_ROWS.map((row) => (
-          <TableRow key={row}>
-            <TableCell>
-              <Skeleton className="h-4 w-32" />
-            </TableCell>
-            <TableCell>
-              <Skeleton className="h-4 w-28" />
-            </TableCell>
-            <TableCell>
-              <Skeleton className="h-4 w-24" />
-            </TableCell>
-            <TableCell>
-              <Skeleton className="h-4 w-20" />
-            </TableCell>
-            <TableCell>
-              <Skeleton className="h-4 w-24" />
-            </TableCell>
-            <TableCell>
-              <Skeleton className="size-8 rounded-md" />
-            </TableCell>
-          </TableRow>
-        ))}
-      </>
-    );
-  }
-
-  if (keys.length === 0) {
-    return (
-      <TableRow>
-        <TableCell
-          className="text-muted-foreground h-24 text-center"
-          colSpan={6}
-        >
-          No API keys yet
-        </TableCell>
-      </TableRow>
-    );
-  }
-
-  return keys.map((apiKey) => (
-    <TableRow key={apiKey.keyId}>
-      <TableCell className="font-medium">{apiKey.name}</TableCell>
-      <TableCell className="text-muted-foreground font-mono text-sm">
-        {apiKey.start}…
-      </TableCell>
-      <TableCell>{formatPermissionLabel(apiKey)}</TableCell>
-      <TableCell className="text-muted-foreground text-sm">
-        {formatExpiry(apiKey.expires)}
-      </TableCell>
-      <TableCell className="text-muted-foreground text-sm">
-        {new Date(apiKey.createdAt).toLocaleDateString()}
-      </TableCell>
-      <TableCell className="text-muted-foreground text-sm">
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button size="icon" variant="ghost">
-                <HugeiconsIcon className="size-4" icon={Dots} />
-              </Button>
-            }
-          />
-          <DropdownMenuContent align="end" className="min-w-44">
-            <DropdownMenuGroup>
-              <DropdownMenuItem
-                disabled={actionsDisabled}
-                onClick={() => onEdit(apiKey)}
-              >
-                <HugeiconsIcon className="size-4" icon={Edit02Icon} />
-                Edit API key
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                disabled={actionsDisabled}
-                onClick={() => onDelete(apiKey)}
-                variant="destructive"
-              >
-                <HugeiconsIcon className="size-4" icon={Delete02Icon} />
-                Delete API key
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </TableCell>
-    </TableRow>
-  ));
-}
-
 function ApiKeysHeader({ onCreate }: { onCreate: () => void }) {
   return (
     <div className="flex items-center justify-between">
@@ -446,53 +296,119 @@ function ApiKeysHeader({ onCreate }: { onCreate: () => void }) {
 
 function ApiKeysTable({
   actionsDisabled,
-  createdSortOrder,
   isPending,
   keys,
   onDelete,
   onEdit,
-  onSort,
 }: {
   actionsDisabled: boolean;
-  createdSortOrder: false | "asc" | "desc";
   isPending: boolean;
   keys: ApiKeyListItem[];
   onDelete: (key: ApiKeyListItem) => void;
   onEdit: (key: ApiKeyListItem) => void;
-  onSort: () => void;
 }) {
-  return (
-    <div className="smooth-shadow-ring-xs bg-muted/80 overflow-hidden rounded-lg">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Key</TableHead>
-            <TableHead>Permission</TableHead>
-            <TableHead className="w-35">Expires</TableHead>
-            <TableHead className="w-35">
-              <Button className="-ml-4" onClick={onSort} variant="ghost">
-                Created At
-                <HugeiconsIcon
-                  className="ml-2 size-4"
-                  icon={getSortIcon(createdSortOrder)}
-                />
+  const columns: TableColumn<ApiKeyListItem>[] = [
+    {
+      key: "name",
+      header: "Name",
+      width: "1fr",
+      minWidth: "10rem",
+      cell: (apiKey) => <span className="font-medium">{apiKey.name}</span>,
+    },
+    {
+      key: "start",
+      header: "Key",
+      width: "1fr",
+      minWidth: "9rem",
+      cell: (apiKey) => (
+        <span className="text-muted-foreground font-mono text-sm">
+          {apiKey.start}…
+        </span>
+      ),
+    },
+    {
+      key: "permission",
+      header: "Permission",
+      width: "1fr",
+      minWidth: "9rem",
+      cell: formatPermissionLabel,
+    },
+    {
+      key: "expires",
+      header: "Expires",
+      width: "8.75rem",
+      cell: (apiKey) => (
+        <span className="text-muted-foreground text-sm">
+          {formatExpiry(apiKey.expires)}
+        </span>
+      ),
+    },
+    {
+      key: "createdAt",
+      header: "Created At",
+      sortable: true,
+      width: "9.5rem",
+      cell: (apiKey) => (
+        <span className="text-muted-foreground text-sm">
+          {new Date(apiKey.createdAt).toLocaleDateString()}
+        </span>
+      ),
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      width: "4rem",
+      minWidth: "4rem",
+      cell: (apiKey) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                aria-label={`Actions for ${apiKey.name}`}
+                size="icon"
+                variant="ghost"
+              >
+                <HugeiconsIcon className="size-4" icon={Dots} />
               </Button>
-            </TableHead>
-            <TableHead className="w-12" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          <ApiKeysTableContent
-            actionsDisabled={actionsDisabled}
-            isPending={isPending}
-            keys={keys}
-            onDelete={onDelete}
-            onEdit={onEdit}
+            }
           />
-        </TableBody>
-      </Table>
-    </div>
+          <DropdownMenuContent align="end" className="min-w-44">
+            <DropdownMenuGroup>
+              <DropdownMenuItem
+                disabled={actionsDisabled}
+                onClick={() => onEdit(apiKey)}
+              >
+                <HugeiconsIcon className="size-4" icon={Edit02Icon} />
+                Edit API key
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={actionsDisabled}
+                onClick={() => onDelete(apiKey)}
+                variant="destructive"
+              >
+                <HugeiconsIcon className="size-4" icon={Delete02Icon} />
+                Delete API key
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+    },
+  ];
+  const visibleRows = isPending ? 3 : Math.max(keys.length, 1);
+
+  return (
+    <Table
+      columns={columns}
+      data={keys}
+      emptyState="No API keys yet"
+      getRowId={(apiKey) => apiKey.keyId}
+      height={(visibleRows + 1) * 48}
+      loading={isPending}
+      rowHeight={48}
+    />
   );
 }
 
@@ -820,14 +736,7 @@ export default function ApiKeysPage() {
   const organizationId = activeOrganization?.id;
   const queryClient = useQueryClient();
   const [
-    {
-      dialogOpen,
-      createdKey,
-      createError,
-      editDialogOpen,
-      deletingKey,
-      createdSortOrder,
-    },
+    { dialogOpen, createdKey, createError, editDialogOpen, deletingKey },
     dispatchUi,
   ] = useReducer(apiKeysUiReducer, initialApiKeysUiState);
   const [newKeyConfig, setNewKeyConfig] = useQueryStates(
@@ -857,8 +766,6 @@ export default function ApiKeysPage() {
     }),
     enabled: !!organizationId,
   });
-
-  const sortedKeys = sortApiKeys(keys, createdSortOrder);
 
   const newKeyName = newKeyConfig.name;
   const newKeyScopes = newKeyConfig.scopes ?? DEFAULT_NEW_KEY_CONFIG.scopes;
@@ -1058,9 +965,8 @@ export default function ApiKeysPage() {
 
         <ApiKeysTable
           actionsDisabled={editMutation.isPending || deleteMutation.isPending}
-          createdSortOrder={createdSortOrder}
           isPending={isPending}
-          keys={sortedKeys}
+          keys={keys}
           onDelete={(key) =>
             dispatchUi({
               type: "deletingKeyChanged",
@@ -1068,12 +974,6 @@ export default function ApiKeysPage() {
             })
           }
           onEdit={openEditDialog}
-          onSort={() =>
-            dispatchUi({
-              type: "createdSortOrderChanged",
-              sortOrder: createdSortOrder === "asc" ? "desc" : "asc",
-            })
-          }
         />
 
         <ApiKeyQuickStart onSelect={handlePresetSelect} />


### PR DESCRIPTION
### Description
Replaces the custom API keys table with the shared duotone motion table used throughout the dashboard. Preserves sorting, loading and empty states, and edit/delete actions while aligning the page with the established table design.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the custom API keys table with the shared duotone motion table so the page matches the rest of the dashboard. Created At sorting, loading skeletons, and the empty state are now handled by the shared table component, and the previous custom sort state is removed.

<sup>Written for commit 7e9e5fa1cdf1ce41a31566ea92beeaecf285e5bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

