### PR TITLE
fix(auth): add initiate login route so AuthKit invites resume sign-in

### DIFF
--- a/apps/dashboard/src/app/auth/initiate/route.ts
+++ b/apps/dashboard/src/app/auth/initiate/route.ts
@@ -1,0 +1,8 @@
+import { getSignInUrl } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+
+export async function GET() {
+  const signInUrl = await getSignInUrl();
+
+  redirect(signInUrl);
+}


### PR DESCRIPTION
## Why

Organization invite links stopped working after today's AuthKit domain change. The AuthKit invite page no longer renders sign-up itself. It redirects to WorkOS initiate_login, which stores the invitation on the AuthKit side and sends the browser to the Initiate login URL configured in the WorkOS dashboard (currently `/login`). WorkOS only resumes the invitation if that URL starts an AuthKit sign-in. Our `/login` is self-hosted and authenticates through the API directly, so the invitation was dropped and invitees landed on a plain login page.

Verified live: starting an AuthKit sign-in after visiting the invite link lands on the hosted "Accept invitation" page, and the existing `/auth/callback` handler completes it.

## What

- Adds `GET /auth/initiate`, which redirects to the AuthKit sign-in URL via `getSignInUrl()` from `@workos-inc/authkit-nextjs`. No UI.

## Follow-up (WorkOS dashboard, per environment)

Set the Initiate login URL under Redirects to:

- Production: `https://app.usenotra.com/auth/initiate`
- Development: `http://localhost:3000/auth/initiate`

No env var changes needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /auth/initiate` so AuthKit invite links resume sign-in after the WorkOS domain change. Invitees previously landed on the self-hosted `/login` and lost the invitation because it doesn't start an AuthKit sign-in; now they get the hosted "Accept invitation" page and the existing `/auth/callback` completes it.

- The new route has no UI; it redirects to the AuthKit sign-in URL via `getSignInUrl()`.
- Migration: set WorkOS "Initiate login URL" to `/auth/initiate` per environment (prod and dev URLs). No env var changes.

<sup>Written for commit 2e99ac06d3dbfcc53fe8af11ce308fa0b9025623. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

