### PR TITLE
fix(geo): restore scan logging, retry timeouts, and correct model charts

### DIFF
--- a/apps/dashboard/src/components/evilcharts/charts/echarts-area-chart.tsx
+++ b/apps/dashboard/src/components/evilcharts/charts/echarts-area-chart.tsx
@@ -1085,7 +1085,8 @@ function createTooltipFormatter(ctx: OptionBuildContext) {
           [group.headingKey],
           config,
           tooltipSlot.valueFormatter,
-          resolved.series
+          resolved.series,
+          tooltipSlot.hideZeros
         );
         if (heading === undefined) {
           continue;
@@ -1097,7 +1098,8 @@ function createTooltipFormatter(ctx: OptionBuildContext) {
             group.rowKeys,
             config,
             tooltipSlot.valueFormatter,
-            resolved.series
+            resolved.series,
+            tooltipSlot.hideZeros
           ),
         });
       }
@@ -1119,7 +1121,8 @@ function createTooltipFormatter(ctx: OptionBuildContext) {
         rowKeys,
         config,
         tooltipSlot.valueFormatter,
-        resolved.series
+        resolved.series,
+        tooltipSlot.hideZeros
       );
       return tooltipShell({
         label,

--- a/apps/dashboard/src/components/evilcharts/charts/echarts-area-chart.tsx
+++ b/apps/dashboard/src/components/evilcharts/charts/echarts-area-chart.tsx
@@ -497,7 +497,8 @@ function collectConfig(children: ReactNode): CollectedConfig {
         confine: props.confine ?? true,
         rowKeys: props.rowKeys,
         rowGroups: props.rowGroups,
-        hideZeros: props.hideZeros ?? false,
+        hideZeros:
+          props.hideZeros ?? Boolean(props.rowKeys || props.rowGroups),
         excludeKeys: props.excludeKeys ?? [],
         emptyLabel: props.emptyLabel,
       };

--- a/apps/dashboard/src/components/evilcharts/ui/echarts-tooltip.tsx
+++ b/apps/dashboard/src/components/evilcharts/ui/echarts-tooltip.tsx
@@ -186,7 +186,8 @@ export function tooltipItemsFromRow(
   keys: readonly string[],
   config: ChartConfig,
   valueFormatter?: TooltipValueFormatter,
-  seriesSlots?: ResolvedColors["series"]
+  seriesSlots?: ResolvedColors["series"],
+  hideZeros = true
 ): TooltipBodyItem[] {
   if (!row) {
     return [];
@@ -194,7 +195,11 @@ export function tooltipItemsFromRow(
   const items: TooltipBodyItem[] = [];
   for (const key of keys) {
     const raw = row[key];
-    if (typeof raw !== "number" || raw <= 0) {
+    if (
+      typeof raw !== "number" ||
+      !Number.isFinite(raw) ||
+      (hideZeros && raw <= 0)
+    ) {
       continue;
     }
     const item = config[key];

--- a/apps/dashboard/src/components/geo/mention-trend-agents.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-agents.tsx
@@ -7,6 +7,7 @@ import {
   GEO_MENTION_TREND_AGENT_ICON_LIMIT,
   GEO_MENTION_TREND_ALL_PROVIDERS_LABEL,
 } from "@notra/geo-core/constants/geo";
+import { engineFamilyOf } from "@notra/geo-core/utils/geo-engine-family";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -26,7 +27,17 @@ export function MentionTrendAgentsPicker({
   onToggle,
   disabled = false,
 }: MentionTrendAgentsPickerProps) {
-  const preview = series.slice(0, GEO_MENTION_TREND_AGENT_ICON_LIMIT);
+  const seenProviders = new Set<string>();
+  const preview = series
+    .filter((entry) => {
+      const provider = engineFamilyOf(entry.engine);
+      if (seenProviders.has(provider)) {
+        return false;
+      }
+      seenProviders.add(provider);
+      return true;
+    })
+    .slice(0, GEO_MENTION_TREND_AGENT_ICON_LIMIT);
   const active = series.filter((entry) => activeKeys.has(entry.key));
   const accessibleLabel = `Mention activity for all providers. ${
     active.length === 0

--- a/apps/dashboard/src/components/geo/mention-trend-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-card.tsx
@@ -204,7 +204,6 @@ export function MentionTrendCard({
           <EChartsAreaChart.Tooltip
             confine={false}
             emptyLabel={(row) => mentionTrendEmptyLabel(row, allKeys)}
-            hideZeros
             labelFormatter={formatFullDayLabel}
             labelKey="rawDay"
             layout="activity"

--- a/apps/dashboard/src/components/geo/mention-trend-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-card.tsx
@@ -203,6 +203,7 @@ export function MentionTrendCard({
           />
           <EChartsAreaChart.Tooltip
             confine={false}
+            hideZeros={false}
             emptyLabel={(row) => mentionTrendEmptyLabel(row, allKeys)}
             labelFormatter={formatFullDayLabel}
             labelKey="rawDay"

--- a/apps/dashboard/src/utils/geo-charts.ts
+++ b/apps/dashboard/src/utils/geo-charts.ts
@@ -54,6 +54,7 @@ import {
   isTrackedShareOfVoiceBrand,
   mergeCompetitorSharePoints,
 } from "./geo-competitors";
+import { formatModelLabel } from "./geo-model-display";
 
 const GPT_PREFIX_PATTERN = /^gpt-/i;
 const MINI_SUFFIX_PATTERN = /-mini$/i;
@@ -413,7 +414,7 @@ export function formatEngineFamily(engine: string): string {
     GEO_ENGINE_LABELS[model] ??
     GEO_ENGINE_LABELS[engine] ??
     GEO_ENGINE_LABELS[`${model}-grounded`] ??
-    engineFamilyLabel(engineFamilyOf(engine))
+    formatModelLabel(model)
   );
 }
 

--- a/apps/dashboard/src/workflows/geo-scan.ts
+++ b/apps/dashboard/src/workflows/geo-scan.ts
@@ -184,6 +184,9 @@ export async function geoScanWorkflow(
       return { scanProjectId, outcome };
     })
   );
+  if (outcomes.every(({ outcome }) => outcome === null)) {
+    return { status: "skipped" };
+  }
   for (const { scanProjectId, outcome } of outcomes) {
     if (!outcome) {
       continue;

--- a/packages/ai/src/constants/router.ts
+++ b/packages/ai/src/constants/router.ts
@@ -22,17 +22,52 @@ export const VERCEL_NAMESPACE_PREFIX = "vercel/";
 
 export const OPENROUTER_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "google/gemini-3-flash": "google/gemini-3-flash-preview",
+  "meta/llama-4-maverick": "meta-llama/llama-4-maverick",
+  "meta/llama-4-scout": "meta-llama/llama-4-scout",
+  "meta/llama-3.3-70b": "meta-llama/llama-3.3-70b-instruct",
+  "meta/llama-3.1-70b": "meta-llama/llama-3.1-70b-instruct",
+  "meta/llama-3.1-8b": "meta-llama/llama-3.1-8b-instruct",
+  "mistral/mistral-medium-3.5": "mistralai/mistral-medium-3-5",
+  "mistral/mistral-large-3": "mistralai/mistral-large-2512",
+  "spacexai/grok-4.6": "x-ai/grok-4.6",
+  "spacexai/grok-4.5": "x-ai/grok-4.5",
+  "spacexai/grok-build-0.1": "x-ai/grok-build-0.1",
+  "spacexai/grok-4.3": "x-ai/grok-4.3",
+  "spacexai/grok-4.20-multi-agent": "x-ai/grok-4.20-multi-agent",
+  "zai/glm-5.3-flash": "z-ai/glm-5.3-flash",
+  "zai/glm-5.3": "z-ai/glm-5.3",
+  "zai/glm-5.2": "z-ai/glm-5.2",
+  "zai/glm-5.1": "z-ai/glm-5.1",
+  "zai/glm-5v-turbo": "z-ai/glm-5v-turbo",
+  "zai/glm-5-turbo": "z-ai/glm-5-turbo",
+  "zai/glm-5": "z-ai/glm-5",
+  "zai/glm-4.7-flash": "z-ai/glm-4.7-flash",
 };
 
-export const OPENROUTER_UNSUPPORTED_MODELS: ReadonlySet<string> =
-  new Set<string>();
+// No verified equivalent in OpenRouter's catalog. Keep these on Vercel;
+// mapping to a different version or reasoning mode changes the GEO check.
+export const OPENROUTER_UNSUPPORTED_MODELS: ReadonlySet<string> = new Set([
+  "moonshotai/kimi-k2.7-code-highspeed",
+  "zai/glm-5.3-promo-50",
+  "zai/glm-4.7-flashx",
+  "spacexai/grok-4.20-non-reasoning",
+  "spacexai/grok-4.20-reasoning",
+  "spacexai/grok-4.1-fast-non-reasoning",
+  "spacexai/grok-4.1-fast-reasoning",
+  "deepseek/deepseek-v3.2-thinking",
+  "deepseek/deepseek-v3.1",
+  "mistral/mistral-medium",
+  "mistral/mistral-small",
+  "mistral/magistral-medium",
+]);
 
 /**
- * Models that only exist on OpenRouter (stealth/preview models, community
- * hosts). The router skips Vercel for them instead of discovering the 404
- * at call time. Keep in sync with catalog entries that pin `openrouter`.
+ * Models Vercel does not serve, including retired IDs. The router skips
+ * them instead of discovering the 404 during a scan.
  */
-export const VERCEL_UNSUPPORTED_MODELS: ReadonlySet<string> = new Set<string>();
+export const VERCEL_UNSUPPORTED_MODELS: ReadonlySet<string> = new Set([
+  "mistral/magistral-medium",
+]);
 
 export const VERCEL_OPTIONS_KEY = "gateway";
 export const OPENROUTER_OPTIONS_KEY = "openrouter";

--- a/packages/ai/src/constants/router.ts
+++ b/packages/ai/src/constants/router.ts
@@ -44,8 +44,8 @@ export const OPENROUTER_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "zai/glm-4.7-flash": "z-ai/glm-4.7-flash",
 };
 
-// No verified equivalent in OpenRouter's catalog. Keep these on Vercel;
-// mapping to a different version or reasoning mode changes the GEO check.
+const RETIRED_MODELS = ["mistral/magistral-medium"];
+
 export const OPENROUTER_UNSUPPORTED_MODELS: ReadonlySet<string> = new Set([
   "moonshotai/kimi-k2.7-code-highspeed",
   "zai/glm-5.3-promo-50",
@@ -58,16 +58,12 @@ export const OPENROUTER_UNSUPPORTED_MODELS: ReadonlySet<string> = new Set([
   "deepseek/deepseek-v3.1",
   "mistral/mistral-medium",
   "mistral/mistral-small",
-  "mistral/magistral-medium",
+  ...RETIRED_MODELS,
 ]);
 
-/**
- * Models Vercel does not serve, including retired IDs. The router skips
- * them instead of discovering the 404 during a scan.
- */
-export const VERCEL_UNSUPPORTED_MODELS: ReadonlySet<string> = new Set([
-  "mistral/magistral-medium",
-]);
+export const VERCEL_UNSUPPORTED_MODELS: ReadonlySet<string> = new Set(
+  RETIRED_MODELS
+);
 
 export const VERCEL_OPTIONS_KEY = "gateway";
 export const OPENROUTER_OPTIONS_KEY = "openrouter";

--- a/packages/ai/src/evlog.ts
+++ b/packages/ai/src/evlog.ts
@@ -63,9 +63,20 @@ export const { register, onRequestError } = createInstrumentation(config);
 export const geoLogDrainEnabled = geoDrain !== undefined;
 
 export const geoLog: GeoLogger = {
-  info: (event: GeoLogEvent) => log.info(event),
-  warn: (event: GeoLogEvent) => log.warn(event),
-  error: (event: GeoLogEvent) => log.error(event),
+  // Workflow steps can load a separate bundle from Next instrumentation.
+  // Initialize this instance before logging so its drain is actually attached.
+  info: (event: GeoLogEvent) => {
+    register();
+    log.info(event);
+  },
+  warn: (event: GeoLogEvent) => {
+    register();
+    log.warn(event);
+  },
+  error: (event: GeoLogEvent) => {
+    register();
+    log.error(event);
+  },
 };
 
 export async function flushGeoLog(): Promise<void> {

--- a/packages/ai/src/evlog.ts
+++ b/packages/ai/src/evlog.ts
@@ -62,21 +62,12 @@ export const { register, onRequestError } = createInstrumentation(config);
 
 export const geoLogDrainEnabled = geoDrain !== undefined;
 
+register();
+
 export const geoLog: GeoLogger = {
-  // Workflow steps can load a separate bundle from Next instrumentation.
-  // Initialize this instance before logging so its drain is actually attached.
-  info: (event: GeoLogEvent) => {
-    register();
-    log.info(event);
-  },
-  warn: (event: GeoLogEvent) => {
-    register();
-    log.warn(event);
-  },
-  error: (event: GeoLogEvent) => {
-    register();
-    log.error(event);
-  },
+  info: (event: GeoLogEvent) => log.info(event),
+  warn: (event: GeoLogEvent) => log.warn(event),
+  error: (event: GeoLogEvent) => log.error(event),
 };
 
 export async function flushGeoLog(): Promise<void> {

--- a/packages/geo-core/src/constants/geo-model-catalog.ts
+++ b/packages/geo-core/src/constants/geo-model-catalog.ts
@@ -321,15 +321,6 @@ export const GEO_MODEL_CATALOG_SEED: readonly GeoModelCatalogEntry[] = [
     gateways: ["vercel"],
   },
   {
-    id: "mistral/magistral-medium",
-    provider: "mistral",
-    label: "Magistral Medium",
-    zdr: "all",
-    released: "2025-06-10",
-    default: false,
-    gateways: ["vercel"],
-  },
-  {
     id: "mistral/mistral-small",
     provider: "mistral",
     label: "Mistral Small",

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -45,11 +45,8 @@ export const GEO_CURSOR_API_KEY_ENV = "CURSOR_API_KEY";
 export const GEO_CURSOR_ENGINE_ID = "cursor/composer-2.5";
 export const GEO_CURSOR_MODEL_ID = "composer-2.5";
 export const GEO_OPENCODE_ENGINE_ID = "opencode/gpt-5.6-sol-medium";
-/** Maximum wall-clock time for a single judge or translation call. */
 export const GEO_PROVIDER_TIMEOUT_MS = 120_000;
-/** Slow answer models get three minutes before a check may be retried. */
 export const GEO_ANSWER_TIMEOUT_MS = 180_000;
-/** Cursor answers use the same deadline as gateway answers. */
 export const GEO_CURSOR_TIMEOUT_MS = GEO_ANSWER_TIMEOUT_MS;
 /** Databuddy flag that exposes the Cursor engine to an organization. */
 export const GEO_CURSOR_FLAG_KEY = "geo-cursor";
@@ -469,7 +466,6 @@ export const GEO_SCAN_INTERVAL_LABEL_PREFIX = /^Every\s+/;
 export const GEO_SCAN_INTERVAL_FALLBACK_NOUN = "scan interval";
 export const GEO_SCAN_NO_RESULTS_RETRY_DELAY = "5m";
 export const GEO_SCAN_STALE_MS = 2 * 60 * 60 * 1000;
-/** One concurrent wave per workflow step, including individual timeout retries. */
 export const GEO_SCAN_TASK_BATCH_SIZE = GEO_SCAN_CONCURRENCY;
 export const GEO_SCAN_CLAIM_RENEW_AFTER_MS = 30 * 60 * 1000;
 export const GEO_SCAN_SEQUENCE_BATCH_SIZE = 3;

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -45,10 +45,12 @@ export const GEO_CURSOR_API_KEY_ENV = "CURSOR_API_KEY";
 export const GEO_CURSOR_ENGINE_ID = "cursor/composer-2.5";
 export const GEO_CURSOR_MODEL_ID = "composer-2.5";
 export const GEO_OPENCODE_ENGINE_ID = "opencode/gpt-5.6-sol-medium";
-/** Maximum wall-clock time for a single answer, judge, or translation call. */
-export const GEO_PROVIDER_TIMEOUT_MS = 90_000;
-/** Local Cursor runs took ~8s in testing; cold starts can be slower. */
-export const GEO_CURSOR_TIMEOUT_MS = 90_000;
+/** Maximum wall-clock time for a single judge or translation call. */
+export const GEO_PROVIDER_TIMEOUT_MS = 120_000;
+/** Slow answer models get three minutes before a check may be retried. */
+export const GEO_ANSWER_TIMEOUT_MS = 180_000;
+/** Cursor answers use the same deadline as gateway answers. */
+export const GEO_CURSOR_TIMEOUT_MS = GEO_ANSWER_TIMEOUT_MS;
 /** Databuddy flag that exposes the Cursor engine to an organization. */
 export const GEO_CURSOR_FLAG_KEY = "geo-cursor";
 /** Databuddy flag that exposes the OpenCode engine to an organization. */
@@ -467,7 +469,8 @@ export const GEO_SCAN_INTERVAL_LABEL_PREFIX = /^Every\s+/;
 export const GEO_SCAN_INTERVAL_FALLBACK_NOUN = "scan interval";
 export const GEO_SCAN_NO_RESULTS_RETRY_DELAY = "5m";
 export const GEO_SCAN_STALE_MS = 2 * 60 * 60 * 1000;
-export const GEO_SCAN_TASK_BATCH_SIZE = 8;
+/** One concurrent wave per workflow step, including individual timeout retries. */
+export const GEO_SCAN_TASK_BATCH_SIZE = GEO_SCAN_CONCURRENCY;
 export const GEO_SCAN_CLAIM_RENEW_AFTER_MS = 30 * 60 * 1000;
 export const GEO_SCAN_SEQUENCE_BATCH_SIZE = 3;
 export const GEO_SEQUENCE_PAIR_TIMEOUT_MS = 7 * 60 * 1000;
@@ -981,12 +984,12 @@ export const GEO_PROMPT_NO_MENTION = "No engine named you";
 
 export const GEO_MENTION_TREND_BACKFILL_DAYS = 6;
 export const GEO_MENTION_TREND_TOTAL_KEY = "total";
-export const GEO_MENTION_TREND_TOTAL_LABEL = "All providers";
+export const GEO_MENTION_TREND_TOTAL_LABEL = "All Models";
 export const GEO_DEFAULT_RANGE: GeoRangePreset = "30d";
 export const GEO_MENTION_TREND_LINE_KEY = "trend";
 export const GEO_MENTION_TREND_LINE_LABEL = "Trend";
 export const GEO_MENTION_TREND_AGENT_ICON_LIMIT = 4;
-export const GEO_MENTION_TREND_ALL_PROVIDERS_LABEL = "All providers";
+export const GEO_MENTION_TREND_ALL_PROVIDERS_LABEL = "All Models";
 export const GEO_MENTION_ACTIVITY_LABEL = "Mention activity";
 export const GEO_MENTION_SUMMARY_VISIBLE = 5;
 export const GEO_MENTION_ROW_HEIGHT_REM = 2.75;

--- a/packages/geo-core/src/geo/errors.ts
+++ b/packages/geo-core/src/geo/errors.ts
@@ -4,6 +4,7 @@ import { Data } from "effect";
 
 export class GeoScanError extends Data.TaggedError("GeoScanError")<{
   readonly message: string;
+  readonly timedOut?: boolean;
   readonly cause?: unknown;
 }> {}
 
@@ -27,6 +28,7 @@ export class GeoEmptyAnswerError extends Data.TaggedError(
 
 export class GeoJudgeError extends Data.TaggedError("GeoJudgeError")<{
   readonly message: string;
+  readonly timedOut?: boolean;
   readonly cause: unknown;
 }> {}
 

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -28,6 +28,7 @@ import { Effect } from "effect";
 import {
   GEO_ANSWER_MAX_TOKENS,
   GEO_ANSWER_SYSTEM_PROMPT,
+  GEO_ANSWER_TIMEOUT_MS,
   GEO_CURSOR_TIMEOUT_MS,
   GEO_DIRECT_GROUNDED_PROVIDERS,
   GEO_EXCERPT_MAX_LENGTH,
@@ -61,7 +62,6 @@ import type {
   GeoEngineAnswer,
   GeoGroundedAnswer,
   GeoGroundedEngine,
-  GeoJudgeResult,
   GeoModelGateway,
   GeoPromptDefinition,
   GeoScanBatchOutcome,
@@ -282,11 +282,12 @@ const askGatewayEngine = Effect.fn("geo.askGatewayEngine")(function* (
       }),
   }).pipe(
     Effect.timeoutOrElse({
-      duration: GEO_PROVIDER_TIMEOUT_MS,
+      duration: GEO_ANSWER_TIMEOUT_MS,
       orElse: () =>
         Effect.fail(
           new GeoScanError({
-            message: `Engine ${engine} timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+            message: `Engine ${engine} timed out after ${GEO_ANSWER_TIMEOUT_MS}ms`,
+            timedOut: true,
           })
         ),
     })
@@ -306,7 +307,7 @@ const askOpenCodeEngineEffect = Effect.fn("geo.askOpenCodeEngine")(function* (
   engine: string,
   promptText: string
 ) {
-  const deadlineAtMs = Date.now() + GEO_PROVIDER_TIMEOUT_MS;
+  const deadlineAtMs = Date.now() + GEO_ANSWER_TIMEOUT_MS;
   let openCodePromise: ReturnType<typeof askGeoOpenCode> | null = null;
   const result = yield* Effect.tryPromise({
     try: (signal) => {
@@ -339,7 +340,8 @@ const askOpenCodeEngineEffect = Effect.fn("geo.askOpenCodeEngine")(function* (
       orElse: () =>
         Effect.fail(
           new GeoScanError({
-            message: `Engine ${engine} timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+            message: `Engine ${engine} timed out after ${GEO_ANSWER_TIMEOUT_MS}ms`,
+            timedOut: true,
           })
         ),
     })
@@ -378,6 +380,7 @@ const askCursorEngineEffect = Effect.fn("geo.askCursorEngine")(function* (
         Effect.fail(
           new GeoScanError({
             message: `Engine ${engine} timed out after ${GEO_CURSOR_TIMEOUT_MS}ms`,
+            timedOut: true,
           })
         ),
     })
@@ -459,11 +462,12 @@ const askGroundedConversation = Effect.fn("geo.askGroundedConversation")(
         }),
     }).pipe(
       Effect.timeoutOrElse({
-        duration: GEO_PROVIDER_TIMEOUT_MS,
+        duration: GEO_ANSWER_TIMEOUT_MS,
         orElse: () =>
           Effect.fail(
             new GeoScanError({
-              message: `Grounded engine ${engine.key} timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+              message: `Grounded engine ${engine.key} timed out after ${GEO_ANSWER_TIMEOUT_MS}ms`,
+              timedOut: true,
             })
           ),
       })
@@ -492,9 +496,9 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
   promptText: string,
   answer: string
 ) {
-  const result = yield* Effect.tryPromise({
-    try: (signal) =>
-      generateText({
+  const judged = yield* Effect.tryPromise({
+    try: async (signal) => {
+      const result = await generateText({
         model: gateway(GEO_JUDGE_MODEL, {
           organizationId: context.organizationId,
         }),
@@ -504,7 +508,10 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
           "You analyze AI assistant answers for brand mentions. Respond only with the requested structured data.",
         maxOutputTokens: GEO_JUDGE_MAX_TOKENS,
         abortSignal: signal,
-      }),
+      });
+      // The SDK output getter can throw even after generateText resolves.
+      return result.output;
+    },
     catch: (cause) =>
       new GeoJudgeError({ message: "Judge model failed", cause }),
   }).pipe(
@@ -514,12 +521,12 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
         Effect.fail(
           new GeoJudgeError({
             message: `Judge model timed out after ${GEO_PROVIDER_TIMEOUT_MS}ms`,
+            timedOut: true,
             cause: new Error("Judge model request timed out"),
           })
         ),
     })
   );
-  const judged: GeoJudgeResult = result.output;
   return judged;
 });
 
@@ -528,9 +535,9 @@ const translatePrompts = Effect.fn("geo.translatePrompts")(function* (
   language: string,
   prompts: GeoPromptDefinition[]
 ) {
-  const result = yield* Effect.tryPromise({
-    try: (signal) =>
-      generateText({
+  const translations = yield* Effect.tryPromise({
+    try: async (signal) => {
+      const result = await generateText({
         model: gateway(GEO_JUDGE_MODEL, {
           organizationId,
         }),
@@ -540,7 +547,9 @@ const translatePrompts = Effect.fn("geo.translatePrompts")(function* (
           "You translate user prompts faithfully, preserving intent and named entities. Respond only with the requested structured data.",
         maxOutputTokens: GEO_TRANSLATION_MAX_TOKENS,
         abortSignal: signal,
-      }),
+      });
+      return result.output.translations;
+    },
     catch: (cause) =>
       new GeoTranslationError({
         message: `Translation to ${language} failed`,
@@ -559,7 +568,6 @@ const translatePrompts = Effect.fn("geo.translatePrompts")(function* (
         ),
     })
   );
-  const translations = result.output.translations;
   if (translations.length !== prompts.length) {
     return yield* Effect.fail(
       new GeoTranslationError({
@@ -1266,6 +1274,24 @@ export const runGeoScanTaskBatch = Effect.fn("geo.runScanTaskBatch")(function* (
     (task) => {
       const fields = checkFailureFields(checkContext, task);
       return runGeoCheck(checkContext, task).pipe(
+        // Retry only this check, before any rows are persisted. Non-timeout
+        // errors still follow the existing drop/failure handling below.
+        Effect.tapError((error) =>
+          (error._tag === "GeoScanError" || error._tag === "GeoJudgeError") &&
+          error.timedOut === true
+            ? geoLogWarn({
+                ...fields,
+                event: "geo.check.timeout",
+                detail: error.message,
+              })
+            : Effect.void
+        ),
+        Effect.retry({
+          times: 1,
+          while: (error) =>
+            (error._tag === "GeoScanError" || error._tag === "GeoJudgeError") &&
+            error.timedOut === true,
+        }),
         Effect.catchTag("GeoEmptyAnswerError", (error) =>
           Effect.sync(() => droppedCheckOutcome(fields, error))
         ),

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -509,7 +509,6 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
         maxOutputTokens: GEO_JUDGE_MAX_TOKENS,
         abortSignal: signal,
       });
-      // The SDK output getter can throw even after generateText resolves.
       return result.output;
     },
     catch: (cause) =>
@@ -1274,8 +1273,6 @@ export const runGeoScanTaskBatch = Effect.fn("geo.runScanTaskBatch")(function* (
     (task) => {
       const fields = checkFailureFields(checkContext, task);
       return runGeoCheck(checkContext, task).pipe(
-        // Retry only this check, before any rows are persisted. Non-timeout
-        // errors still follow the existing drop/failure handling below.
         Effect.tapError((error) =>
           (error._tag === "GeoScanError" || error._tag === "GeoJudgeError") &&
           error.timedOut === true

--- a/packages/geo-core/src/schemas/geo-model-feed.ts
+++ b/packages/geo-core/src/schemas/geo-model-feed.ts
@@ -6,7 +6,7 @@ export const geoGatewayModelSchema = object({
   owned_by: string().min(1),
   type: string(),
   zdr: enumType(["all", "some", "none"]),
-  released: number(),
+  released: number().optional(),
   deprecated_at: union([number(), string()]).nullish(),
   tags: array(string()).optional(),
 });

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -1141,8 +1141,8 @@ export interface GeoGatewayModel {
   owned_by: string;
   type: string;
   zdr: GeoModelZdr;
-  /** Unix seconds. */
-  released: number;
+  /** Unix seconds, when the gateway publishes a release date. */
+  released?: number;
   deprecated_at?: number | string | null;
   tags?: string[];
 }

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -1141,7 +1141,6 @@ export interface GeoGatewayModel {
   owned_by: string;
   type: string;
   zdr: GeoModelZdr;
-  /** Unix seconds, when the gateway publishes a release date. */
   released?: number;
   deprecated_at?: number | string | null;
   tags?: string[];

--- a/packages/geo-core/src/utils/day-label.ts
+++ b/packages/geo-core/src/utils/day-label.ts
@@ -1,6 +1,7 @@
 const dayLabelFormatter = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
+  timeZone: "UTC",
 });
 
 export function todayIsoDate(): string {

--- a/packages/geo-core/src/utils/geo-model-catalog.ts
+++ b/packages/geo-core/src/utils/geo-model-catalog.ts
@@ -48,7 +48,10 @@ function toCatalogEntry(
   };
 }
 
-function toDayString(seconds: number): string {
+function toDayString(seconds: number | undefined): string {
+  if (seconds === undefined) {
+    return "";
+  }
   return new Date(seconds * MS_PER_SECOND).toISOString().slice(0, DAY_LENGTH);
 }
 
@@ -86,7 +89,7 @@ export function buildGeoModelCatalogFromFeed(
       .filter(
         (model) => model.owned_by === provider.id && isEligibleFeedModel(model)
       )
-      .sort((left, right) => right.released - left.released)
+      .sort((left, right) => (right.released ?? 0) - (left.released ?? 0))
       .map((model) => toCatalogEntry(model, provider.id));
     const newest = entries.slice(0, GEO_MODELS_PER_PROVIDER);
     const olderDefaults = entries


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores geo scan logging, retries timed-out checks, and fixes model activity chart rendering.

**Geo scan recovery**
- Initializes the geo log drain before each log call so scan logs are actually emitted.
- Retries a check once when an answer or judge call times out, before applying the existing drop/failure handling.
- Raises answer timeouts to 180s and keeps judge/translation timeouts at 120s; Cursor uses the same deadline as answers.
- Marks timed-out errors so the retry only applies to timeouts, not other failures.
- Returns a skipped batch status when every check in a batch yields no outcome.

**Model catalog and charts**
- Deduplicates agent picker icons by engine family and formats model labels from the catalog instead of the fallback label.
- Defaults tooltip `hideZeros` to true when row keys or groups are configured and always hides non-finite values; the mention trend card opts out so zeros show.
- Uses UTC for day labels and renames "All providers" to "All Models".
- Adds OpenRouter aliases and unsupported model sets, removes the unsupported `mistral/magistral-medium`, and makes the feed `released` field optional.

<sup>Written for commit b065316068d89b1eaefc1c63f58c72cceb1db50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

