### PR TITLE
feat(web): publish /.well-known/integrations.json manifest for integrations.sh

### DIFF
--- a/apps/web/src/app/(site)/agent/page.tsx
+++ b/apps/web/src/app/(site)/agent/page.tsx
@@ -31,6 +31,9 @@ export default function AgentPage() {
             <li>Agent JSON: {siteUrl("/.well-known/agent.json")}</li>
             <li>Agent Card: {siteUrl("/.well-known/agent-card.json")}</li>
             <li>API Catalog: {siteUrl("/.well-known/api-catalog")}</li>
+            <li>
+              Integration Surfaces: {siteUrl("/.well-known/integrations.json")}
+            </li>
             <li>Auth guide: {siteUrl("/auth.md")}</li>
           </ul>
         </div>

--- a/apps/web/src/app/.well-known/integrations.json/route.ts
+++ b/apps/web/src/app/.well-known/integrations.json/route.ts
@@ -1,0 +1,11 @@
+import { jsonResponse } from "@/utils/http";
+import { buildIntegrationsManifest } from "@/utils/integrations-manifest";
+
+export function GET() {
+  return jsonResponse(buildIntegrationsManifest(), {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "cache-control": "public, max-age=3600",
+    },
+  });
+}

--- a/apps/web/src/app/api/llms.txt/route.ts
+++ b/apps/web/src/app/api/llms.txt/route.ts
@@ -9,6 +9,7 @@ Notra's public API is served from ${API_URL}. Use it when an agent needs to read
 
 - OpenAPI: [${API_URL}/openapi.json](${API_URL}/openapi.json)
 - API catalog: [${SITE_URL}/.well-known/api-catalog](${SITE_URL}/.well-known/api-catalog)
+- Integration surfaces: [${SITE_URL}/.well-known/integrations.json](${SITE_URL}/.well-known/integrations.json)
 - Authentication guide: [${SITE_URL}/auth.md](${SITE_URL}/auth.md)
 - Developer docs: [${DOCS_URL}](${DOCS_URL})
 

--- a/apps/web/src/app/developers/llms.txt/route.ts
+++ b/apps/web/src/app/developers/llms.txt/route.ts
@@ -10,6 +10,7 @@ Use Notra developer resources when integrating AI agents, SDKs, MCP clients, or 
 - API quickstart: [${SITE_URL}/api/llms.txt](${SITE_URL}/api/llms.txt)
 - Auth guide: [${SITE_URL}/auth.md](${SITE_URL}/auth.md)
 - API catalog: [${SITE_URL}/.well-known/api-catalog](${SITE_URL}/.well-known/api-catalog)
+- Integration surfaces: [${SITE_URL}/.well-known/integrations.json](${SITE_URL}/.well-known/integrations.json)
 - Agent discovery: [${SITE_URL}/.well-known/agent.json](${SITE_URL}/.well-known/agent.json)
 - Documentation: [${DOCS_URL}](${DOCS_URL})
 

--- a/apps/web/src/types/integrations-manifest.ts
+++ b/apps/web/src/types/integrations-manifest.ts
@@ -1,0 +1,76 @@
+export type IntegrationsManifestBasis = {
+  via: "declared";
+  source: string;
+};
+
+type IntegrationsManifestCredential = {
+  type: "api_key" | "oauth2";
+  label: string;
+  generateUrl?: string;
+  setup: string;
+};
+
+export type IntegrationsManifestMechanics =
+  | {
+      source: "http";
+      in: "header";
+      headerName: string;
+      scheme: string;
+    }
+  | {
+      source: "cli";
+      command?: string;
+      env?: string[];
+    }
+  | {
+      source: "well-known";
+    };
+
+export type IntegrationsManifestAuthEntry = {
+  use: {
+    id: string;
+    mechanics: IntegrationsManifestMechanics;
+  }[];
+  basis: IntegrationsManifestBasis;
+};
+
+type IntegrationsManifestAuth = {
+  status: "required";
+  entries: IntegrationsManifestAuthEntry[];
+};
+
+type IntegrationsManifestSurfaceBase = {
+  slug: string;
+  name: string;
+  docs: string;
+  basis: IntegrationsManifestBasis;
+  auth: IntegrationsManifestAuth;
+};
+
+type IntegrationsManifestSurface =
+  | (IntegrationsManifestSurfaceBase & {
+      type: "http";
+      spec: string;
+      url: string;
+    })
+  | (IntegrationsManifestSurfaceBase & {
+      type: "mcp";
+      url: string;
+      transports: ["streamable-http"];
+    })
+  | (IntegrationsManifestSurfaceBase & {
+      type: "cli";
+      command: string;
+      packages: {
+        registryType: "npm";
+        identifier: string;
+        runtimeHint: string;
+      }[];
+    });
+
+export type IntegrationsManifest = {
+  version: 3;
+  summary: string;
+  credentials: Record<string, IntegrationsManifestCredential>;
+  surfaces: IntegrationsManifestSurface[];
+};

