### PR TITLE
fix(dashboard): enable sidebar scrolling

### DIFF
--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -113,7 +113,7 @@ export function DashboardSidebar({
       <SidebarContent>
         <SidebarSwap
           activeId={panelId}
-          className="flex min-h-0 flex-1 flex-col overflow-x-clip"
+          className="overflow-x-clip"
           items={[
             {
               id: "main",

--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -118,13 +118,11 @@ export function DashboardSidebar({
             {
               id: "main",
               side: "left",
-              className: "flex-1",
               children: <NavMain />,
             },
             {
               id: "chat",
               side: "right",
-              className: "flex-1",
               children: (
                 <>
                   <SidebarBackButton onBack={handleBack} />
@@ -135,7 +133,6 @@ export function DashboardSidebar({
             {
               id: "settings",
               side: "right",
-              className: "flex-1",
               children: (
                 <>
                   <SidebarBackButton onBack={handleBack} />
@@ -146,7 +143,6 @@ export function DashboardSidebar({
             {
               id: "brand",
               side: "right",
-              className: "flex-1",
               children: (
                 <>
                   <SidebarBackButton onBack={handleBack} />


### PR DESCRIPTION
### Description
Fixes the dashboard sidebar on short viewports by allowing the navigation panel to size to its content. The existing vertical scroll container can now reach all navigation entries, while horizontal overflow remains clipped.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard sidebar so all navigation entries are reachable on short viewports. Removes stale flex classes from the sidebar panels, letting the scroll container size to its content while keeping horizontal overflow clipped.

<sup>Written for commit cfd3b6e71f42c7f042b1359899f89c81834b3f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

