### PR TITLE
fix(geo): unify mention delta styling

### DIFF
--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -131,11 +131,7 @@ function ProviderRow({
         >
           {totals.mentions.toLocaleString()}
         </span>
-        <GeoStatDelta
-          delta={mentionDelta}
-          label={`${name} mentions`}
-          variant="plain"
-        />
+        <GeoStatDelta delta={mentionDelta} label={`${name} mentions`} />
       </span>
     </>
   );
@@ -346,7 +342,6 @@ export function MentionRateCard({
                 delta={overviewDelta}
                 hint={GEO_FAMILY_STAT_TREND_HINT}
                 label={GEO_MENTIONS_LABEL}
-                variant="plain"
               />
             </div>
 


### PR DESCRIPTION
### Description
Unifies the Mentions card delta indicators with the existing pill style used by Engines and Share of Voice. Applies the shared pill treatment to both the overview metric and provider rows.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Mentions card delta indicators with the shared pill style used by Engines and Share of Voice, so mention deltas no longer render as plain text.

- Applies the pill treatment to both the overview metric and the provider rows.

<sup>Written for commit 5027cda4ed6f2d007ed82d67cf8f621d4a4bbdc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