--- a/apps/web/src/utils/integrations-manifest.ts
+++ b/apps/web/src/utils/integrations-manifest.ts
@@ -1,0 +1,138 @@
+import type {
+  IntegrationsManifest,
+  IntegrationsManifestAuthEntry,
+  IntegrationsManifestBasis,
+  IntegrationsManifestMechanics,
+} from "@/types/integrations-manifest";
+import { apiUrl, siteUrl } from "@/utils/agent-metadata";
+import {
+  API_URL,
+  APP_URL,
+  DOCS_URL,
+  MCP_PROTECTED_RESOURCE_METADATA_URL,
+  MCP_URL,
+} from "@/utils/urls";
+
+const INTEGRATIONS_MANIFEST_PATH = "/.well-known/integrations.json";
+
+const API_KEY_CREDENTIAL_ID = "notra_api_key";
+const OAUTH_CREDENTIAL_ID = "notra_oauth";
+
+const BEARER_HEADER_MECHANICS: IntegrationsManifestMechanics = {
+  source: "http",
+  in: "header",
+  headerName: "Authorization",
+  scheme: "Bearer",
+};
+
+const WELL_KNOWN_MECHANICS: IntegrationsManifestMechanics = {
+  source: "well-known",
+};
+
+const CLI_OAUTH_MECHANICS: IntegrationsManifestMechanics = {
+  source: "cli",
+  command: "notra auth login",
+};
+
+const CLI_API_KEY_MECHANICS: IntegrationsManifestMechanics = {
+  source: "cli",
+  command: "notra init",
+  env: ["NOTRA_API_KEY"],
+};
+
+function buildBasis(): IntegrationsManifestBasis {
+  return {
+    via: "declared",
+    source: siteUrl(INTEGRATIONS_MANIFEST_PATH),
+  };
+}
+
+function buildAuthEntry(
+  id: string,
+  mechanics: IntegrationsManifestMechanics
+): IntegrationsManifestAuthEntry {
+  return {
+    use: [{ id, mechanics }],
+    basis: buildBasis(),
+  };
+}
+
+export function buildIntegrationsManifest(): IntegrationsManifest {
+  const basis = buildBasis();
+
+  return {
+    version: 3,
+    summary:
+      "Notra exposes an HTTP API, a hosted MCP server, and a CLI for turning shipped engineering work into changelogs, blog posts, and social updates in a saved brand voice.",
+    credentials: {
+      [API_KEY_CREDENTIAL_ID]: {
+        type: "api_key",
+        label: "Notra API key",
+        generateUrl: APP_URL,
+        setup:
+          "Open Developer, then API Keys, in the Notra dashboard and create a key scoped to the resources you need. Store it as NOTRA_API_KEY and send it as an Authorization bearer token.",
+      },
+      [OAUTH_CREDENTIAL_ID]: {
+        type: "oauth2",
+        label: "Notra OAuth 2.1",
+        setup: `Read the protected resource metadata at ${MCP_PROTECTED_RESOURCE_METADATA_URL} to find the authorization server, register a client at https://oauth.usenotra.com/oauth2/register, and run the authorization code flow with PKCE. Request least privilege scopes such as posts.read and include offline_access when you need a refresh token. Headless clients can use the device authorization grant instead, which is what notra auth login does. Send the access token as an Authorization bearer token.`,
+      },
+    },
+    surfaces: [
+      {
+        slug: "notra-api",
+        name: "Notra API",
+        type: "http",
+        docs: `${DOCS_URL}/api/getting-started`,
+        spec: apiUrl("/openapi.json"),
+        url: API_URL,
+        basis,
+        auth: {
+          status: "required",
+          entries: [
+            buildAuthEntry(API_KEY_CREDENTIAL_ID, BEARER_HEADER_MECHANICS),
+            buildAuthEntry(OAUTH_CREDENTIAL_ID, WELL_KNOWN_MECHANICS),
+          ],
+        },
+      },
+      {
+        slug: "notra-mcp-server",
+        name: "Notra MCP server",
+        type: "mcp",
+        docs: `${DOCS_URL}/devtools/mcp`,
+        url: MCP_URL,
+        transports: ["streamable-http"],
+        basis,
+        auth: {
+          status: "required",
+          entries: [
+            buildAuthEntry(OAUTH_CREDENTIAL_ID, WELL_KNOWN_MECHANICS),
+            buildAuthEntry(API_KEY_CREDENTIAL_ID, BEARER_HEADER_MECHANICS),
+          ],
+        },
+      },
+      {
+        slug: "notra-cli",
+        name: "Notra CLI",
+        type: "cli",
+        docs: `${DOCS_URL}/devtools/cli`,
+        command: "notra",
+        packages: [
+          {
+            registryType: "npm",
+            identifier: "notra",
+            runtimeHint: "npx",
+          },
+        ],
+        basis,
+        auth: {
+          status: "required",
+          entries: [
+            buildAuthEntry(OAUTH_CREDENTIAL_ID, CLI_OAUTH_MECHANICS),
+            buildAuthEntry(API_KEY_CREDENTIAL_ID, CLI_API_KEY_MECHANICS),
+          ],
+        },
+      },
+    ],
+  };
+}

