### PR TITLE
feat(geo): add project deletion controls

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/settings/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/settings/page-client.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { GeoSettingsForm } from "@/components/geo/geo-settings-form";
+import { GeoProjectDeleteSection } from "@/components/geo/project-delete-section";
 import { PageContainer } from "@/components/layout/container";
 import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
-import { useGeoModelCatalog, useGeoSettings } from "@/lib/hooks/use-geo";
+import {
+  useGeoModelCatalog,
+  useGeoProjects,
+  useGeoSettings,
+} from "@/lib/hooks/use-geo";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import type { GeoPageClientProps } from "@/types/geo";
 
@@ -21,6 +26,7 @@ export default function PageClient({ organizationSlug }: GeoPageClientProps) {
 }
 
 function SettingsPageContent({ organizationSlug }: GeoPageClientProps) {
+  const [projectParam, setProjectParam] = useGeoProjectQueryState();
   const { getOrganization, activeOrganization } = useOrganizationsContext();
   const orgFromList = getOrganization(organizationSlug);
   const organization =
@@ -31,6 +37,16 @@ function SettingsPageContent({ organizationSlug }: GeoPageClientProps) {
 
   const { data: settingsData, isPending } = useGeoSettings(organizationId);
   const { data: catalog } = useGeoModelCatalog(organizationId);
+  const { data: projectsData } = useGeoProjects(organizationId);
+  const projects = projectsData?.projects ?? [];
+  const activeProjectId =
+    settingsData?.settings?.projectId ?? projectParam ?? projects.at(0)?.id;
+  const activeProject = projects.find(
+    (project) => project.id === activeProjectId
+  );
+  const replacementProjectId = projects.find(
+    (project) => project.id !== activeProjectId
+  )?.id;
 
   if (isPending || !catalog) {
     return <GeoSettingsSkeleton />;
@@ -38,12 +54,20 @@ function SettingsPageContent({ organizationSlug }: GeoPageClientProps) {
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full px-4 lg:px-6">
+      <div className="w-full space-y-10 px-4 lg:px-6">
         <GeoSettingsForm
           catalog={catalog}
           organizationId={organizationId}
           settings={settingsData?.settings ?? null}
         />
+        {activeProject ? (
+          <GeoProjectDeleteSection
+            onDeleted={setProjectParam}
+            organizationId={organizationId}
+            project={activeProject}
+            replacementProjectId={replacementProjectId}
+          />
+        ) : null}
       </div>
     </PageContainer>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/settings/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/settings/page-client.tsx
@@ -57,6 +57,7 @@ function SettingsPageContent({ organizationSlug }: GeoPageClientProps) {
       <div className="w-full space-y-10 px-4 lg:px-6">
         <GeoSettingsForm
           catalog={catalog}
+          key={activeProjectId}
           organizationId={organizationId}
           settings={settingsData?.settings ?? null}
         />

--- a/apps/dashboard/src/components/geo/project-delete-section.tsx
+++ b/apps/dashboard/src/components/geo/project-delete-section.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Delete02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogAction,
+  ResponsiveAlertDialogCancel,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogDescription,
+  ResponsiveAlertDialogFooter,
+  ResponsiveAlertDialogHeader,
+  ResponsiveAlertDialogTitle,
+} from "@notra/ui/components/shared/responsive-alert-dialog";
+import { useState } from "react";
+
+import { Button } from "@/components/button";
+import { useGeoProjectDelete } from "@/lib/hooks/use-geo";
+import type { GeoProjectDeleteSectionProps } from "@/types/geo";
+
+export function GeoProjectDeleteSection({
+  organizationId,
+  project,
+  replacementProjectId,
+  onDeleted,
+}: GeoProjectDeleteSectionProps) {
+  const [open, setOpen] = useState(false);
+  const deleteProject = useGeoProjectDelete(organizationId);
+  const isLastProject = replacementProjectId === undefined;
+
+  const handleDelete = async () => {
+    if (isLastProject || deleteProject.isPending) {
+      return;
+    }
+
+    try {
+      await deleteProject.mutateAsync(project.id);
+    } catch {
+      return;
+    }
+    setOpen(false);
+    onDeleted(replacementProjectId);
+  };
+
+  return (
+    <section className="border-destructive/20 bg-destructive/5 space-y-4 rounded-xl border p-4 sm:p-5">
+      <div className="space-y-1">
+        <h2 className="text-destructive text-sm font-medium">Delete project</h2>
+        <p className="text-muted-foreground text-sm text-pretty">
+          {isLastProject
+            ? "This is your only project. Create another project before deleting it."
+            : "Permanently delete this project and all of its tracking data."}
+        </p>
+      </div>
+      <Button
+        disabled={isLastProject}
+        onClick={() => setOpen(true)}
+        type="button"
+        variant="destructive"
+      >
+        <HugeiconsIcon className="size-4" icon={Delete02Icon} />
+        Delete project
+      </Button>
+
+      <ResponsiveAlertDialog
+        onOpenChange={(nextOpen) => {
+          if (!deleteProject.isPending) {
+            setOpen(nextOpen);
+          }
+        }}
+        open={open}
+      >
+        <ResponsiveAlertDialogContent>
+          <ResponsiveAlertDialogHeader>
+            <ResponsiveAlertDialogTitle>
+              Delete “{project.name}”?
+            </ResponsiveAlertDialogTitle>
+            <ResponsiveAlertDialogDescription>
+              This permanently deletes its settings, prompts, competitors,
+              scans, and reports. This action cannot be undone.
+            </ResponsiveAlertDialogDescription>
+          </ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogFooter>
+            <ResponsiveAlertDialogCancel disabled={deleteProject.isPending}>
+              Cancel
+            </ResponsiveAlertDialogCancel>
+            <ResponsiveAlertDialogAction
+              disabled={deleteProject.isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                handleDelete();
+              }}
+              variant="destructive"
+            >
+              {deleteProject.isPending ? "Deleting..." : "Delete project"}
+            </ResponsiveAlertDialogAction>
+          </ResponsiveAlertDialogFooter>
+        </ResponsiveAlertDialogContent>
+      </ResponsiveAlertDialog>
+    </section>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -798,6 +798,25 @@ export function useGeoProjectCreate(organizationId: string) {
   });
 }
 
+export function useGeoProjectDelete(organizationId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (projectId: string) =>
+      dashboardOrpc.geo.projectsDelete.call({ organizationId, projectId }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: dashboardOrpc.geo.projectsList.queryKey({
+          input: { organizationId },
+        }),
+      });
+      toast.success("Project deleted");
+    },
+    onError: (error) => {
+      toast.error(toErrorMessage(error, "Failed to delete project"));
+    },
+  });
+}
+
 export function useGeoRunSequence(organizationId: string) {
   const { projectId } = useGeoProjectScope();
   const queryClient = useQueryClient();

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -78,6 +78,7 @@ import {
   upsertGeoSettings,
 } from "@notra/geo-core/geo/programs";
 import {
+  deleteGeoProject,
   listGeoProjects,
   requireBrandIdentity,
   requireGeoProject,
@@ -119,6 +120,7 @@ import {
   geoOnboardingBrandInputSchema,
   geoOrganizationInputSchema,
   geoProjectCreateInputSchema,
+  geoProjectDeleteInputSchema,
   geoPromptCreateInputSchema,
   geoPromptsImportInputSchema,
   geoPromptDeleteInputSchema,
@@ -897,6 +899,13 @@ export const geoRouter = {
             properties: { is_sample: false, project_count: projectCount },
           });
         }
+      )
+    ),
+  projectsDelete: authorizedProcedure
+    .input(geoProjectDeleteInputSchema)
+    .handler(
+      geoHandler((input) =>
+        deleteGeoProject(input.organizationId, input.projectId)
       )
     ),
   generateFromWebsite: authorizedProcedure

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -74,6 +74,13 @@ export interface GeoProjectCreateDialogProps {
   onCreated: (projectId: string) => void;
 }
 
