### PR TITLE
feat(dashboard): use geo project scope in traffic page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/traffic/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/traffic/page-client.tsx
@@ -16,7 +16,10 @@ import { TrafficEmpty } from "@/components/geo/traffic-empty";
 import { TrafficPagesCard } from "@/components/geo/traffic-pages-card";
 import { InstrumentReveal } from "@/components/instrument/instrument-reveal";
 import { PageContainer } from "@/components/layout/container";
-import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
+import {
+  GeoProjectProvider,
+  useGeoProjectScope,
+} from "@/components/providers/geo-project-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   EMPTY_STATE_TABLE_COLUMNS,
@@ -32,6 +35,7 @@ import {
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { useGeoRange } from "@/lib/hooks/use-geo-range";
 import type { GeoPageClientProps } from "@/types/geo";
+import { withGeoProject } from "@/utils/geo-paths";
 
 import { GeoTrafficSkeleton } from "./skeleton";
 
@@ -46,6 +50,7 @@ export default function PageClient({ organizationSlug }: GeoPageClientProps) {
 }
 
 function TrafficPageContent({ organizationSlug }: GeoPageClientProps) {
+  const { projectId } = useGeoProjectScope();
   const { getOrganization, activeOrganization } = useOrganizationsContext();
   const orgFromList = getOrganization(organizationSlug);
   const organization =


### PR DESCRIPTION
Use geo project scope in traffic page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the traffic page to use the active geo project scope instead of the organization-level scope, so traffic data and navigation reflect the selected project.

- Pulls `projectId` from `useGeoProjectScope` and uses `withGeoProject` for project-scoped links.

<sup>Written for commit 8a57e7d9b16911f0f1b46064490e2ed794f96481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

