### PR TITLE
fix(email): display current Notra icon in email headers

### DIFF
--- a/packages/email/src/components/logo.tsx
+++ b/packages/email/src/components/logo.tsx
@@ -1,0 +1,18 @@
+import { Img, Link, Section } from "react-email";
+
+import { EMAIL_CONFIG } from "../utils/config";
+
+export const EmailLogo = () => (
+  <Section className="mt-[32px] text-center">
+    <Link href={EMAIL_CONFIG.getSiteUrl()}>
+      <Img
+        alt="Notra"
+        className="mx-auto"
+        height="64"
+        src={EMAIL_CONFIG.getLogoUrl()}
+        style={{ borderRadius: "14px" }}
+        width="64"
+      />
+    </Link>
+  </Section>
+);

--- a/packages/email/src/components/scheduled-content-status.tsx
+++ b/packages/email/src/components/scheduled-content-status.tsx
@@ -1,0 +1,88 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "react-email";
+
+import type { ScheduledContentStatusTemplateProps } from "../types/scheduled-content-status";
+import { EMAIL_CONFIG } from "../utils/config";
+import { EmailButton } from "./button";
+import { EmailFooter } from "./footer";
+import { EmailLogo } from "./logo";
+
+export const ScheduledContentStatusEmail = ({
+  organizationName,
+  scheduleName,
+  reason,
+  settingsLink,
+  organizationSlug,
+  status,
+}: ScheduledContentStatusTemplateProps) => {
+  const failed = status === "failed";
+  const statusLabel = failed ? "failed" : "was skipped";
+
+  return (
+    <Html>
+      <Head />
+      <Preview>Your scheduled content generation {statusLabel}</Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white px-2 font-sans">
+          <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
+            <EmailLogo />
+
+            <Heading className="my-6 text-center text-2xl font-medium text-black">
+              Scheduled content generation {statusLabel}
+            </Heading>
+
+            <Text className="text-center text-base leading-relaxed text-[#737373]">
+              Your <strong>{scheduleName}</strong> schedule in{" "}
+              <strong>{organizationName}</strong>{" "}
+              {failed
+                ? "was unable to generate content."
+                : "ran successfully, but did not create content."}
+            </Text>
+
+            <Section className="mt-8">
+              <Text className="m-0 text-[12px] tracking-wide text-[#666666] uppercase">
+                Reason:
+              </Text>
+              <Text className="mt-2 mb-0 text-[14px] leading-[22px] text-black">
+                {reason}
+              </Text>
+            </Section>
+
+            <Section className="my-8 text-center">
+              <EmailButton href={settingsLink}>View Schedule</EmailButton>
+            </Section>
+
+            <Text className="text-[14px] leading-[24px] text-black">
+              If the button does not work, copy and paste this URL into your
+              browser: <Link href={settingsLink}>{settingsLink}</Link>
+            </Text>
+
+            <Section className="mt-8">
+              <Text className="m-0 text-center text-[12px] tracking-wide text-[#666666] uppercase">
+                If you don't want to receive these emails, you can click{" "}
+                <Link
+                  href={`${EMAIL_CONFIG.getAppUrl()}/${organizationSlug}/settings/notifications`}
+                >
+                  here
+                </Link>{" "}
+                to update your notification settings.
+              </Text>
+            </Section>
+
+            <EmailFooter />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};

--- a/packages/email/src/emails/ai-credits-depleted.tsx
+++ b/packages/email/src/emails/ai-credits-depleted.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Link,
   Preview,
   Section,
@@ -14,6 +13,7 @@ import {
 
 import { EmailButton } from "../components/button";
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import type { AiCreditsDepletedEmailProps } from "../types/ai-credits-depleted";
 import { EMAIL_CONFIG } from "../utils/config";
 
@@ -24,7 +24,6 @@ export const AiCreditsDepletedEmail = ({
   creditsLink = `${EMAIL_CONFIG.getAppUrl()}/${organizationSlug}/settings/credits`,
   limitLabel,
 }: AiCreditsDepletedEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
   const heading = limitLabel ? "Plan limit reached" : "AI credits are depleted";
   const previewText = limitLabel
     ? "Your Notra plan limit was reached"
@@ -38,15 +37,7 @@ export const AiCreditsDepletedEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               {heading}

--- a/packages/email/src/emails/contact.tsx
+++ b/packages/email/src/emails/contact.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Preview,
   Section,
   Tailwind,
@@ -12,8 +11,8 @@ import {
 } from "react-email";
 
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import type { ContactMessageEmailProps } from "../types/contact";
-import { EMAIL_CONFIG } from "../utils/config";
 
 export const ContactMessageEmail = ({
   name = "Jane Doe",
@@ -21,8 +20,6 @@ export const ContactMessageEmail = ({
   company,
   message = "We're evaluating Notra for our team and would love to chat about volume pricing.",
 }: ContactMessageEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
-
   return (
     <Html>
       <Head />
@@ -33,15 +30,7 @@ export const ContactMessageEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[520px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               New contact message

--- a/packages/email/src/emails/feedback.tsx
+++ b/packages/email/src/emails/feedback.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Preview,
   Section,
   Tailwind,
@@ -12,8 +11,8 @@ import {
 } from "react-email";
 
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import type { FeedbackEmailProps } from "../types/feedback";
-import { EMAIL_CONFIG } from "../utils/config";
 import { FEEDBACK_SENTIMENT_META } from "../utils/feedback";
 
 export const FeedbackEmail = ({
@@ -26,7 +25,6 @@ export const FeedbackEmail = ({
   pageUrl,
   userAgent,
 }: FeedbackEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
   const sentimentMeta = sentiment ? FEEDBACK_SENTIMENT_META[sentiment] : null;
 
   return (
@@ -39,15 +37,7 @@ export const FeedbackEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[520px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               {sentimentMeta ? `${sentimentMeta.emoji} ` : ""}New feedback

--- a/packages/email/src/emails/oss-application.tsx
+++ b/packages/email/src/emails/oss-application.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Link,
   Preview,
   Section,
@@ -13,8 +12,8 @@ import {
 } from "react-email";
 
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import type { OssApplicationEmailProps } from "../types/oss-application";
-import { EMAIL_CONFIG } from "../utils/config";
 
 export const OssApplicationEmail = ({
   name = "Linus Torvalds",
@@ -24,8 +23,6 @@ export const OssApplicationEmail = ({
   description = "A free and open source operating system kernel used by everything from phones to supercomputers.",
   assetNeeds = "We need help turning releases into clear changelogs, launch posts, and social updates so new contributors can understand what's shipping.",
 }: OssApplicationEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
-
   return (
     <Html>
       <Head />
@@ -35,15 +32,7 @@ export const OssApplicationEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[520px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               New OSS program application

--- a/packages/email/src/emails/schedule-content-created.tsx
+++ b/packages/email/src/emails/schedule-content-created.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Link,
   Preview,
   Section,
@@ -14,6 +13,7 @@ import {
 
 import { EmailButton } from "../components/button";
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import type { ScheduledContentCreatedEmailProps } from "../types/schedule-content-created";
 import { EMAIL_CONFIG } from "../utils/config";
 
@@ -38,7 +38,6 @@ export const ScheduledContentCreatedEmail = ({
   organizationSlug = "acme",
   contentOverviewLink = `https://app.usenotra.com/${organizationSlug}/content`,
 }: ScheduledContentCreatedEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
   const contentCount = createdContent.length;
   const primaryContent = createdContent[0];
   const contentLabel = CONTENT_TYPE_MAP[contentType] ?? "Content";
@@ -54,15 +53,7 @@ export const ScheduledContentCreatedEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               New scheduled content is ready

--- a/packages/email/src/emails/schedule-content-failed.tsx
+++ b/packages/email/src/emails/schedule-content-failed.tsx
@@ -1,28 +1,5 @@
-import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Html,
-  Link,
-  Preview,
-  Section,
-  Tailwind,
-  Text,
-} from "react-email";
-
-import { EmailButton } from "../components/button";
-import { EmailFooter } from "../components/footer";
-import { EmailLogo } from "../components/logo";
-import { EMAIL_CONFIG } from "../utils/config";
-
-interface ScheduledContentFailedEmailProps {
-  organizationName: string;
-  scheduleName: string;
-  reason: string;
-  settingsLink: string;
-  organizationSlug: string;
-}
+import { ScheduledContentStatusEmail } from "../components/scheduled-content-status";
+import type { ScheduledContentStatusEmailProps } from "../types/scheduled-content-status";
 
 export const ScheduledContentFailedEmail = ({
   organizationName = "Acme Inc",
@@ -30,60 +7,13 @@ export const ScheduledContentFailedEmail = ({
   reason = "No meaningful changes were found in the lookback window.",
   organizationSlug = "acme",
   settingsLink = `https://app.usenotra.com/${organizationSlug}/automation/schedules`,
-}: ScheduledContentFailedEmailProps) => {
-  return (
-    <Html>
-      <Head />
-      <Preview>Your scheduled content generation failed</Preview>
-      <Tailwind>
-        <Body className="mx-auto my-auto bg-white px-2 font-sans">
-          <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
-            <EmailLogo />
-
-            <Heading className="my-6 text-center text-2xl font-medium text-black">
-              Scheduled content generation failed
-            </Heading>
-
-            <Text className="text-center text-base leading-relaxed text-[#737373]">
-              Your <strong>{scheduleName}</strong> schedule in{" "}
-              <strong>{organizationName}</strong> was unable to generate
-              content.
-            </Text>
-
-            <Section className="mt-8">
-              <Text className="m-0 text-[12px] tracking-wide text-[#666666] uppercase">
-                Reason:
-              </Text>
-              <Text className="mt-2 mb-0 text-[14px] leading-[22px] text-black">
-                {reason}
-              </Text>
-            </Section>
-
-            <Section className="my-8 text-center">
-              <EmailButton href={settingsLink}>View Schedule</EmailButton>
-            </Section>
-
-            <Text className="text-[14px] leading-[24px] text-black">
-              If the button does not work, copy and paste this URL into your
-              browser: <Link href={settingsLink}>{settingsLink}</Link>
-            </Text>
-
-            <Section className="mt-8">
-              <Text className="m-0 text-center text-[12px] tracking-wide text-[#666666] uppercase">
-                If you don't want to receive these emails, you can click{" "}
-                <Link
-                  href={`${EMAIL_CONFIG.getAppUrl()}/${organizationSlug}/settings/notifications`}
-                >
-                  here
-                </Link>{" "}
-                to update your notification settings.
-              </Text>
-            </Section>
-
-            <EmailFooter />
-          </Container>
-        </Body>
-      </Tailwind>
-    </Html>
-  );
-};
+}: ScheduledContentStatusEmailProps) => (
+  <ScheduledContentStatusEmail
+    organizationName={organizationName}
+    organizationSlug={organizationSlug}
+    reason={reason}
+    scheduleName={scheduleName}
+    settingsLink={settingsLink}
+    status="failed"
+  />
+);

--- a/packages/email/src/emails/schedule-content-failed.tsx
+++ b/packages/email/src/emails/schedule-content-failed.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Link,
   Preview,
   Section,
@@ -14,6 +13,7 @@ import {
 
 import { EmailButton } from "../components/button";
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import { EMAIL_CONFIG } from "../utils/config";
 
 interface ScheduledContentFailedEmailProps {
@@ -31,8 +31,6 @@ export const ScheduledContentFailedEmail = ({
   organizationSlug = "acme",
   settingsLink = `https://app.usenotra.com/${organizationSlug}/automation/schedules`,
 }: ScheduledContentFailedEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
-
   return (
     <Html>
       <Head />
@@ -40,15 +38,7 @@ export const ScheduledContentFailedEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               Scheduled content generation failed

--- a/packages/email/src/emails/schedule-content-skipped.tsx
+++ b/packages/email/src/emails/schedule-content-skipped.tsx
@@ -1,28 +1,5 @@
-import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Html,
-  Link,
-  Preview,
-  Section,
-  Tailwind,
-  Text,
-} from "react-email";
-
-import { EmailButton } from "../components/button";
-import { EmailFooter } from "../components/footer";
-import { EmailLogo } from "../components/logo";
-import { EMAIL_CONFIG } from "../utils/config";
-
-interface ScheduledContentSkippedEmailProps {
-  organizationName: string;
-  scheduleName: string;
-  reason: string;
-  settingsLink: string;
-  organizationSlug: string;
-}
+import { ScheduledContentStatusEmail } from "../components/scheduled-content-status";
+import type { ScheduledContentStatusEmailProps } from "../types/scheduled-content-status";
 
 export const ScheduledContentSkippedEmail = ({
   organizationName = "Acme Inc",
@@ -30,60 +7,13 @@ export const ScheduledContentSkippedEmail = ({
   reason = "No meaningful changes were found in the lookback window.",
   organizationSlug = "acme",
   settingsLink = `https://app.usenotra.com/${organizationSlug}/automation/schedules`,
-}: ScheduledContentSkippedEmailProps) => {
-  return (
-    <Html>
-      <Head />
-      <Preview>Your scheduled content generation was skipped</Preview>
-      <Tailwind>
-        <Body className="mx-auto my-auto bg-white px-2 font-sans">
-          <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
-            <EmailLogo />
-
-            <Heading className="my-6 text-center text-2xl font-medium text-black">
-              Scheduled content generation was skipped
-            </Heading>
-
-            <Text className="text-center text-base leading-relaxed text-[#737373]">
-              Your <strong>{scheduleName}</strong> schedule in{" "}
-              <strong>{organizationName}</strong> ran successfully, but did not
-              create content.
-            </Text>
-
-            <Section className="mt-8">
-              <Text className="m-0 text-[12px] tracking-wide text-[#666666] uppercase">
-                Reason:
-              </Text>
-              <Text className="mt-2 mb-0 text-[14px] leading-[22px] text-black">
-                {reason}
-              </Text>
-            </Section>
-
-            <Section className="my-8 text-center">
-              <EmailButton href={settingsLink}>View Schedule</EmailButton>
-            </Section>
-
-            <Text className="text-[14px] leading-[24px] text-black">
-              If the button does not work, copy and paste this URL into your
-              browser: <Link href={settingsLink}>{settingsLink}</Link>
-            </Text>
-
-            <Section className="mt-8">
-              <Text className="m-0 text-center text-[12px] tracking-wide text-[#666666] uppercase">
-                If you don't want to receive these emails, you can click{" "}
-                <Link
-                  href={`${EMAIL_CONFIG.getAppUrl()}/${organizationSlug}/settings/notifications`}
-                >
-                  here
-                </Link>{" "}
-                to update your notification settings.
-              </Text>
-            </Section>
-
-            <EmailFooter />
-          </Container>
-        </Body>
-      </Tailwind>
-    </Html>
-  );
-};
+}: ScheduledContentStatusEmailProps) => (
+  <ScheduledContentStatusEmail
+    organizationName={organizationName}
+    organizationSlug={organizationSlug}
+    reason={reason}
+    scheduleName={scheduleName}
+    settingsLink={settingsLink}
+    status="skipped"
+  />
+);

--- a/packages/email/src/emails/schedule-content-skipped.tsx
+++ b/packages/email/src/emails/schedule-content-skipped.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Link,
   Preview,
   Section,
@@ -14,6 +13,7 @@ import {
 
 import { EmailButton } from "../components/button";
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import { EMAIL_CONFIG } from "../utils/config";
 
 interface ScheduledContentSkippedEmailProps {
@@ -31,8 +31,6 @@ export const ScheduledContentSkippedEmail = ({
   organizationSlug = "acme",
   settingsLink = `https://app.usenotra.com/${organizationSlug}/automation/schedules`,
 }: ScheduledContentSkippedEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
-
   return (
     <Html>
       <Head />
@@ -40,15 +38,7 @@ export const ScheduledContentSkippedEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               Scheduled content generation was skipped

--- a/packages/email/src/emails/workflow-paused.tsx
+++ b/packages/email/src/emails/workflow-paused.tsx
@@ -4,7 +4,6 @@ import {
   Head,
   Heading,
   Html,
-  Img,
   Link,
   Preview,
   Section,
@@ -14,6 +13,7 @@ import {
 
 import { EmailButton } from "../components/button";
 import { EmailFooter } from "../components/footer";
+import { EmailLogo } from "../components/logo";
 import type {
   WorkflowPausedEmailProps,
   WorkflowPausedReason,
@@ -39,8 +39,6 @@ export const WorkflowPausedEmail = ({
   reason = "workflow_errors",
   settingsLink = `${EMAIL_CONFIG.getAppUrl()}/${organizationSlug}/automation/schedules`,
 }: WorkflowPausedEmailProps) => {
-  const logoUrl = EMAIL_CONFIG.getLogoUrl();
-
   return (
     <Html>
       <Head />
@@ -48,15 +46,7 @@ export const WorkflowPausedEmail = ({
       <Tailwind>
         <Body className="mx-auto my-auto bg-white px-2 font-sans">
           <Container className="mx-auto my-[40px] max-w-[465px] rounded p-[20px]">
-            <Section className="mt-[32px]">
-              <Img
-                alt="Notra Logo"
-                className="mx-auto"
-                height="40"
-                src={logoUrl}
-                width="40"
-              />
-            </Section>
+            <EmailLogo />
 
             <Heading className="my-6 text-center text-2xl font-medium text-black">
               Workflow paused

--- a/packages/email/src/types/scheduled-content-status.ts
+++ b/packages/email/src/types/scheduled-content-status.ts
@@ -1,0 +1,13 @@
+export interface ScheduledContentStatusEmailProps {
+  organizationName: string;
+  scheduleName: string;
+  reason: string;
+  settingsLink: string;
+  organizationSlug: string;
+}
+
+export type ScheduledContentStatus = "failed" | "skipped";
+
+export interface ScheduledContentStatusTemplateProps extends ScheduledContentStatusEmailProps {
+  status: ScheduledContentStatus;
+}

--- a/packages/email/src/utils/config.ts
+++ b/packages/email/src/utils/config.ts
@@ -26,11 +26,11 @@ export const EMAIL_CONFIG = {
   },
 
   /**
-   * Get logo URL with fallback (uses site URL)
+   * Get the email-safe PNG icon URL (uses site URL)
    */
   getLogoUrl(): string {
     const siteUrl = this.getSiteUrl();
-    return `${siteUrl}/icon1.png`;
+    return `${siteUrl}/web-app-manifest-192x192.png`;
   },
 
   /**


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces duplicated logo markup in eight email templates with a shared `EmailLogo` component, updates the logo source to the current Notra icon, and merges the failed and skipped scheduled content emails into a shared `ScheduledContentStatusEmail` template.

- The logo now renders at 64px (was 40px) and links to the site URL.
- The logo URL changed from `icon1.png` to `web-app-manifest-192x192.png`, so email clients show the current icon instead of an outdated one.
- The failed and skipped templates keep their existing props, so no caller changes are required.

<sup>Written for commit eb81446000d4c9e0f57f8a7732d7f1f1b4e572e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

