### PR TITLE
refactor(geo): order the due scan sweep with drizzle helpers instead of raw sql

### DIFF
--- a/packages/geo-core/src/geo/scan-schedule.ts
+++ b/packages/geo-core/src/geo/scan-schedule.ts
@@ -1,7 +1,7 @@
 import { deleteStaleGeoOpenCodeBoxes } from "@notra/ai/utils/geo-opencode-box";
 import { db } from "@notra/db/drizzle";
 import { geoSettings } from "@notra/db/schema";
-import { and, eq, isNull, lte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm";
 import { Effect } from "effect";
 
 import { GEO_SCAN_DUE_LIMIT_PER_SWEEP } from "../constants/geo";
@@ -79,7 +79,10 @@ export const runGeoScanCronSweep = Effect.fn("geo.runScanCronSweep")(
           eq(geoSettings.enabled, true),
           or(isNull(geoSettings.nextScanAt), lte(geoSettings.nextScanAt, now))
         ),
-        orderBy: [sql`${geoSettings.nextScanAt} asc nulls first`],
+        orderBy: [
+          desc(isNull(geoSettings.nextScanAt)),
+          asc(geoSettings.nextScanAt),
+        ],
         limit: GEO_SCAN_DUE_LIMIT_PER_SWEEP,
       })
     );


### PR DESCRIPTION
## Summary

- Replaces the raw `sql\`... asc nulls first\`` ordering in the due-scan cron sweep (`packages/geo-core/src/geo/scan-schedule.ts`) with drizzle helpers only: `desc(isNull(nextScanAt))` followed by `asc(nextScanAt)`.
- Drops the `sql` import. Drizzle 0.45.2 has no nulls-ordering helper, so sorting on the null check first is how the ORM expresses nulls-first.
- Follows up on #854, which fixed the syntax of the same line. Behaviour is unchanged: never-scanned rows (`next_scan_at IS NULL`) still come first, then the oldest due rows.

## Verification

- Generated SQL: `order by "next_scan_at" is null desc, "next_scan_at" asc`.
- Ran that query in a throwaway Postgres 16 container against a seeded `geo_settings` table. Null rows came first, then oldest due, with future and disabled rows excluded.
- `tsc --noEmit` for geo-core, oxfmt and oxlint pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the due scan sweep ordering to use drizzle helpers instead of raw SQL, keeping the same nulls-first ordering. The old `sql\`... asc nulls first\`` is replaced with `desc(isNull(nextScanAt))` followed by `asc(nextScanAt)`. No behavior change: never-scanned rows still come first, then the oldest due rows.

<sup>Written for commit e80e051e9a34a16300d30fd95a62c553e161bf2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

