### PR TITLE
fix(geo): make the scan cron sweep query valid Postgres so scheduled scans start again

### DIFF
--- a/packages/geo-core/src/geo/scan-schedule.ts
+++ b/packages/geo-core/src/geo/scan-schedule.ts
@@ -1,7 +1,7 @@
 import { deleteStaleGeoOpenCodeBoxes } from "@notra/ai/utils/geo-opencode-box";
 import { db } from "@notra/db/drizzle";
 import { geoSettings } from "@notra/db/schema";
-import { and, asc, eq, isNull, lte, or, sql } from "drizzle-orm";
+import { and, eq, isNull, lte, or, sql } from "drizzle-orm";
 import { Effect } from "effect";
 
 import { GEO_SCAN_DUE_LIMIT_PER_SWEEP } from "../constants/geo";
@@ -79,7 +79,7 @@ export const runGeoScanCronSweep = Effect.fn("geo.runScanCronSweep")(
           eq(geoSettings.enabled, true),
           or(isNull(geoSettings.nextScanAt), lte(geoSettings.nextScanAt, now))
         ),
-        orderBy: [asc(sql`${geoSettings.nextScanAt} nulls first`)],
+        orderBy: [sql`${geoSettings.nextScanAt} asc nulls first`],
         limit: GEO_SCAN_DUE_LIMIT_PER_SWEEP,
       })
     );


### PR DESCRIPTION
No scheduled GEO scan has run since #831 switched scheduling to the Vercel cron: every sweep died before starting a single project.

The due-scan lookup ordered by `next_scan_at nulls first asc`, which Postgres rejects with `syntax error at or near "asc"` (visible on every `/api/cron/geo-scan` invocation in the production runtime logs). The sweep now orders by `next_scan_at asc nulls first`, so due projects are found and their scans start. All seven enabled projects currently have `next_scan_at = NULL` and will catch up on the first sweep after deploy.

## Notes
- Verified against Postgres: the old query fails with the same error as production, the fixed query returns the due rows. `tsc --noEmit` for geo-core and Ultracite are clean.
- The project's Cron Jobs had also been disabled at the Vercel project level since 2026-02-02; they were re-enabled today, so this fix is the only remaining blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GEO scan cron query so scheduled sweeps no longer fail before scanning any projects. Due projects are now ordered with valid PostgreSQL syntax, allowing scans to start again after deployment.

- Projects without a `next_scan_at` value are processed first.
- Enabled projects due for scanning will be picked up on the next cron sweep.

<sup>Written for commit 7d7d25d6a7b3a4c30a91ebd364506ace2bffe147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

