### PR TITLE
feat(web): add PR merge video generator

### DIFF
--- a/apps/web/src/app/(site)/pr-merge-video/page.tsx
+++ b/apps/web/src/app/(site)/pr-merge-video/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from "next";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Suspense } from "react";
+
+import { MarketingHeroWash } from "@/components/marketing-hero-wash";
+import { PrMergeVideoPreview } from "@/components/pr-merge-video/pr-merge-video-preview";
+import { RepoInputForm } from "@/components/star-video/repo-input-form";
+import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
+import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
+import { SITE_URL } from "@/utils/urls";
+
+const title = "GitHub PR Merge Video Generator";
+const description =
+  "Turn a GitHub repository's recent pull request merges into an animated people leaderboard. Free, no sign-up.";
+const url = `${SITE_URL}/pr-merge-video`;
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: url },
+  openGraph: {
+    title,
+    description,
+    url,
+    type: "website",
+    siteName: "Notra",
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE.url],
+    site: TWITTER_HANDLE,
+    creator: TWITTER_HANDLE,
+  },
+};
+
+const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+  { name: "Home", url: SITE_URL },
+  { name: "GitHub PR Merge Video Generator", url },
+]);
+
+const softwareJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "GitHub PR Merge Video Generator",
+  url,
+  applicationCategory: "MultimediaApplication",
+  operatingSystem: "Web",
+  description,
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+};
+
+export default function PrMergeVideoPage() {
+  return (
+    <div className="flex w-full flex-col items-center">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        type="application/ld+json"
+      />
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: server-built JSON-LD
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(softwareJsonLd) }}
+        type="application/ld+json"
+      />
+
+      <NuqsAdapter>
+        <section className="flex w-full flex-col items-center gap-10 pb-16 antialiased [font-synthesis:none] md:gap-12 md:pb-24">
+          <MarketingHeroWash
+            subtitle="See who shipped the most pull requests. Pick a repo and time range, choose the people, then download a share-ready bubble video."
+            title={
+              <>
+                GitHub PR <span className="text-primary">Merge</span> Video
+                Generator
+              </>
+            }
+          >
+            <Suspense fallback={null}>
+              <RepoInputForm
+                actionLabel="Analyze merges"
+                tool="pr-merge-video"
+              />
+            </Suspense>
+          </MarketingHeroWash>
+
+          <Suspense fallback={null}>
+            <PrMergeVideoPreview />
+          </Suspense>
+        </section>
+      </NuqsAdapter>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/star-video/github/authorize/route.ts
+++ b/apps/web/src/app/api/star-video/github/authorize/route.ts
@@ -13,7 +13,10 @@ import {
   getGithubOAuthConfig,
   readPendingOAuthStates,
 } from "@/lib/star-video/github-oauth";
-import { githubReturnRepoSchema } from "@/schemas/star-video";
+import {
+  githubReturnRepoSchema,
+  githubVideoToolSchema,
+} from "@/schemas/star-video";
 
 export const runtime = "nodejs";
 
@@ -22,8 +25,15 @@ export function GET(request: NextRequest) {
     request.nextUrl.searchParams.get("repo") ?? ""
   );
   const repo = parsedRepo.success ? parsedRepo.data : null;
+  const parsedTool = githubVideoToolSchema.safeParse(
+    request.nextUrl.searchParams.get("tool") ?? ""
+  );
+  const tool = parsedTool.success ? parsedTool.data : "star-video";
 
-  const returnUrl = new URL("/repo-star-video", request.nextUrl.origin);
+  const returnUrl = new URL(
+    tool === "pr-merge-video" ? "/pr-merge-video" : "/repo-star-video",
+    request.nextUrl.origin
+  );
   if (repo) {
     returnUrl.searchParams.set("repo", repo);
   }
@@ -41,7 +51,7 @@ export function GET(request: NextRequest) {
   );
   const pendingStates = appendPendingOAuthState(
     readPendingOAuthStates(request.cookies.get(GITHUB_STATE_COOKIE)?.value),
-    { state, repo: repo ?? undefined }
+    { state, repo: repo ?? undefined, tool }
   );
   response.cookies.set(GITHUB_STATE_COOKIE, JSON.stringify(pendingStates), {
     httpOnly: true,

--- a/apps/web/src/app/api/star-video/github/callback/route.ts
+++ b/apps/web/src/app/api/star-video/github/callback/route.ts
@@ -33,7 +33,12 @@ export async function GET(request: NextRequest) {
     ? pendingStates.find((entry) => entry.state === query.data.state)
     : undefined;
 
-  const returnUrl = new URL("/repo-star-video", request.nextUrl.origin);
+  const returnUrl = new URL(
+    stateData?.tool === "pr-merge-video"
+      ? "/pr-merge-video"
+      : "/repo-star-video",
+    request.nextUrl.origin
+  );
   if (stateData?.repo) {
     returnUrl.searchParams.set("repo", stateData.repo);
   }

--- a/apps/web/src/app/api/star-video/pr-merges/render/route.ts
+++ b/apps/web/src/app/api/star-video/pr-merges/render/route.ts
@@ -1,0 +1,85 @@
+import { Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { GITHUB_CONNECTION_REQUIRED_MESSAGE } from "@/lib/star-video/github-cookies";
+import { readGithubToken } from "@/lib/star-video/github-oauth";
+import {
+  enforceGlobalRenderLimit,
+  enforceStarVideoRateLimit,
+} from "@/lib/star-video/ratelimit";
+import { renderPrMergeVideo } from "@/lib/star-video/render";
+import { prMergeVideoInputSchema } from "@/schemas/pr-merge-video";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+export async function POST(request: NextRequest) {
+  if (!readGithubToken(request)) {
+    return NextResponse.json(
+      { error: GITHUB_CONNECTION_REQUIRED_MESSAGE },
+      { status: 401 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 }
+    );
+  }
+
+  const parsed = prMergeVideoInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input" },
+      { status: 400 }
+    );
+  }
+
+  const filename = `${parsed.data.owner}-${parsed.data.repo}-pr-merges.mp4`;
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* enforceStarVideoRateLimit(request, "render");
+      yield* enforceGlobalRenderLimit();
+
+      const video = yield* Effect.tryPromise({
+        try: () => renderPrMergeVideo(parsed.data),
+        catch: (cause) =>
+          cause instanceof Error ? cause : new Error("Failed to render video"),
+      });
+
+      return new NextResponse(new Uint8Array(video), {
+        headers: {
+          "Content-Type": "video/mp4",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+        },
+      });
+    }).pipe(
+      Effect.match({
+        onFailure: (error) => {
+          if (
+            "_tag" in error &&
+            (error._tag === "StarVideoRateLimitExceeded" ||
+              error._tag === "RenderBusy")
+          ) {
+            return NextResponse.json(
+              { error: "Too many render requests. Please try again shortly." },
+              { status: 429 }
+            );
+          }
+          console.error("Failed to render PR merge video", error);
+          return NextResponse.json(
+            { error: "Failed to render the video. Please try again." },
+            { status: 500 }
+          );
+        },
+        onSuccess: (response) => response,
+      })
+    )
+  );
+}

