### PR TITLE
fix(geo): initialize new projects from brand website

### DIFF
--- a/apps/dashboard/src/components/geo/project-create-dialog.tsx
+++ b/apps/dashboard/src/components/geo/project-create-dialog.tsx
@@ -81,8 +81,8 @@ export function GeoProjectCreateDialog({
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle>New project</ResponsiveDialogTitle>
             <ResponsiveDialogDescription>
-              Track a separate website or brand with its own prompts,
-              competitors and visibility data.
+              We’ll analyze the brand’s website, find competitors, generate
+              prompts, and start tracking it automatically.
             </ResponsiveDialogDescription>
           </ResponsiveDialogHeader>
           <div className="space-y-4 px-4 sm:px-0">
@@ -183,7 +183,9 @@ export function GeoProjectCreateDialog({
               {createProject.isPending && (
                 <Loader2Icon className="size-4 animate-spin" />
               )}
-              Create project
+              {createProject.isPending
+                ? "Setting up project"
+                : "Create project"}
             </Button>
           </ResponsiveDialogFooter>
         </ResponsiveDialogContent>

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -78,7 +78,9 @@ import {
 } from "@notra/geo-core/geo/programs";
 import {
   createGeoProject,
+  discardGeoProjectCreation,
   listGeoProjects,
+  requireBrandIdentity,
   requireGeoProject,
 } from "@notra/geo-core/geo/projects";
 import { promptKey } from "@notra/geo-core/geo/prompt-key";
@@ -864,6 +866,38 @@ export const geoRouter = {
             input.organizationId,
             input.name,
             input.brandSettingsId
+          ).pipe(
+            Effect.flatMap((project) =>
+              requireBrandIdentity(
+                input.organizationId,
+                project.brandSettingsId
+              ).pipe(
+                Effect.flatMap((identity) =>
+                  generateGeoFromWebsite(
+                    {
+                      organizationId: input.organizationId,
+                      projectId: project.id,
+                    },
+                    identity.websiteUrl
+                  )
+                ),
+                Effect.as(project),
+                Effect.tapError(() =>
+                  discardGeoProjectCreation(
+                    input.organizationId,
+                    project.id
+                  ).pipe(
+                    Effect.catch((cleanupError) => {
+                      console.error(
+                        "[GEO] Failed to remove project after setup failed:",
+                        cleanupError
+                      );
+                      return Effect.void;
+                    })
+                  )
+                )
+              )
+            )
           ),
         async ({ context, input, output }) => {
           const projectCount = await countGeoProjects(

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -32,6 +32,7 @@ import {
   startAgentReadinessScan,
 } from "@notra/geo-core/geo/agent-readiness";
 import {
+  createGeoProjectFromWebsite,
   discoverGeoWebsite,
   generateGeoFromWebsite,
 } from "@notra/geo-core/geo/discover";
@@ -77,8 +78,6 @@ import {
   upsertGeoSettings,
 } from "@notra/geo-core/geo/programs";
 import {
-  createGeoProject,
-  discardGeoProjectCreation,
   listGeoProjects,
   requireBrandIdentity,
   requireGeoProject,
@@ -862,40 +861,16 @@ export const geoRouter = {
     .handler(
       geoHandler(
         (input) =>
-          createGeoProject(
+          requireBrandIdentity(
             input.organizationId,
-            input.name,
             input.brandSettingsId
           ).pipe(
-            Effect.flatMap((project) =>
-              requireBrandIdentity(
+            Effect.flatMap((identity) =>
+              createGeoProjectFromWebsite(
                 input.organizationId,
-                project.brandSettingsId
-              ).pipe(
-                Effect.flatMap((identity) =>
-                  generateGeoFromWebsite(
-                    {
-                      organizationId: input.organizationId,
-                      projectId: project.id,
-                    },
-                    identity.websiteUrl
-                  )
-                ),
-                Effect.as(project),
-                Effect.tapError(() =>
-                  discardGeoProjectCreation(
-                    input.organizationId,
-                    project.id
-                  ).pipe(
-                    Effect.catch((cleanupError) => {
-                      console.error(
-                        "[GEO] Failed to remove project after setup failed:",
-                        cleanupError
-                      );
-                      return Effect.void;
-                    })
-                  )
-                )
+                input.name,
+                input.brandSettingsId,
+                identity.websiteUrl
               )
             )
           ),

--- a/packages/geo-core/src/geo/discover.ts
+++ b/packages/geo-core/src/geo/discover.ts
@@ -1,7 +1,7 @@
 import { gateway } from "@notra/ai/gateway";
 import { scrapeWebsiteForBrandAnalysis } from "@notra/ai/utils/context-dev";
 import { db } from "@notra/db/drizzle";
-import { geoSettings } from "@notra/db/schema";
+import { geoSettings, projects } from "@notra/db/schema";
 import { generateText, Output } from "ai";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
@@ -25,6 +25,7 @@ import {
   GEO_TRACKED_PROMPT_VOICE,
 } from "../constants/geo";
 import { geoWebsiteDiscoverySchema } from "../schemas/geo";
+import type { DbTransaction } from "../types/db";
 import type {
   GeoCompetitorSeed,
   GeoDiscoverWebsiteResult,
@@ -37,7 +38,11 @@ import { readGeoCache, writeGeoCache } from "./cache";
 import { competitorKey, normalizeCompetitorDomain } from "./domain";
 import { geoSkip } from "./effect";
 import { GeoDiscoveryError } from "./errors";
-import { insertGeoPrompts, reconcileGeoCompetitors } from "./programs";
+import { toGeoProject } from "./mappers";
+import {
+  insertPromptsInTransaction,
+  reconcileCompetitorsInTransaction,
+} from "./programs";
 import { ensureGeoProject } from "./projects";
 import { startClaimedGeoScanRun } from "./scan-handoff";
 import { claimGeoScanRun } from "./scan-status";
@@ -115,6 +120,46 @@ function buildCompetitorSeeds(
   }));
 }
 
+const prepareGeoWebsiteGeneration = Effect.fn(
+  "geo.generateFromWebsite.prepare"
+)(function* (
+  discovery: GeoWebsiteDiscovery,
+  existingCompanyName?: string,
+  existingAliases: string[] = []
+) {
+  const aliases = unionValues(
+    existingAliases,
+    discovery.aliases,
+    GEO_DISCOVERY_ALIAS_LIMIT
+  );
+  const companyName = existingCompanyName ?? discovery.companyName;
+  const brandTerms = buildBrandTerms({ companyName, aliases });
+  const entries: GeoPromptInsert[] = [];
+
+  for (const entry of discovery.prompts) {
+    const prompt = entry.prompt.trim();
+    const title = entry.title.trim().slice(0, GEO_GAP_TITLE_MAX_LENGTH);
+    if (
+      prompt.length < MIN_PROMPT_LENGTH ||
+      prompt.length > MAX_PROMPT_LENGTH ||
+      promptMentionsBrand(prompt, brandTerms)
+    ) {
+      continue;
+    }
+    entries.push({ prompt, title: title.length > 0 ? title : null });
+  }
+
+  if (entries.length === 0) {
+    return yield* Effect.fail(
+      new GeoDiscoveryError({
+        message: "Website analysis did not produce any usable prompts",
+      })
+    );
+  }
+
+  return { aliases, companyName, entries };
+});
+
 const scrapeWebsite = Effect.fn("geo.discover.scrape")(function* (url: string) {
   const result = yield* Effect.tryPromise({
     try: () => scrapeWebsiteForBrandAnalysis(url),
@@ -177,6 +222,116 @@ export const discoverGeoWebsite = Effect.fn("geo.discoverWebsite")(function* (
   return result;
 });
 
+const persistGeoWebsiteGeneration = Effect.fn(
+  "geo.generateFromWebsite.persist"
+)(function* (
+  tx: DbTransaction,
+  organizationId: string,
+  projectId: string,
+  companyName: string,
+  aliases: string[],
+  entries: readonly GeoPromptInsert[],
+  discoveredCompetitors: readonly GeoCompetitorSeed[]
+) {
+  yield* Effect.tryPromise({
+    try: () =>
+      tx
+        .insert(geoSettings)
+        .values({
+          id: crypto.randomUUID(),
+          organizationId,
+          projectId,
+          companyName,
+          aliases,
+          competitors: [],
+          enabled: true,
+        })
+        .onConflictDoUpdate({
+          target: geoSettings.projectId,
+          set: { companyName, aliases },
+        }),
+    catch: (cause) =>
+      new GeoDiscoveryError({
+        message: "Failed to save GEO settings",
+        cause,
+      }),
+  });
+
+  const competitorOutcome = yield* reconcileCompetitorsInTransaction(
+    tx,
+    organizationId,
+    projectId,
+    (current) =>
+      buildCompetitorSeeds(
+        unionValues(
+          current.map((competitor) => competitor.name),
+          discoveredCompetitors.map((entry) => entry.name),
+          GEO_DISCOVERY_COMPETITOR_LIMIT
+        ),
+        discoveredCompetitors
+      ),
+    GEO_DISCOVERY_COMPETITOR_LIMIT
+  );
+  if (competitorOutcome.status === "limit") {
+    return yield* Effect.fail(
+      new GeoDiscoveryError({
+        message: "Website analysis produced too many competitors",
+      })
+    );
+  }
+
+  const inserted = yield* insertPromptsInTransaction(
+    tx,
+    organizationId,
+    projectId,
+    entries
+  );
+
+  const summary: GeoGenerateFromWebsiteResult = {
+    companyName,
+    aliases,
+    competitors: competitorOutcome.competitors.map(
+      (competitor) => competitor.name
+    ),
+    promptsAdded: inserted.length,
+  };
+  return summary;
+});
+
+const startGeoScanAfterWebsiteGeneration = Effect.fn(
+  "geo.generateFromWebsite.startScan"
+)(function* (organizationId: string, projectId: string, scanEnabled: boolean) {
+  if (!scanEnabled) {
+    return;
+  }
+
+  // Take the same atomic claim every other trigger takes, rather than
+  // stamping a start blindly. The stamp is what the dashboard reads as
+  // "Scanning…", and writing it without owning the slot both lied about a
+  // scan that a concurrent trigger is already running and overwrote the
+  // token that run needs to release it. Losing the claim means a scan is
+  // already in flight for this project — its results are what onboarding
+  // is waiting for anyway, so start nothing.
+  const claim = yield* claimGeoScanRun(projectId).pipe(
+    geoSkip("scan claim failed")
+  );
+  if (claim) {
+    yield* startClaimedGeoScanRun(
+      organizationId,
+      projectId,
+      claim.claimedAt
+    ).pipe(
+      Effect.catch((error) => {
+        console.error(
+          "[GEO] Failed to start scan after website generate:",
+          error
+        );
+        return Effect.void;
+      })
+    );
+  }
+});
+
 export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
   function* (scopeInput: GeoScopeInput, url: string) {
     const organizationId = scopeInput.organizationId;
@@ -223,125 +378,96 @@ export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
         }),
     });
 
-    const aliases = unionValues(
-      existing?.aliases ?? [],
-      discovery.aliases,
-      GEO_DISCOVERY_ALIAS_LIMIT
-    );
-    const companyName = existing?.companyName ?? discovery.companyName;
-
-    const brandTerms = buildBrandTerms({ companyName, aliases });
-    const entries: GeoPromptInsert[] = [];
-    for (const entry of discovery.prompts) {
-      const trimmed = entry.prompt.trim();
-      const title = entry.title.trim().slice(0, GEO_GAP_TITLE_MAX_LENGTH);
-      if (
-        trimmed.length < MIN_PROMPT_LENGTH ||
-        trimmed.length > MAX_PROMPT_LENGTH ||
-        promptMentionsBrand(trimmed, brandTerms)
-      ) {
-        continue;
-      }
-      entries.push({ prompt: trimmed, title: title.length > 0 ? title : null });
-    }
-
-    if (entries.length === 0) {
-      return yield* Effect.fail(
-        new GeoDiscoveryError({
-          message: "Website analysis did not produce any usable prompts",
-        })
+    const { aliases, companyName, entries } =
+      yield* prepareGeoWebsiteGeneration(
+        discovery,
+        existing?.companyName,
+        existing?.aliases
       );
-    }
 
-    yield* Effect.tryPromise({
+    const summary = yield* Effect.tryPromise({
       try: () =>
-        db
-          .insert(geoSettings)
-          .values({
-            id: crypto.randomUUID(),
-            organizationId,
-            projectId,
-            companyName,
-            aliases,
-            competitors: [],
-            enabled: true,
-          })
-          .onConflictDoUpdate({
-            target: geoSettings.projectId,
-            set: { companyName, aliases },
-          }),
+        db.transaction((tx) =>
+          Effect.runPromise(
+            persistGeoWebsiteGeneration(
+              tx,
+              organizationId,
+              projectId,
+              companyName,
+              aliases,
+              entries,
+              discovery.competitors
+            )
+          )
+        ),
       catch: (cause) =>
         new GeoDiscoveryError({
-          message: "Failed to save GEO settings",
+          message: "Failed to save GEO tracking",
           cause,
         }),
     });
 
-    const competitorRows = yield* reconcileGeoCompetitors(
-      { organizationId, projectId },
-      (current) =>
-        buildCompetitorSeeds(
-          unionValues(
-            current.map((competitor) => competitor.name),
-            discovery.competitors.map((entry) => entry.name),
-            GEO_DISCOVERY_COMPETITOR_LIMIT
-          ),
-          discovery.competitors
-        )
-    );
-    const competitors = competitorRows.map((competitor) => competitor.name);
-
-    const inserted = yield* insertGeoPrompts(
-      { organizationId, projectId },
-      entries
-    ).pipe(
-      Effect.mapError(
-        (cause) =>
-          new GeoDiscoveryError({
-            message: "Failed to save GEO prompts",
-            cause,
-          })
-      )
-    );
-
-    const summary: GeoGenerateFromWebsiteResult = {
-      companyName,
-      aliases,
-      competitors,
-      promptsAdded: inserted.length,
-    };
-
     // Newly created settings default to enabled; an existing disabled row is
     // left alone so we never stamp a scan start that the scan will skip.
-    const scanEnabled = existing?.enabled ?? true;
-    if (scanEnabled) {
-      // Take the same atomic claim every other trigger takes, rather than
-      // stamping a start blindly. The stamp is what the dashboard reads as
-      // "Scanning…", and writing it without owning the slot both lied about a
-      // scan that a concurrent trigger is already running and overwrote the
-      // token that run needs to release it. Losing the claim means a scan is
-      // already in flight for this project — its results are what onboarding
-      // is waiting for anyway, so start nothing.
-      const claim = yield* claimGeoScanRun(projectId).pipe(
-        geoSkip("scan claim failed")
-      );
-      if (claim) {
-        yield* startClaimedGeoScanRun(
-          organizationId,
-          projectId,
-          claim.claimedAt
-        ).pipe(
-          Effect.catch((error) => {
-            console.error(
-              "[GEO] Failed to start scan after website generate:",
-              error
-            );
-            return Effect.void;
-          })
-        );
-      }
-    }
+    yield* startGeoScanAfterWebsiteGeneration(
+      organizationId,
+      projectId,
+      existing?.enabled ?? true
+    );
 
     return summary;
   }
 );
+
+export const createGeoProjectFromWebsite = Effect.fn(
+  "geo.projectCreateFromWebsite"
+)(function* (
+  organizationId: string,
+  name: string,
+  brandSettingsId: string,
+  url: string
+) {
+  const { discovery } = yield* discoverGeoWebsite(organizationId, url);
+  const { aliases, companyName, entries } =
+    yield* prepareGeoWebsiteGeneration(discovery);
+
+  const project = yield* Effect.tryPromise({
+    try: () =>
+      db.transaction(async (tx) => {
+        const rows = await tx
+          .insert(projects)
+          .values({
+            id: crypto.randomUUID(),
+            organizationId,
+            name: name.trim(),
+            brandSettingsId,
+          })
+          .returning();
+        const row = rows.at(0);
+        if (!row) {
+          throw new Error("Project insert returned no row");
+        }
+
+        await Effect.runPromise(
+          persistGeoWebsiteGeneration(
+            tx,
+            organizationId,
+            row.id,
+            companyName,
+            aliases,
+            entries,
+            discovery.competitors
+          )
+        );
+        return toGeoProject(row);
+      }),
+    catch: (cause) =>
+      new GeoDiscoveryError({
+        message: "Failed to create and configure the project",
+        cause,
+      }),
+  });
+
+  yield* startGeoScanAfterWebsiteGeneration(organizationId, project.id, true);
+  return project;
+});

--- a/packages/geo-core/src/geo/discover.ts
+++ b/packages/geo-core/src/geo/discover.ts
@@ -230,6 +230,29 @@ export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
     );
     const companyName = existing?.companyName ?? discovery.companyName;
 
+    const brandTerms = buildBrandTerms({ companyName, aliases });
+    const entries: GeoPromptInsert[] = [];
+    for (const entry of discovery.prompts) {
+      const trimmed = entry.prompt.trim();
+      const title = entry.title.trim().slice(0, GEO_GAP_TITLE_MAX_LENGTH);
+      if (
+        trimmed.length < MIN_PROMPT_LENGTH ||
+        trimmed.length > MAX_PROMPT_LENGTH ||
+        promptMentionsBrand(trimmed, brandTerms)
+      ) {
+        continue;
+      }
+      entries.push({ prompt: trimmed, title: title.length > 0 ? title : null });
+    }
+
+    if (entries.length === 0) {
+      return yield* Effect.fail(
+        new GeoDiscoveryError({
+          message: "Website analysis did not produce any usable prompts",
+        })
+      );
+    }
+
     yield* Effect.tryPromise({
       try: () =>
         db
@@ -267,29 +290,6 @@ export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
         )
     );
     const competitors = competitorRows.map((competitor) => competitor.name);
-
-    const brandTerms = buildBrandTerms({ companyName, aliases });
-    const entries: GeoPromptInsert[] = [];
-    for (const entry of discovery.prompts) {
-      const trimmed = entry.prompt.trim();
-      const title = entry.title.trim().slice(0, GEO_GAP_TITLE_MAX_LENGTH);
-      if (
-        trimmed.length < MIN_PROMPT_LENGTH ||
-        trimmed.length > MAX_PROMPT_LENGTH ||
-        promptMentionsBrand(trimmed, brandTerms)
-      ) {
-        continue;
-      }
-      entries.push({ prompt: trimmed, title: title.length > 0 ? title : null });
-    }
-
-    if (entries.length === 0) {
-      return yield* Effect.fail(
-        new GeoDiscoveryError({
-          message: "Website analysis did not produce any usable prompts",
-        })
-      );
-    }
 
     const inserted = yield* insertGeoPrompts(
       { organizationId, projectId },

--- a/packages/geo-core/src/geo/discover.ts
+++ b/packages/geo-core/src/geo/discover.ts
@@ -283,6 +283,14 @@ export const generateGeoFromWebsite = Effect.fn("geo.generateFromWebsite")(
       entries.push({ prompt: trimmed, title: title.length > 0 ? title : null });
     }
 
+    if (entries.length === 0) {
+      return yield* Effect.fail(
+        new GeoDiscoveryError({
+          message: "Website analysis did not produce any usable prompts",
+        })
+      );
+    }
+
     const inserted = yield* insertGeoPrompts(
       { organizationId, projectId },
       entries

--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -1318,6 +1318,8 @@ const insertPromptsInTransaction = Effect.fn("geo.promptsInsertTx")(function* (
   return inserted;
 });
 
+export { insertPromptsInTransaction, reconcileCompetitorsInTransaction };
+
 export const insertGeoPrompts = Effect.fn("geo.promptsInsert")(function* (
   input: GeoScopeInput,
   entries: readonly GeoPromptInsert[]

--- a/packages/geo-core/src/geo/projects.ts
+++ b/packages/geo-core/src/geo/projects.ts
@@ -42,7 +42,7 @@ export const requireBrandIdentity = Effect.fn("geo.requireBrandIdentity")(
   function* (organizationId: string, brandSettingsId: string) {
     const identity = yield* geoDb("brand identity lookup failed", () =>
       db.query.brandSettings.findFirst({
-        columns: { id: true },
+        columns: { id: true, websiteUrl: true },
         where: and(
           eq(brandSettings.id, brandSettingsId),
           eq(brandSettings.organizationId, organizationId)
@@ -56,7 +56,7 @@ export const requireBrandIdentity = Effect.fn("geo.requireBrandIdentity")(
       );
     }
 
-    return identity.id;
+    return identity;
   }
 );
 
@@ -100,7 +100,7 @@ export const createGeoProject = Effect.fn("geo.projectCreate")(function* (
   brandSettingsId?: string
 ) {
   const linkedBrandSettingsId = brandSettingsId
-    ? yield* requireBrandIdentity(organizationId, brandSettingsId)
+    ? (yield* requireBrandIdentity(organizationId, brandSettingsId)).id
     : yield* resolveDefaultBrandIdentity(organizationId);
 
   const rows = yield* geoDb("project create failed", () =>
@@ -129,7 +129,7 @@ export const updateGeoProject = Effect.fn("geo.projectUpdate")(function* (
   update: GeoProjectUpdateInput
 ) {
   const linkedBrandSettingsId = update.brandSettingsId
-    ? yield* requireBrandIdentity(organizationId, update.brandSettingsId)
+    ? (yield* requireBrandIdentity(organizationId, update.brandSettingsId)).id
     : undefined;
 
   const rows = yield* geoDb("project update failed", () =>
@@ -156,6 +156,26 @@ export const updateGeoProject = Effect.fn("geo.projectUpdate")(function* (
   }
 
   return toGeoProject(row);
+});
+
+/**
+ * Removes a project that has not completed creation. Unlike the user-facing
+ * delete operation, compensation must also remove an organization's first
+ * project and is idempotent when another actor already removed it.
+ */
+export const discardGeoProjectCreation = Effect.fn(
+  "geo.projectCreationDiscard"
+)(function* (organizationId: string, projectId: string) {
+  yield* geoDb("project creation discard failed", () =>
+    db
+      .delete(projects)
+      .where(
+        and(
+          eq(projects.id, projectId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+  );
 });
 
 /**

--- a/packages/geo-core/src/geo/projects.ts
+++ b/packages/geo-core/src/geo/projects.ts
@@ -159,26 +159,6 @@ export const updateGeoProject = Effect.fn("geo.projectUpdate")(function* (
 });
 
 /**
- * Removes a project that has not completed creation. Unlike the user-facing
- * delete operation, compensation must also remove an organization's first
- * project and is idempotent when another actor already removed it.
- */
-export const discardGeoProjectCreation = Effect.fn(
-  "geo.projectCreationDiscard"
-)(function* (organizationId: string, projectId: string) {
-  yield* geoDb("project creation discard failed", () =>
-    db
-      .delete(projects)
-      .where(
-        and(
-          eq(projects.id, projectId),
-          eq(projects.organizationId, organizationId)
-        )
-      )
-  );
-});
-
-/**
  * Deletes a project and everything hanging off it.
  *
  * Safety notes:


### PR DESCRIPTION
### Description
New GEO projects now run the same website-driven setup used during onboarding.

The selected Brand Identity website is analyzed to generate project settings, competitors, and prompts before starting the initial scan. Failed setup is rolled back cleanly, and projects with no usable prompts are rejected before scan handoff.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New GEO projects now run the same website-driven setup used during onboarding. The selected brand website is analyzed to generate project settings, competitors, and prompts before the initial scan starts. Project creation and setup are committed in a single transaction, so failed setup rolls back cleanly, and projects with no usable prompts are rejected before scan handoff.

<sup>Written for commit ffb777c8cf461603d131f780604434ee55d938f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

