### PR TITLE
fix(dashboard): align button sizing

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-header.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/brand-identity-header.tsx
@@ -49,11 +49,7 @@ export function BrandIdentityHeader({
         </p>
       </div>
       {activeTab === "guidelines" ? (
-        <Button
-          className="w-fit gap-1.5 px-3"
-          disabled={isRefreshingGuidelines}
-          onClick={onRefreshGuidelines}
-        >
+        <Button disabled={isRefreshingGuidelines} onClick={onRefreshGuidelines}>
           {isRefreshingGuidelines ? (
             <Loader2Icon className="size-4 animate-spin" />
           ) : (
@@ -63,7 +59,7 @@ export function BrandIdentityHeader({
         </Button>
       ) : null}
       {action ? (
-        <Button className="w-fit gap-1.5 px-3" onClick={action.onClick}>
+        <Button onClick={action.onClick}>
           <HugeiconsIcon className="size-4" icon={Add01Icon} />
           {action.label}
           <Kbd className="ml-1 hidden sm:inline-flex">C</Kbd>

--- a/apps/dashboard/src/components/empty-state.tsx
+++ b/apps/dashboard/src/components/empty-state.tsx
@@ -18,11 +18,7 @@ function EmptyState({
   const renderedAction =
     action ??
     (actionLabel ? (
-      <Button
-        className="w-fit gap-1.5 px-3"
-        onClick={onActionClick}
-        variant={actionVariant}
-      >
+      <Button onClick={onActionClick} variant={actionVariant}>
         {actionIcon}
         {actionLabel}
       </Button>
@@ -64,7 +60,7 @@ function EmptyState({
           {description}
         </p>
         {renderedAction ? (
-          <div className="relative z-10 mt-5 flex flex-wrap items-center justify-center gap-2 [&_a]:inline-flex [&_a]:items-center [&_a]:justify-center [&_button]:h-8 [&_button]:w-fit [&_button]:gap-1.5 [&_button]:px-3 [&_button]:text-sm">
+          <div className="relative z-10 mt-5 flex flex-wrap items-center justify-center gap-2">
             {renderedAction}
           </div>
         ) : null}

--- a/apps/dashboard/src/components/geo/prompt-add-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-add-dialog.tsx
@@ -256,33 +256,16 @@ export function PromptAddDialog({
           >
             Cancel
           </Button>
-          <div className="grid">
-            <Button
-              className={cn(
-                "col-start-1 row-start-1",
-                !writeMode && "invisible"
-              )}
-              disabled={!writeMode || !canAdd}
-              form={formId}
-              tabIndex={writeMode ? undefined : -1}
-              type="submit"
-            >
+          {writeMode ? (
+            <Button disabled={!canAdd} form={formId} type="submit">
               Add prompt
             </Button>
-            <Button
-              className={cn(
-                "col-start-1 row-start-1",
-                writeMode && "invisible"
-              )}
-              disabled={writeMode || !canGenerate}
-              form={formId}
-              tabIndex={writeMode ? -1 : undefined}
-              type="submit"
-            >
+          ) : (
+            <Button disabled={!canGenerate} form={formId} type="submit">
               {generate.isPending ? <StatusSpinner /> : null}
               Generate prompts
             </Button>
-          </div>
+          )}
         </ResponsiveDialogFooter>
       </ResponsiveDialogContent>
     </ResponsiveDialog>

--- a/apps/dashboard/src/components/integrations/wehook-setup-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/wehook-setup-dialog.tsx
@@ -248,14 +248,10 @@ export function WebhookSetupDialog({
         </div>
 
         <ResponsiveDialogFooter className="gap-2">
-          <ResponsiveDialogClose
-            className="h-9"
-            render={<Button variant="outline" />}
-          >
+          <ResponsiveDialogClose render={<Button variant="outline" />}>
             Skip for now
           </ResponsiveDialogClose>
           <Button
-            className="h-9"
             disabled={!webhookConfig}
             onClick={() => setOpen(false)}
             type="button"


### PR DESCRIPTION
### Description
Standardizes dashboard button sizing by making prompt actions content-sized and removing one-off sizing overrides from webhook footers, Brand Identity headers, and empty states. This keeps actions aligned with the shared Button design tokens.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes dashboard button sizing by removing one-off width, padding, and height overrides from brand identity headers, empty states, prompt add dialogs, and webhook footers so all actions follow the shared Button design tokens.

The prompt add dialog also replaces the invisible-button overlay trick with conditional rendering, so only the active action button is mounted.

<sup>Written for commit bda3f65a895442ec5617fbede193cf366805f5c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