+export interface GeoProjectDeleteSectionProps {
+  organizationId: string;
+  project: GeoProject;
+  replacementProjectId: string | undefined;
+  onDeleted: (projectId: string) => void;
+}
+
 export interface GeoProjectLogoProps {
   name: string;
   domain: string | null;

--- a/packages/geo-core/src/schemas/geo.ts
+++ b/packages/geo-core/src/schemas/geo.ts
@@ -219,6 +219,11 @@ export const geoProjectCreateInputSchema = object({
   brandSettingsId: string().min(1),
 });
 
+export const geoProjectDeleteInputSchema = object({
+  organizationId: string().min(1),
+  projectId: string().min(1),
+});
+
 export const geoTimeseriesInputSchema = geoOrganizationInputSchema.extend({
   ...geoWindowFields,
 });


### PR DESCRIPTION
### Description
Adds a danger zone to GEO project settings with a project deletion button and confirmation dialog.

The flow prevents users from deleting their only project, calls the existing safe deletion backend, refreshes the project list, and switches to another available project after deletion.

### Screenshot/Recording (if applicable)
<img width="382" height="208" alt="image" src="https://github.com/user-attachments/assets/c0f46b96-0df1-41a1-9e15-546f9fc30850" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a danger zone to GEO project settings so users can permanently delete a project from the dashboard; previously, projects could only be created in the UI. After deletion, the settings form resets and the dashboard switches to another available project.

**New Features**
- Requires confirmation and disables deletion when the organization has only one project.
- Removes settings, prompts, competitors, scans, and reports.
- Refreshes the project list and shows success or failure feedback.

<sup>Written for commit ef679cb70a0dcbe50fe7c8d4a3e382dd7ccabf10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

