### PR TITLE
fix(dashboard): restore last visited organization and project

### DIFF
--- a/apps/dashboard/src/app/(auth)/layout.tsx
+++ b/apps/dashboard/src/app/(auth)/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import { AuthBrandPanel } from "@/components/auth/auth-brand-panel";
 import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
+import { withGeoProject } from "@/utils/geo-paths";
 
 export default async function AuthLayout({
   children,
@@ -16,7 +17,7 @@ export default async function AuthLayout({
     const organization = await getLastActiveOrganization();
 
     if (organization) {
-      redirect(`/${organization.slug}`);
+      redirect(withGeoProject(`/${organization.slug}`, organization.projectId));
     } else {
       redirect("/onboarding");
     }

--- a/apps/dashboard/src/app/callback/page.tsx
+++ b/apps/dashboard/src/app/callback/page.tsx
@@ -11,6 +11,7 @@ import { readRequestHeaders } from "@/lib/analytics/request-headers";
 import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
 import { isSessionBanned } from "@/lib/auth/banned";
 import type { CallbackDestination } from "@/types/analytics/events";
+import { withGeoProject } from "@/utils/geo-paths";
 import {
   marketingAttributionServerSearchParams,
   marketingAttributionServerUrlKeys,
@@ -111,5 +112,5 @@ export default async function AuthCallback(props: {
   }
 
   trackRouted(CALLBACK_DESTINATIONS.DASHBOARD);
-  redirect(`/${organization.slug}`);
+  redirect(withGeoProject(`/${organization.slug}`, organization.projectId));
 }

--- a/apps/dashboard/src/app/callback/page.tsx
+++ b/apps/dashboard/src/app/callback/page.tsx
@@ -8,13 +8,8 @@ import {
   trackServerEvent,
 } from "@/lib/analytics/posthog-server";
 import { readRequestHeaders } from "@/lib/analytics/request-headers";
-import {
-  getAllUserOrganizations,
-  getLastActiveOrganization,
-  getSession,
-} from "@/lib/auth/actions";
+import { getLastActiveOrganization, getSession } from "@/lib/auth/actions";
 import { isSessionBanned } from "@/lib/auth/banned";
-import { hasPaidSubscriptionHistory } from "@/lib/billing/subscription";
 import type { CallbackDestination } from "@/types/analytics/events";
 import {
   marketingAttributionServerSearchParams,
@@ -107,32 +102,14 @@ export default async function AuthCallback(props: {
   const organization = await getLastActiveOrganization();
 
   if (!organization) {
+    const onboardingUrl = serializeMarketingAttribution(
+      "/onboarding",
+      marketingAttribution
+    );
     trackRouted(CALLBACK_DESTINATIONS.ONBOARDING);
-    redirect("/onboarding");
+    redirect(onboardingUrl);
   }
 
-  const hasSubHistory = await hasPaidSubscriptionHistory(organization.id);
-
-  if (hasSubHistory) {
-    trackRouted(CALLBACK_DESTINATIONS.DASHBOARD);
-    redirect(`/${organization.slug}`);
-  }
-
-  const allOrgs = await getAllUserOrganizations();
-  for (const org of allOrgs) {
-    if (
-      org.id !== organization.id &&
-      (await hasPaidSubscriptionHistory(org.id))
-    ) {
-      trackRouted(CALLBACK_DESTINATIONS.DASHBOARD);
-      redirect(`/${org.slug}`);
-    }
-  }
-
-  const onboardingUrl = serializeMarketingAttribution(
-    "/onboarding",
-    marketingAttribution
-  );
-  trackRouted(CALLBACK_DESTINATIONS.ONBOARDING);
-  redirect(onboardingUrl);
+  trackRouted(CALLBACK_DESTINATIONS.DASHBOARD);
+  redirect(`/${organization.slug}`);
 }

--- a/apps/dashboard/src/components/dashboard/sidebar-project-switcher.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-project-switcher.tsx
@@ -39,8 +39,12 @@ import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import { useGeoProjects } from "@/lib/hooks/use-geo";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { getWebsiteDomain } from "@/utils/brand";
+import {
+  getLastVisitedProjectFromClient,
+  setLastVisitedProject,
+} from "@/utils/cookies";
 import { geoNavHref } from "@/utils/geo-paths";
-import { isStaleGeoProjectParam, resolveNavItems } from "@/utils/nav";
+import { resolveNavItems } from "@/utils/nav";
 
 import { SidebarBrandHeader } from "./sidebar-brand-header";
 import { SidebarLabel } from "./sidebar-label";
@@ -57,25 +61,41 @@ export function SidebarProjectSwitcher() {
 
   const { data, isPending } = useGeoProjects(organizationId);
   const { data: brandData } = useBrandSettings(organizationId);
-  const projects = data?.projects ?? [];
+  const loadedProjects = data?.projects;
+  const projects = loadedProjects ?? [];
   const voices = brandData?.voices ?? [];
 
   const activeProject =
     projects.find((project) => project.id === projectParam) ??
     projects.at(0) ??
     null;
-  const staleProjectParam =
-    data !== undefined &&
-    isStaleGeoProjectParam(
-      projects.map((project) => project.id),
-      projectParam
-    );
 
   useEffect(() => {
-    if (staleProjectParam) {
-      setProjectParam(null);
+    if (loadedProjects === undefined || !slug) {
+      return;
     }
-  }, [staleProjectParam, setProjectParam]);
+
+    const selectedProject = loadedProjects.find(
+      (project) => project.id === projectParam
+    );
+    if (selectedProject) {
+      setLastVisitedProject(slug, selectedProject.id).catch(() => {
+        // The current URL remains the source of truth if cookies fail.
+      });
+      return;
+    }
+
+    const lastVisitedProjectId = getLastVisitedProjectFromClient(slug);
+    const restoredProject =
+      loadedProjects.find((project) => project.id === lastVisitedProjectId) ??
+      loadedProjects.at(0) ??
+      null;
+    const restoredProjectId = restoredProject?.id ?? null;
+
+    if (projectParam !== restoredProjectId) {
+      setProjectParam(restoredProjectId);
+    }
+  }, [loadedProjects, projectParam, setProjectParam, slug]);
 
   const projectDomain = (brandSettingsId: string) =>
     getWebsiteDomain(

--- a/apps/dashboard/src/components/providers/organization-provider.tsx
+++ b/apps/dashboard/src/components/providers/organization-provider.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 
 import { authClient } from "@/lib/auth/client";
+import { setLastVisitedOrganization } from "@/utils/cookies";
 import { QUERY_KEYS } from "@/utils/query-keys";
 
 export type Organization = NonNullable<
@@ -136,6 +137,16 @@ export function OrganizationsProvider({
       setOptimisticActiveOrg(null);
     }
   }
+
+  useEffect(() => {
+    if (resolvedActiveOrganization?.slug !== slugFromPath) {
+      return;
+    }
+
+    setLastVisitedOrganization(slugFromPath).catch(() => {
+      // The active server session is still synchronized below if cookies fail.
+    });
+  }, [resolvedActiveOrganization?.slug, slugFromPath]);
 
   useEffect(() => {
     if (isLoadingOrgs || isLoadingActive) {

--- a/apps/dashboard/src/constants/cookies.ts
+++ b/apps/dashboard/src/constants/cookies.ts
@@ -1,4 +1,6 @@
 export const LAST_VISITED_ORGANIZATION_COOKIE = "notra_last_organization";
+export const LAST_VISITED_PROJECT_COOKIE = "notra_last_project";
 export const SIDEBAR_MODE_COOKIE = "notra_sidebar_mode";
 export const SIDEBAR_MODE_COOKIE_MAX_AGE = 365 * 86_400;
 export const LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE = 30 * 86_400;
+export const LAST_VISITED_PROJECT_COOKIE_MAX_AGE = 30 * 86_400;

--- a/apps/dashboard/src/lib/auth/actions.ts
+++ b/apps/dashboard/src/lib/auth/actions.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { db } from "@notra/db/drizzle";
-import { members, organizations } from "@notra/db/schema";
-import { eq } from "drizzle-orm";
+import { members, organizations, projects } from "@notra/db/schema";
+import { and, eq } from "drizzle-orm";
 import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 
@@ -11,6 +11,7 @@ import { isSessionBanned } from "@/lib/auth/banned";
 import { getAuthSession } from "@/lib/auth/server";
 import { retryTransientDbError } from "@/lib/db/retry";
 import { organizationSlugParamSchema } from "@/schemas/auth/organization";
+import { getLastVisitedProject } from "@/utils/cookies";
 
 export async function validateOrganizationAccess(rawSlug: string) {
   const slugValidation = organizationSlugParamSchema.safeParse(rawSlug);
@@ -78,6 +79,7 @@ async function getLastActiveOrganizationForUser(userId: string) {
   const lastVisitedOrgSlug = cookieStore.get(
     LAST_VISITED_ORGANIZATION_COOKIE
   )?.value;
+  let activeOrganization: { id: string; slug: string } | undefined;
 
   if (lastVisitedOrgSlug) {
     const organization = await retryTransientDbError(() =>
@@ -94,32 +96,51 @@ async function getLastActiveOrganizationForUser(userId: string) {
     );
 
     if (organization && organization.members.length > 0) {
-      return { slug: organization.slug, id: organization.id };
+      activeOrganization = { slug: organization.slug, id: organization.id };
     }
   }
 
-  const ownerMembership = await retryTransientDbError(() =>
-    db.query.members.findFirst({
-      where: eq(members.userId, userId),
-      columns: { organizationId: true, role: true },
-      orderBy: (m, { desc }) => [desc(m.createdAt)],
-    })
-  );
-
-  if (ownerMembership) {
-    const org = await retryTransientDbError(() =>
-      db.query.organizations.findFirst({
-        where: eq(organizations.id, ownerMembership.organizationId),
-        columns: { slug: true, id: true },
+  if (!activeOrganization) {
+    const membership = await retryTransientDbError(() =>
+      db.query.members.findFirst({
+        where: eq(members.userId, userId),
+        columns: { organizationId: true },
+        orderBy: (m, { desc }) => [desc(m.createdAt)],
       })
     );
 
-    if (org) {
-      return { slug: org.slug, id: org.id };
+    if (membership) {
+      activeOrganization = await retryTransientDbError(() =>
+        db.query.organizations.findFirst({
+          where: eq(organizations.id, membership.organizationId),
+          columns: { slug: true, id: true },
+        })
+      );
     }
   }
 
-  return;
+  if (!activeOrganization) {
+    return;
+  }
+
+  const organization = activeOrganization;
+  const lastVisitedProjectId = getLastVisitedProject(
+    cookieStore,
+    organization.slug
+  );
+  const project = lastVisitedProjectId
+    ? await retryTransientDbError(() =>
+        db.query.projects.findFirst({
+          where: and(
+            eq(projects.id, lastVisitedProjectId),
+            eq(projects.organizationId, organization.id)
+          ),
+          columns: { id: true },
+        })
+      )
+    : undefined;
+
+  return { ...organization, projectId: project?.id };
 }
 
 export async function getLastActiveOrganization() {

--- a/apps/dashboard/src/lib/nav/org-root-redirect.ts
+++ b/apps/dashboard/src/lib/nav/org-root-redirect.ts
@@ -4,7 +4,10 @@ import { redirect } from "next/navigation";
 
 import { DEFAULT_SIDEBAR_ENTRY_MODE } from "@/constants/studio-analytics";
 import { trackServerEvent } from "@/lib/analytics/posthog-server";
-import { getSidebarModeFromCookies } from "@/utils/cookies";
+import {
+  getLastVisitedProject,
+  getSidebarModeFromCookies,
+} from "@/utils/cookies";
 import { resolveOrgRootRedirect } from "@/utils/nav";
 
 type OrgRootSearchParams = Promise<
@@ -20,8 +23,10 @@ export async function redirectOrgRootToStoredMode(
     headers(),
     searchParams,
   ]);
-  const projectId =
+  const requestedProjectId =
     typeof query.project === "string" ? query.project : undefined;
+  const projectId =
+    requestedProjectId ?? getLastVisitedProject(cookieStore, slug);
   const storedMode = getSidebarModeFromCookies(cookieStore);
   trackServerEvent({
     event: POSTHOG_EVENTS.DASHBOARD_ENTRY,

--- a/apps/dashboard/src/utils/cookies.ts
+++ b/apps/dashboard/src/utils/cookies.ts
@@ -4,6 +4,8 @@ import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension
 import {
   LAST_VISITED_ORGANIZATION_COOKIE,
   LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE,
+  LAST_VISITED_PROJECT_COOKIE,
+  LAST_VISITED_PROJECT_COOKIE_MAX_AGE,
   SIDEBAR_MODE_COOKIE,
   SIDEBAR_MODE_COOKIE_MAX_AGE,
 } from "@/constants/cookies";
@@ -11,6 +13,41 @@ import type { SidebarMode } from "@/types/components/nav";
 import { isSidebarMode } from "@/utils/nav";
 
 type CookieJar = RequestCookies | ReadonlyRequestCookies;
+
+function parseLastVisitedProject(
+  value: string | undefined,
+  organizationSlug: string
+): string | undefined {
+  if (!value) {
+    return;
+  }
+
+  const [storedSlug, projectId, extra] = value.split(":");
+  if (!(storedSlug && projectId) || extra !== undefined) {
+    return;
+  }
+
+  try {
+    return decodeURIComponent(storedSlug) === organizationSlug
+      ? decodeURIComponent(projectId)
+      : undefined;
+  } catch {
+    return;
+  }
+}
+
+function readClientCookie(name: string): string | undefined {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const prefix = `${name}=`;
+  // biome-ignore lint/suspicious/noDocumentCookie: The active project must be restored before the next navigation
+  const entry = document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith(prefix));
+  return entry?.slice(prefix.length);
+}
 
 async function setClientCookie(
   name: string,
@@ -62,6 +99,35 @@ export const setLastVisitedOrganization = async (
 export const getLastVisitedOrganization = (
   cookies: CookieJar
 ): string | undefined => cookies.get(LAST_VISITED_ORGANIZATION_COOKIE)?.value;
+
+export const setLastVisitedProject = async (
+  organizationSlug: string,
+  projectId: string,
+  maxAge: number = LAST_VISITED_PROJECT_COOKIE_MAX_AGE
+): Promise<void> => {
+  await setClientCookie(
+    LAST_VISITED_PROJECT_COOKIE,
+    `${encodeURIComponent(organizationSlug)}:${encodeURIComponent(projectId)}`,
+    maxAge
+  );
+};
+
+export const getLastVisitedProject = (
+  cookies: CookieJar,
+  organizationSlug: string
+): string | undefined =>
+  parseLastVisitedProject(
+    cookies.get(LAST_VISITED_PROJECT_COOKIE)?.value,
+    organizationSlug
+  );
+
+export const getLastVisitedProjectFromClient = (
+  organizationSlug: string
+): string | undefined =>
+  parseLastVisitedProject(
+    readClientCookie(LAST_VISITED_PROJECT_COOKIE),
+    organizationSlug
+  );
 
 export const setSidebarModeCookie = async (
   mode: SidebarMode,

--- a/apps/dashboard/src/utils/nav.ts
+++ b/apps/dashboard/src/utils/nav.ts
@@ -94,16 +94,6 @@ export function resolveGeoImproveLinks(
   return NAV_GEO_IMPROVE_LINKS.filter((link) => link !== GEO_WRITER_NAV_LINK);
 }
 
-export function isStaleGeoProjectParam(
-  projectIds: readonly string[],
-  projectParam: string | null
-): boolean {
-  if (projectParam === null) {
-    return false;
-  }
-  return !projectIds.includes(projectParam);
-}
-
 export function resolveActiveNavLink(
   pathname: string,
   slug: string,


### PR DESCRIPTION
### Description
Persist the user’s last visited organization and GEO project so returning users reopen the same workspace context instead of defaulting to their owned or paid organization. Stored projects are validated against the active organization, with a safe fallback when a project is missing or stale. Authentication and organization-root redirects now preserve this context consistently.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the last visited organization and GEO project so returning users reopen the same workspace context instead of defaulting to their owned or paid organization.

- Saves the last visited org and project in cookies; the saved project is validated against the active org with a fallback when stale.
- Auth callback and org-root redirects preserve the saved context; the callback no longer redirects based on paid subscription history.

<sup>Written for commit 7c048ee703e0d96c64290e9947149c8d3c649af2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

