### PR TITLE
feat(automation): add custom instructions to schedules

### DIFF
--- a/apps/api/src/routes/geo-visibility.ts
+++ b/apps/api/src/routes/geo-visibility.ts
@@ -224,6 +224,7 @@ geoVisibilityRoutes.openapi(promptResultsRoute, async (c) => {
     mentioned: result.mentioned,
     position: result.position,
     sentiment: result.sentiment,
+    competitors: result.competitors,
     excerpt: result.excerpt,
     searchQueries: result.searchQueries,
     sources: result.sources,

--- a/apps/api/src/schemas/schedules.ts
+++ b/apps/api/src/schemas/schedules.ts
@@ -14,6 +14,7 @@ import { resourceIdSchema } from "./ids";
 
 const CRON_FREQUENCIES = ["daily", "weekly", "monthly", "custom"] as const;
 const MAX_SCHEDULE_NAME_LENGTH = 120;
+const MAX_SCHEDULE_INSTRUCTIONS_LENGTH = 2000;
 
 export const scheduleParamsSchema = z.object({
   scheduleId: resourceIdSchema("scheduleId").openapi({
@@ -139,6 +140,18 @@ export const scheduleOutputConfigSchema = z
         "Brand identity ID to write in. Defaults to the organization's default brand identity.",
       example: "51c2f3aa-efdd-4e28-8e69-23fa2dfd3561",
     }),
+    instructions: z
+      .string()
+      .trim()
+      .min(1)
+      .max(MAX_SCHEDULE_INSTRUCTIONS_LENGTH)
+      .optional()
+      .openapi({
+        description:
+          "Free-text brief for this schedule, passed to the writer on every run on top of the brand's custom instructions. Use it to steer the angle of the content, for example tutorial-style blog posts.",
+        example:
+          "Write a tutorial-style post that walks through one feature shipped in this window, with code samples.",
+      }),
   })
   .optional();
 

--- a/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
+++ b/apps/dashboard/src/components/automation/schedules/create-schedule-dialog.tsx
@@ -41,6 +41,7 @@ import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { Github } from "@notra/ui/components/ui/svgs/github";
 import { Linear } from "@notra/ui/components/ui/svgs/linear";
 import { Switch } from "@notra/ui/components/ui/switch";
+import { Textarea } from "@notra/ui/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -68,6 +69,7 @@ import {
 import {
   LOOKBACK_WINDOWS,
   type LookbackWindow,
+  MAX_SCHEDULE_INSTRUCTIONS_LENGTH,
   MAX_SCHEDULE_NAME_LENGTH,
 } from "@/schemas/integrations";
 import type {
@@ -123,6 +125,7 @@ export function CreateScheduleDialog({
           (id) => !id.startsWith("linear:")
         );
 
+        const instructions = value.instructions.trim();
         const schedulePayload = {
           organizationId,
           name: value.name.trim(),
@@ -132,6 +135,7 @@ export function CreateScheduleDialog({
           outputType: value.outputType,
           outputConfig: {
             ...(value.brandVoiceId ? { brandVoiceId: value.brandVoiceId } : {}),
+            ...(instructions ? { instructions } : {}),
           },
           enabled: isEditMode ? editTrigger.enabled : true,
           autoPublish: supportsAutoPublish(value.outputType)
@@ -392,6 +396,48 @@ export function CreateScheduleDialog({
                             selected={field.state.value === type}
                           />
                         ))}
+                      </div>
+                    )}
+                  </form.Field>
+                </section>
+
+                <section className="space-y-3">
+                  <div className="space-y-1">
+                    <h3 className="flex items-center gap-2 text-base font-semibold">
+                      Instructions
+                      <span className="text-muted-foreground rounded-full border px-2 py-0.5 text-[11px] font-medium">
+                        Optional
+                      </span>
+                    </h3>
+                    <p className="text-muted-foreground text-sm">
+                      Tell us what this schedule should write about. Brand voice
+                      still applies.
+                    </p>
+                  </div>
+                  <form.Field name="instructions">
+                    {(field) => (
+                      <div className="space-y-2">
+                        <Textarea
+                          aria-label="Instructions"
+                          className="min-h-24"
+                          id={field.name}
+                          maxLength={MAX_SCHEDULE_INSTRUCTIONS_LENGTH}
+                          onBlur={field.handleBlur}
+                          onChange={(event) => {
+                            field.handleChange(event.target.value);
+                          }}
+                          placeholder="e.g. Write a tutorial-style post that walks through one feature shipped in this window, with code samples."
+                          value={field.state.value}
+                        />
+                        <div className="text-muted-foreground flex items-center justify-between text-xs">
+                          <span>
+                            Passed to the writer as extra guidance on every run.
+                          </span>
+                          <span className="tabular-nums">
+                            {field.state.value.length} /{" "}
+                            {MAX_SCHEDULE_INSTRUCTIONS_LENGTH}
+                          </span>
+                        </div>
                       </div>
                     )}
                   </form.Field>

--- a/apps/dashboard/src/lib/orpc/routers/automation.ts
+++ b/apps/dashboard/src/lib/orpc/routers/automation.ts
@@ -546,6 +546,7 @@ export const automationRouter = {
           targets: normalized.targets,
           outputType: input.outputType,
           lookbackWindow: input.lookbackWindow,
+          instructions: input.outputConfig?.instructions,
         });
 
         const existing = await db.query.contentTriggers.findFirst({
@@ -693,6 +694,7 @@ export const automationRouter = {
           targets: normalized.targets,
           outputType: input.outputType,
           lookbackWindow: input.lookbackWindow,
+          instructions: input.outputConfig?.instructions,
         });
 
         const duplicate = await db.query.contentTriggers.findFirst({

--- a/apps/dashboard/src/lib/workflows/schedule/instructions.ts
+++ b/apps/dashboard/src/lib/workflows/schedule/instructions.ts
@@ -1,0 +1,13 @@
+/**
+ * Wraps the per-schedule brief so the writer can tell it apart from the
+ * organization-wide brand instructions it is concatenated with.
+ */
+export function buildScheduleInstructions(
+  instructions: string | null | undefined
+): string | null {
+  const trimmed = instructions?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return `<schedule-focus>\nThe person who set up this schedule asked for the following. Treat it as the brief for this specific run and follow it over any generic defaults, while keeping the brand voice above.\n${trimmed}\n</schedule-focus>`;
+}

--- a/apps/dashboard/src/schemas/automation/schedule-form.ts
+++ b/apps/dashboard/src/schemas/automation/schedule-form.ts
@@ -7,6 +7,7 @@ import {
   cronAnchorDateSchema,
   cronIntervalDaysSchema,
   LOOKBACK_WINDOWS,
+  MAX_SCHEDULE_INSTRUCTIONS_LENGTH,
   MAX_SCHEDULE_NAME_LENGTH,
   SUPPORTED_AUTOMATION_OUTPUT_TYPES,
 } from "@/schemas/integrations";
@@ -35,6 +36,13 @@ export const scheduleFormSchema = z.object({
     .min(1, "Give this schedule a name")
     .max(MAX_SCHEDULE_NAME_LENGTH),
   outputType: z.enum(SUPPORTED_AUTOMATION_OUTPUT_TYPES),
+  instructions: z
+    .string()
+    .trim()
+    .max(
+      MAX_SCHEDULE_INSTRUCTIONS_LENGTH,
+      `Keep instructions under ${MAX_SCHEDULE_INSTRUCTIONS_LENGTH} characters`
+    ),
   schedule: scheduleCronSchema,
   repositoryIds: z
     .array(z.string())

--- a/apps/dashboard/src/schemas/integrations.ts
+++ b/apps/dashboard/src/schemas/integrations.ts
@@ -315,10 +315,18 @@ export const triggerTargetsSchema = z.object({
   repositoryIds: z.array(z.string()).min(1),
 });
 
+export const MAX_SCHEDULE_INSTRUCTIONS_LENGTH = 2000;
+
 export const triggerOutputConfigSchema = z
   .object({
     publishDestination: z.enum(["webflow", "framer", "custom"]).optional(),
     brandVoiceId: z.string().optional(),
+    instructions: z
+      .string()
+      .trim()
+      .min(1)
+      .max(MAX_SCHEDULE_INSTRUCTIONS_LENGTH)
+      .optional(),
   })
   .optional();
 

--- a/apps/dashboard/src/types/triggers/triggers.ts
+++ b/apps/dashboard/src/types/triggers/triggers.ts
@@ -31,6 +31,7 @@ export interface TriggerSourceConfig {
 export interface TriggerOutputConfig {
   publishDestination?: "webflow" | "framer" | "custom";
   brandVoiceId?: string;
+  instructions?: string;
 }
 
 export interface Trigger {

--- a/apps/dashboard/src/utils/schedule-form.ts
+++ b/apps/dashboard/src/utils/schedule-form.ts
@@ -52,6 +52,7 @@ export function getDefaultScheduleValues(
     return {
       name: editTrigger.name ?? "",
       outputType: supportedType,
+      instructions: editTrigger.outputConfig?.instructions ?? "",
       schedule: editTrigger.sourceConfig.cron ?? DEFAULT_SCHEDULE,
       repositoryIds: editTrigger.targets.repositoryIds,
       lookbackWindow: editTrigger.lookbackWindow ?? "last_7_days",
@@ -66,6 +67,7 @@ export function getDefaultScheduleValues(
   return {
     name: "",
     outputType: "changelog",
+    instructions: "",
     schedule: DEFAULT_SCHEDULE,
     repositoryIds: [],
     lookbackWindow: "last_7_days",

--- a/apps/dashboard/src/workflows/steps/schedule-generation-step.ts
+++ b/apps/dashboard/src/workflows/steps/schedule-generation-step.ts
@@ -7,7 +7,9 @@ import { createRequestLogger } from "evlog";
 
 import { buildDataPointRestrictionInstructions } from "@/lib/workflows/on-demand/helpers";
 import { generateScheduledContent } from "@/lib/workflows/schedule/handlers";
+import { buildScheduleInstructions } from "@/lib/workflows/schedule/instructions";
 import type { ContentGenerationResult } from "@/lib/workflows/schedule/types";
+import { parseTriggerOutputConfig } from "@/lib/workflows/shared/parsing";
 import type { ScheduleGenerationStepInput } from "@/types/workflows/schedule-generation";
 import { formatTodayContext, resolveLookbackRange } from "@/utils/lookback";
 
@@ -51,8 +53,12 @@ export async function runScheduledGeneration(
 
   const restrictionInstructions =
     buildDataPointRestrictionInstructions(dataPointSettings);
+  const scheduleInstructions = buildScheduleInstructions(
+    parseTriggerOutputConfig(trigger.outputConfig)?.instructions
+  );
   const customInstructions = [
     brand?.customInstructions?.trim() ?? "",
+    scheduleInstructions ?? "",
     restrictionInstructions ?? "",
   ]
     .filter((value) => value.length > 0)

--- a/packages/ai/src/types/trigger-hash.ts
+++ b/packages/ai/src/types/trigger-hash.ts
@@ -19,4 +19,6 @@ export interface TriggerHashInput extends TriggerConfigInput {
   sourceType: string;
   outputType: string;
   lookbackWindow?: string;
+  /** Per-schedule brief. Two otherwise identical schedules with different briefs are distinct. */
+  instructions?: string;
 }

--- a/packages/ai/src/utils/trigger-hash.ts
+++ b/packages/ai/src/utils/trigger-hash.ts
@@ -34,14 +34,18 @@ export function hashTrigger({
   targets,
   outputType,
   lookbackWindow,
+  instructions,
 }: TriggerHashInput) {
   const normalized = normalizeTriggerConfig({ sourceConfig, targets });
+  const trimmedInstructions = instructions?.trim();
   const payload = JSON.stringify({
     sourceType,
     sourceConfig: normalized.sourceConfig,
     targets: normalized.targets,
     outputType,
     lookbackWindow,
+    // Omitted when empty so hashes of existing triggers stay unchanged.
+    ...(trimmedInstructions ? { instructions: trimmedInstructions } : {}),
   });
 
   return crypto.createHash("sha256").update(payload).digest("hex");


### PR DESCRIPTION
Schedules can now carry an optional free-text brief that is passed to the writer on every run. Until now the only way to steer a scheduled blog post was the organization-wide brand instructions, so every blog schedule produced the same changelog-style article. With a per-schedule brief you can run "every 3 days: tutorial-style post" next to "weekly: release recap" from the same repos.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional per-schedule instructions so each automation run can carry a brief on top of the org-wide brand voice, and includes competitors in geo-visibility prompt results.

- New `instructions` field in the schedule form, API schema, and trigger output config, capped at 2000 characters.
- Instructions are wrapped with a `<schedule-focus>` tag and passed to the writer on every run alongside brand custom instructions.
- Trigger hash now includes instructions, so two otherwise identical schedules with different briefs are treated as distinct.
- Empty instructions are left out of the hash, so hashes of existing triggers stay unchanged.
- Geo-visibility prompt results now return the `competitors` field that was previously missing.

<sup>Written for commit 1720efa4c07639aebafecd7eebbd91e58157bde1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



