### PR TITLE
fix(geo): remove share of voice brand tags

### DIFF
--- a/apps/dashboard/src/components/geo/share-of-voice-brand-tag.tsx
+++ b/apps/dashboard/src/components/geo/share-of-voice-brand-tag.tsx
@@ -8,11 +8,9 @@ import {
 import { Badge } from "@notra/ui/components/ui/badge";
 
 import { Button } from "@/components/button";
-import { CHART_OTHER_SLICE_LABEL } from "@/constants/charts";
 import { cn } from "@/lib/utils";
 import type {
   BrandTrackingBadgeProps,
-  ShareOfVoiceBrandTagProps,
   TrackBrandButtonProps,
 } from "@/types/geo";
 
@@ -49,24 +47,5 @@ export function TrackBrandButton({
     >
       {GEO_BRAND_TRACK_ACTION}
     </Button>
-  );
-}
-
-export function ShareOfVoiceBrandTag({
-  row,
-  own,
-  onTrack,
-}: ShareOfVoiceBrandTagProps) {
-  if (own || row.brand === CHART_OTHER_SLICE_LABEL || row.tracked) {
-    return null;
-  }
-
-  return (
-    <span className="flex shrink-0 items-center gap-1">
-      <BrandTrackingBadge tracked={row.tracked} />
-      {!row.tracked && onTrack ? (
-        <TrackBrandButton brand={row.brand} onTrack={onTrack} />
-      ) : null}
-    </span>
   );
 }

--- a/apps/dashboard/src/components/geo/share-of-voice-card.tsx
+++ b/apps/dashboard/src/components/geo/share-of-voice-card.tsx
@@ -55,7 +55,6 @@ export function ShareOfVoiceCard({
         isScanning={isScanning}
         onRowClick={organizationSlug ? openRow : undefined}
         onRowPointerEnter={organizationSlug ? prefetchRow : undefined}
-        organizationId={organizationId}
         points={points}
         timeseries={timeseries}
       />

--- a/apps/dashboard/src/components/geo/share-of-voice-table.tsx
+++ b/apps/dashboard/src/components/geo/share-of-voice-table.tsx
@@ -9,14 +9,12 @@ import { findCompetitorDomain } from "@notra/geo-core/geo/domain";
 import type { ShareOfVoiceRow } from "@notra/geo-core/types/geo";
 import { geoScanEmptyMessage } from "@notra/geo-core/utils/geo-scan";
 import { GeoBar } from "@notra/ui/components/geo/geo-bar";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { EmptyStateTablePreview } from "@/components/empty-state-preview";
-import { CompetitorEditDialog } from "@/components/geo/competitor-edit-dialog";
 import { CompetitorLogo } from "@/components/geo/competitor-logo";
 import { GeoRateSparkline } from "@/components/geo/geo-rate-sparkline";
 import { GeoStatDelta } from "@/components/geo/geo-stat-delta";
-import { ShareOfVoiceBrandTag } from "@/components/geo/share-of-voice-brand-tag";
 import { InstrumentEmpty } from "@/components/instrument/instrument-module";
 import { Table, type TableColumn } from "@/components/motion/table";
 import { CHART_OTHER_SLICE_LABEL } from "@/constants/charts";
@@ -47,9 +45,7 @@ export function ShareOfVoiceTable({
   onRowPointerEnter,
   companyName,
   aliases,
-  organizationId,
 }: ShareOfVoiceTableProps) {
-  const [trackBrand, setTrackBrand] = useState<string | null>(null);
   const rows = buildShareOfVoiceRows(points, {
     limit,
     competitors,
@@ -82,11 +78,6 @@ export function ShareOfVoiceTable({
             />
           )}
           <span className="truncate">{row.brand}</span>
-          <ShareOfVoiceBrandTag
-            onTrack={organizationId ? setTrackBrand : undefined}
-            own={isOwnBrandName(row.brand, companyName, aliases)}
-            row={row}
-          />
         </span>
       ),
     },
@@ -192,34 +183,19 @@ export function ShareOfVoiceTable({
   }
 
   return (
-    <>
-      <Table
-        className="rounded-2xl"
-        columns={columns}
-        data={rows}
-        defaultSort={{ key: "share", direction: "desc" }}
-        emptyState="No competitor data yet"
-        getRowId={(row) => row.brand}
-        height={GEO_VISIBILITY_TABLE_HEIGHT}
-        minHeight={GEO_VISIBILITY_TABLE_HEIGHT}
-        onRowClick={onRowClick}
-        onRowPointerEnter={onRowPointerEnter}
-        resizable
-        rowHeight={TABLE_ROW_HEIGHT}
-      />
-      {organizationId ? (
-        <CompetitorEditDialog
-          competitor={null}
-          initialName={trackBrand ?? undefined}
-          onOpenChange={(open) => {
-            if (!open) {
-              setTrackBrand(null);
-            }
-          }}
-          open={trackBrand !== null}
-          organizationId={organizationId}
-        />
-      ) : null}
-    </>
+    <Table
+      className="rounded-2xl"
+      columns={columns}
+      data={rows}
+      defaultSort={{ key: "share", direction: "desc" }}
+      emptyState="No competitor data yet"
+      getRowId={(row) => row.brand}
+      height={GEO_VISIBILITY_TABLE_HEIGHT}
+      minHeight={GEO_VISIBILITY_TABLE_HEIGHT}
+      onRowClick={onRowClick}
+      onRowPointerEnter={onRowPointerEnter}
+      resizable
+      rowHeight={TABLE_ROW_HEIGHT}
+    />
   );
 }

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -868,18 +868,11 @@ export interface ShareOfVoiceTableProps {
   onRowPointerEnter?: (row: ShareOfVoiceRow) => void;
   companyName?: string | null;
   aliases?: readonly string[];
-  organizationId?: string;
 }
 
 export interface BrandTrackingBadgeProps {
   tracked: boolean;
   className?: string;
-}
-
-export interface ShareOfVoiceBrandTagProps {
-  row: ShareOfVoiceRow;
-  own: boolean;
-  onTrack?: (brand: string) => void;
 }
 
 export interface TrackBrandButtonProps {


### PR DESCRIPTION
### Description
Removes the “Discovered” badge, “Track” action, and other trailing labels from brand names in the Share of Voice table. Sorting and tracking controls in other GEO views remain unchanged.

### Screenshot/Recording (if applicable)
<img width="1694" height="929" alt="image" src="https://github.com/user-attachments/assets/2fc10071-18ff-4ae8-a7ac-50e94261911a" />

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the "Discovered" badge, "Track" action, and other trailing labels from brand names in the Share of Voice table. Sorting and tracking controls in other GEO views remain unchanged.

<sup>Written for commit 239923d5b49a726d89c54174ebcc630c32d0bad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

