### PR TITLE
fix(geo): allow dismissing upgrade paywall

### DIFF
--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -6,6 +6,7 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { SIDEBAR_MODE_HOME_LINKS } from "@/constants/nav";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { useSidebarMode } from "@/lib/hooks/use-sidebar-mode";
+import { sidebarRouteFromPathname } from "@/utils/nav";
 
 import { NavGeo } from "./nav-geo";
 import { NavModePrimaryAction } from "./nav-mode-primary-action";
@@ -17,8 +18,8 @@ export function NavMain() {
   const { activeOrganization } = useOrganizationsContext();
   const pathname = usePathname();
   const [projectParam] = useGeoProjectQueryState();
-  const route = pathname.split("/").filter(Boolean).slice(1).join("/");
-  const { mode, setMode, pendingMode } = useSidebarMode(route || undefined);
+  const route = sidebarRouteFromPathname(pathname);
+  const { mode, setMode, pendingMode } = useSidebarMode(route);
 
   if (!activeOrganization?.slug) {
     return null;

--- a/apps/dashboard/src/components/geo/geo-upgrade-gate.tsx
+++ b/apps/dashboard/src/components/geo/geo-upgrade-gate.tsx
@@ -17,7 +17,9 @@ import { PAYWALL_KINDS } from "@/constants/analytics-events";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import { toAnalyticsRoute } from "@/lib/analytics/route";
 import { useHasGeoFeature } from "@/lib/hooks/use-plan";
+import { pickSidebarMode } from "@/lib/hooks/use-sidebar-mode";
 import type { GeoUpgradeGateProps } from "@/types/components/geo";
+import { sidebarRouteFromPathname } from "@/utils/nav";
 
 export function GeoUpgradeGate({ slug, children }: GeoUpgradeGateProps) {
   const router = useRouter();
@@ -43,6 +45,14 @@ export function GeoUpgradeGate({ slug, children }: GeoUpgradeGateProps) {
 
   if (!isLocked) {
     return children;
+  }
+
+  function handleDismiss(): void {
+    // The org root restores a stored "geo" mode by redirecting straight back
+    // here, which would reopen this paywall in a loop. Switch the sidebar to
+    // Studio first so the redirect lets the user land on the Studio home.
+    pickSidebarMode("studio", sidebarRouteFromPathname(pathname));
+    router.push(`/${slug}`);
   }
 
   return (
@@ -72,7 +82,7 @@ export function GeoUpgradeGate({ slug, children }: GeoUpgradeGateProps) {
       <GeoUpgradeDialog
         onOpenChange={(open) => {
           if (!open) {
-            router.push(`/${slug}`);
+            handleDismiss();
           }
         }}
         open

--- a/apps/dashboard/src/lib/hooks/use-sidebar-mode.ts
+++ b/apps/dashboard/src/lib/hooks/use-sidebar-mode.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 
 import { localStorageKeys } from "@/constants/storage";
 import type {
@@ -13,6 +13,10 @@ import { isSidebarMode, resolveSidebarMode } from "@/utils/nav";
 
 const SIDEBAR_MODE_EVENT = "notra:sidebar-mode-change";
 
+// Module-level so a pick made outside the sidebar (e.g. dismissing the GEO
+// paywall) reaches the nav's mode resolution before the route changes.
+let pendingMode: PendingSidebarMode | null = null;
+
 function readStoredMode(): SidebarMode | null {
   try {
     const value = window.localStorage.getItem(localStorageKeys.sidebarMode);
@@ -22,7 +26,11 @@ function readStoredMode(): SidebarMode | null {
   }
 }
 
-function getServerSnapshot(): SidebarMode | null {
+function readPendingMode(): PendingSidebarMode | null {
+  return pendingMode;
+}
+
+function getServerSnapshot(): null {
   return null;
 }
 
@@ -35,6 +43,10 @@ function subscribe(onChange: () => void): () => void {
   };
 }
 
+function notifyModeChange(): void {
+  window.dispatchEvent(new Event(SIDEBAR_MODE_EVENT));
+}
+
 function persistMode(mode: SidebarMode): void {
   try {
     window.localStorage.setItem(localStorageKeys.sidebarMode, mode);
@@ -45,7 +57,29 @@ function persistMode(mode: SidebarMode): void {
   setSidebarModeCookie(mode).catch(() => {
     // Cookie write is best-effort, same as localStorage.
   });
-  window.dispatchEvent(new Event(SIDEBAR_MODE_EVENT));
+  notifyModeChange();
+}
+
+function clearPendingMode(): void {
+  if (pendingMode === null) {
+    return;
+  }
+  pendingMode = null;
+  notifyModeChange();
+}
+
+/**
+ * Pick a sidebar mode from the route it is picked in. Persists the mode
+ * synchronously so a navigation issued right after already carries the updated
+ * cookie, and keeps the pick pinned until the route changes so the route-derived
+ * mode cannot write the old mode back in between.
+ */
+export function pickSidebarMode(
+  mode: SidebarMode,
+  route: string | undefined
+): void {
+  pendingMode = { mode, route };
+  persistMode(mode);
 }
 
 export function useSidebarMode(
@@ -56,25 +90,28 @@ export function useSidebarMode(
     readStoredMode,
     getServerSnapshot
   );
+  const pending = useSyncExternalStore(
+    subscribe,
+    readPendingMode,
+    getServerSnapshot
+  );
   const routeMode = resolveSidebarMode(route, storedMode);
 
   // Picking a mode navigates, so `route` — which outranks the stored mode —
   // only catches up once the new route commits. Deriving the mode from the route
   // alone leaves the switch frozen for the whole navigation and then snaps
   // everything at once. The pending pick wins until the route agrees with it.
-  const [pending, setPending] = useState<PendingSidebarMode | null>(null);
-  const [lastRoute, setLastRoute] = useState(route);
-
-  // Drop a pick the route has moved past, so returning to where it was
-  // made in does not resurrect it. Done during render rather than in an effect
-  // so the stale pick never reaches the screen.
-  if (lastRoute !== route) {
-    setLastRoute(route);
-    setPending(null);
-  }
-
   const mode =
     pending !== null && pending.route === route ? pending.mode : routeMode;
+
+  // Drop a pick once the route has moved past it, so returning to where it was
+  // made does not resurrect it. The route check above keeps it off-screen while
+  // this effect clears the shared pending state.
+  useEffect(() => {
+    if (pending !== null && pending.route !== route) {
+      clearPendingMode();
+    }
+  }, [pending, route]);
 
   useEffect(() => {
     // The org root is an entry URL, not a mode signal. Persisting studio
@@ -87,10 +124,12 @@ export function useSidebarMode(
     }
   }, [mode, route, storedMode]);
 
-  const setMode = (next: SidebarMode) => {
-    setPending({ mode: next, route });
-    persistMode(next);
-  };
+  const setMode = useCallback(
+    (next: SidebarMode) => {
+      pickSidebarMode(next, route);
+    },
+    [route]
+  );
 
   return { mode, setMode, pendingMode: mode === routeMode ? null : mode };
 }

--- a/apps/dashboard/src/lib/hooks/use-sidebar-mode.ts
+++ b/apps/dashboard/src/lib/hooks/use-sidebar-mode.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 
 import { localStorageKeys } from "@/constants/storage";
 import type {
@@ -60,8 +60,8 @@ function persistMode(mode: SidebarMode): void {
   notifyModeChange();
 }
 
-function clearPendingMode(): void {
-  if (pendingMode === null) {
+function clearPendingMode(expected: PendingSidebarMode): void {
+  if (pendingMode !== expected) {
     return;
   }
   pendingMode = null;
@@ -104,12 +104,24 @@ export function useSidebarMode(
   const mode =
     pending !== null && pending.route === route ? pending.mode : routeMode;
 
+  // Read the store again during unmount instead of closing over `pending`: a pick
+  // can be followed by navigation before React commits the snapshot update.
+  useEffect(
+    () => () => {
+      const pendingAtUnmount = readPendingMode();
+      if (pendingAtUnmount !== null) {
+        clearPendingMode(pendingAtUnmount);
+      }
+    },
+    []
+  );
+
   // Drop a pick once the route has moved past it, so returning to where it was
-  // made does not resurrect it. The route check above keeps it off-screen while
-  // this effect clears the shared pending state.
+  // made does not resurrect it. Comparing by identity prevents this effect from
+  // clearing a newer pick made before it runs.
   useEffect(() => {
     if (pending !== null && pending.route !== route) {
-      clearPendingMode();
+      clearPendingMode(pending);
     }
   }, [pending, route]);
 
@@ -124,12 +136,9 @@ export function useSidebarMode(
     }
   }, [mode, route, storedMode]);
 
-  const setMode = useCallback(
-    (next: SidebarMode) => {
-      pickSidebarMode(next, route);
-    },
-    [route]
-  );
+  const setMode = (next: SidebarMode) => {
+    pickSidebarMode(next, route);
+  };
 
   return { mode, setMode, pendingMode: mode === routeMode ? null : mode };
 }

--- a/apps/dashboard/src/utils/nav.ts
+++ b/apps/dashboard/src/utils/nav.ts
@@ -57,6 +57,11 @@ export function resolveSidebarMode(
   return storedMode ?? SIDEBAR_DEFAULT_MODE;
 }
 
+/** Route after the org slug (`/{slug}/geo/prompts` → "geo/prompts"), or undefined on the org root. */
+export function sidebarRouteFromPathname(pathname: string): string | undefined {
+  return pathname.split("/").filter(Boolean).slice(1).join("/") || undefined;
+}
+
 export function isOrgRootPath(pathname: string, slug: string): boolean {
   return pathname === `/${slug}` || pathname === `/${slug}/`;
 }


### PR DESCRIPTION
### Description
Users without GEO access could get trapped in a loop when dismissing the upgrade paywall: navigating to the organization root restored GEO as their saved sidebar mode and immediately reopened the paywall.

This change switches the persisted sidebar mode to Studio before leaving the GEO paywall. The pending mode is shared across sidebar consumers so navigation updates immediately, while preserving full route-based mode resolution for shared dashboard pages.

### Screenshot/Recording (if applicable)
Not included.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