--- a/apps/web/src/app/api/star-video/pr-merges/repo/route.ts
+++ b/apps/web/src/app/api/star-video/pr-merges/repo/route.ts
@@ -1,0 +1,75 @@
+import { Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { loadRepoPrMergeData } from "@/lib/pr-merge-video/load-repo";
+import { GITHUB_CONNECTION_REQUIRED_MESSAGE } from "@/lib/star-video/github-cookies";
+import {
+  clearGithubCookies,
+  readGithubToken,
+} from "@/lib/star-video/github-oauth";
+import { enforceStarVideoRateLimit } from "@/lib/star-video/ratelimit";
+import { prMergeRepoQuerySchema } from "@/schemas/pr-merge-video";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const parsed = prMergeRepoQuerySchema.safeParse({
+    owner: searchParams.get("owner") ?? "",
+    repo: searchParams.get("repo") ?? "",
+    days: searchParams.get("days") ?? "",
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid request" },
+      { status: 400 }
+    );
+  }
+
+  const rateLimited = await Effect.runPromise(
+    enforceStarVideoRateLimit(request, "lookup").pipe(
+      Effect.match({ onSuccess: () => false, onFailure: () => true })
+    )
+  );
+  if (rateLimited) {
+    return NextResponse.json(
+      { error: "Too many requests. Please try again shortly." },
+      { status: 429 }
+    );
+  }
+
+  const githubToken = readGithubToken(request);
+  if (!githubToken) {
+    return NextResponse.json(
+      { error: GITHUB_CONNECTION_REQUIRED_MESSAGE },
+      { status: 401 }
+    );
+  }
+
+  const { owner, repo, days } = parsed.data;
+  const result = await loadRepoPrMergeData(owner, repo, days, githubToken);
+  if (!result.ok) {
+    if (result.kind === "unauthorized") {
+      const response = NextResponse.json(
+        { error: GITHUB_CONNECTION_REQUIRED_MESSAGE },
+        { status: 401 }
+      );
+      clearGithubCookies(response);
+      return response;
+    }
+    if (result.kind === "unavailable") {
+      return NextResponse.json(
+        { error: "GitHub is unavailable right now. Please try again." },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Repository not found." },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -163,6 +163,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: STATIC_PAGE_LAST_MODIFIED,
     },
     {
+      url: `${SITE_URL}/pr-merge-video`,
+      lastModified: STATIC_PAGE_LAST_MODIFIED,
+    },
+    {
       url: `${SITE_URL}/privacy`,
       lastModified: STATIC_PAGE_LAST_MODIFIED,
     },

--- a/apps/web/src/components/pr-merge-video/pr-merge-video-preview.tsx
+++ b/apps/web/src/components/pr-merge-video/pr-merge-video-preview.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import {
+  Download04Icon,
+  GitPullRequestIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { CtaButton } from "@notra/ui/components/shared/cta-button";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { cn } from "@notra/ui/lib/utils";
+import { Player } from "@remotion/player";
+import Image from "next/image";
+import { useQueryState } from "nuqs";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { toast } from "sonner";
+
+import {
+  DEFAULT_PR_MERGE_PERIOD_DAYS,
+  DEFAULT_SELECTED_PEOPLE,
+  MAX_SELECTED_PEOPLE,
+  PR_MERGE_PERIODS,
+} from "@/constants/pr-merge-video";
+import {
+  getGithubLogin,
+  getServerGithubLogin,
+  subscribeToGithubConnection,
+} from "@/lib/star-video/github-connection";
+import { parseRepoInput } from "@/lib/star-video/parse-repo";
+import {
+  PR_MERGE_VIDEO_DURATION_IN_FRAMES,
+  PR_MERGE_VIDEO_FPS,
+  PR_MERGE_VIDEO_HEIGHT,
+  PR_MERGE_VIDEO_WIDTH,
+} from "@/remotion/pr-merge-video/constants";
+import { PrMergeVideo } from "@/remotion/pr-merge-video/pr-merge-video";
+import type {
+  PrMergePeriodDays,
+  PrMergeVideoInputProps,
+  RepoPrMergeData,
+} from "@/types/pr-merge-video";
+
+const AVATAR_SIZE_PX = 80;
+
+export function PrMergeVideoPreview() {
+  const [repoParam] = useQueryState("repo");
+  const [days, setDays] = useState<PrMergePeriodDays>(
+    DEFAULT_PR_MERGE_PERIOD_DAYS
+  );
+  const [data, setData] = useState<RepoPrMergeData | null>(null);
+  const [selectedLogins, setSelectedLogins] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRendering, setIsRendering] = useState(false);
+  const githubLogin = useSyncExternalStore(
+    subscribeToGithubConnection,
+    getGithubLogin,
+    getServerGithubLogin
+  );
+  const githubConnected = githubLogin !== null;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousRepo = useRef<string | null>(null);
+
+  useEffect(() => {
+    const parsed = repoParam ? parseRepoInput(repoParam) : null;
+
+    if (repoParam && previousRepo.current !== repoParam) {
+      containerRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+    previousRepo.current = repoParam;
+
+    if (!(githubConnected && parsed)) {
+      setData(null);
+      setSelectedLogins([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setData(null);
+    setSelectedLogins([]);
+    setIsLoading(true);
+
+    (async () => {
+      try {
+        const response = await fetch(
+          `/api/star-video/pr-merges/repo?owner=${encodeURIComponent(parsed.owner)}&repo=${encodeURIComponent(parsed.repo)}&days=${days}`,
+          { signal: controller.signal }
+        );
+        if (response.ok) {
+          const json: RepoPrMergeData = await response.json();
+          setData(json);
+          setSelectedLogins(
+            json.people
+              .slice(0, DEFAULT_SELECTED_PEOPLE)
+              .map((person) => person.login)
+          );
+        } else {
+          const json: { error?: string } = await response
+            .json()
+            .catch(() => ({}));
+          toast.error(json.error ?? "Could not load that repository.");
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          toast.error("Something went wrong loading that repository.");
+        }
+      }
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [repoParam, githubConnected, days]);
+
+  const inputProps = useMemo<PrMergeVideoInputProps | null>(() => {
+    if (!data) {
+      return null;
+    }
+    const selected = new Set(selectedLogins);
+    const people = data.people.filter((person) => selected.has(person.login));
+    if (people.length === 0) {
+      return null;
+    }
+    return {
+      owner: data.owner,
+      repo: data.repo,
+      days,
+      people,
+    };
+  }, [data, days, selectedLogins]);
+
+  const togglePerson = (login: string) => {
+    if (selectedLogins.includes(login)) {
+      setSelectedLogins(
+        selectedLogins.filter((selectedLogin) => selectedLogin !== login)
+      );
+      return;
+    }
+    if (selectedLogins.length >= MAX_SELECTED_PEOPLE) {
+      toast.error(`Choose up to ${MAX_SELECTED_PEOPLE} people.`);
+      return;
+    }
+    setSelectedLogins([...selectedLogins, login]);
+  };
+
+  const onDownload = async () => {
+    if (!inputProps) {
+      return;
+    }
+    setIsRendering(true);
+    const pending = toast.loading(
+      "Rendering your video. This can take a minute."
+    );
+    try {
+      const response = await fetch("/api/star-video/pr-merges/render", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(inputProps),
+      });
+      if (response.ok) {
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${inputProps.owner}-${inputProps.repo}-pr-merges.mp4`;
+        link.click();
+        URL.revokeObjectURL(url);
+        toast.success("Video ready.", { id: pending });
+      } else {
+        const json: { error?: string } = await response
+          .json()
+          .catch(() => ({}));
+        toast.error(json.error ?? "Could not render the video.", {
+          id: pending,
+        });
+      }
+    } catch {
+      toast.error("Something went wrong rendering the video.", { id: pending });
+    }
+    setIsRendering(false);
+  };
+
+  return (
+    <div
+      className="flex w-full max-w-4xl scroll-mt-24 flex-col items-center gap-7 px-4 sm:px-6"
+      ref={containerRef}
+    >
+      <div className="flex w-full flex-col items-center justify-between gap-3 sm:flex-row">
+        <span className="font-sans text-sm text-[#1E1E1E99] dark:text-white/50">
+          Time range
+        </span>
+        <div
+          aria-label="Time range"
+          className="flex rounded-full bg-[#1E1E1E0A] p-1 dark:bg-white/[0.06]"
+          role="group"
+        >
+          {PR_MERGE_PERIODS.map((period) => (
+            <button
+              aria-pressed={days === period}
+              className={cn(
+                "cursor-pointer rounded-full px-4 py-2 font-sans text-sm font-medium transition-colors",
+                days === period
+                  ? "bg-white text-[#1E1E1E] [box-shadow:0_1px_3px_#1E1E1E14] dark:bg-white/15 dark:text-white"
+                  : "text-[#1E1E1E99] hover:text-[#1E1E1E] dark:text-white/55 dark:hover:text-white"
+              )}
+              key={period}
+              onClick={() => setDays(period)}
+              type="button"
+            >
+              {period} days
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="w-full rounded-3xl border border-[#1E1E1E14] bg-[linear-gradient(in_oklab_180deg,oklab(95.1%_0.011_-0.018_/_15%)_0%,oklab(93.7%_0.019_-0.031_/_75%)_100%)] p-2 sm:p-4 dark:border-white/10 dark:bg-white/[0.02] dark:bg-none">
+        <div className="bg-background overflow-hidden rounded-2xl border border-[#1E1E1E0D] dark:border-white/5">
+          {isLoading ? (
+            <Skeleton className="aspect-square w-full rounded-none" />
+          ) : null}
+
+          {!isLoading && inputProps ? (
+            <Player
+              acknowledgeRemotionLicense
+              autoPlay
+              className="aspect-square !h-auto !w-full"
+              component={PrMergeVideo}
+              compositionHeight={PR_MERGE_VIDEO_HEIGHT}
+              compositionWidth={PR_MERGE_VIDEO_WIDTH}
+              controls
+              durationInFrames={PR_MERGE_VIDEO_DURATION_IN_FRAMES}
+              fps={PR_MERGE_VIDEO_FPS}
+              initiallyMuted
+              inputProps={inputProps}
+              key={`${data?.id}-${days}-${selectedLogins.join("-")}`}
+              loop
+            />
+          ) : null}
+
+          {!(isLoading || inputProps) ? (
+            <div className="flex aspect-square w-full flex-col items-center justify-center gap-3 px-6 text-center">
+              <HugeiconsIcon
+                className="size-7 text-[#1E1E1E4D] dark:text-white/30"
+                icon={GitPullRequestIcon}
+              />
+              <p className="max-w-sm font-sans text-sm text-[#1E1E1E99] dark:text-white/50">
+                {data
+                  ? "No people with merged pull requests were found for this time range."
+                  : "Enter a repository above to build its PR merge video."}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {data?.people.length ? (
+        <div className="flex w-full flex-col gap-3">
+          <div className="flex flex-col justify-between gap-1 sm:flex-row sm:items-end">
+            <div>
+              <h2 className="font-display text-lg font-medium tracking-[-0.02em] text-[#1E1E1E] dark:text-white">
+                Choose people
+              </h2>
+              <p className="font-sans text-sm text-[#1E1E1E99] dark:text-white/50">
+                Bots are excluded. Select up to {MAX_SELECTED_PEOPLE} people.
+              </p>
+            </div>
+            <span className="font-sans text-xs text-[#1E1E1E80] dark:text-white/45">
+              {selectedLogins.length}/{MAX_SELECTED_PEOPLE} selected
+            </span>
+          </div>
+          <div className="grid max-h-72 grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+            {data.people.map((person) => {
+              const selected = selectedLogins.includes(person.login);
+              return (
+                <button
+                  aria-pressed={selected}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-3 rounded-2xl border p-3 text-left transition-colors",
+                    selected
+                      ? "border-primary/35 bg-primary/[0.06] dark:bg-primary/10"
+                      : "border-[#1E1E1E12] bg-white hover:bg-[#1E1E1E05] dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/[0.06]"
+                  )}
+                  key={person.login}
+                  onClick={() => togglePerson(person.login)}
+                  type="button"
+                >
+                  <Image
+                    alt=""
+                    className="size-10 rounded-full object-cover"
+                    height={AVATAR_SIZE_PX}
+                    src={person.avatarUrl}
+                    width={AVATAR_SIZE_PX}
+                  />
+                  <span className="min-w-0 grow">
+                    <span className="block truncate font-sans text-sm font-semibold text-[#1E1E1E] dark:text-white">
+                      {person.name || person.login}
+                    </span>
+                    <span className="block truncate font-sans text-xs text-[#1E1E1E80] dark:text-white/45">
+                      @{person.login} · {person.merges.toLocaleString()}{" "}
+                      {person.merges === 1 ? "merge" : "merges"}
+                    </span>
+                  </span>
+                  <span
+                    className={cn(
+                      "flex size-5 shrink-0 items-center justify-center rounded-full border",
+                      selected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-[#1E1E1E24] dark:border-white/20"
+                    )}
+                  >
+                    {selected ? (
+                      <HugeiconsIcon className="size-3" icon={Tick02Icon} />
+                    ) : null}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          {data.truncated ? (
+            <p className="font-sans text-xs text-[#1E1E1E80] dark:text-white/45">
+              This repository exceeded GitHub&apos;s 1,000-result search limit;
+              the ranking uses the available results.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex w-full flex-col items-center gap-2 sm:items-end">
+        <CtaButton
+          className="font-display h-12 rounded-2xl px-6 text-[1.0625rem] font-medium tracking-[-0.015em]"
+          disabled={!inputProps || isRendering}
+          onClick={onDownload}
+          variant="light"
+        >
+          <HugeiconsIcon className="size-4" icon={Download04Icon} />
+          {isRendering ? "Rendering" : "Download MP4"}
+        </CtaButton>
+        {inputProps ? (
+          <p className="font-sans text-xs text-[#1E1E1E99] dark:text-white/50">
+            {inputProps.people.reduce(
+              (total, person) => total + person.merges,
+              0
+            )}{" "}
+            merges · {inputProps.owner}/{inputProps.repo}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/star-video/repo-input-form.tsx
+++ b/apps/web/src/components/star-video/repo-input-form.tsx
@@ -13,11 +13,15 @@ import {
   subscribeToGithubConnection,
 } from "@/lib/star-video/github-connection";
 import { parseRepoInput } from "@/lib/star-video/parse-repo";
+import type { RepoInputFormProps } from "@/types/star-video";
 
 const DEFAULT_INPUT = "usenotra/notra";
 const AVATAR_SIZE_PX = 40;
 
-export function RepoInputForm() {
+export function RepoInputForm({
+  tool = "star-video",
+  actionLabel = "Generate video",
+}: RepoInputFormProps) {
   const [repoParam, setRepoParam] = useQueryState("repo");
   const [value, setValue] = useState(repoParam ?? DEFAULT_INPUT);
   const githubLogin = useSyncExternalStore(
@@ -36,7 +40,7 @@ export function RepoInputForm() {
     }
     const repoId = `${parsed.owner}/${parsed.repo}`.toLowerCase();
     if (!githubConnected) {
-      window.location.assign(buildGithubConnectHref(repoId));
+      window.location.assign(buildGithubConnectHref(repoId, tool));
       return;
     }
     setRepoParam(repoId);
@@ -62,7 +66,7 @@ export function RepoInputForm() {
           className="cta-gradient-primary-flat flex shrink-0 cursor-pointer items-center justify-center rounded-full px-5 py-3 font-sans text-[0.9375rem] leading-[1.29] font-semibold text-white sm:px-4.5 sm:py-2 sm:text-[0.875rem]"
           type="submit"
         >
-          {githubConnected ? "Generate video" : "Connect GitHub"}
+          {githubConnected ? actionLabel : "Connect GitHub"}
         </button>
       </form>
       <p className="font-sans text-sm text-[#1E1E1E99] dark:text-white/60">

--- a/apps/web/src/constants/landing/footer.ts
+++ b/apps/web/src/constants/landing/footer.ts
@@ -129,6 +129,7 @@ export const FOOTER_LINK_COLUMNS: readonly FooterLinkColumn[] = [
         title: "Free Tools",
         links: [
           { label: "GitHub Star Video Generator", href: "/repo-star-video" },
+          { label: "GitHub PR Merge Video Generator", href: "/pr-merge-video" },
           { label: "AI Crawler IP Checker", href: "/ip-checker" },
         ],
       },

--- a/apps/web/src/constants/pr-merge-video.ts
+++ b/apps/web/src/constants/pr-merge-video.ts
@@ -1,0 +1,6 @@
+export const PR_MERGE_PERIODS = [3, 7, 14] as const;
+export const DEFAULT_PR_MERGE_PERIOD_DAYS = 7;
+export const DEFAULT_SELECTED_PEOPLE = 5;
+export const MAX_SELECTED_PEOPLE = 6;
+export const GITHUB_SEARCH_PAGE_SIZE = 100;
+export const MAX_GITHUB_SEARCH_PAGES = 10;

--- a/apps/web/src/lib/pr-merge-video/github.ts
+++ b/apps/web/src/lib/pr-merge-video/github.ts
@@ -1,0 +1,234 @@
+import { Data, Effect } from "effect";
+
+import {
+  GITHUB_SEARCH_PAGE_SIZE,
+  MAX_GITHUB_SEARCH_PAGES,
+} from "@/constants/pr-merge-video";
+import type {
+  GithubGraphqlResponse,
+  GithubPrMergeActor,
+  GithubPrMergeSearchData,
+  PrMergePeriodDays,
+  PrMergePerson,
+  RepoPrMergeData,
+} from "@/types/pr-merge-video";
+
+const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+const HTTP_UNAUTHORIZED = 401;
+
+const PR_MERGE_QUERY = `
+  query PrMerges(
+    $owner: String!
+    $repo: String!
+    $queryString: String!
+    $after: String
+  ) {
+    repository(owner: $owner, name: $repo) {
+      name
+      nameWithOwner
+      url
+      isPrivate
+    }
+    search(
+      query: $queryString
+      type: ISSUE
+      first: ${GITHUB_SEARCH_PAGE_SIZE}
+      after: $after
+    ) {
+      issueCount
+      nodes {
+        ... on PullRequest {
+          mergedAt
+          mergedBy {
+            __typename
+            login
+            avatarUrl(size: 280)
+            ... on User {
+              name
+            }
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+class RepoNotFound extends Data.TaggedError("RepoNotFound")<{
+  readonly owner: string;
+  readonly repo: string;
+}> {}
+
+class RepoUnavailable extends Data.TaggedError("RepoUnavailable")<{
+  readonly owner: string;
+  readonly repo: string;
+}> {}
+
+class RepoUnauthorized extends Data.TaggedError("RepoUnauthorized")<{
+  readonly owner: string;
+  readonly repo: string;
+}> {}
+
+function buildFetchOptions(
+  owner: string,
+  repo: string,
+  queryString: string,
+  after: string | null,
+  token: string
+): RequestInit {
+  return {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "notra-pr-merge-video",
+    },
+    body: JSON.stringify({
+      query: PR_MERGE_QUERY,
+      variables: { owner, repo, queryString, after },
+    }),
+    cache: "no-store",
+  };
+}
+
+async function fetchPage(
+  owner: string,
+  repo: string,
+  queryString: string,
+  after: string | null,
+  token: string
+): Promise<{
+  status: number;
+  payload: GithubGraphqlResponse<GithubPrMergeSearchData> | null;
+}> {
+  try {
+    const response = await fetch(
+      GITHUB_GRAPHQL_URL,
+      buildFetchOptions(owner, repo, queryString, after, token)
+    );
+    const payload = (await response
+      .json()
+      .catch(
+        () => null
+      )) as GithubGraphqlResponse<GithubPrMergeSearchData> | null;
+    return { status: response.status, payload };
+  } catch {
+    return { status: 0, payload: null };
+  }
+}
+
+function isHumanActor(typename: string, login: string): boolean {
+  return typename === "User" && !login.toLowerCase().endsWith("[bot]");
+}
+
+function addMerge(
+  people: Map<string, PrMergePerson>,
+  actor: GithubPrMergeActor | null
+): void {
+  if (!(actor && isHumanActor(actor.__typename, actor.login))) {
+    return;
+  }
+
+  const key = actor.login.toLowerCase();
+  const existing = people.get(key);
+  if (existing) {
+    existing.merges += 1;
+    return;
+  }
+
+  people.set(key, {
+    login: actor.login,
+    name: actor.name?.trim() || null,
+    avatarUrl: actor.avatarUrl,
+    merges: 1,
+  });
+}
+
+export const fetchRepoPrMergeData = Effect.fn("fetchRepoPrMergeData")(
+  function* (
+    owner: string,
+    repo: string,
+    days: PrMergePeriodDays,
+    token: string,
+    now = new Date()
+  ) {
+    const cutoff = new Date(
+      now.getTime() - days * MILLISECONDS_PER_DAY
+    ).toISOString();
+    const queryDate = cutoff.slice(0, 10);
+    const queryString = `repo:${owner}/${repo} is:pr is:merged merged:>=${queryDate}`;
+    const people = new Map<string, PrMergePerson>();
+
+    let after: string | null = null;
+    let repository: GithubPrMergeSearchData["repository"] = null;
+    let fetchedSearchResultCount = 0;
+    let issueCount = 0;
+    let hasNextPage = false;
+
+    for (let page = 0; page < MAX_GITHUB_SEARCH_PAGES; page += 1) {
+      const pagePromise = fetchPage(owner, repo, queryString, after, token);
+      const response = yield* Effect.promise(() => pagePromise);
+
+      if (response.status === HTTP_UNAUTHORIZED) {
+        return yield* Effect.fail(new RepoUnauthorized({ owner, repo }));
+      }
+
+      const data = response.payload?.data;
+      if (!(response.status >= 200 && response.status < 300 && data)) {
+        return yield* Effect.fail(new RepoUnavailable({ owner, repo }));
+      }
+
+      if (page === 0) {
+        repository = data.repository;
+        if (!repository || repository.isPrivate) {
+          return yield* Effect.fail(new RepoNotFound({ owner, repo }));
+        }
+        issueCount = data.search.issueCount;
+      }
+
+      fetchedSearchResultCount += data.search.nodes.length;
+      for (const node of data.search.nodes) {
+        if (!(node?.mergedAt && node.mergedAt >= cutoff)) {
+          continue;
+        }
+        addMerge(people, node.mergedBy);
+      }
+
+      hasNextPage = data.search.pageInfo.hasNextPage;
+      after = data.search.pageInfo.endCursor;
+      if (!(hasNextPage && after)) {
+        break;
+      }
+    }
+
+    if (!repository) {
+      return yield* Effect.fail(new RepoNotFound({ owner, repo }));
+    }
+
+    const rankedPeople = [...people.values()].sort(
+      (first, second) =>
+        second.merges - first.merges || first.login.localeCompare(second.login)
+    );
+    const [resolvedOwner] = repository.nameWithOwner.split("/");
+
+    return {
+      id: repository.nameWithOwner.toLowerCase(),
+      owner: resolvedOwner || owner,
+      repo: repository.name,
+      days,
+      people: rankedPeople,
+      htmlUrl: repository.url,
+      totalMerges: rankedPeople.reduce(
+        (total, person) => total + person.merges,
+        0
+      ),
+      truncated: hasNextPage || issueCount > fetchedSearchResultCount,
+    } satisfies RepoPrMergeData;
+  }
+);

--- a/apps/web/src/lib/pr-merge-video/load-repo.ts
+++ b/apps/web/src/lib/pr-merge-video/load-repo.ts
@@ -1,0 +1,54 @@
+import { Effect } from "effect";
+
+import { fingerprintGithubToken } from "@/lib/star-video/github-oauth";
+import type {
+  LoadRepoPrMergeResult,
+  PrMergePeriodDays,
+} from "@/types/pr-merge-video";
+
+import { fetchRepoPrMergeData } from "./github";
+
+function failureKind(
+  tag: string
+): "not-found" | "unavailable" | "unauthorized" {
+  if (tag === "RepoUnavailable") {
+    return "unavailable";
+  }
+  if (tag === "RepoUnauthorized") {
+    return "unauthorized";
+  }
+  return "not-found";
+}
+
+const inflight = new Map<string, Promise<LoadRepoPrMergeResult>>();
+
+export function loadRepoPrMergeData(
+  owner: string,
+  repo: string,
+  days: PrMergePeriodDays,
+  token: string
+): Promise<LoadRepoPrMergeResult> {
+  const inflightKey = `${owner}/${repo}:${days}:${fingerprintGithubToken(token)}`;
+  const existing = inflight.get(inflightKey);
+  if (existing) {
+    return existing;
+  }
+
+  const promise = Effect.runPromise(
+    fetchRepoPrMergeData(owner, repo, days, token).pipe(
+      Effect.match({
+        onSuccess: (data): LoadRepoPrMergeResult => ({ ok: true, data }),
+        onFailure: (error): LoadRepoPrMergeResult => ({
+          ok: false,
+          kind: failureKind(error._tag),
+        }),
+      })
+    )
+  );
+
+  inflight.set(inflightKey, promise);
+  promise.finally(() => {
+    inflight.delete(inflightKey);
+  });
+  return promise;
+}

--- a/apps/web/src/lib/star-video/github-connection.ts
+++ b/apps/web/src/lib/star-video/github-connection.ts
@@ -1,3 +1,5 @@
+import type { GithubVideoTool } from "@/types/star-video";
+
 import { GITHUB_CONNECTED_COOKIE } from "./github-cookies";
 
 export function subscribeToGithubConnection(listener: () => void): () => void {
@@ -25,9 +27,17 @@ export function getServerGithubLogin(): string | null {
   return null;
 }
 
-export function buildGithubConnectHref(repoParam: string | null): string {
-  if (!repoParam) {
-    return "/api/star-video/github/authorize";
+export function buildGithubConnectHref(
+  repoParam: string | null,
+  tool: GithubVideoTool = "star-video"
+): string {
+  const params = new URLSearchParams();
+  if (repoParam) {
+    params.set("repo", repoParam);
   }
-  return `/api/star-video/github/authorize?repo=${encodeURIComponent(repoParam)}`;
+  if (tool !== "star-video") {
+    params.set("tool", tool);
+  }
+  const query = params.toString();
+  return `/api/star-video/github/authorize${query ? `?${query}` : ""}`;
 }

--- a/apps/web/src/lib/star-video/render.ts
+++ b/apps/web/src/lib/star-video/render.ts
@@ -9,6 +9,7 @@ import {
   selectComposition,
 } from "@remotion/renderer";
 
+import type { PrMergeVideoInputProps } from "@/types/pr-merge-video";
 import type { StarVideoInputProps } from "@/types/star-video";
 
 class RenderBusy extends Error {
@@ -40,8 +41,10 @@ function getServeUrl(): Promise<string> {
   return serveUrlPromise;
 }
 
-export async function renderStarVideo(
-  inputProps: StarVideoInputProps
+async function renderVideo(
+  compositionId: "StarVideo" | "PrMergeVideo",
+  outputName: string,
+  inputProps: Record<string, unknown>
 ): Promise<Buffer> {
   if (activeRenders >= MAX_CONCURRENT_RENDERS) {
     throw new RenderBusy("The renderer is busy. Please try again shortly.");
@@ -53,12 +56,12 @@ export async function renderStarVideo(
 
     const composition = await selectComposition({
       serveUrl,
-      id: "StarVideo",
+      id: compositionId,
       inputProps,
     });
 
-    const dir = await mkdtemp(join(tmpdir(), "star-video-"));
-    const outputLocation = join(dir, "star-video.mp4");
+    const dir = await mkdtemp(join(tmpdir(), `${outputName}-`));
+    const outputLocation = join(dir, `${outputName}.mp4`);
 
     try {
       await renderMedia({
@@ -75,4 +78,16 @@ export async function renderStarVideo(
   } finally {
     activeRenders -= 1;
   }
+}
+
+export function renderStarVideo(
+  inputProps: StarVideoInputProps
+): Promise<Buffer> {
+  return renderVideo("StarVideo", "star-video", inputProps);
+}
+
+export function renderPrMergeVideo(
+  inputProps: PrMergeVideoInputProps
+): Promise<Buffer> {
+  return renderVideo("PrMergeVideo", "pr-merge-video", inputProps);
 }

--- a/apps/web/src/remotion/pr-merge-video/constants.ts
+++ b/apps/web/src/remotion/pr-merge-video/constants.ts
@@ -1,0 +1,35 @@
+import type { PrMergeVideoInputProps } from "../../types/pr-merge-video";
+
+export const PR_MERGE_VIDEO_WIDTH = 1080;
+export const PR_MERGE_VIDEO_HEIGHT = 1080;
+export const PR_MERGE_VIDEO_FPS = 60;
+export const PR_MERGE_VIDEO_DURATION_IN_FRAMES = 960;
+
+export const ROWS_TOP = 210;
+export const ROWS_BOTTOM = 40;
+export const MAX_ROW_HEIGHT = 180;
+export const LABEL_LEFT = 70;
+export const BALL_TRACK_LEFT = 350;
+export const BALL_TRACK_RIGHT = 1000;
+export const BALL_DIAMETER = 150;
+export const BALL_SPEED_PER_MERGE = 14.4;
+
+export const DEFAULT_PR_MERGE_VIDEO_PROPS = {
+  owner: "usenotra",
+  repo: "notra",
+  days: 7,
+  people: [
+    {
+      login: "janburzinski",
+      name: "Jan Burzinski",
+      avatarUrl: "https://avatars.githubusercontent.com/u/156842394?v=4",
+      merges: 65,
+    },
+    {
+      login: "mezotv",
+      name: "Dominik K.",
+      avatarUrl: "https://avatars.githubusercontent.com/u/68947960?v=4",
+      merges: 51,
+    },
+  ],
+} satisfies PrMergeVideoInputProps;

--- a/apps/web/src/remotion/pr-merge-video/merge-row.tsx
+++ b/apps/web/src/remotion/pr-merge-video/merge-row.tsx
@@ -1,0 +1,96 @@
+import { Img, useCurrentFrame, useVideoConfig } from "remotion";
+
+import type { PrMergeRowProps } from "../../types/pr-merge-video";
+import {
+  BALL_DIAMETER,
+  BALL_SPEED_PER_MERGE,
+  BALL_TRACK_LEFT,
+  BALL_TRACK_RIGHT,
+  LABEL_LEFT,
+  MAX_ROW_HEIGHT,
+  PR_MERGE_VIDEO_HEIGHT,
+  ROWS_BOTTOM,
+  ROWS_TOP,
+} from "./constants";
+
+export function MergeRow({
+  person,
+  index,
+  total,
+  fontFamily,
+}: PrMergeRowProps) {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const rowHeight = Math.min(
+    MAX_ROW_HEIGHT,
+    (PR_MERGE_VIDEO_HEIGHT - ROWS_TOP - ROWS_BOTTOM) / total
+  );
+  const centerY = ROWS_TOP + rowHeight * (index + 0.5);
+  const diameter = Math.min(BALL_DIAMETER, rowHeight - 12);
+  const travelDistance = BALL_TRACK_RIGHT - BALL_TRACK_LEFT;
+  const distance = (frame / fps) * person.merges * BALL_SPEED_PER_MERGE;
+  const bounceProgress = distance % (travelDistance * 2);
+  const centerX =
+    BALL_TRACK_LEFT +
+    (bounceProgress <= travelDistance
+      ? bounceProgress
+      : travelDistance * 2 - bounceProgress);
+
+  return (
+    <div style={{ fontFamily }}>
+      <div
+        style={{
+          position: "absolute",
+          top: centerY,
+          left: LABEL_LEFT,
+          width: 270,
+          transform: "translateY(-50%)",
+        }}
+      >
+        <div
+          style={{
+            color: "#171717",
+            fontSize: 34,
+            fontWeight: 600,
+            letterSpacing: "-0.04em",
+            lineHeight: 1.05,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {person.name || person.login}
+        </div>
+        <div
+          style={{
+            color: "#737373",
+            fontSize: 21,
+            lineHeight: 1.25,
+            marginTop: 9,
+          }}
+        >
+          {person.merges.toLocaleString("en-US")}{" "}
+          {person.merges === 1 ? "merge" : "merges"}
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          left: centerX,
+          top: centerY,
+          width: diameter,
+          height: diameter,
+          borderRadius: "50%",
+          overflow: "hidden",
+          transform: "translate(-50%, -50%)",
+        }}
+      >
+        <Img
+          src={person.avatarUrl}
+          style={{ width: "100%", height: "100%", objectFit: "cover" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/remotion/pr-merge-video/pr-merge-video.tsx
+++ b/apps/web/src/remotion/pr-merge-video/pr-merge-video.tsx
@@ -1,0 +1,61 @@
+import { AbsoluteFill } from "remotion";
+
+import type { PrMergeVideoInputProps } from "../../types/pr-merge-video";
+import { ensureStarVideoFonts } from "../star-video/load-fonts";
+import { MergeRow } from "./merge-row";
+
+ensureStarVideoFonts();
+
+const fontFamily = 'Inter, "Helvetica Neue", Arial, system-ui, sans-serif';
+
+export function PrMergeVideo({
+  owner,
+  repo,
+  days,
+  people,
+}: PrMergeVideoInputProps) {
+  return (
+    <AbsoluteFill style={{ backgroundColor: "#ffffff", fontFamily }}>
+      <div
+        style={{
+          position: "absolute",
+          top: 68,
+          left: 70,
+          right: 70,
+        }}
+      >
+        <div
+          style={{
+            color: "#171717",
+            fontSize: 43,
+            fontWeight: 600,
+            letterSpacing: "-0.04em",
+            lineHeight: 1.1,
+          }}
+        >
+          Pull requests merged in the past {days} days
+        </div>
+        <div
+          style={{
+            color: "#8a8a8a",
+            fontSize: 22,
+            marginTop: 15,
+            letterSpacing: "-0.01em",
+          }}
+        >
+          {owner}/{repo}
+        </div>
+      </div>
+
+      {people.map((person, index) => (
+        <MergeRow
+          fontFamily={fontFamily}
+          index={index}
+          key={person.login}
+          person={person}
+          total={people.length}
+        />
+      ))}
+    </AbsoluteFill>
+  );
+}

--- a/apps/web/src/remotion/root.tsx
+++ b/apps/web/src/remotion/root.tsx
@@ -1,6 +1,15 @@
 import { Composition } from "remotion";
 
+import { prMergeVideoInputSchema } from "../schemas/pr-merge-video";
 import { starVideoInputSchema } from "../schemas/star-video";
+import {
+  DEFAULT_PR_MERGE_VIDEO_PROPS,
+  PR_MERGE_VIDEO_DURATION_IN_FRAMES,
+  PR_MERGE_VIDEO_FPS,
+  PR_MERGE_VIDEO_HEIGHT,
+  PR_MERGE_VIDEO_WIDTH,
+} from "./pr-merge-video/constants";
+import { PrMergeVideo } from "./pr-merge-video/pr-merge-video";
 import {
   DEFAULT_STAR_VIDEO_PROPS,
   VIDEO_DURATION_IN_FRAMES,
@@ -12,15 +21,27 @@ import { StarVideo } from "./star-video/star-video";
 
 export function RemotionRoot() {
   return (
-    <Composition
-      component={StarVideo}
-      defaultProps={DEFAULT_STAR_VIDEO_PROPS}
-      durationInFrames={VIDEO_DURATION_IN_FRAMES}
-      fps={VIDEO_FPS}
-      height={VIDEO_HEIGHT}
-      id="StarVideo"
-      schema={starVideoInputSchema}
-      width={VIDEO_WIDTH}
-    />
+    <>
+      <Composition
+        component={StarVideo}
+        defaultProps={DEFAULT_STAR_VIDEO_PROPS}
+        durationInFrames={VIDEO_DURATION_IN_FRAMES}
+        fps={VIDEO_FPS}
+        height={VIDEO_HEIGHT}
+        id="StarVideo"
+        schema={starVideoInputSchema}
+        width={VIDEO_WIDTH}
+      />
+      <Composition
+        component={PrMergeVideo}
+        defaultProps={DEFAULT_PR_MERGE_VIDEO_PROPS}
+        durationInFrames={PR_MERGE_VIDEO_DURATION_IN_FRAMES}
+        fps={PR_MERGE_VIDEO_FPS}
+        height={PR_MERGE_VIDEO_HEIGHT}
+        id="PrMergeVideo"
+        schema={prMergeVideoInputSchema}
+        width={PR_MERGE_VIDEO_WIDTH}
+      />
+    </>
   );
 }

--- a/apps/web/src/schemas/pr-merge-video.ts
+++ b/apps/web/src/schemas/pr-merge-video.ts
@@ -1,0 +1,35 @@
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+import { MAX_SELECTED_PEOPLE } from "../constants/pr-merge-video";
+import {
+  githubAvatarUrlSchema,
+  githubOwnerSlugSchema,
+  githubRepoSlugSchema,
+} from "./star-video";
+
+const prMergePeriodSchema = z.union([
+  z.literal(3),
+  z.literal(7),
+  z.literal(14),
+]);
+
+export const prMergeRepoQuerySchema = z.object({
+  owner: githubOwnerSlugSchema,
+  repo: githubRepoSlugSchema,
+  days: z.coerce.number().pipe(prMergePeriodSchema),
+});
+
+const prMergePersonSchema = z.object({
+  login: z.string().trim().min(1).max(100),
+  name: z.string().trim().min(1).max(100).nullable(),
+  avatarUrl: githubAvatarUrlSchema,
+  merges: z.number().int().min(1).max(1000),
+});
+
+export const prMergeVideoInputSchema = z.object({
+  owner: githubOwnerSlugSchema,
+  repo: githubRepoSlugSchema,
+  days: prMergePeriodSchema,
+  people: z.array(prMergePersonSchema).min(1).max(MAX_SELECTED_PEOPLE),
+});

--- a/apps/web/src/schemas/star-video.ts
+++ b/apps/web/src/schemas/star-video.ts
@@ -20,18 +20,18 @@ function isAllowedAvatarUrl(value: string): boolean {
   }
 }
 
-const avatarUrl = z
+export const githubAvatarUrlSchema = z
   .url()
   .refine(isAllowedAvatarUrl, "Avatar URLs must be on githubusercontent.com.");
 
-const ownerSlug = z
+export const githubOwnerSlugSchema = z
   .string()
   .trim()
   .min(1, "Owner is required.")
   .max(100)
   .regex(REPO_SLUG, "Enter a valid GitHub owner.");
 
-const repoSlug = z
+export const githubRepoSlugSchema = z
   .string()
   .trim()
   .min(1, "Repository is required.")
@@ -39,16 +39,16 @@ const repoSlug = z
   .regex(REPO_SLUG, "Enter a valid GitHub repository.");
 
 export const starVideoInputSchema = z.object({
-  owner: ownerSlug,
-  repo: repoSlug,
+  owner: githubOwnerSlugSchema,
+  repo: githubRepoSlugSchema,
   stars: z.number().int().min(0),
-  avatars: z.array(avatarUrl).max(MAX_AVATARS),
+  avatars: z.array(githubAvatarUrlSchema).max(MAX_AVATARS),
   backgroundColor: z.string().regex(HEX_COLOR).default("#b9f0cd"),
 });
 
 export const repoQuerySchema = z.object({
-  owner: ownerSlug,
-  repo: repoSlug,
+  owner: githubOwnerSlugSchema,
+  repo: githubRepoSlugSchema,
 });
 
 const REPO_PAIR = /^[\w.-]{1,100}\/[\w.-]{1,100}$/;
@@ -57,9 +57,12 @@ export const githubReturnRepoSchema = z.string().trim().regex(REPO_PAIR);
 
 export const MAX_PENDING_OAUTH_STATES = 5;
 
+export const githubVideoToolSchema = z.enum(["star-video", "pr-merge-video"]);
+
 const githubOAuthStateSchema = z.object({
   state: z.string().min(1),
   repo: githubReturnRepoSchema.optional(),
+  tool: githubVideoToolSchema.optional(),
 });
 
 export const githubOAuthStatesSchema = z

--- a/apps/web/src/types/pr-merge-video.ts
+++ b/apps/web/src/types/pr-merge-video.ts
@@ -1,0 +1,69 @@
+import type { PR_MERGE_PERIODS } from "../constants/pr-merge-video";
+
+export type PrMergePeriodDays = (typeof PR_MERGE_PERIODS)[number];
+
+export interface PrMergePerson {
+  login: string;
+  name: string | null;
+  avatarUrl: string;
+  merges: number;
+}
+
+export type PrMergeVideoInputProps = {
+  owner: string;
+  repo: string;
+  days: PrMergePeriodDays;
+  people: PrMergePerson[];
+};
+
+export interface RepoPrMergeData extends PrMergeVideoInputProps {
+  id: string;
+  htmlUrl: string;
+  totalMerges: number;
+  truncated: boolean;
+}
+
+export interface PrMergeRowProps {
+  person: PrMergePerson;
+  index: number;
+  total: number;
+  fontFamily: string;
+}
+
+export type LoadRepoPrMergeResult =
+  | { ok: true; data: RepoPrMergeData }
+  | { ok: false; kind: "not-found" | "unavailable" | "unauthorized" };
+
+export interface GithubPrMergeActor {
+  __typename: string;
+  login: string;
+  name?: string | null;
+  avatarUrl: string;
+}
+
+interface GithubPrMergeNode {
+  mergedAt: string | null;
+  mergedBy: GithubPrMergeActor | null;
+}
+
+export interface GithubPrMergeSearchData {
+  repository: {
+    name: string;
+    nameWithOwner: string;
+    url: string;
+    isPrivate: boolean;
+  } | null;
+  search: {
+    issueCount: number;
+    nodes: Array<GithubPrMergeNode | null>;
+    pageInfo: {
+      hasNextPage: boolean;
+      endCursor: string | null;
+    };
+  };
+}
+
+export interface GithubGraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}

--- a/apps/web/src/types/star-video.ts
+++ b/apps/web/src/types/star-video.ts
@@ -6,9 +6,17 @@ export type StarVideoInputProps = {
   backgroundColor: string;
 };
 
+export type GithubVideoTool = "star-video" | "pr-merge-video";
+
+export interface RepoInputFormProps {
+  tool?: GithubVideoTool;
+  actionLabel?: string;
+}
+
 export interface GithubOAuthState {
   state: string;
   repo?: string;
+  tool?: GithubVideoTool;
 }
 
 export interface GithubOAuthConfig {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub PR merge video generator at `/pr-merge-video`, turning recent merges from a public repository into an animated leaderboard and downloadable MP4. Users connect GitHub, choose a time range, and select contributors without changing the existing star video flow.

**New Features**

- Ranks human contributors through GitHub GraphQL and excludes bots.
- Marks results that exceed GitHub’s 1,000-result search limit.
- Adds tool-specific OAuth redirects, footer navigation, and sitemap coverage.
- Applies rate limits to repository lookups and video rendering.

<sup>Written for commit 1a0d37921e2555c1e6bf6342ae5f7dc1d6cd1b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

