### PR TITLE
fix(web): reduce contact form spam

### DIFF
--- a/apps/web/src/app/api/contact/route.ts
+++ b/apps/web/src/app/api/contact/route.ts
@@ -29,7 +29,10 @@ export async function POST(request: NextRequest) {
 
   return Effect.runPromise(
     Effect.gen(function* () {
-      const rateLimit = yield* enforceContactMessageRateLimit(request);
+      const rateLimit = yield* enforceContactMessageRateLimit(
+        request,
+        parsed.data.email
+      );
       yield* sendContactMessageEmail(parsed.data);
 
       return NextResponse.json(

--- a/apps/web/src/constants/contact.ts
+++ b/apps/web/src/constants/contact.ts
@@ -2,9 +2,27 @@ import type { ContactResourceLink } from "@/types/contact";
 
 export const CONTACT_RECIPIENT = "hello@usenotra.com";
 
-export const CONTACT_RATE_LIMIT = {
-  requests: 3,
-  window: "1h",
+export const CONTACT_RATE_LIMITS = {
+  ipHourly: {
+    requests: 2,
+    window: "1h",
+    windowMs: 60 * 60 * 1000,
+  },
+  ipDaily: {
+    requests: 5,
+    window: "1d",
+    windowMs: 24 * 60 * 60 * 1000,
+  },
+  emailDaily: {
+    requests: 2,
+    window: "1d",
+    windowMs: 24 * 60 * 60 * 1000,
+  },
+  globalHourly: {
+    requests: 20,
+    window: "1h",
+    windowMs: 60 * 60 * 1000,
+  },
 } as const;
 
 export const CONTACT_MESSAGE_MIN_LENGTH = 10;

--- a/apps/web/src/lib/contact/ratelimit.ts
+++ b/apps/web/src/lib/contact/ratelimit.ts
@@ -5,7 +5,15 @@ import { Redis } from "@upstash/redis";
 import { Data, Effect } from "effect";
 import type { NextRequest } from "next/server";
 
-import { CONTACT_RATE_LIMIT } from "@/constants/contact";
+import { CONTACT_RATE_LIMITS } from "@/constants/contact";
+
+type LimiterKind = keyof typeof CONTACT_RATE_LIMITS;
+
+interface RateLimitResult {
+  readonly limit: number;
+  readonly remaining: number;
+  readonly reset: number;
+}
 
 class ContactMessageRateLimitExceeded extends Data.TaggedError(
   "ContactMessageRateLimitExceeded"
@@ -22,31 +30,35 @@ class ContactMessageRateLimitError extends Data.TaggedError(
   readonly cause: unknown;
 }> {}
 
-let limiter: Ratelimit | null = null;
+const limiters: Partial<Record<LimiterKind, Ratelimit | null>> = {};
 
-function getLimiter(): Ratelimit | null {
-  if (limiter) {
-    return limiter;
+function getLimiter(kind: LimiterKind): Ratelimit | null {
+  if (limiters[kind] !== undefined) {
+    return limiters[kind] ?? null;
   }
 
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
 
   if (!(url && token)) {
+    limiters[kind] = null;
     return null;
   }
 
-  limiter = new Ratelimit({
+  const config = CONTACT_RATE_LIMITS[kind];
+  const prefix =
+    kind === "ipHourly"
+      ? "ratelimit:web:contact-message"
+      : `ratelimit:web:contact-message-${kind}`;
+
+  limiters[kind] = new Ratelimit({
     redis: new Redis({ url, token }),
     analytics: true,
-    prefix: "ratelimit:web:contact-message",
-    limiter: Ratelimit.slidingWindow(
-      CONTACT_RATE_LIMIT.requests,
-      CONTACT_RATE_LIMIT.window
-    ),
+    prefix,
+    limiter: Ratelimit.slidingWindow(config.requests, config.window),
   });
 
-  return limiter;
+  return limiters[kind] ?? null;
 }
 
 function getClientIp(request: NextRequest): string {
@@ -70,16 +82,16 @@ function getClientIp(request: NextRequest): string {
   );
 }
 
-function getRateLimitKey(request: NextRequest): string {
+function getIpRateLimitKey(request: NextRequest): string {
   return createHash("sha256").update(getClientIp(request)).digest("hex");
 }
 
+function getEmailRateLimitKey(email: string): string {
+  return createHash("sha256").update(email.trim().toLowerCase()).digest("hex");
+}
+
 export function getContactRateLimitHeaders(
-  result: {
-    limit: number;
-    remaining: number;
-    reset: number;
-  },
+  result: RateLimitResult,
   includeRetryAfter = false
 ): Headers {
   const resetSeconds = Math.max(
@@ -103,10 +115,12 @@ export function getContactRateLimitHeaders(
   return headers;
 }
 
-export const enforceContactMessageRateLimit = Effect.fn(
-  "enforceContactMessageRateLimit"
-)(function* (request: NextRequest) {
-  const ratelimit = getLimiter();
+const enforceLimit = Effect.fn("enforceContactMessageLimit")(function* (
+  kind: LimiterKind,
+  key: string
+) {
+  const ratelimit = getLimiter(kind);
+  const config = CONTACT_RATE_LIMITS[kind];
 
   if (!ratelimit) {
     if (process.env.NODE_ENV === "production") {
@@ -121,17 +135,17 @@ export const enforceContactMessageRateLimit = Effect.fn(
     }
 
     return {
-      limit: CONTACT_RATE_LIMIT.requests,
-      remaining: CONTACT_RATE_LIMIT.requests,
-      reset: Date.now() + 60 * 60 * 1000,
+      limit: config.requests,
+      remaining: config.requests,
+      reset: Date.now() + config.windowMs,
     };
   }
 
   const result = yield* Effect.tryPromise({
-    try: () => ratelimit.limit(getRateLimitKey(request)),
+    try: () => ratelimit.limit(key),
     catch: (cause) =>
       new ContactMessageRateLimitError({
-        message: "Failed to enforce contact message rate limit",
+        message: `Failed to enforce ${kind} contact message rate limit`,
         cause,
       }),
   });
@@ -151,4 +165,17 @@ export const enforceContactMessageRateLimit = Effect.fn(
     remaining: result.remaining,
     reset: result.reset,
   };
+});
+
+export const enforceContactMessageRateLimit = Effect.fn(
+  "enforceContactMessageRateLimit"
+)(function* (request: NextRequest, email: string) {
+  const ipKey = getIpRateLimitKey(request);
+  const hourlyResult = yield* enforceLimit("ipHourly", ipKey);
+
+  yield* enforceLimit("ipDaily", ipKey);
+  yield* enforceLimit("emailDaily", getEmailRateLimitKey(email));
+  yield* enforceLimit("globalHourly", "global");
+
+  return hourlyResult;
 });

--- a/apps/web/src/lib/contact/ratelimit.ts
+++ b/apps/web/src/lib/contact/ratelimit.ts
@@ -90,6 +90,17 @@ function getEmailRateLimitKey(email: string): string {
   return createHash("sha256").update(email.trim().toLowerCase()).digest("hex");
 }
 
+function getMoreBindingRateLimit(
+  current: RateLimitResult,
+  candidate: RateLimitResult
+): RateLimitResult {
+  if (candidate.remaining !== current.remaining) {
+    return candidate.remaining < current.remaining ? candidate : current;
+  }
+
+  return candidate.reset > current.reset ? candidate : current;
+}
+
 export function getContactRateLimitHeaders(
   result: RateLimitResult,
   includeRetryAfter = false
@@ -172,10 +183,15 @@ export const enforceContactMessageRateLimit = Effect.fn(
 )(function* (request: NextRequest, email: string) {
   const ipKey = getIpRateLimitKey(request);
   const hourlyResult = yield* enforceLimit("ipHourly", ipKey);
+  const dailyResult = yield* enforceLimit("ipDaily", ipKey);
+  const emailResult = yield* enforceLimit(
+    "emailDaily",
+    getEmailRateLimitKey(email)
+  );
+  const globalResult = yield* enforceLimit("globalHourly", "global");
 
-  yield* enforceLimit("ipDaily", ipKey);
-  yield* enforceLimit("emailDaily", getEmailRateLimitKey(email));
-  yield* enforceLimit("globalHourly", "global");
-
-  return hourlyResult;
+  return [dailyResult, emailResult, globalResult].reduce(
+    getMoreBindingRateLimit,
+    hourlyResult
+  );
 });


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens contact form rate limits to reduce spam by layering multiple limits instead of a single per-IP cap.

**Rate limits**
- The old limit was 3 requests per hour per IP.
- Now the form enforces 2 per hour per IP, 5 per day per IP, 2 per day per email address, and 20 per hour globally.
- The email address is hashed before being used as a rate limit key.
- Rate limit headers reflect the most binding limit across all enforced limits.

<sup>Written for commit b6c24f8af654e4766abb6afd4f8c05ba1f8e33df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

