### PR TITLE
feat(dashboard): sync pricing benefits

### DIFF
--- a/apps/dashboard/src/constants/billing.ts
+++ b/apps/dashboard/src/constants/billing.ts
@@ -1,5 +1,7 @@
 import { ADDONS, LEGACY_PLANS, PLANS } from "@notra/ai/billing/features";
 
+import type { ProductFeature } from "@/types/hooks/billing";
+
 export const BILLING_SECTION_VALUES = ["billing", "usage"] as const;
 
 export const BILLING_PRICE_REGEX = /^\d+([.,]\d+)?$/;
@@ -19,9 +21,43 @@ export const LEGACY_PLAN_TIERS: Record<string, string> = {
 };
 
 export const PLAN_TIER_DESCRIPTIONS: Record<string, string> = {
-  [PLANS.STARTER]: "For founders shipping their first content engine.",
-  [PLANS.GROWTH]: "For teams publishing across channels every week.",
-  [PLANS.SCALE]: "For content teams running multiple brands at volume.",
+  [PLANS.STARTER]: "For founders tracking their first prompts.",
+  [PLANS.GROWTH]:
+    "For teams tracking prompts across engines and languages.",
+  [PLANS.SCALE]: "For agencies and teams running several brands.",
+};
+
+export const PLAN_TIER_FEATURES: Record<string, ProductFeature[]> = {
+  [PLANS.STARTER]: [
+    { text: "2,000 AI answers tracked / mo" },
+    { text: "8 image generations / mo" },
+    { text: "10 long-form posts / mo" },
+    { text: "Unlimited social posts" },
+    { text: "1 project" },
+    { text: "100 references", overageText: "then $0.05 per ref / mo" },
+    { text: "Standard support + Slack" },
+    { text: "ZDR available (+20%)" },
+  ],
+  [PLANS.GROWTH]: [
+    { text: "6,000 AI answers tracked / mo" },
+    { text: "20 image generations / mo" },
+    { text: "25 long-form posts / mo" },
+    { text: "Unlimited social posts" },
+    { text: "3 projects" },
+    { text: "500 references", overageText: "then $0.04 per ref / mo" },
+    { text: "Standard support + Slack" },
+    { text: "ZDR available (+20%)" },
+  ],
+  [PLANS.SCALE]: [
+    { text: "12,000 AI answers tracked / mo" },
+    { text: "45 image generations / mo" },
+    { text: "50 long-form posts / mo" },
+    { text: "Unlimited social posts" },
+    { text: "10 projects" },
+    { text: "1,000 references", overageText: "then $0.03 per ref / mo" },
+    { text: "Priority support" },
+    { text: "ZDR available (+20%)" },
+  ],
 };
 
 export const BILLING_SCENARIO_TEXT: Record<string, string> = {

--- a/apps/dashboard/src/utils/billing-plans.ts
+++ b/apps/dashboard/src/utils/billing-plans.ts
@@ -9,6 +9,7 @@ import {
   LEGACY_PLAN_TIERS,
   PLAN_NAME_BILLING_INTERVAL_SUFFIX,
   PLAN_TIER_DESCRIPTIONS,
+  PLAN_TIER_FEATURES,
   ZDR_ADDON_BY_TIER,
   ZDR_ADDON_HINT,
   ZDR_ADDON_PREFIX,
@@ -72,6 +73,12 @@ export function getProductPrice(
 export function getProductFeatures(
   plan: BillingPlan | null | undefined
 ): ProductFeature[] {
+  const tier = planTierId(plan?.id);
+  const tierFeatures = tier ? PLAN_TIER_FEATURES[tier] : undefined;
+  if (tierFeatures) {
+    return tierFeatures;
+  }
+
   if (!plan?.items) {
     return [];
   }


### PR DESCRIPTION
### Description
Sync the dashboard pricing plan descriptions and benefits with the landing page. This keeps Starter, Growth, and Scale messaging consistent across onboarding, billing settings, and the GEO upgrade dialog.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the dashboard pricing plan descriptions and benefits with the landing page so Starter, Growth, and Scale show consistent messaging across onboarding, billing settings, and the GEO upgrade dialog.

- Updates `PLAN_TIER_DESCRIPTIONS` for all three tiers.
- Adds `PLAN_TIER_FEATURES` with the feature list per tier.
- `getProductFeatures` now returns tier features before falling back to plan items.

<sup>Written for commit c6041d941036fb6fbee8bca4d4cb91b31c2f2bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

