### PR TITLE
perf(web): reduce mobile dither rendering cost

### DIFF
--- a/apps/web/src/components/deferred-dithering.tsx
+++ b/apps/web/src/components/deferred-dithering.tsx
@@ -2,9 +2,16 @@
 
 import { cn } from "@notra/ui/lib/utils";
 import dynamic from "next/dynamic";
+import { useSyncExternalStore } from "react";
 
+import { DITHER_MOBILE_MAX_PIXELS } from "@/constants/dithering";
 import { useDitherVisibility } from "@/lib/dithering/use-dither-visibility";
 import type { DeferredDitheringProps } from "@/types/dithering";
+import {
+  getDitherEnvironmentServerSnapshot,
+  getDitherMobileSnapshot,
+  subscribeToDitherViewport,
+} from "@/utils/dither-environment";
 
 const Dithering = dynamic(
   () =>
@@ -18,6 +25,11 @@ export function DeferredDithering({
   ...shaderProps
 }: DeferredDitheringProps) {
   const { containerRef, shouldRender, isAnimating } = useDitherVisibility();
+  const isMobile = useSyncExternalStore(
+    subscribeToDitherViewport,
+    getDitherMobileSnapshot,
+    getDitherEnvironmentServerSnapshot
+  );
 
   return (
     <div
@@ -29,6 +41,8 @@ export function DeferredDithering({
         <Dithering
           {...shaderProps}
           className="h-full w-full"
+          maxPixelCount={isMobile ? DITHER_MOBILE_MAX_PIXELS : undefined}
+          minPixelRatio={isMobile ? 1 : undefined}
           speed={isAnimating ? speed : 0}
         />
       )}

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -43,7 +43,7 @@ export function HeroSection() {
     <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
       <div className="relative isolate overflow-clip rounded-3xl bg-[#C8B2EE40] lg:h-[59.9375rem] dark:bg-[#2a2140]">
         <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
-          <HeroDither className="absolute -top-1.25 -left-10.75 h-[66.125rem] w-[calc(100%+21.5rem)] min-w-[100.8125rem] bg-[#00000000]" />
+          <HeroDither className="absolute inset-0 h-full w-full bg-[#00000000] sm:inset-auto sm:-top-1.25 sm:-left-10.75 sm:h-[66.125rem] sm:w-[calc(100%+21.5rem)] sm:min-w-[100.8125rem]" />
         </div>
 
         <div className="relative flex h-full w-full flex-col items-center">

--- a/apps/web/src/constants/dithering.ts
+++ b/apps/web/src/constants/dithering.ts
@@ -1,0 +1,2 @@
+export const DITHER_MOBILE_QUERY = "(width < 640px)";
+export const DITHER_MOBILE_MAX_PIXELS = 1_000_000;

--- a/apps/web/src/lib/dithering/use-dither-visibility.ts
+++ b/apps/web/src/lib/dithering/use-dither-visibility.ts
@@ -4,6 +4,11 @@ import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import type { DitherVisibilityState } from "@/types/dithering";
 import {
+  getDitherEnvironmentServerSnapshot,
+  getPageVisibleSnapshot,
+  subscribeToPageVisibility,
+} from "@/utils/dither-environment";
+import {
   getReducedMotionServerSnapshot,
   getReducedMotionSnapshot,
   subscribeToReducedMotion,
@@ -17,6 +22,11 @@ export function useDitherVisibility(): DitherVisibilityState {
   const [isIdle, setIsIdle] = useState(false);
   const [isInView, setIsInView] = useState(false);
   const [hasEntered, setHasEntered] = useState(false);
+  const isPageVisible = useSyncExternalStore(
+    subscribeToPageVisibility,
+    getPageVisibleSnapshot,
+    getDitherEnvironmentServerSnapshot
+  );
   const prefersReducedMotion = useSyncExternalStore(
     subscribeToReducedMotion,
     getReducedMotionSnapshot,
@@ -57,6 +67,6 @@ export function useDitherVisibility(): DitherVisibilityState {
   return {
     containerRef,
     shouldRender: isIdle && hasEntered,
-    isAnimating: isInView && !prefersReducedMotion,
+    isAnimating: isInView && isPageVisible && !prefersReducedMotion,
   };
 }

--- a/apps/web/src/utils/dither-environment.ts
+++ b/apps/web/src/utils/dither-environment.ts
@@ -1,0 +1,24 @@
+import { DITHER_MOBILE_QUERY } from "@/constants/dithering";
+
+export function subscribeToDitherViewport(onChange: () => void) {
+  const query = window.matchMedia(DITHER_MOBILE_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+export function getDitherMobileSnapshot() {
+  return window.matchMedia(DITHER_MOBILE_QUERY).matches;
+}
+
+export function subscribeToPageVisibility(onChange: () => void) {
+  document.addEventListener("visibilitychange", onChange);
+  return () => document.removeEventListener("visibilitychange", onChange);
+}
+
+export function getPageVisibleSnapshot() {
+  return document.visibilityState === "visible";
+}
+
+export function getDitherEnvironmentServerSnapshot() {
+  return false;
+}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces the dithering effect's rendering cost on mobile and pauses its animation when the tab is hidden.

- Applies a 1M pixel cap and a 1:1 pixel ratio to the dither shader on viewports narrower than 640px.
- The hero section dither now fills its container on small screens instead of using fixed desktop dimensions.
- Dither animation pauses when the document becomes hidden and resumes when it becomes visible again.
- Viewport and visibility state are tracked through the new `dither-environment.ts` util with `useSyncExternalStore`.

<sup>Written for commit 00f398023e726c2a8615d135cffe084cb4da9d41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

