### PR TITLE
fix(api-keys): accept legacy access mode input

### DIFF
--- a/apps/dashboard/src/lib/orpc/routers/api-keys.ts
+++ b/apps/dashboard/src/lib/orpc/routers/api-keys.ts
@@ -265,11 +265,14 @@ export const apiKeysRouter = {
             (permission): permission is string => typeof permission === "string"
           )
         : [];
+      const accessMode =
+        input.payload.accessMode ??
+        getApiKeyAccessMode(currentPermissions, meta.accessMode);
       const unknownPermissions =
         getUnknownApiKeyPermissions(currentPermissions);
       const permissions = [
         ...getApiKeyPermissionsForAccessMode(
-          input.payload.accessMode,
+          accessMode,
           input.payload.scopes
         ),
         ...unknownPermissions,
@@ -281,7 +284,7 @@ export const apiKeysRouter = {
         keyId: input.payload.keyId,
         meta: {
           ...meta,
-          accessMode: input.payload.accessMode,
+          accessMode,
         },
         name: input.payload.name,
         permissions,

--- a/apps/dashboard/src/schemas/api-keys.ts
+++ b/apps/dashboard/src/schemas/api-keys.ts
@@ -23,7 +23,7 @@ export const createApiKeySchema = z.object({
 export const updateApiKeySchema = z.object({
   keyId: z.string().min(1, "Key ID is required"),
   name: z.string().min(1, "Name is required").max(100).trim(),
-  accessMode: z.enum(API_KEY_ACCESS_MODE_VALUES).default("restricted"),
+  accessMode: z.enum(API_KEY_ACCESS_MODE_VALUES).optional(),
   scopes: scopesSchema,
   expiration: z.enum(API_KEY_EXPIRATION_VALUES),
 });

--- a/apps/dashboard/src/schemas/api-keys.ts
+++ b/apps/dashboard/src/schemas/api-keys.ts
@@ -15,7 +15,7 @@ const scopesSchema = z
 
 export const createApiKeySchema = z.object({
   name: z.string().min(1, "Name is required").max(100).trim(),
-  accessMode: z.enum(API_KEY_ACCESS_MODE_VALUES),
+  accessMode: z.enum(API_KEY_ACCESS_MODE_VALUES).default("restricted"),
   scopes: scopesSchema,
   expiration: z.enum(API_KEY_EXPIRATION_VALUES),
 });
@@ -23,7 +23,7 @@ export const createApiKeySchema = z.object({
 export const updateApiKeySchema = z.object({
   keyId: z.string().min(1, "Key ID is required"),
   name: z.string().min(1, "Name is required").max(100).trim(),
-  accessMode: z.enum(API_KEY_ACCESS_MODE_VALUES),
+  accessMode: z.enum(API_KEY_ACCESS_MODE_VALUES).default("restricted"),
   scopes: scopesSchema,
   expiration: z.enum(API_KEY_EXPIRATION_VALUES),
 });


### PR DESCRIPTION
### Description
Defaults missing API key access modes to `restricted` when creating or updating keys. This keeps the API compatible with older or cached dashboard clients that do not yet send `accessMode`, preventing “Input validation failed” errors.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the API key create and update endpoints compatible with older or cached dashboard clients that don't send `accessMode`.

- Create defaults missing `accessMode` to `restricted`.
- Update preserves the key's existing access mode when `accessMode` isn't sent.

<sup>Written for commit 248b2a8d003b6c0f6cc09b0079dafded816afcb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

