### PR TITLE
feat(geo): open property picker after GSC connection

### DIFF
--- a/apps/dashboard/src/app/api/integrations/google-search-console/callback/route.ts
+++ b/apps/dashboard/src/app/api/integrations/google-search-console/callback/route.ts
@@ -83,7 +83,10 @@ export async function GET(request: NextRequest) {
     if (error) {
       return NextResponse.redirect(
         buildCallbackUrl(baseUrl, callbackPath, {
-          error: error === "access_denied" ? "gsc_access_denied" : error,
+          error:
+            error === "access_denied"
+              ? "gsc_access_denied"
+              : "gsc_auth_failed",
         })
       );
     }

--- a/apps/dashboard/src/components/geo/prompt-suggestions.tsx
+++ b/apps/dashboard/src/components/geo/prompt-suggestions.tsx
@@ -19,6 +19,7 @@ import {
   useGscCardDismissal,
   useGscStatus,
 } from "@/lib/hooks/use-geo";
+import { useGscConnectionToast } from "@/lib/hooks/use-gsc-connection-toast";
 import type {
   PromptSuggestionsProps,
   SuggestionRowActionsProps,
@@ -94,6 +95,7 @@ export function PromptSuggestions({
   const { data } = useGeoSuggestions(organizationId);
   const { data: searchConsoleStatus, isPending: isSearchConsolePending } =
     useGscStatus(organizationId);
+  const connectionSucceeded = useGscConnectionToast();
   const { dismiss: dismissCard, dismissed } =
     useGscCardDismissal(organizationId);
   const checking = useGscAnalyzing(organizationId);
@@ -107,6 +109,8 @@ export function PromptSuggestions({
     ReadonlySet<string>
   >(() => new Set());
   const [isTrackAllQueued, setIsTrackAllQueued] = useState(false);
+  const [propertyPickerOpen, setPropertyPickerOpen] =
+    useState(connectionSucceeded);
   const pendingSuggestionRequests = useRef(new Map<string, Promise<unknown>>());
   const trackAllQueued = useRef(false);
   const suggestions = data?.suggestions ?? [];
@@ -318,7 +322,9 @@ export function PromptSuggestions({
       callbackPath={callbackPath}
       isPending={isSearchConsolePending}
       onDismiss={connectPromo ? dismissCard : undefined}
+      onPropertyPickerOpenChange={setPropertyPickerOpen}
       organizationId={organizationId}
+      propertyPickerOpen={propertyPickerOpen}
       status={searchConsoleStatus}
     />
   ) : (

--- a/apps/dashboard/src/components/geo/search-console-card.tsx
+++ b/apps/dashboard/src/components/geo/search-console-card.tsx
@@ -44,7 +44,6 @@ import {
   useGscSync,
   useGeoProjects,
 } from "@/lib/hooks/use-geo";
-import { useGscConnectionToast } from "@/lib/hooks/use-gsc-connection-toast";
 import { cn } from "@/lib/utils";
 import type {
   SearchConsoleConnectActionProps,
@@ -212,9 +211,12 @@ function PropertyPicker({
         aria-busy={selectSite.isPending}
         className={cn("w-full", selectSite.isPending && "disabled:opacity-100")}
         disabled={siteUrl.length === 0 || selectSite.isPending}
-        onClick={() =>
-          selectSite.mutate({ siteUrl }, { onSuccess: () => onSelected?.() })
-        }
+        onClick={() => {
+          void selectSite
+            .mutateAsync({ siteUrl })
+            .then(() => onSelected?.())
+            .catch(() => undefined);
+        }}
       >
         {selectSite.isPending ? <StatusSpinner /> : null}
         {selectSite.isPending ? "Connecting…" : "Connect property"}
@@ -226,11 +228,13 @@ function PropertyPicker({
 function SelectSiteState({
   organizationId,
   callbackPath,
+  onOpenChange,
+  open,
   status,
   websiteUrl,
 }: SearchConsoleSelectSiteStateProps) {
   return (
-    <ResponsiveDialog>
+    <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
       <div className="flex flex-col items-start gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-muted-foreground text-sm">
           {status.lastError ??
@@ -256,6 +260,7 @@ function SelectSiteState({
         {status.sites.length > 0 ? (
           <div className="px-4 md:px-0">
             <PropertyPicker
+              onSelected={() => onOpenChange(false)}
               organizationId={organizationId}
               sites={status.sites}
               websiteUrl={websiteUrl}
@@ -307,12 +312,13 @@ function ConnectedState({
   action,
   organizationId,
   callbackPath,
+  onPropertyPickerOpenChange,
+  propertyPickerOpen,
   status,
   websiteUrl,
 }: SearchConsoleConnectedStateProps) {
-  const [changeOpen, setChangeOpen] = useState(false);
   const sync = useGscSync(organizationId);
-  const sites = useGscSites(organizationId, changeOpen);
+  const sites = useGscSites(organizationId, propertyPickerOpen);
   const disconnect = useGscDisconnect(organizationId);
   const busy = sync.isPending || disconnect.isPending;
 
@@ -328,7 +334,7 @@ function ConnectedState({
     changeDialogBody = (
       <div className="px-4 md:px-0">
         <PropertyPicker
-          onSelected={() => setChangeOpen(false)}
+          onSelected={() => onPropertyPickerOpenChange(false)}
           organizationId={organizationId}
           sites={sites.data.sites}
           websiteUrl={websiteUrl}
@@ -408,7 +414,7 @@ function ConnectedState({
             <DropdownMenuContent align="end" className="w-44">
               <DropdownMenuItem
                 disabled={busy}
-                onClick={() => setChangeOpen(true)}
+                onClick={() => onPropertyPickerOpenChange(true)}
               >
                 Change property
               </DropdownMenuItem>
@@ -433,7 +439,10 @@ function ConnectedState({
           {action}
         </div>
       </div>
-      <ResponsiveDialog onOpenChange={setChangeOpen} open={changeOpen}>
+      <ResponsiveDialog
+        onOpenChange={onPropertyPickerOpenChange}
+        open={propertyPickerOpen}
+      >
         <ResponsiveDialogContent className="sm:max-w-md">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle>
@@ -456,11 +465,12 @@ export function SearchConsoleToolbar({
   callbackPath,
   isPending,
   onDismiss,
+  onPropertyPickerOpenChange,
+  propertyPickerOpen,
   status,
 }: SearchConsoleToolbarProps) {
   const headingId = useId();
   const { projectId } = useGeoProjectScope();
-  useGscConnectionToast();
   const { data: projectsData } = useGeoProjects(organizationId);
   const { data: brandData } = useBrandSettings(organizationId);
 
@@ -484,7 +494,9 @@ export function SearchConsoleToolbar({
       <ConnectedState
         action={action}
         callbackPath={callbackPath}
+        onPropertyPickerOpenChange={onPropertyPickerOpenChange}
         organizationId={organizationId}
+        propertyPickerOpen={propertyPickerOpen}
         status={status}
         websiteUrl={websiteUrl}
       />
@@ -529,7 +541,8 @@ export function SearchConsoleToolbar({
     body = (
       <SelectSiteState
         callbackPath={callbackPath}
-        key={activeProject?.id}
+        onOpenChange={onPropertyPickerOpenChange}
+        open={propertyPickerOpen}
         organizationId={organizationId}
         status={status}
         websiteUrl={websiteUrl}

--- a/apps/dashboard/src/lib/hooks/use-gsc-connection-toast.ts
+++ b/apps/dashboard/src/lib/hooks/use-gsc-connection-toast.ts
@@ -28,6 +28,7 @@ export function useGscConnectionToast() {
   const pathname = usePathname();
   const router = useRouter();
   const trackedResultRef = useRef<string | null>(null);
+  const connectionSucceeded = searchParams.get("gscConnected") === "true";
 
   useEffect(() => {
     const connected = searchParams.get("gscConnected");
@@ -60,4 +61,6 @@ export function useGscConnectionToast() {
       scroll: false,
     });
   }, [searchParams, pathname, router]);
+
+  return connectionSucceeded;
 }

--- a/apps/dashboard/src/types/components/geo.ts
+++ b/apps/dashboard/src/types/components/geo.ts
@@ -27,6 +27,8 @@ export interface SearchConsoleToolbarProps {
   callbackPath: string;
   isPending: boolean;
   onDismiss?: () => void;
+  onPropertyPickerOpenChange: (open: boolean) => void;
+  propertyPickerOpen: boolean;
   status: GeoSearchConsoleStatus | undefined;
 }
 
@@ -46,6 +48,8 @@ export interface SearchConsoleConnectActionProps {
 export interface SearchConsoleSelectSiteStateProps {
   organizationId: string;
   callbackPath: string;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
   status: GeoSearchConsoleStatus;
   websiteUrl: string | null;
 }
@@ -61,6 +65,8 @@ export interface SearchConsoleConnectedStateProps {
   action?: ReactNode;
   organizationId: string;
   callbackPath: string;
+  onPropertyPickerOpenChange: (open: boolean) => void;
+  propertyPickerOpen: boolean;
   status: GeoSearchConsoleStatus;
   websiteUrl: string | null;
 }


### PR DESCRIPTION
### Description
After a successful Google Search Console connection, open the property picker automatically so users can select their domain immediately.

The picker state now survives async status and project loading, works for both new connections and reconnects, and closes only after a property is selected successfully. Unknown Google OAuth errors are also normalized so they receive the expected error toast and URL cleanup.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the Google Search Console property picker automatically after a successful connection, so users can select their domain without an extra manual step. The picker now opens for both new connections and reconnects, survives async status and project loading, and closes only after a property is selected. Unknown OAuth errors are normalized to `gsc_auth_failed` so they receive the expected error toast and URL cleanup.

<sup>Written for commit e2dc42d36120643c0ab1fa29433f3c9457d3466b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

