### PR TITLE
feat(geo): open project setup dialog from GEO empty states

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/agent-readiness/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/agent-readiness/page-client.tsx
@@ -8,21 +8,17 @@ import {
 } from "@notra/geo-core/constants/agent-readiness";
 import { getAgentReadinessScanErrorMessage } from "@notra/geo-core/utils/agent-readiness";
 import { stripWebsiteProtocol } from "@notra/geo-core/utils/geo-website";
-import Link from "next/link";
 import { useState } from "react";
 
-import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
 import { EmptyStateReadinessPreview } from "@/components/empty-state-preview";
 import { AgentReadinessChecklist } from "@/components/geo/agent-readiness/readiness-checklist";
 import { AgentReadinessScanDialog } from "@/components/geo/agent-readiness/readiness-scan-dialog";
 import { AgentReadinessScanningNotice } from "@/components/geo/agent-readiness/readiness-scanning-notice";
 import { AgentReadinessScoreCard } from "@/components/geo/agent-readiness/readiness-score-card";
+import { GeoSetupButton } from "@/components/geo/geo-setup-button";
 import { PageContainer } from "@/components/layout/container";
-import {
-  GeoProjectProvider,
-  useGeoProjectScope,
-} from "@/components/providers/geo-project-provider";
+import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   useAgentReadiness,
@@ -32,7 +28,6 @@ import {
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import type { AgentReadinessBodyProps } from "@/types/agent-readiness";
 import type { GeoPageClientProps } from "@/types/geo";
-import { withGeoProject } from "@/utils/geo-paths";
 
 import { AgentReadinessSkeleton } from "./skeleton";
 
@@ -118,7 +113,6 @@ function ReadinessBody({
 }
 
 function AgentReadinessPageContent({ organizationSlug }: GeoPageClientProps) {
-  const { projectId } = useGeoProjectScope();
   const { getOrganization, activeOrganization } = useOrganizationsContext();
   const orgFromList = getOrganization(organizationSlug);
   const organization =
@@ -146,18 +140,7 @@ function AgentReadinessPageContent({ organizationSlug }: GeoPageClientProps) {
             </p>
           </header>
           <EmptyState
-            action={
-              <Button
-                nativeButton={false}
-                render={
-                  <Link
-                    href={withGeoProject(`/${organizationSlug}/geo`, projectId)}
-                  />
-                }
-              >
-                Set up GEO tracking
-              </Button>
-            }
+            action={<GeoSetupButton organizationId={organizationId} />}
             description="The scan uses the website from your GEO project. Set up GEO tracking first."
             preview={<EmptyStateReadinessPreview />}
             title="Set up GEO tracking"

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/page-client.tsx
@@ -6,7 +6,6 @@ import { Kbd } from "@notra/ui/components/ui/kbd";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import { useState } from "react";
 
 import { Button } from "@/components/button";
@@ -16,12 +15,10 @@ import { CompetitorEditDialog } from "@/components/geo/competitor-edit-dialog";
 import { CompetitorsTable } from "@/components/geo/competitors-table";
 import { CompetitorsCsvImportDialog } from "@/components/geo/geo-csv-import-dialog";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
+import { GeoSetupButton } from "@/components/geo/geo-setup-button";
 import { GeoSectionSkeleton } from "@/components/geo/skeleton-parts";
 import { PageContainer } from "@/components/layout/container";
-import {
-  GeoProjectProvider,
-  useGeoProjectScope,
-} from "@/components/providers/geo-project-provider";
+import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   EMPTY_STATE_TABLE_COLUMNS,
@@ -36,7 +33,6 @@ import { useGeoActiveProject } from "@/lib/hooks/use-geo-active-project";
 import { useGeoCompetitorsDb } from "@/lib/hooks/use-geo-db";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { useGeoRange } from "@/lib/hooks/use-geo-range";
-import { withGeoProject } from "@/utils/geo-paths";
 
 import { GeoPageSkeleton } from "../skeleton";
 
@@ -70,7 +66,6 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
 }
 
 function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
-  const { projectId } = useGeoProjectScope();
   const { getOrganization, activeOrganization } = useOrganizationsContext();
   const orgFromList = getOrganization(organizationSlug);
   const organization =
@@ -113,18 +108,7 @@ function GeoCompetitorsPageContent({ organizationSlug }: PageClientProps) {
             </p>
           </header>
           <EmptyState
-            action={
-              <Button
-                nativeButton={false}
-                render={
-                  <Link
-                    href={withGeoProject(`/${organizationSlug}/geo`, projectId)}
-                  />
-                }
-              >
-                Set up GEO tracking
-              </Button>
-            }
+            action={<GeoSetupButton organizationId={organizationId} />}
             description="Set up GEO tracking first, then track which competitors AI engines surface."
             preview={
               <EmptyStateTablePreview

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/gaps/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/gaps/page-client.tsx
@@ -69,7 +69,7 @@ function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
     return (
       <GeoWriterNeedsSetup
         description="Questions engines answer without mentioning you"
-        organizationSlug={organizationSlug}
+        organizationId={organizationId}
         title="Content Gaps"
       />
     );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
@@ -13,10 +13,7 @@ import { Button } from "@/components/button";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
 import { GeoSetupEmpty } from "@/components/geo/geo-setup-empty";
 import { PageContainer } from "@/components/layout/container";
-import {
-  GeoProjectProvider,
-  useGeoProjectScope,
-} from "@/components/providers/geo-project-provider";
+import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import {
@@ -35,7 +32,6 @@ import {
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { useGeoRange } from "@/lib/hooks/use-geo-range";
 import type { GeoPageClientProps, GeoPageContentProps } from "@/types/geo";
-import { geoNavHref } from "@/utils/geo-paths";
 
 import { GeoTabs } from "./components/geo-tabs";
 import { GeoPageSkeleton } from "./skeleton";
@@ -60,7 +56,6 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
       ? activeOrganization
       : orgFromList;
   const organizationId = organization?.id ?? "";
-  const { projectId } = useGeoProjectScope();
   const geoRange = useGeoRange();
 
   const { data: settingsData, isPending: isSettingsPending } =
@@ -141,14 +136,7 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
     return (
       <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
         <div className="w-full px-4 lg:px-6">
-          <GeoSetupEmpty
-            page="overview"
-            settingsHref={geoNavHref(
-              organizationSlug,
-              "/geo/settings",
-              projectId
-            )}
-          />
+          <GeoSetupEmpty organizationId={organizationId} page="overview" />
         </div>
       </PageContainer>
     );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
@@ -4,7 +4,6 @@ import { PlusSignIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import Link from "next/link";
 import { useState } from "react";
 
 import { Button } from "@/components/button";
@@ -13,6 +12,7 @@ import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { ConversationsCard } from "@/components/geo/conversations-card";
 import { PromptsCsvImportDialog } from "@/components/geo/geo-csv-import-dialog";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
+import { GeoSetupButton } from "@/components/geo/geo-setup-button";
 import { PromptAddDialog } from "@/components/geo/prompt-add-dialog";
 import { PromptSuggestions } from "@/components/geo/prompt-suggestions";
 import { PromptsTable } from "@/components/geo/prompts-table";
@@ -90,18 +90,7 @@ function GeoPromptsPageContent({ organizationSlug }: PageClientProps) {
             </p>
           </header>
           <EmptyState
-            action={
-              <Button
-                nativeButton={false}
-                render={
-                  <Link
-                    href={withGeoProject(`/${organizationSlug}/geo`, projectId)}
-                  />
-                }
-              >
-                Set up GEO tracking
-              </Button>
-            }
+            action={<GeoSetupButton organizationId={organizationId} />}
             description="Set up GEO tracking first, then manage the prompts scanned across AI engines."
             preview={
               <EmptyStateTablePreview

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/traffic/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/traffic/page-client.tsx
@@ -4,23 +4,19 @@ import { GEO_TRAFFIC_REVEAL_MS } from "@notra/geo-core/constants/geo";
 import { isTrafficPagePending } from "@notra/geo-core/utils/ai-traffic";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { useReducedMotion } from "motion/react";
-import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
-import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
 import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { AiTrafficCard } from "@/components/geo/ai-traffic-card";
 import { AiTrafficLogCard } from "@/components/geo/ai-traffic-log-card";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
+import { GeoSetupButton } from "@/components/geo/geo-setup-button";
 import { TrafficEmpty } from "@/components/geo/traffic-empty";
 import { TrafficPagesCard } from "@/components/geo/traffic-pages-card";
 import { InstrumentReveal } from "@/components/instrument/instrument-reveal";
 import { PageContainer } from "@/components/layout/container";
-import {
-  GeoProjectProvider,
-  useGeoProjectScope,
-} from "@/components/providers/geo-project-provider";
+import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   EMPTY_STATE_TABLE_COLUMNS,
@@ -36,7 +32,6 @@ import {
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { useGeoRange } from "@/lib/hooks/use-geo-range";
 import type { GeoPageClientProps } from "@/types/geo";
-import { withGeoProject } from "@/utils/geo-paths";
 
 import { GeoTrafficSkeleton } from "./skeleton";
 
@@ -51,7 +46,6 @@ export default function PageClient({ organizationSlug }: GeoPageClientProps) {
 }
 
 function TrafficPageContent({ organizationSlug }: GeoPageClientProps) {
-  const { projectId } = useGeoProjectScope();
   const { getOrganization, activeOrganization } = useOrganizationsContext();
   const orgFromList = getOrganization(organizationSlug);
   const organization =
@@ -132,18 +126,7 @@ function TrafficPageContent({ organizationSlug }: GeoPageClientProps) {
             </p>
           </header>
           <EmptyState
-            action={
-              <Button
-                nativeButton={false}
-                render={
-                  <Link
-                    href={withGeoProject(`/${organizationSlug}/geo`, projectId)}
-                  />
-                }
-              >
-                Set up GEO tracking
-              </Button>
-            }
+            action={<GeoSetupButton organizationId={organizationId} />}
             description="Set up GEO tracking first, then watch AI crawlers and referrals as they arrive."
             preview={
               <EmptyStateTablePreview

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/write/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/write/page-client.tsx
@@ -80,7 +80,7 @@ function GeoWriterPageContent({ organizationSlug }: GeoWriterPageContentProps) {
     return (
       <GeoWriterNeedsSetup
         description="Plan a custom article from a prompt, type, brand, and competitors"
-        organizationSlug={organizationSlug}
+        organizationId={organizationId}
         title="Write"
       />
     );

--- a/apps/dashboard/src/components/geo/geo-setup-button.tsx
+++ b/apps/dashboard/src/components/geo/geo-setup-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/button";
+import { GeoProjectCreateDialog } from "@/components/geo/project-create-dialog";
+import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
+import type { GeoSetupButtonProps } from "@/types/geo";
+
+export function GeoSetupButton({
+  organizationId,
+  children = "Set up GEO tracking",
+  className,
+  size,
+}: GeoSetupButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [, setProjectParam] = useGeoProjectQueryState();
+
+  return (
+    <>
+      <Button
+        className={className}
+        onClick={() => setOpen(true)}
+        size={size}
+        type="button"
+      >
+        {children}
+      </Button>
+      <GeoProjectCreateDialog
+        onCreated={(projectId) => setProjectParam(projectId)}
+        onOpenChange={setOpen}
+        open={open}
+        organizationId={organizationId}
+      />
+    </>
+  );
+}

--- a/apps/dashboard/src/components/geo/geo-setup-empty.tsx
+++ b/apps/dashboard/src/components/geo/geo-setup-empty.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
-import Link from "next/link";
 import { useEffect, useRef } from "react";
 
-import { Button } from "@/components/button";
 import { EmptyStateAnalyticsPreview } from "@/components/empty-state-preview";
+import { GeoSetupButton } from "@/components/geo/geo-setup-button";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import type { GeoSetupEmptyProps } from "@/types/geo";
 
-export function GeoSetupEmpty({ settingsHref, page }: GeoSetupEmptyProps) {
+export function GeoSetupEmpty({ organizationId, page }: GeoSetupEmptyProps) {
   const viewedRef = useRef(false);
 
   useEffect(() => {
@@ -38,14 +37,13 @@ export function GeoSetupEmpty({ settingsHref, page }: GeoSetupEmptyProps) {
           Add your brand name and the engines to track, then run a scan to see
           how AI answers talk about you.
         </p>
-        <Button
+        <GeoSetupButton
           className="mt-6"
-          nativeButton={false}
-          render={<Link href={settingsHref} />}
+          organizationId={organizationId}
           size="sm"
         >
           Set up tracking
-        </Button>
+        </GeoSetupButton>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/geo/writer/page-gate.tsx
+++ b/apps/dashboard/src/components/geo/writer/page-gate.tsx
@@ -1,21 +1,15 @@
 "use client";
 
-import Link from "next/link";
-
-import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
+import { GeoSetupButton } from "@/components/geo/geo-setup-button";
 import { PageContainer } from "@/components/layout/container";
-import { useGeoProjectScope } from "@/components/providers/geo-project-provider";
 import type { GeoWriterNeedsSetupProps } from "@/types/components/geo-writer";
-import { withGeoProject } from "@/utils/geo-paths";
 
 export function GeoWriterNeedsSetup({
-  organizationSlug,
+  organizationId,
   title,
   description,
 }: GeoWriterNeedsSetupProps) {
-  const { projectId } = useGeoProjectScope();
-
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
@@ -24,18 +18,7 @@ export function GeoWriterNeedsSetup({
           <p className="text-muted-foreground">{description}</p>
         </header>
         <EmptyState
-          action={
-            <Button
-              nativeButton={false}
-              render={
-                <Link
-                  href={withGeoProject(`/${organizationSlug}/geo`, projectId)}
-                />
-              }
-            >
-              Set up GEO tracking
-            </Button>
-          }
+          action={<GeoSetupButton organizationId={organizationId} />}
           description="The writer uses your tracked prompts, competitors, and sitemap. Set up GEO tracking first."
           title="Set up GEO tracking"
         />

--- a/apps/dashboard/src/types/components/geo-writer.ts
+++ b/apps/dashboard/src/types/components/geo-writer.ts
@@ -17,7 +17,7 @@ export interface BriefHistoryProps {
 }
 
 export interface GeoWriterNeedsSetupProps {
-  organizationSlug: string;
+  organizationId: string;
   title: string;
   description: string;
 }

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -41,8 +41,9 @@ import type {
   ShareOfVoiceRow,
 } from "@notra/geo-core/types/geo";
 import type { GeoRequestPayload } from "@usenotra/geo";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
+import type { Button } from "@/components/button";
 import type { TableColumn } from "@/components/motion/table";
 import type { GeoPromptDetailSurface } from "@/types/analytics/geo-events";
 import type { ChartConfig, ChartSeriesColors } from "@/types/charts";
@@ -354,8 +355,15 @@ export interface TrafficEmptyProps {
 }
 
 export interface GeoSetupEmptyProps {
-  settingsHref: string;
+  organizationId: string;
   page?: string;
+}
+
+export interface GeoSetupButtonProps {
+  organizationId: string;
+  children?: ReactNode;
+  className?: string;
+  size?: ComponentProps<typeof Button>["size"];
 }
 
 export interface GeoScanScheduleProps {


### PR DESCRIPTION
The "Set up GEO tracking" buttons on GEO pages without a project used to link to the overview, which in turn linked to the settings page. That was a confusing detour for a first-time setup.

They now open the existing "New project" dialog (the same one the sidebar project switcher uses) directly on the page. After creating the project, the `project` query param is set so the page switches from the empty state to the real view.
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the GEO setup empty states to use a shared `GeoSetupButton` that opens the project creation dialog directly, instead of linking to the settings page. This drops the `projectId` dependency from the setup components.

**Refactors**
- `GeoSetupEmpty` and `GeoWriterNeedsSetup` now accept `organizationId` instead of `settingsHref`/`organizationSlug`.
- All GEO page empty states now use the shared `GeoSetupButton`.

<sup>Written for commit aa618d0cb3e9b0ebb5c3c8865237f9e7dc09ede8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

