### PR TITLE
feat(web): add Adopted by section to the feedback.md page

### DIFF
--- a/apps/web/src/app/(site)/feedback-md/page.tsx
+++ b/apps/web/src/app/(site)/feedback-md/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { FeedbackMdAdopters } from "@/components/feedback-md/feedback-md-adopters";
 import { FeedbackMdAnatomy } from "@/components/feedback-md/feedback-md-anatomy";
 import { FeedbackMdFaq } from "@/components/feedback-md/feedback-md-faq";
 import { FeedbackMdHero } from "@/components/feedback-md/feedback-md-hero";
@@ -10,6 +11,7 @@ import { FeedbackMdSteps } from "@/components/feedback-md/feedback-md-steps";
 import { FeedbackMdTerminalDemo } from "@/components/feedback-md/feedback-md-terminal-demo";
 import { FeedbackMdUpsell } from "@/components/feedback-md/feedback-md-upsell";
 import {
+  FEEDBACK_MD_ADOPTERS_DESCRIPTION,
   FEEDBACK_MD_DESCRIPTION,
   FEEDBACK_MD_PAGE_PATH,
   FEEDBACK_MD_TITLE,
@@ -89,6 +91,13 @@ export default function FeedbackMdPage() {
           title="Where it sits"
         >
           <FeedbackMdSiblingsTable />
+        </FeedbackMdSection>
+
+        <FeedbackMdSection
+          description={FEEDBACK_MD_ADOPTERS_DESCRIPTION}
+          title="Adopted by"
+        >
+          <FeedbackMdAdopters />
         </FeedbackMdSection>
 
         <FeedbackMdSection

--- a/apps/web/src/app/(site)/feedback-md/page.tsx
+++ b/apps/web/src/app/(site)/feedback-md/page.tsx
@@ -11,7 +11,6 @@ import { FeedbackMdSteps } from "@/components/feedback-md/feedback-md-steps";
 import { FeedbackMdTerminalDemo } from "@/components/feedback-md/feedback-md-terminal-demo";
 import { FeedbackMdUpsell } from "@/components/feedback-md/feedback-md-upsell";
 import {
-  FEEDBACK_MD_ADOPTERS_DESCRIPTION,
   FEEDBACK_MD_DESCRIPTION,
   FEEDBACK_MD_PAGE_PATH,
   FEEDBACK_MD_TITLE,
@@ -65,6 +64,8 @@ export default function FeedbackMdPage() {
       <div className="flex w-[min(100%-3rem,62.5rem)] flex-col gap-14 pt-6">
         <FeedbackMdTerminalDemo />
 
+        <FeedbackMdAdopters />
+
         <FeedbackMdSection
           description={FEEDBACK_MD_DESCRIPTION}
           title={
@@ -91,13 +92,6 @@ export default function FeedbackMdPage() {
           title="Where it sits"
         >
           <FeedbackMdSiblingsTable />
-        </FeedbackMdSection>
-
-        <FeedbackMdSection
-          description={FEEDBACK_MD_ADOPTERS_DESCRIPTION}
-          title="Adopted by"
-        >
-          <FeedbackMdAdopters />
         </FeedbackMdSection>
 
         <FeedbackMdSection

--- a/apps/web/src/components/feedback-md/feedback-md-adopters.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-adopters.tsx
@@ -1,0 +1,44 @@
+import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+
+import { FEEDBACK_MD_ADOPTERS } from "@/lib/feedback-md/constants";
+
+export function FeedbackMdAdopters() {
+  return (
+    <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {FEEDBACK_MD_ADOPTERS.map(({ name, label, feedbackUrl, Logo }) => {
+        const displayUrl = feedbackUrl.replace(/^https?:\/\/(www\.)?/, "");
+        return (
+          <li key={name}>
+            <Link
+              className="group flex h-full flex-col justify-between gap-8 rounded-2xl border border-[#1E1E1E1F] p-5 transition-colors hover:bg-[#1E1E1E05] dark:border-white/10 dark:hover:bg-white/5"
+              href={feedbackUrl}
+              rel="noopener"
+              target="_blank"
+            >
+              <Logo
+                aria-hidden="true"
+                className="h-7 w-auto shrink-0 self-start text-[#1E1E1E] dark:text-white"
+              />
+              <span className="flex items-end justify-between gap-3">
+                <span className="flex min-w-0 flex-col gap-0.5">
+                  <span className="font-sans text-[0.9375rem] leading-[1.36] font-medium text-[#1E1E1E] dark:text-white">
+                    {label}
+                  </span>
+                  <span className="truncate font-mono text-[0.75rem] leading-4 text-[#1E1E1EA6] dark:text-white/60">
+                    {displayUrl}
+                  </span>
+                </span>
+                <HugeiconsIcon
+                  className="size-3.5 shrink-0 text-[#1E1E1EA6] transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 dark:text-white/60"
+                  icon={ArrowUpRight01Icon}
+                />
+              </span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/components/feedback-md/feedback-md-adopters.tsx
+++ b/apps/web/src/components/feedback-md/feedback-md-adopters.tsx
@@ -1,44 +1,59 @@
-import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 
-import { FEEDBACK_MD_ADOPTERS } from "@/lib/feedback-md/constants";
+import {
+  FEEDBACK_MD_ADOPTERS,
+  FEEDBACK_MD_ADOPTERS_CAPTION,
+  FEEDBACK_MD_ADOPTERS_CTA_HREF,
+  FEEDBACK_MD_ADOPTERS_CTA_LABEL,
+} from "@/lib/feedback-md/constants";
 
 export function FeedbackMdAdopters() {
   return (
-    <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {FEEDBACK_MD_ADOPTERS.map(({ name, label, feedbackUrl, Logo }) => {
-        const displayUrl = feedbackUrl.replace(/^https?:\/\/(www\.)?/, "");
-        return (
-          <li key={name}>
+    <section className="flex w-full flex-col items-center gap-8">
+      <p className="font-mono text-[0.75rem] leading-4 tracking-[0.2em] text-[#1E1E1E80] uppercase dark:text-white/50">
+        {FEEDBACK_MD_ADOPTERS_CAPTION}
+      </p>
+      <ul className="flex w-full flex-wrap items-center justify-center gap-x-6 gap-y-8">
+        {FEEDBACK_MD_ADOPTERS.map(({ name, label, feedbackUrl, Logo }) => (
+          <li className="flex w-[13rem] items-center justify-center" key={name}>
             <Link
-              className="group flex h-full flex-col justify-between gap-8 rounded-2xl border border-[#1E1E1E1F] p-5 transition-colors hover:bg-[#1E1E1E05] dark:border-white/10 dark:hover:bg-white/5"
+              className="flex h-12 items-center justify-center text-[#52525B] transition-colors hover:text-[#1E1E1E] dark:text-[#9CA3AF] dark:hover:text-white"
               href={feedbackUrl}
               rel="noopener"
               target="_blank"
             >
-              <Logo
-                aria-hidden="true"
-                className="h-7 w-auto shrink-0 self-start text-[#1E1E1E] dark:text-white"
-              />
-              <span className="flex items-end justify-between gap-3">
-                <span className="flex min-w-0 flex-col gap-0.5">
-                  <span className="font-sans text-[0.9375rem] leading-[1.36] font-medium text-[#1E1E1E] dark:text-white">
-                    {label}
-                  </span>
-                  <span className="truncate font-mono text-[0.75rem] leading-4 text-[#1E1E1EA6] dark:text-white/60">
-                    {displayUrl}
-                  </span>
-                </span>
-                <HugeiconsIcon
-                  className="size-3.5 shrink-0 text-[#1E1E1EA6] transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 dark:text-white/60"
-                  icon={ArrowUpRight01Icon}
-                />
-              </span>
+              <Logo aria-label={label} className="h-7 w-auto shrink-0" />
             </Link>
           </li>
-        );
-      })}
-    </ul>
+        ))}
+        <li className="flex w-[13rem] items-center justify-center">
+          <Link
+            className="group relative flex h-12 w-full items-center justify-center gap-2 rounded-lg font-sans text-[0.875rem] text-[#1E1E1E99] transition-colors hover:text-[#1E1E1E] dark:text-white/60 dark:hover:text-white"
+            href={FEEDBACK_MD_ADOPTERS_CTA_HREF}
+          >
+            <svg
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 h-full w-full text-[#1E1E1E33] transition-colors group-hover:text-[#1E1E1E66] dark:text-white/20 dark:group-hover:text-white/40"
+            >
+              <rect
+                fill="none"
+                height="calc(100% - 1px)"
+                rx="8"
+                stroke="currentColor"
+                strokeDasharray="5 7"
+                strokeWidth="1"
+                width="calc(100% - 1px)"
+                x="0.5"
+                y="0.5"
+              />
+            </svg>
+            <HugeiconsIcon className="size-4" icon={Add01Icon} />
+            {FEEDBACK_MD_ADOPTERS_CTA_LABEL}
+          </Link>
+        </li>
+      </ul>
+    </section>
   );
 }

--- a/apps/web/src/lib/feedback-md/constants.ts
+++ b/apps/web/src/lib/feedback-md/constants.ts
@@ -11,6 +11,7 @@ import type {
   FeedbackMdTerminalHeader,
   FeedbackMdTerminalToolCall,
 } from "@/types/feedback-md";
+import { NOTRA_SUPPORT_EMAIL } from "@/utils/agent-metadata";
 import { DOCS_URL, SITE_URL } from "@/utils/urls";
 
 export const FEEDBACK_MD_PATH = "/feedback.md";
@@ -221,8 +222,14 @@ export const FEEDBACK_MD_ADOPTERS: FeedbackMdAdopter[] = [
   },
 ];
 
+export const FEEDBACK_MD_ADOPTERS_CAPTION = "Adopted by";
+
 export const FEEDBACK_MD_ADOPTERS_DESCRIPTION =
   "Teams already serving a feedback.md at their root. Each one links to the live file.";
+
+export const FEEDBACK_MD_ADOPTERS_CTA_LABEL = "This could be you";
+
+export const FEEDBACK_MD_ADOPTERS_CTA_HREF = `mailto:${NOTRA_SUPPORT_EMAIL}?subject=${encodeURIComponent("We adopted feedback.md")}`;
 
 const FEEDBACK_MD_PAGE_URL = `${SITE_URL}${FEEDBACK_MD_PAGE_PATH}`;
 

--- a/apps/web/src/lib/feedback-md/constants.ts
+++ b/apps/web/src/lib/feedback-md/constants.ts
@@ -1,6 +1,8 @@
 import type { ClaudeTodo } from "@notra/ui/components/brainless/claude/claude-todo-list";
 
+import { DatabuddyLogo } from "@/components/landing/marquee-logos/databuddy-logo";
 import type {
+  FeedbackMdAdopter,
   FeedbackMdClient,
   FeedbackMdPrinciple,
   FeedbackMdQuestion,
@@ -208,6 +210,19 @@ export const FEEDBACK_MD_SIBLINGS: FeedbackMdSibling[] = [
     href: FEEDBACK_MD_PATH,
   },
 ];
+
+export const FEEDBACK_MD_ADOPTERS: FeedbackMdAdopter[] = [
+  {
+    name: "databuddy",
+    label: "Databuddy",
+    siteUrl: "https://www.databuddy.cc",
+    feedbackUrl: "https://www.databuddy.cc/feedback.md",
+    Logo: DatabuddyLogo,
+  },
+];
+
+export const FEEDBACK_MD_ADOPTERS_DESCRIPTION =
+  "Teams already serving a feedback.md at their root. Each one links to the live file.";
 
 const FEEDBACK_MD_PAGE_URL = `${SITE_URL}${FEEDBACK_MD_PAGE_PATH}`;
 

--- a/apps/web/src/lib/feedback-md/markdown.ts
+++ b/apps/web/src/lib/feedback-md/markdown.ts
@@ -1,4 +1,6 @@
 import {
+  FEEDBACK_MD_ADOPTERS,
+  FEEDBACK_MD_ADOPTERS_DESCRIPTION,
   FEEDBACK_MD_DESCRIPTION,
   FEEDBACK_MD_EXAMPLE_DISCLAIMER,
   FEEDBACK_MD_HERO_LEAD,
@@ -83,6 +85,9 @@ export function buildFeedbackMdPageMarkdown() {
   const siblings = FEEDBACK_MD_SIBLINGS.map(
     (sibling) => `- ${sibling.file}: ${sibling.answers} (${sibling.direction})`
   );
+  const adopters = FEEDBACK_MD_ADOPTERS.map(
+    (adopter) => `- ${adopter.label}: ${adopter.feedbackUrl}`
+  );
   const questions = FEEDBACK_MD_QUESTIONS.flatMap((item) => [
     `### ${item.question}`,
     item.answer,
@@ -108,6 +113,11 @@ export function buildFeedbackMdPageMarkdown() {
     ]),
     markdownSection("Sections", sections),
     markdownSection("Where it sits", siblings),
+    markdownSection("Adopted by", [
+      FEEDBACK_MD_ADOPTERS_DESCRIPTION,
+      "",
+      ...adopters,
+    ]),
     markdownSection("Add it to your site", [
       "Paste this into your agent:",
       "",

--- a/apps/web/src/lib/feedback-md/markdown.ts
+++ b/apps/web/src/lib/feedback-md/markdown.ts
@@ -1,5 +1,6 @@
 import {
   FEEDBACK_MD_ADOPTERS,
+  FEEDBACK_MD_ADOPTERS_CTA_LABEL,
   FEEDBACK_MD_ADOPTERS_DESCRIPTION,
   FEEDBACK_MD_DESCRIPTION,
   FEEDBACK_MD_EXAMPLE_DISCLAIMER,
@@ -103,6 +104,13 @@ export function buildFeedbackMdPageMarkdown() {
     "",
     `Notra's own file: ${SITE_URL}${FEEDBACK_MD_PATH}`,
     "",
+    markdownSection("Adopted by", [
+      FEEDBACK_MD_ADOPTERS_DESCRIPTION,
+      "",
+      ...adopters,
+      "",
+      `${FEEDBACK_MD_ADOPTERS_CTA_LABEL}: serve your own feedback.md and email ${NOTRA_SUPPORT_EMAIL}.`,
+    ]),
     markdownSection("What it is", principles),
     markdownSection("Template", [
       "```markdown",
@@ -113,11 +121,6 @@ export function buildFeedbackMdPageMarkdown() {
     ]),
     markdownSection("Sections", sections),
     markdownSection("Where it sits", siblings),
-    markdownSection("Adopted by", [
-      FEEDBACK_MD_ADOPTERS_DESCRIPTION,
-      "",
-      ...adopters,
-    ]),
     markdownSection("Add it to your site", [
       "Paste this into your agent:",
       "",

--- a/apps/web/src/types/feedback-md.ts
+++ b/apps/web/src/types/feedback-md.ts
@@ -1,5 +1,5 @@
 import type { ClaudeToolCallStatus } from "@notra/ui/components/brainless/claude/claude-tool-call";
-import type { ReactNode } from "react";
+import type { ComponentType, ReactNode, SVGProps } from "react";
 
 export interface FeedbackMdPrinciple {
   title: string;
@@ -17,6 +17,14 @@ export interface FeedbackMdSibling {
   answers: string;
   direction: "site to agent" | "agent to site";
   href: string;
+}
+
+export interface FeedbackMdAdopter {
+  name: string;
+  label: string;
+  siteUrl: string;
+  feedbackUrl: string;
+  Logo: ComponentType<SVGProps<SVGSVGElement>>;
 }
 
 export interface FeedbackMdQuestion {


### PR DESCRIPTION
## What

Adds an **Adopted by** section to `/feedback-md`, between "Where it sits" and "Add it to your site". It lists teams already serving a `feedback.md` at their root, starting with Databuddy.

- Card links straight to https://www.databuddy.cc/feedback.md (verified 200, `text/markdown`). The bare `databuddy.cc` host 308-redirects to www, so the www host is used to avoid the hop.
- The link is a plain dofollow anchor: `rel="noopener"` only, no `nofollow`, no `noreferrer`. Visible anchor text is "Databuddy" plus the file URL. Page carries `robots: index, follow` and is in the sitemap.
- The Markdown twin at `/feedback-md.md` gets the same section with the same link.
- Adopters live in `FEEDBACK_MD_ADOPTERS` in the feedback-md constants, so the next one is a single array entry. Logo reuses the landing marquee's Databuddy wordmark.

## Checks

- `bun run format` and `bun run check` pass with only pre-existing warnings outside these files.
- `tsc` reports zero errors in the touched files. Remaining errors are the generated fumadocs `.source` missing in a fresh worktree.
- Verified in the dev server: the rendered anchor is `<a rel="noopener" target="_blank" href="https://www.databuddy.cc/feedback.md">` with text "Databuddy / databuddy.cc/feedback.md".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Adopted by section to the `feedback.md` page and its Markdown twin, listing teams already serving a `feedback.md` at their root. Databuddy is the first listed adopter, linked directly to `https://www.databuddy.cc/feedback.md`.

- The section sits under the terminal demo as a caption plus bare adopter logos, with a dashed "This could be you" cell linking to a mailto.
- Adopter links are plain dofollow links with `target="_blank"` and `rel="noopener"` only.
- Adopters live in `FEEDBACK_MD_ADOPTERS`, so adding the next one is a single array entry.
- Uses the `www` Databuddy host because the bare host 308-redirects.

<sup>Written for commit b8e19e8ca0dde8fc1f5b075da850639183c0706f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

