### PR TITLE
perf(dashboard): reduce repeated auth and organization queries

### DIFF
--- a/apps/dashboard/src/lib/auth/actions.ts
+++ b/apps/dashboard/src/lib/auth/actions.ts
@@ -5,6 +5,7 @@ import { members, organizations, projects } from "@notra/db/schema";
 import { and, eq } from "drizzle-orm";
 import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
+import { cache } from "react";
 
 import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
 import { isSessionBanned } from "@/lib/auth/banned";
@@ -13,7 +14,7 @@ import { retryTransientDbError } from "@/lib/db/retry";
 import { organizationSlugParamSchema } from "@/schemas/auth/organization";
 import { getLastVisitedProject } from "@/utils/cookies";
 
-export async function validateOrganizationAccess(rawSlug: string) {
+const getOrganizationAccess = cache(async (rawSlug: string) => {
   const slugValidation = organizationSlugParamSchema.safeParse(rawSlug);
 
   if (!slugValidation.success) {
@@ -50,6 +51,10 @@ export async function validateOrganizationAccess(rawSlug: string) {
     user: session.user,
     member: organization.members[0],
   };
+});
+
+export async function validateOrganizationAccess(rawSlug: string) {
+  return getOrganizationAccess(rawSlug);
 }
 
 export async function getSession() {
@@ -154,26 +159,12 @@ export async function getLastActiveOrganization() {
 }
 
 async function getAllOrganizationsForUser(userId: string) {
-  const userMemberships = await retryTransientDbError(() =>
-    db.query.members.findMany({
-      where: eq(members.userId, userId),
-      columns: { organizationId: true },
-    })
-  );
-
-  const orgs = await Promise.all(
-    userMemberships.map((m) =>
-      retryTransientDbError(() =>
-        db.query.organizations.findFirst({
-          where: eq(organizations.id, m.organizationId),
-          columns: { slug: true, id: true },
-        })
-      )
-    )
-  );
-
-  return orgs.filter(
-    (org): org is { slug: string; id: string } => org !== undefined
+  return retryTransientDbError(() =>
+    db
+      .select({ slug: organizations.slug, id: organizations.id })
+      .from(members)
+      .innerJoin(organizations, eq(organizations.id, members.organizationId))
+      .where(eq(members.userId, userId))
   );
 }
 

--- a/apps/dashboard/src/lib/auth/server.ts
+++ b/apps/dashboard/src/lib/auth/server.ts
@@ -6,6 +6,7 @@ import { Effect } from "effect";
 import { cookies } from "next/headers";
 import { unstable_rethrow } from "next/navigation";
 import { connection } from "next/server";
+import { cache } from "react";
 
 import { LAST_VISITED_ORGANIZATION_COOKIE } from "@/constants/cookies";
 import { isUserBanned } from "@/lib/auth/banned";
@@ -104,37 +105,39 @@ const buildAuthSession = Effect.fn("auth.session.build")(function* (
   return session;
 });
 
-export async function getAuthSession(): Promise<AuthSessionData | null> {
-  await connection();
+export const getAuthSession = cache(
+  async (): Promise<AuthSessionData | null> => {
+    await connection();
 
-  let authResult: Awaited<ReturnType<typeof withAuth>>;
+    let authResult: Awaited<ReturnType<typeof withAuth>>;
 
-  try {
-    authResult = await withAuth();
-  } catch (error) {
-    unstable_rethrow(error);
-    console.error("Error reading AuthKit session", error);
-    return null;
-  }
+    try {
+      authResult = await withAuth();
+    } catch (error) {
+      unstable_rethrow(error);
+      console.error("Error reading AuthKit session", error);
+      return null;
+    }
 
-  if (!authResult.user) {
-    return null;
-  }
+    if (!authResult.user) {
+      return null;
+    }
 
-  return await Effect.runPromise(
-    buildAuthSession(
-      authResult.user,
-      authResult.impersonator?.email ?? null
-    ).pipe(
-      Effect.catch((error) =>
-        Effect.logWarning("Failed to build auth session").pipe(
-          Effect.annotateLogs({
-            workosUserId: authResult.user?.id,
-            error: error.message,
-          }),
-          Effect.as(null)
+    return await Effect.runPromise(
+      buildAuthSession(
+        authResult.user,
+        authResult.impersonator?.email ?? null
+      ).pipe(
+        Effect.catch((error) =>
+          Effect.logWarning("Failed to build auth session").pipe(
+            Effect.annotateLogs({
+              workosUserId: authResult.user?.id,
+              error: error.message,
+            }),
+            Effect.as(null)
+          )
         )
       )
-    )
-  );
-}
+    );
+  }
+);


### PR DESCRIPTION
### Description
Reduce unnecessary database work when loading the dashboard and resolving the user's organizations.

Session construction and organization access checks now use React's request-scoped cache to avoid repeating the same work across server-rendered layouts and pages. Organization listing uses a single SQL join instead of one membership query plus one query per organization. Authorization checks remain in place, and the React cache is not shared across requests or users.

Validation: repository lint, dashboard typecheck, and all 35 existing dashboard tests passed. React Doctor reported 100/100 with no findings in the two changed files. The existing tests do not cover the authentication flow. The production build was stopped after five minutes without further compiler output, so build verification remains incomplete. No end-to-end latency improvement has been measured.

AI assistance was used to implement these changes.

### Screenshot/Recording (if applicable)
Not applicable; this change affects server-side data access only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces repeated database work when loading the dashboard by caching session construction and organization access checks per React request, and by replacing per-organization membership queries with a single SQL join. The old behavior ran the same auth and organization queries across server-rendered layouts and pages; the new behavior preserves the same results and authorization checks.

- Wraps `getAuthSession` and organization access validation in React's `cache()`.
- Loads the organization list with one `innerJoin` query instead of a membership query plus one query per organization.
- Does not share the cache across requests or users.
- Only lint and existing tests have passed; production build verification remains incomplete.

<sup>Written for commit f91c89abc77c3e10dae26d4e3e3f0c5d42452abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

