### PR TITLE
fix(web): serve a markdown 404 body that points agents at llms.txt and the sitemap

### DIFF
--- a/apps/web/src/app/md/[...path]/route.ts
+++ b/apps/web/src/app/md/[...path]/route.ts
@@ -3,6 +3,7 @@ import {
   type DualmarkRouteHandler,
 } from "@dualmark/nextjs";
 
+import { MARKDOWN_CACHE_CONTROL } from "@/constants/not-found";
 import {
   buildDualmarkCollections,
   buildDualmarkStaticPages,
@@ -15,7 +16,7 @@ const handler = createDualmarkRouteHandler({
   collections: buildDualmarkCollections(),
   staticPages: buildDualmarkStaticPages(),
   headers: {
-    cacheControl: "public, max-age=300",
+    cacheControl: MARKDOWN_CACHE_CONTROL,
   },
 });
 

--- a/apps/web/src/app/md/[...path]/route.ts
+++ b/apps/web/src/app/md/[...path]/route.ts
@@ -1,9 +1,13 @@
-import { createDualmarkRouteHandler } from "@dualmark/nextjs";
+import {
+  createDualmarkRouteHandler,
+  type DualmarkRouteHandler,
+} from "@dualmark/nextjs";
 
 import {
   buildDualmarkCollections,
   buildDualmarkStaticPages,
 } from "@/utils/markdown-twins";
+import { markdownNotFoundResponse } from "@/utils/not-found";
 import { SITE_URL } from "@/utils/urls";
 
 const handler = createDualmarkRouteHandler({
@@ -17,5 +21,14 @@ const handler = createDualmarkRouteHandler({
 
 export const runtime = "nodejs";
 export const revalidate = 300;
-export const GET = handler.GET;
 export const generateStaticParams = handler.generateStaticParams;
+
+export const GET: DualmarkRouteHandler["GET"] = async (request, context) => {
+  const response = await handler.GET(request, context);
+
+  if (response.status === 404) {
+    return markdownNotFoundResponse();
+  }
+
+  return response;
+};

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import FooterSection from "@/components/footer-section";
 import { Navbar } from "@/components/navbar";
+import { NOT_FOUND_AGENT_LINKS } from "@/constants/not-found";
 
 export default function NotFound() {
   return (
@@ -23,6 +24,21 @@ export default function NotFound() {
           >
             Back to home
           </Link>
+          <nav
+            aria-label="Site indexes"
+            className="text-muted-foreground flex flex-wrap items-center justify-center gap-x-4 gap-y-2 font-sans text-xs"
+          >
+            <span>Looking for an index?</span>
+            {NOT_FOUND_AGENT_LINKS.map((link) => (
+              <a
+                className="hover:text-foreground underline underline-offset-4 transition-colors"
+                href={link.href}
+                key={link.href}
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
         </div>
         <FooterSection />
       </div>

--- a/apps/web/src/constants/not-found.ts
+++ b/apps/web/src/constants/not-found.ts
@@ -1,6 +1,8 @@
 import type { NotFoundLink } from "@/types/not-found";
 import { DOCS_URL, SITE_URL } from "@/utils/urls";
 
+export const MARKDOWN_CACHE_CONTROL = "public, max-age=300";
+
 export const NOT_FOUND_AGENT_LINKS: NotFoundLink[] = [
   { label: "llms.txt", href: `${SITE_URL}/llms.txt` },
   { label: "sitemap.xml", href: `${SITE_URL}/sitemap.xml` },

--- a/apps/web/src/constants/not-found.ts
+++ b/apps/web/src/constants/not-found.ts
@@ -1,0 +1,22 @@
+import type { NotFoundLink } from "@/types/not-found";
+import { DOCS_URL, SITE_URL } from "@/utils/urls";
+
+export const NOT_FOUND_AGENT_LINKS: NotFoundLink[] = [
+  { label: "llms.txt", href: `${SITE_URL}/llms.txt` },
+  { label: "sitemap.xml", href: `${SITE_URL}/sitemap.xml` },
+  { label: "Docs", href: DOCS_URL },
+];
+
+export const NOT_FOUND_MARKDOWN = `# 404 Not Found
+
+There is no page at this URL on ${new URL(SITE_URL).hostname}.
+
+Start from one of these instead:
+
+- [Site index for agents](${SITE_URL}/llms.txt)
+- [Full site context](${SITE_URL}/llms-full.txt)
+- [Sitemap](${SITE_URL}/sitemap.xml)
+- [Documentation](${DOCS_URL})
+
+Markdown versions of pages are served with \`Accept: text/markdown\` or by appending \`.md\` to the path.
+`;

--- a/apps/web/src/types/not-found.ts
+++ b/apps/web/src/types/not-found.ts
@@ -1,0 +1,4 @@
+export interface NotFoundLink {
+  label: string;
+  href: string;
+}

--- a/apps/web/src/utils/not-found.ts
+++ b/apps/web/src/utils/not-found.ts
@@ -1,11 +1,14 @@
-import { NOT_FOUND_MARKDOWN } from "@/constants/not-found";
+import {
+  MARKDOWN_CACHE_CONTROL,
+  NOT_FOUND_MARKDOWN,
+} from "@/constants/not-found";
 
 export function markdownNotFoundResponse() {
   return new Response(NOT_FOUND_MARKDOWN, {
     status: 404,
     headers: {
       "content-type": "text/markdown; charset=utf-8",
-      "cache-control": "public, max-age=300",
+      "cache-control": MARKDOWN_CACHE_CONTROL,
       vary: "Accept",
     },
   });

--- a/apps/web/src/utils/not-found.ts
+++ b/apps/web/src/utils/not-found.ts
@@ -1,0 +1,12 @@
+import { NOT_FOUND_MARKDOWN } from "@/constants/not-found";
+
+export function markdownNotFoundResponse() {
+  return new Response(NOT_FOUND_MARKDOWN, {
+    status: 404,
+    headers: {
+      "content-type": "text/markdown; charset=utf-8",
+      "cache-control": "public, max-age=300",
+      vary: "Accept",
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Unknown paths on www.usenotra.com already returned a real 404 for HTML, but every agent-facing entry point (`Accept: text/markdown`, `.md` suffix, `/md/*`, AI bot user agents) fell through to dualmark's hardcoded `Not Found` plain-text body with no pointers. Agents that land there had nothing to follow.

- Wrap the dualmark route handler in `apps/web/src/app/md/[...path]/route.ts`: any 404 it produces is replaced with a short `text/markdown` body linking `/llms.txt`, `/llms-full.txt`, `/sitemap.xml`, and the docs, and telling agents how to request markdown twins.
- Add the same index links to the HTML `not-found.tsx` so agents that read HTML get the pointers too.
- Body text and link list live in `constants/not-found.ts`, response helper in `utils/not-found.ts`, link type in `types/not-found.ts`.

## Verification (local dev server)

| Request | Status | Content type |
| --- | --- | --- |
| `GET /some-path-that-does-not-exist` | 404 | text/html |
| `GET /some-path-that-does-not-exist` with `Accept: text/markdown` | 404 | text/markdown |
| `GET /some-path-that-does-not-exist.md` | 404 | text/markdown |
| `GET /md/some/nested/missing` | 404 | text/markdown |
| `GET /some-path-that-does-not-exist` as `GPTBot/1.0` | 404 | text/markdown |
| `GET /blog/does-not-exist.md` | 404 | text/markdown |
| `GET /pricing`, `/blog`, `/changelog`, `/privacy` with `Accept: text/markdown` | 200 | text/markdown |

```
curl -s -o /dev/null -w "%{http_code}" https://www.usenotra.com/some-path-that-does-not-exist
```

prints `404` in production already (HTML) and will keep doing so; the markdown variants gain the body below.

```markdown
# 404 Not Found

There is no page at this URL on www.usenotra.com.

Start from one of these instead:

- [Site index for agents](https://www.usenotra.com/llms.txt)
- [Full site context](https://www.usenotra.com/llms-full.txt)
- [Sitemap](https://www.usenotra.com/sitemap.xml)
- [Documentation](https://docs.usenotra.com)

Markdown versions of pages are served with `Accept: text/markdown` or by appending `.md` to the path.
```

## Out of scope, noted

- `app.usenotra.com/<anything>` answers 200 with the dashboard shell for unauthenticated requests because the `[slug]` layout streams its static shell before `validateOrganizationAccess` can redirect or call `notFound()`. A real status there needs the auth check in the proxy (authkit `middlewareAuth`), which touches every public dashboard route, so it is left for a separate change.
- Apex `usenotra.com/<path>` returns a 307 to `www` before the 404; that is the Vercel domain redirect, not app code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404 responses for agent-facing entry points on www.usenotra.com. Unknown paths already returned a real HTML 404, but agent requests (`Accept: text/markdown`, `.md` suffix, `/md/*`, AI bot user agents) got dualmark's hardcoded plain-text "Not Found" body with no pointers. Now those 404s return a short `text/markdown` body linking to `/llms.txt`, `/llms-full.txt`, `/sitemap.xml`, and the docs, and the HTML 404 page shows the same index links.

- Wraps the dualmark route handler so any 404 it produces is replaced with the markdown body.
- Adds the index links to the HTML `not-found.tsx`.
- Shares link constants, the markdown body, the cache-control constant, and the response helper across both.

**Out of scope**
- `app.usenotra.com/<anything>` still returns 200 with the dashboard shell for unauthenticated requests; fixing it requires auth checks in the proxy.
- Apex `usenotra.com/<path>` returns a 307 to `www` via the Vercel domain redirect, not app code.

<sup>Written for commit c8f98d99e70f021ea3f776a513bc2fe8fdae9a9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

