### PR TITLE
feat(geo): add prompt engine dropdown

### DIFF
--- a/apps/dashboard/src/components/geo/engine-family-sheet.tsx
+++ b/apps/dashboard/src/components/geo/engine-family-sheet.tsx
@@ -24,7 +24,10 @@ import type {
 } from "@notra/geo-core/types/geo";
 import { formatAiTrafficTimestamp } from "@notra/geo-core/utils/ai-traffic";
 import { todayIsoDate } from "@notra/geo-core/utils/day-label";
-import { engineFamilyLabel } from "@notra/geo-core/utils/geo-engine-family";
+import {
+  engineFamilyLabel,
+  engineFamilyOf,
+} from "@notra/geo-core/utils/geo-engine-family";
 import { GeoBar } from "@notra/ui/components/geo/geo-bar";
 import { TruncateWithTooltip } from "@notra/ui/components/shared/truncate-with-tooltip";
 import {
@@ -525,6 +528,10 @@ function EngineFamilySheetSession({
   const selectedRow = selectedPromptId
     ? promptTableRowForId(selectedPromptId, promptResults)
     : null;
+  const selectedEngine =
+    selectedRow?.results.find(
+      (result) => engineFamilyOf(result.engine) === family.family
+    )?.engine ?? null;
   const promptHits = engineFamilyPromptHits(family.family, promptResults);
   const brandScope: EngineFamilyBrandScope = {
     companyName,
@@ -594,6 +601,7 @@ function EngineFamilySheetSession({
             setSelectedPromptId(null);
           }
         }}
+        initialEngine={selectedEngine}
         open={selectedRow !== null}
         organizationId={organizationId || undefined}
         row={selectedRow}

--- a/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
@@ -102,10 +102,16 @@ function PromptAnswerPage({
   organizationId,
   isScanning = false,
   surface,
+  initialEngine,
 }: PromptAnswerPageProps) {
   const results = row.results;
   const engines = results.map((result) => result.engine);
-  const [engine, setEngine] = useState(engines[0] ?? "");
+  const [engine, setEngine] = useState(
+    () =>
+      engines.find((candidate) => candidate === initialEngine) ??
+      engines[0] ??
+      ""
+  );
   const [view, setView] = useState<GeoPromptReceiptView>("analysis");
   const [selectedCheck, setSelectedCheck] =
     useState<GeoPromptHistoryCheck | null>(null);
@@ -289,6 +295,7 @@ export function PromptDetailDialog({
   isScanning = false,
   surface,
   organizationId,
+  initialEngine,
 }: PromptDetailDialogProps) {
   const { activeOrganization } = useOrganizationsContext();
   const resolvedOrganizationId = organizationId ?? activeOrganization?.id ?? "";
@@ -299,6 +306,7 @@ export function PromptDetailDialog({
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
       <PromptAnswerPage
+        initialEngine={initialEngine}
         isScanning={isScanning}
         key={row.id}
         organizationId={resolvedOrganizationId}

--- a/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
+++ b/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
@@ -14,7 +14,13 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m,
+  useReducedMotion,
+} from "motion/react";
 
 import { Button } from "@/components/button";
 import { EngineIcon } from "@/components/geo/engine-icon";
@@ -63,27 +69,29 @@ export function PromptEngineSwitcher({
     answerMode === null && engineAnswerMode(engine) !== null;
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-2">
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button
-              aria-label={`Engine: ${engineLabel(active.engine, answerMode)}`}
-              className="max-w-full min-w-0"
-              size="sm"
-              variant="outline"
-            />
-          }
-        >
-          <EngineIcon className="size-3.5 shrink-0" engine={active.engine} />
-          <span className="truncate">
-            {engineLabel(active.engine, answerMode)}
-          </span>
-          {showsSearchIcon(active.engine) ? <SearchModeIcon /> : null}
-          {results.length > 1 ? (
-            <span className="text-muted-foreground/70 inline-flex items-center text-xs tabular-nums">
+    <LazyMotion features={domAnimation}>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                aria-label={`Engine: ${engineLabel(active.engine, answerMode)}`}
+                className="max-w-full min-w-0"
+                size="sm"
+                variant="outline"
+              />
+            }
+          >
+            <EngineIcon className="size-3.5 shrink-0" engine={active.engine} />
+            <span className="truncate">
+              {engineLabel(active.engine, answerMode)}
+            </span>
+            {showsSearchIcon(active.engine) ? <SearchModeIcon /> : null}
+            <span
+              className={`text-muted-foreground/70 items-center text-xs tabular-nums ${results.length > 1 ? "inline-flex" : "hidden"}`}
+            >
               <AnimatePresence initial={false} mode="popLayout">
-                <motion.span
+                <m.span
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -4 }}
                   initial={{ opacity: 0, y: 4 }}
@@ -91,72 +99,72 @@ export function PromptEngineSwitcher({
                   transition={counterTransition}
                 >
                   {activeIndex + 1}
-                </motion.span>
+                </m.span>
               </AnimatePresence>
               <span className="mx-0.5 opacity-60">/</span>
               <span>{results.length}</span>
             </span>
-          ) : null}
-          <HugeiconsIcon
-            aria-hidden="true"
-            className="text-muted-foreground size-3.5 shrink-0"
-            icon={ArrowDown01Icon}
-            strokeWidth={2}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="start"
-          className="max-h-[min(60vh,24rem)] w-64 overflow-y-auto"
-        >
-          <DropdownMenuRadioGroup
-            onValueChange={(next) => {
-              const nextIndex = engines.indexOf(next);
-              onChange(next, nextIndex >= activeIndex ? 1 : -1);
-            }}
-            value={active.engine}
+            <HugeiconsIcon
+              aria-hidden="true"
+              className="text-muted-foreground size-3.5 shrink-0"
+              icon={ArrowDown01Icon}
+              strokeWidth={2}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="max-h-[min(60vh,24rem)] w-64 overflow-y-auto"
           >
-            {results.map((result) => (
-              <DropdownMenuRadioItem
-                closeOnClick
-                key={result.engine}
-                value={result.engine}
-              >
-                <EngineIcon className="size-3.5" engine={result.engine} />
-                <span className="truncate">
-                  {engineLabel(result.engine, answerMode)}
-                </span>
-                {showsSearchIcon(result.engine) ? <SearchModeIcon /> : null}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      {results.length > 1 ? (
-        <div className="flex shrink-0 items-center gap-0.5">
-          <Button
-            aria-label="Previous engine"
-            onClick={() =>
-              onChange(adjacentPromptEngine(engines, active.engine, -1), -1)
-            }
-            size="icon-sm"
-            type="button"
-            variant="ghost"
-          >
-            <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={2} />
-          </Button>
-          <Button
-            aria-label="Next engine"
-            onClick={() =>
-              onChange(adjacentPromptEngine(engines, active.engine, 1), 1)
-            }
-            size="icon-sm"
-            type="button"
-            variant="ghost"
-          >
-            <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />
-          </Button>
-        </div>
-      ) : null}
-    </div>
+            <DropdownMenuRadioGroup
+              onValueChange={(next) => {
+                const nextIndex = engines.indexOf(next);
+                onChange(next, nextIndex >= activeIndex ? 1 : -1);
+              }}
+              value={active.engine}
+            >
+              {results.map((result) => (
+                <DropdownMenuRadioItem
+                  closeOnClick
+                  key={result.engine}
+                  value={result.engine}
+                >
+                  <EngineIcon className="size-3.5" engine={result.engine} />
+                  <span className="truncate">
+                    {engineLabel(result.engine, answerMode)}
+                  </span>
+                  {showsSearchIcon(result.engine) ? <SearchModeIcon /> : null}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {results.length > 1 ? (
+          <div className="flex shrink-0 items-center gap-0.5">
+            <Button
+              aria-label="Previous engine"
+              onClick={() =>
+                onChange(adjacentPromptEngine(engines, active.engine, -1), -1)
+              }
+              size="icon-sm"
+              type="button"
+              variant="ghost"
+            >
+              <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={2} />
+            </Button>
+            <Button
+              aria-label="Next engine"
+              onClick={() =>
+                onChange(adjacentPromptEngine(engines, active.engine, 1), 1)
+              }
+              size="icon-sm"
+              type="button"
+              variant="ghost"
+            >
+              <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </LazyMotion>
   );
 }

--- a/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
+++ b/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
@@ -7,7 +7,6 @@ import {
   GlobalIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { GEO_SEARCH_LABEL } from "@notra/geo-core/constants/geo";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -42,7 +41,7 @@ function engineLabel(engine: string, answerMode: string | null): string {
 function SearchModeIcon() {
   return (
     <HugeiconsIcon
-      aria-label={GEO_SEARCH_LABEL}
+      aria-hidden="true"
       className="text-muted-foreground size-3 shrink-0"
       icon={GlobalIcon}
       strokeWidth={2}

--- a/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
+++ b/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  ArrowDown01Icon,
   ArrowLeft01Icon,
   ArrowRight01Icon,
   GlobalIcon,
@@ -8,16 +9,16 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { GEO_SEARCH_LABEL } from "@notra/geo-core/constants/geo";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@notra/ui/components/ui/tooltip";
-import { LayoutGroup, motion, useReducedMotion } from "motion/react";
-import { useId } from "react";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@notra/ui/components/ui/dropdown-menu";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { Button } from "@/components/button";
 import { EngineIcon } from "@/components/geo/engine-icon";
-import { cn } from "@/lib/utils";
 import type { PromptEngineSwitcherProps } from "@/types/geo";
 import {
   engineAnswerMode,
@@ -27,11 +28,26 @@ import {
 } from "@/utils/geo-charts";
 import { adjacentPromptEngine } from "@/utils/geo-prompt-engines";
 
-const PILL_TRANSITION = { type: "spring", bounce: 0, duration: 0.3 } as const;
+const COUNTER_TRANSITION = {
+  type: "spring",
+  bounce: 0,
+  duration: 0.25,
+} as const;
 const INSTANT = { duration: 0 } as const;
 
 function engineLabel(engine: string, answerMode: string | null): string {
   return answerMode ? formatEngineFamily(engine) : formatEngineWithMode(engine);
+}
+
+function SearchModeIcon() {
+  return (
+    <HugeiconsIcon
+      aria-label={GEO_SEARCH_LABEL}
+      className="text-muted-foreground size-3 shrink-0"
+      icon={GlobalIcon}
+      strokeWidth={2}
+    />
+  );
 }
 
 export function PromptEngineSwitcher({
@@ -41,82 +57,83 @@ export function PromptEngineSwitcher({
 }: PromptEngineSwitcherProps) {
   const engines = results.map((result) => result.engine);
   const answerMode = sharedEngineAnswerMode(engines);
-  const layoutId = useId();
-  const reduceMotion = useReducedMotion();
-  const pillTransition = reduceMotion ? INSTANT : PILL_TRANSITION;
   const activeIndex = engines.indexOf(active.engine);
+  const reduceMotion = useReducedMotion();
+  const counterTransition = reduceMotion ? INSTANT : COUNTER_TRANSITION;
+  const showsSearchIcon = (engine: string) =>
+    answerMode === null && engineAnswerMode(engine) !== null;
 
   return (
-    <div className="flex min-w-0 flex-1 items-start gap-3">
-      <LayoutGroup id={layoutId}>
-        <div
-          aria-label="Engines"
-          className="flex min-w-0 flex-1 flex-wrap items-center gap-1 p-0.5"
-          role="tablist"
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={`Engine: ${engineLabel(active.engine, answerMode)}`}
+              className="max-w-full min-w-0"
+              size="sm"
+              variant="outline"
+            />
+          }
         >
-          {results.map((result, index) => {
-            const selected = result.engine === active.engine;
-            const label = engineLabel(result.engine, answerMode);
-            const family = formatEngineFamily(result.engine);
-            const showSearchIcon =
-              answerMode === null && engineAnswerMode(result.engine) !== null;
-            return (
-              <button
-                aria-label={label}
-                aria-selected={selected}
-                className={cn(
-                  "relative inline-flex h-8 items-center gap-1.5 rounded-full px-2.5 text-sm",
-                  "duration-fast transition-[color,transform] ease-out",
-                  "focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none",
-                  "active:scale-[0.96]",
-                  selected
-                    ? "text-foreground font-medium"
-                    : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-                )}
+          <EngineIcon className="size-3.5 shrink-0" engine={active.engine} />
+          <span className="truncate">
+            {engineLabel(active.engine, answerMode)}
+          </span>
+          {showsSearchIcon(active.engine) ? <SearchModeIcon /> : null}
+          {results.length > 1 ? (
+            <span className="text-muted-foreground/70 inline-flex items-center text-xs tabular-nums">
+              <AnimatePresence initial={false} mode="popLayout">
+                <motion.span
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -4 }}
+                  initial={{ opacity: 0, y: 4 }}
+                  key={activeIndex}
+                  transition={counterTransition}
+                >
+                  {activeIndex + 1}
+                </motion.span>
+              </AnimatePresence>
+              <span className="mx-0.5 opacity-60">/</span>
+              <span>{results.length}</span>
+            </span>
+          ) : null}
+          <HugeiconsIcon
+            aria-hidden="true"
+            className="text-muted-foreground size-3.5 shrink-0"
+            icon={ArrowDown01Icon}
+            strokeWidth={2}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="max-h-[min(60vh,24rem)] w-64 overflow-y-auto"
+        >
+          <DropdownMenuRadioGroup
+            onValueChange={(next) => {
+              const nextIndex = engines.indexOf(next);
+              onChange(next, nextIndex >= activeIndex ? 1 : -1);
+            }}
+            value={active.engine}
+          >
+            {results.map((result) => (
+              <DropdownMenuRadioItem
+                closeOnClick
                 key={result.engine}
-                onClick={() =>
-                  onChange(result.engine, index >= activeIndex ? 1 : -1)
-                }
-                role="tab"
-                type="button"
+                value={result.engine}
               >
-                {selected ? (
-                  <motion.span
-                    className="bg-muted absolute inset-0 rounded-full"
-                    layoutId="geo-engine-pill"
-                    transition={pillTransition}
-                  />
-                ) : null}
-                <span className="relative z-10 inline-flex items-center gap-1.5">
-                  <EngineIcon className="size-3.5" engine={result.engine} />
-                  <span className="inline-flex items-center gap-1">
-                    <span>{family}</span>
-                    {showSearchIcon ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <span className="inline-flex shrink-0 cursor-default" />
-                          }
-                        >
-                          <HugeiconsIcon
-                            aria-hidden="true"
-                            className="size-3 shrink-0"
-                            icon={GlobalIcon}
-                            strokeWidth={2}
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent>{GEO_SEARCH_LABEL}</TooltipContent>
-                      </Tooltip>
-                    ) : null}
-                  </span>
+                <EngineIcon className="size-3.5" engine={result.engine} />
+                <span className="truncate">
+                  {engineLabel(result.engine, answerMode)}
                 </span>
-              </button>
-            );
-          })}
-        </div>
-      </LayoutGroup>
+                {showsSearchIcon(result.engine) ? <SearchModeIcon /> : null}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
       {results.length > 1 ? (
-        <div className="flex shrink-0 items-center gap-0.5 pt-0.5">
+        <div className="flex shrink-0 items-center gap-0.5">
           <Button
             aria-label="Previous engine"
             onClick={() =>

--- a/apps/dashboard/src/components/geo/what-changed-card.tsx
+++ b/apps/dashboard/src/components/geo/what-changed-card.tsx
@@ -380,9 +380,12 @@ export function WhatChangedCard({
   const { projectId } = useGeoProjectScope();
   const router = useRouter();
   const { data, isPending } = useGeoChanges(organizationId);
-  const [detailId, setDetailId] = useState<string | null>(null);
-  const detailRow = detailId
-    ? promptTableRowForId(detailId, promptResults)
+  const [detail, setDetail] = useState<{
+    promptId: string;
+    engine: string;
+  } | null>(null);
+  const detailRow = detail
+    ? promptTableRowForId(detail.promptId, promptResults)
     : null;
 
   const events = data?.events ?? [];
@@ -395,7 +398,7 @@ export function WhatChangedCard({
 
   function openEvent(event: GeoChangeEvent) {
     if (promptTableRowForId(event.promptId, promptResults)) {
-      setDetailId(event.promptId);
+      setDetail({ promptId: event.promptId, engine: event.engine });
       return;
     }
     router.push(
@@ -471,10 +474,11 @@ export function WhatChangedCard({
         {body}
       </InstrumentSection>
       <PromptDetailDialog
+        initialEngine={detail?.engine}
         isScanning={isScanning}
         onOpenChange={(open) => {
           if (!open) {
-            setDetailId(null);
+            setDetail(null);
           }
         }}
         open={detailRow !== null}

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -1013,12 +1013,15 @@ export interface PromptDetailDialogProps {
   isScanning?: boolean;
   surface?: GeoPromptDetailSurface;
   organizationId?: string;
+  /** Engine to show first; falls back to the first result when absent. */
+  initialEngine?: string | null;
 }
 
 export interface PromptAnswerPageProps {
   row: GeoPromptTableRow;
   organizationId: string;
   isScanning?: boolean;
+  initialEngine?: string | null;
   surface?: GeoPromptDetailSurface;
 }
 


### PR DESCRIPTION
Replace prompt engine tabs with a compact dropdown selector.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the prompt engine tabs with a compact dropdown selector, so the switcher takes less space and scales better when many engines are present. The dropdown keeps the search icon indicator, adds a position counter (e.g., 1/3), and now uses optimized motion that respects reduced-motion preferences.

Opening a prompt detail dialog now starts on the engine it was opened from (engine family sheet or what-changed card); when there's no context, it falls back to the first result.

<sup>Written for commit f823cf12d1c17cba236a59b9bcc97d476ad9e624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

