### PR TITLE
fix: resolve code quality warnings

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/analytics/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/analytics/page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useReducedMotion } from "motion/react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { AccountSeriesChartCard } from "@/components/analytics/account-series-chart-card";
 import { useAnalyticsAccounts } from "@/components/analytics/analytics-context";
@@ -144,8 +144,10 @@ export default function PageClient() {
     [volumeTimeline, adoption]
   );
 
-  const colorForKey = (key: string) =>
-    accountColors.get(key) ?? CHART_MUTED_COLOR;
+  const colorForKey = useCallback(
+    (key: string) => accountColors.get(key) ?? CHART_MUTED_COLOR,
+    [accountColors]
+  );
 
   return (
     <InstrumentGrid className="grid-cols-1 gap-4 lg:grid-cols-12">

--- a/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/chat/page-client.tsx
@@ -1358,7 +1358,7 @@ function StandaloneChatPageClient({
         : [];
       await resendFromUserMessage(userMessageId, newText, attachments);
     },
-    [extractUserMessageContent, resendFromUserMessage]
+    [extractUserMessageContent, resendFromUserMessage, stableChatId]
   );
 
   const handleRetryMessage = useCallback(

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
@@ -89,10 +89,10 @@ function BillingPageContent() {
   const [now] = useState(() => Date.now());
   const invoiceListId = useId();
 
-  const invoices = customer?.invoices ?? [];
+  const invoices = customer?.invoices;
 
   const sortedInvoices = useMemo(() => {
-    return [...invoices].sort((a, b) => {
+    return [...(invoices ?? [])].sort((a, b) => {
       const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
       const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
       return dateSortOrder === "desc" ? dateB - dateA : dateA - dateB;

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/general/organization-details-card.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/general/organization-details-card.tsx
@@ -170,7 +170,7 @@ export function OrganizationDetailsCard({
       name: organization.name,
       slug: organization.slug,
     });
-  }, [form.reset, organization.name, organization.slug]);
+  }, [form, organization.name, organization.slug]);
 
   return (
     <TitleCard heading="Organization Details">

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/notifications/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/notifications/page.tsx
@@ -3,7 +3,7 @@
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Suspense, use, useMemo } from "react";
+import { Suspense, use } from "react";
 import { toast } from "sonner";
 
 import { PageContainer } from "@/components/layout/container";
@@ -60,14 +60,12 @@ function NotificationsSettingsPageContent({ params }: PageProps) {
   const currentMember = members.find((m) => m.userId === session?.user?.id);
   const isOwner = currentMember?.role === "owner";
 
-  const ownerEmails = useMemo(
-    () =>
-      members
-        .filter((m) => m.role === "owner")
-        .map((m) => m.user?.email)
-        .filter((email): email is string => Boolean(email)),
-    [members]
-  );
+  const ownerEmails: string[] = [];
+  for (const member of members) {
+    if (member.role === "owner" && member.user?.email) {
+      ownerEmails.push(member.user.email);
+    }
+  }
 
   const { data: settings, isPending: isLoadingSettings } = useQuery({
     ...dashboardOrpc.notifications.get.queryOptions({

--- a/apps/dashboard/src/components/analytics/impressions-share-card.tsx
+++ b/apps/dashboard/src/components/analytics/impressions-share-card.tsx
@@ -65,7 +65,7 @@ export function ImpressionsShareCard({
           ? `${top.account} · ${Math.round((top.impressions / shareTotal) * PERCENT)}% of impressions`
           : null,
     };
-  }, [data?.entries]);
+  }, [colorForKey, data?.entries]);
 
   return (
     <InstrumentModule eyebrow="Impressions share" variant="panel">

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -298,6 +298,12 @@ const ChatInput = ({
     sendTooltip =
       "Enter to queue this message. It will send once the AI finishes.";
   }
+  let sendLabel = "Send message";
+  if (showStop) {
+    sendLabel = "Stop generating";
+  } else if (canQueue) {
+    sendLabel = "Queue message";
+  }
 
   return (
     <Composer.Frame
@@ -483,13 +489,7 @@ const ChatInput = ({
         />
         <Composer.Send
           disabled={isInputLocked || (!showStop && isEmpty)}
-          label={
-            showStop
-              ? "Stop generating"
-              : canQueue
-                ? "Queue message"
-                : "Send message"
-          }
+          label={sendLabel}
           onClick={showStop ? onStop : handleSend}
           tooltip={sendTooltip}
         >

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -543,19 +543,22 @@ export function ChatInputAdvanced({
     [handleFilesSelected]
   );
 
+  const cleanupUnsubmittedAttachments = useCallback(() => {
+    for (const attachment of attachmentsRef.current) {
+      if (submittedKeysRef.current.has(attachment.key)) {
+        continue;
+      }
+      cleanupChatUpload(attachment.key).catch(() => undefined);
+    }
+  }, [cleanupChatUpload]);
+
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
-
-      for (const attachment of attachmentsRef.current) {
-        if (submittedKeysRef.current.has(attachment.key)) {
-          continue;
-        }
-        cleanupChatUpload(attachment.key).catch(() => undefined);
-      }
+      cleanupUnsubmittedAttachments();
     };
-  }, [cleanupChatUpload]);
+  }, [cleanupUnsubmittedAttachments]);
 
   const onEmptyChangeRef = useRef(onEmptyChange);
 
@@ -2072,17 +2075,17 @@ export function ChatInputAdvanced({
                     <HugeiconsIcon className="size-4" icon={StopIcon} />
                   );
                 }
+                let sendLabel = "Send message";
+                if (isLoading && isEmpty) {
+                  sendLabel = "Stop generating";
+                } else if (canQueue) {
+                  sendLabel = "Queue message";
+                }
                 return (
                   <Composer.Send
                     busy={sendBusy}
                     disabled={submitDisabled}
-                    label={
-                      isLoading && isEmpty
-                        ? "Stop generating"
-                        : canQueue
-                          ? "Queue message"
-                          : "Send message"
-                    }
+                    label={sendLabel}
                     onClick={submitOnClick}
                     tooltip={getSubmitTooltipText({
                       canQueue,

--- a/apps/dashboard/src/components/content/content-chat-activity-panel.tsx
+++ b/apps/dashboard/src/components/content/content-chat-activity-panel.tsx
@@ -209,34 +209,36 @@ export function ContentChatActivityPanel({
                 <p className="text-muted-foreground px-2 py-1.5 text-center text-xs">
                   Loading chats...
                 </p>
-              ) : sessions.length === 0 ? (
+              ) : null}
+              {!isHistoryLoading && sessions.length === 0 ? (
                 <p className="text-muted-foreground px-2 py-1.5 text-center text-xs">
                   No previous chats
                 </p>
-              ) : (
-                historyGroups.map((group, groupIndex) => (
-                  <Fragment key={group.label}>
-                    {groupIndex > 0 ? <DropdownMenuSeparator /> : null}
-                    <DropdownMenuGroup>
-                      <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
-                      {group.sessions.map((session) => (
-                        <DropdownMenuItem
-                          className="data-[active=true]:bg-accent/70"
-                          data-active={activeChatId === session.chatId}
-                          disabled={isAgentBusy}
-                          key={session.chatId}
-                          onClick={() => onSelectChat(session.chatId)}
-                          title={session.title}
-                        >
-                          <span className="min-w-0 flex-1 truncate">
-                            {session.title}
-                          </span>
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuGroup>
-                  </Fragment>
-                ))
-              )}
+              ) : null}
+              {!isHistoryLoading && sessions.length > 0
+                ? historyGroups.map((group, groupIndex) => (
+                    <Fragment key={group.label}>
+                      {groupIndex > 0 ? <DropdownMenuSeparator /> : null}
+                      <DropdownMenuGroup>
+                        <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+                        {group.sessions.map((session) => (
+                          <DropdownMenuItem
+                            className="data-[active=true]:bg-accent/70"
+                            data-active={activeChatId === session.chatId}
+                            disabled={isAgentBusy}
+                            key={session.chatId}
+                            onClick={() => onSelectChat(session.chatId)}
+                            title={session.title}
+                          >
+                            <span className="min-w-0 flex-1 truncate">
+                              {session.title}
+                            </span>
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuGroup>
+                    </Fragment>
+                  ))
+                : null}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="gap-2"

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -323,7 +323,7 @@ export function CreateContentDialog({
     [previewResponse]
   );
 
-  const previewFailures = previewResponse?.failures ?? [];
+  const previewFailures = previewResponse?.failures;
 
   useEffect(() => {
     if (
@@ -371,7 +371,7 @@ export function CreateContentDialog({
   }, [previewData, previewParamsKey, previewResponse?.linearIntegrations]);
 
   useEffect(() => {
-    if (!previewFailures.length) {
+    if (!previewFailures?.length) {
       return;
     }
     const warningKey = `${previewParamsKey}:${previewFailures
@@ -385,7 +385,7 @@ export function CreateContentDialog({
     toast.warning(
       `${previewFailures.length} repository preview ${previewFailures.length === 1 ? "issue was" : "issues were"} detected.`
     );
-  }, [previewParamsKey, previewFailures]);
+  }, [previewFailures, previewParamsKey]);
 
   const mutation = useMutation<
     { succeeded: number; total: number },

--- a/apps/dashboard/src/components/dashboard/org-selector.tsx
+++ b/apps/dashboard/src/components/dashboard/org-selector.tsx
@@ -272,7 +272,12 @@ export function OrgSelector() {
   const queryClient = useQueryClient();
   const { isMobile, state } = useSidebar();
   const isCollapsed = state === "collapsed";
-  const dropdownSide = isMobile ? "bottom" : isCollapsed ? "right" : "top";
+  let dropdownSide: "bottom" | "right" | "top" = "top";
+  if (isMobile) {
+    dropdownSide = "bottom";
+  } else if (isCollapsed) {
+    dropdownSide = "right";
+  }
   const { setTheme, resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const toggleTheme = () => setTheme(isDark ? "light" : "dark");

--- a/apps/dashboard/src/components/geo/engine-family-sheet.tsx
+++ b/apps/dashboard/src/components/geo/engine-family-sheet.tsx
@@ -390,12 +390,12 @@ function EngineFamilySheetSession({
     useState<WriteDialogInitialState | null>(null);
   const { projectId } = useGeoProjectScope();
   const { getOrganization, activeOrganization } = useOrganizationsContext();
-  const organization =
-    organizationSlug && activeOrganization?.slug === organizationSlug
-      ? activeOrganization
-      : organizationSlug
-        ? getOrganization(organizationSlug)
-        : null;
+  let organization = null;
+  if (organizationSlug && activeOrganization?.slug === organizationSlug) {
+    organization = activeOrganization;
+  } else if (organizationSlug) {
+    organization = getOrganization(organizationSlug);
+  }
   const organizationId = organization?.id ?? "";
   const canWrite = Boolean(organizationSlug) && Boolean(organizationId);
   const name = engineFamilyLabel(family.family);

--- a/apps/dashboard/src/components/geo/gaps-table.tsx
+++ b/apps/dashboard/src/components/geo/gaps-table.tsx
@@ -245,13 +245,16 @@ function GapsEmpty({
 }: GeoGapsEmptyProps) {
   const { projectId } = useGeoProjectScope();
   const copy = GEO_GAPS_EMPTY[kind];
-  const action =
-    kind === "no-scan" ? (
+  let action = null;
+  if (kind === "no-scan") {
+    action = (
       <Button disabled={isScanning} onClick={onRunScan}>
         {isScanning ? <StatusSpinner /> : null}
         {GEO_GAPS_EMPTY["no-scan"].action}
       </Button>
-    ) : kind === "no-search-gaps" ? (
+    );
+  } else if (kind === "no-search-gaps") {
+    action = (
       <Button
         nativeButton={false}
         render={
@@ -265,7 +268,8 @@ function GapsEmpty({
       >
         {GEO_GAPS_EMPTY["no-search-gaps"].action}
       </Button>
-    ) : null;
+    );
+  }
 
   return (
     <EmptyState

--- a/apps/dashboard/src/components/geo/journey-detail-dialog.tsx
+++ b/apps/dashboard/src/components/geo/journey-detail-dialog.tsx
@@ -102,6 +102,8 @@ export function JourneyDetailDialog({
     Math.max(journey.pages, 1),
     JOURNEY_EVENT_SKELETON_ROW_KEYS.length
   );
+  const displayedPaths =
+    eventPaths.length > 0 ? eventPaths : journey.samplePaths;
 
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
@@ -160,17 +162,13 @@ export function JourneyDetailDialog({
                 )
               )}
             </div>
-          ) : eventPaths.length > 0 ? (
+          ) : null}
+          {!isLoading ? (
             <JourneyPathTrail
               limit={GEO_JOURNEY_TRAIL_DETAIL_LIMIT}
-              paths={eventPaths}
+              paths={displayedPaths}
             />
-          ) : (
-            <JourneyPathTrail
-              limit={GEO_JOURNEY_TRAIL_DETAIL_LIMIT}
-              paths={journey.samplePaths}
-            />
-          )}
+          ) : null}
           <div aria-busy={isLoading} className="max-h-96 overflow-auto">
             <Table>
               <TableHeader>

--- a/apps/dashboard/src/components/geo/language-performance-card.tsx
+++ b/apps/dashboard/src/components/geo/language-performance-card.tsx
@@ -184,24 +184,29 @@ function languagePerformanceColumns({
       key: "trend",
       header: "Trend",
       width: "7.5rem",
-      cell: (row) =>
-        row.kind === "suggested" ? (
-          <LanguageAddButton
-            disabled={adding || atLimit}
-            language={row.language}
-            limitReached={atLimit}
-            onAdd={onAddLanguage}
-            pending={pendingLanguage === row.language}
-          />
-        ) : (row.trend?.length ?? 0) >= GEO_SPARKLINE_MIN_POINTS ? (
-          <GeoRateSparkline
-            className="text-geo-search"
-            label={`${row.language} mention rate trend`}
-            points={row.trend ?? []}
-          />
-        ) : (
-          <span className="text-muted-foreground text-xs">-</span>
-        ),
+      cell: (row) => {
+        if (row.kind === "suggested") {
+          return (
+            <LanguageAddButton
+              disabled={adding || atLimit}
+              language={row.language}
+              limitReached={atLimit}
+              onAdd={onAddLanguage}
+              pending={pendingLanguage === row.language}
+            />
+          );
+        }
+        if ((row.trend?.length ?? 0) >= GEO_SPARKLINE_MIN_POINTS) {
+          return (
+            <GeoRateSparkline
+              className="text-geo-search"
+              label={`${row.language} mention rate trend`}
+              points={row.trend ?? []}
+            />
+          );
+        }
+        return <span className="text-muted-foreground text-xs">-</span>;
+      },
     },
   ];
 }

--- a/apps/dashboard/src/components/geo/prompt-results-preview.tsx
+++ b/apps/dashboard/src/components/geo/prompt-results-preview.tsx
@@ -74,19 +74,13 @@ function PromptSentimentLabel({ sentiment }: PromptSentimentLabelProps) {
   if (!label) {
     return <span className="text-muted-foreground text-xs">-</span>;
   }
-  return (
-    <span
-      className={
-        sentiment === "positive"
-          ? "text-geo-up text-xs"
-          : sentiment === "negative"
-            ? "text-geo-down text-xs"
-            : "text-muted-foreground text-xs"
-      }
-    >
-      {label}
-    </span>
-  );
+  let className = "text-muted-foreground text-xs";
+  if (sentiment === "positive") {
+    className = "text-geo-up text-xs";
+  } else if (sentiment === "negative") {
+    className = "text-geo-down text-xs";
+  }
+  return <span className={className}>{label}</span>;
 }
 
 function PromptCopyCell({ row }: { row: GeoPromptSummary }) {

--- a/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/add-repository-dialog.tsx
@@ -155,14 +155,18 @@ export function AddRepositoryDialog({
   const setOpen = controlledOnOpenChange ?? setInternalOpen;
   const queryClient = useQueryClient();
 
-  const triggerElement =
-    trigger && isValidElement(trigger) ? (
+  let triggerElement = null;
+  if (trigger && isValidElement(trigger)) {
+    triggerElement = (
       <ResponsiveDialogTrigger render={trigger as React.ReactElement} />
-    ) : controlledOpen === undefined ? (
+    );
+  } else if (controlledOpen === undefined) {
+    triggerElement = (
       <ResponsiveDialogTrigger render={<Button size="sm" variant="outline" />}>
         Add Repository
       </ResponsiveDialogTrigger>
-    ) : null;
+    );
+  }
 
   const availableRepositoriesQuery = useQuery(
     dashboardOrpc.integrations.repositories.listAvailable.queryOptions({

--- a/apps/dashboard/src/components/integrations/wehook-setup-dialog.tsx
+++ b/apps/dashboard/src/components/integrations/wehook-setup-dialog.tsx
@@ -140,16 +140,20 @@ export function WebhookSetupDialog({
 
   const githubWebhooksUrl = `https://github.com/${owner}/${repo}/settings/hooks/new`;
 
-  const triggerElement =
-    trigger !== undefined && isValidElement(trigger) ? (
+  let triggerElement = null;
+  if (trigger !== undefined && isValidElement(trigger)) {
+    triggerElement = (
       <ResponsiveDialogTrigger render={trigger as React.ReactElement} />
-    ) : trigger === undefined ? null : (
+    );
+  } else if (trigger !== undefined) {
+    triggerElement = (
       <ResponsiveDialogTrigger>
         <Button size="sm" variant="outline">
           Setup Webhook
         </Button>
       </ResponsiveDialogTrigger>
     );
+  }
 
   return (
     <ResponsiveDialog onOpenChange={setOpen} open={open}>
@@ -185,7 +189,8 @@ export function WebhookSetupDialog({
                 <Skeleton className="h-9 w-full" />
               </div>
             </div>
-          ) : webhookConfig ? (
+          ) : null}
+          {!(loadingConfig || isPending) && webhookConfig ? (
             <>
               <fieldset className="space-y-1.5">
                 <p className="text-sm font-medium">Payload URL</p>
@@ -222,7 +227,8 @@ export function WebhookSetupDialog({
                 </div>
               </fieldset>
             </>
-          ) : (
+          ) : null}
+          {!(loadingConfig || isPending) && !webhookConfig ? (
             <div className="space-y-4">
               <div className="border-destructive/50 bg-destructive/10 rounded-md border p-4 text-center">
                 <p className="text-destructive text-sm font-medium">
@@ -244,7 +250,7 @@ export function WebhookSetupDialog({
                 Retry
               </Button>
             </div>
-          )}
+          ) : null}
         </div>
 
         <ResponsiveDialogFooter className="gap-2">

--- a/apps/dashboard/src/components/motion/checkbox.tsx
+++ b/apps/dashboard/src/components/motion/checkbox.tsx
@@ -36,6 +36,12 @@ export function Checkbox({
   const reduce = useReducedMotion();
   const showMark = checked || indeterminate;
   const path = indeterminate ? INDETERMINATE_PATH : CHECK_PATH;
+  let state = "unchecked";
+  if (checked) {
+    state = "checked";
+  } else if (indeterminate) {
+    state = "indeterminate";
+  }
 
   return (
     <label
@@ -57,9 +63,7 @@ export function Checkbox({
             ? "border-primary bg-primary text-primary-foreground"
             : "border-muted-foreground/50 bg-background hover:border-muted-foreground"
         )}
-        data-state={
-          checked ? "checked" : indeterminate ? "indeterminate" : "unchecked"
-        }
+        data-state={state}
         disabled={disabled}
         id={id}
         onClick={() => !disabled && onCheckedChange(!checked)}

--- a/apps/dashboard/src/components/motion/table/index.tsx
+++ b/apps/dashboard/src/components/motion/table/index.tsx
@@ -394,27 +394,27 @@ export function Table<T>({
         >
           {columnGroup}
           <tbody>
-            {pagedRows.length === 0 ? (
-              loading ? (
-                <SkeletonRows
-                  columns={orderedColumns}
-                  count={Math.max(1, Math.ceil(height / rowHeight))}
-                  rowHeight={rowHeight}
-                  selectable={selectable}
-                />
-              ) : (
-                <tr>
-                  <td className="p-0" colSpan={leadColumns + 1}>
-                    <div
-                      className="text-muted-foreground flex items-center justify-center px-6 text-center"
-                      style={{ height: bodyHeight }}
-                    >
-                      {emptyState}
-                    </div>
-                  </td>
-                </tr>
-              )
-            ) : (
+            {pagedRows.length === 0 && loading ? (
+              <SkeletonRows
+                columns={orderedColumns}
+                count={Math.max(1, Math.ceil(height / rowHeight))}
+                rowHeight={rowHeight}
+                selectable={selectable}
+              />
+            ) : null}
+            {pagedRows.length === 0 && !loading ? (
+              <tr>
+                <td className="p-0" colSpan={leadColumns + 1}>
+                  <div
+                    className="text-muted-foreground flex items-center justify-center px-6 text-center"
+                    style={{ height: bodyHeight }}
+                  >
+                    {emptyState}
+                  </div>
+                </td>
+              </tr>
+            ) : null}
+            {pagedRows.length > 0 ? (
               <>
                 {scrolls && paddingTop > 0 ? (
                   <tr aria-hidden style={{ height: paddingTop }}>
@@ -460,7 +460,7 @@ export function Table<T>({
                   />
                 ) : null}
               </>
-            )}
+            ) : null}
           </tbody>
         </table>
       </div>

--- a/apps/dashboard/src/components/motion/table/table-header.tsx
+++ b/apps/dashboard/src/components/motion/table/table-header.tsx
@@ -214,15 +214,13 @@ export function TableHeader<T>({
             const active = sort?.key === column.key;
             const isDragging = dragKey === column.key;
             const isActive = activeColumn === column.key;
+            let ariaSort: "ascending" | "descending" | undefined;
+            if (active) {
+              ariaSort = sort?.direction === "asc" ? "ascending" : "descending";
+            }
             return (
               <th
-                aria-sort={
-                  active
-                    ? sort?.direction === "asc"
-                      ? "ascending"
-                      : "descending"
-                    : undefined
-                }
+                aria-sort={ariaSort}
                 className={cn(
                   "group bg-muted text-muted-foreground relative p-0 font-medium",
                   "data-[drop=true]:before:bg-primary data-[drop=true]:before:absolute data-[drop=true]:before:inset-y-0 data-[drop=true]:before:left-0 data-[drop=true]:before:w-0.5",
@@ -315,7 +313,8 @@ export function TableHeader<T>({
                         </span>
                       ) : null}
                     </button>
-                  ) : onColumnRename ? (
+                  ) : null}
+                  {!column.sortable && onColumnRename ? (
                     <input
                       aria-label={`Rename ${column.key} column`}
                       className={cn(
@@ -330,7 +329,8 @@ export function TableHeader<T>({
                         typeof column.header === "string" ? column.header : ""
                       }
                     />
-                  ) : (
+                  ) : null}
+                  {!column.sortable && !onColumnRename ? (
                     <span
                       className={cn(
                         "flex-1 px-4 whitespace-nowrap",
@@ -339,7 +339,7 @@ export function TableHeader<T>({
                     >
                       {column.header}
                     </span>
-                  )}
+                  ) : null}
                 </motion.div>
                 {resizable ? (
                   <button

--- a/apps/dashboard/src/constants/billing.ts
+++ b/apps/dashboard/src/constants/billing.ts
@@ -22,8 +22,7 @@ export const LEGACY_PLAN_TIERS: Record<string, string> = {
 
 export const PLAN_TIER_DESCRIPTIONS: Record<string, string> = {
   [PLANS.STARTER]: "For founders tracking their first prompts.",
-  [PLANS.GROWTH]:
-    "For teams tracking prompts across engines and languages.",
+  [PLANS.GROWTH]: "For teams tracking prompts across engines and languages.",
   [PLANS.SCALE]: "For agencies and teams running several brands.",
 };
 

--- a/apps/dashboard/src/lib/hooks/use-brand-analysis.ts
+++ b/apps/dashboard/src/lib/hooks/use-brand-analysis.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import type { UpdateBrandSettingsInput } from "@/schemas/brand";
 import type {
@@ -16,6 +16,12 @@ import type {
 import { QUERY_KEYS } from "@/utils/query-keys";
 
 import { dashboardOrpc } from "../orpc/query";
+
+const IDLE_PROGRESS: ProgressResponse["progress"] = {
+  status: "idle",
+  currentStep: 0,
+  totalSteps: 3,
+};
 
 export function useBrandSettings(organizationId: string) {
   return useQuery<BrandSettingsResponse>(
@@ -80,11 +86,7 @@ export function useBrandAnalysisProgress(
     },
   });
 
-  const progress = query.data?.progress ?? {
-    status: "idle" as const,
-    currentStep: 0,
-    totalSteps: 3,
-  };
+  const progress = query.data?.progress ?? IDLE_PROGRESS;
 
   const startPolling = () => {
     hasReset.current = false;
@@ -95,7 +97,7 @@ export function useBrandAnalysisProgress(
     });
   };
 
-  const onComplete = () => {
+  const onComplete = useCallback(() => {
     hasReset.current = true;
     forcePollUntilMs.current = null;
 
@@ -116,7 +118,7 @@ export function useBrandAnalysisProgress(
       }),
     });
     onAnalysisComplete?.();
-  };
+  }, [onAnalysisComplete, organizationId, queryClient]);
 
   useEffect(() => {
     if (

--- a/apps/dashboard/src/lib/workflows/on-demand/helpers.ts
+++ b/apps/dashboard/src/lib/workflows/on-demand/helpers.ts
@@ -252,9 +252,14 @@ export function buildDataPointRestrictionInstructions(dataPoints: {
     return null;
   }
 
-  return instructions.length === restrictions.length
-    ? `Strict data-point restrictions:\n${restrictions.join("\n")}`
-    : restrictions.length > 0
-      ? `Strict data-point restrictions:\n${restrictions.join("\n")}\n\nCross-source instructions:\n${instructions.filter((i) => !restrictions.includes(i)).join("\n")}`
-      : `Cross-source instructions:\n${instructions.filter((i) => !restrictions.includes(i)).join("\n")}`;
+  if (instructions.length === restrictions.length) {
+    return `Strict data-point restrictions:\n${restrictions.join("\n")}`;
+  }
+
+  const crossSourceInstructions = instructions.slice(restrictions.length);
+  if (restrictions.length > 0) {
+    return `Strict data-point restrictions:\n${restrictions.join("\n")}\n\nCross-source instructions:\n${crossSourceInstructions.join("\n")}`;
+  }
+
+  return `Cross-source instructions:\n${crossSourceInstructions.join("\n")}`;
 }

--- a/apps/dashboard/src/lib/workflows/on-demand/helpers.ts
+++ b/apps/dashboard/src/lib/workflows/on-demand/helpers.ts
@@ -235,7 +235,7 @@ export function buildDataPointRestrictionInstructions(dataPoints: {
     );
   }
 
-  const instructions: string[] = [...restrictions];
+  const crossSourceInstructions: string[] = [];
 
   if (
     dataPoints.includeLinearData &&
@@ -243,20 +243,19 @@ export function buildDataPointRestrictionInstructions(dataPoints: {
       dataPoints.includeCommits ||
       dataPoints.includeReleases)
   ) {
-    instructions.push(
+    crossSourceInstructions.push(
       "- DEDUPLICATION: GitHub and Linear data may describe the same work items. When a GitHub PR and a Linear issue reference the same change, consolidate into a single entry. Do not list the same change twice."
     );
   }
 
-  if (instructions.length === 0) {
+  if (restrictions.length === 0 && crossSourceInstructions.length === 0) {
     return null;
   }
 
-  if (instructions.length === restrictions.length) {
+  if (crossSourceInstructions.length === 0) {
     return `Strict data-point restrictions:\n${restrictions.join("\n")}`;
   }
 
-  const crossSourceInstructions = instructions.slice(restrictions.length);
   if (restrictions.length > 0) {
     return `Strict data-point restrictions:\n${restrictions.join("\n")}\n\nCross-source instructions:\n${crossSourceInstructions.join("\n")}`;
   }

--- a/apps/web/src/utils/rss.ts
+++ b/apps/web/src/utils/rss.ts
@@ -82,8 +82,7 @@ export function buildBlogRssFeed(posts: NotraBlogPost[]) {
     };
   });
 
-  const lastBuildDate =
-    items.length > 0 ? items[0]!.pubDate : new Date().toUTCString();
+  const lastBuildDate = items[0]?.pubDate ?? new Date().toUTCString();
 
   return buildRssFeed({
     title: RSS_FEED_TITLE,

--- a/packages/geo-core/src/geo/prompts.ts
+++ b/packages/geo-core/src/geo/prompts.ts
@@ -149,11 +149,12 @@ function deriveCategory(
   if (isAFor?.[1] && isAFor[2]) {
     const useCase = cleanPhrase(isAFor[2]);
     const typePhrase = nounPhraseFromType(isAFor[1]);
-    const preferred = GERUND_REGEX.test(useCase)
-      ? useCase
-      : AUDIENCE_LIKE_REGEX.test(useCase)
-        ? typePhrase
-        : typePhrase || useCase;
+    let preferred = typePhrase || useCase;
+    if (GERUND_REGEX.test(useCase)) {
+      preferred = useCase;
+    } else if (AUDIENCE_LIKE_REGEX.test(useCase)) {
+      preferred = typePhrase;
+    }
     const category = finalizeCategory(preferred, brandTerms);
     if (category) {
       return category;


### PR DESCRIPTION
### Description
Resolves all current Ultracite formatting and lint warnings across the dashboard, web app, and GEO core package. Refactors nested ternaries for readability, stabilizes React hook dependencies and cleanup behavior, and removes an unsafe non-null assertion without changing application behavior. Verified with formatting, linting, type checks, and the full test suite.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves all Ultracite formatting and lint warnings across the dashboard, web app, and `geo-core` package. No application behavior changes.

**Refactors**
- Converts nested ternaries to if/else statements for readability.
- Stabilizes React hook dependencies and effect cleanup.
- Removes an unsafe non-null assertion in the RSS builder.

<sup>Written for commit 4cca97182bcc4bb2a3fcdff02e2253cca77b2a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