--- a/apps/web/src/utils/llms.ts
+++ b/apps/web/src/utils/llms.ts
@@ -105,6 +105,11 @@ export async function buildLlmsText() {
       "/.well-known/api-catalog",
       "RFC 9727 linkset for API descriptions"
     ),
+    formatLink(
+      "Integration Surfaces",
+      "/.well-known/integrations.json",
+      "integrations.sh manifest of API, MCP, and CLI surfaces with credentials"
+    ),
     "",
     "## Agent Instructions",
     "",


### PR DESCRIPTION
## Summary

Adds an [integrations.sh](https://integrations.sh/publishing/) v3 manifest at `/.well-known/integrations.json` on the marketing site so agents and the integrations.sh directory can discover Notra's integration surfaces and how to authenticate against them.

- New route `apps/web/src/app/.well-known/integrations.json/route.ts`, served as JSON with `Cache-Control: public, max-age=3600` and open CORS, matching the other well-known endpoints.
- Builder in `apps/web/src/utils/integrations-manifest.ts` derives every URL from the shared `utils/urls` constants. Types live in `apps/web/src/types/integrations-manifest.ts`.
- Declares two credentials (dashboard API key, OAuth 2.1 discovered via the MCP protected resource metadata) and three surfaces:
  - **HTTP API** at `api.usenotra.com` with the live OpenAPI spec
  - **MCP server** at `mcp.usenotra.com/mcp` over streamable HTTP
  - **CLI** (`notra` on npm) with OAuth device-flow login via `notra auth login` and API key fallback via `notra init` / `NOTRA_API_KEY`
- Links the manifest from `llms.txt`, `api/llms.txt`, `developers/llms.txt`, and the `/agent` page.

## Notes

- The CLI docs page (`apps/docs/devtools/cli.mdx`) still describes the CLI as API-key only. The published 0.1.0 package signs in with the OAuth device authorization grant. Not touched here, worth a follow-up.
- After deploy, register at `https://integrations.sh/www.usenotra.com/` and pick "Map integration surface".

## Verification

- Rendered the manifest locally and fetched it from the dev server: 200, `application/json`, expected headers and payload.
- OpenAPI URL, MCP protected resource metadata, and the `notra` npm package all resolve.
- oxfmt, oxlint, and knip pass on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes an integrations.sh v3 manifest at `/.well-known/integrations.json` so agents and integrations.sh can discover Notra’s API, MCP server, CLI, and authentication methods.

- Describes the HTTP API, streamable HTTP MCP endpoint, and `notra` npm CLI with OAuth 2.1 and API key setup.
- Adds links from `llms.txt`, developer resources, and the agent page, with public caching and open CORS.
- Register `https://www.usenotra.com/` in integrations.sh after deployment.
- The CLI docs still describe API-key-only authentication and need a follow-up update.

<sup>Written for commit 38338a76b81c64d86af998f6810bfe680a7ab5aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

