### PR TITLE
fix(geo): restrict web-search scans to selected models and fix chart tooltips

### DIFF
--- a/apps/dashboard/src/components/geo/mention-trend-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-card.tsx
@@ -10,7 +10,7 @@ import {
 import type { MentionTrendRow } from "@notra/geo-core/types/geo";
 import { todayIsoDate } from "@notra/geo-core/utils/day-label";
 import { geoScanEmptyMessage } from "@notra/geo-core/utils/geo-scan";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 
 import { EmptyStateTrendPreview } from "@/components/empty-state-preview";
 import { EChartsAreaChart } from "@/components/evilcharts/charts/echarts-area-chart";
@@ -77,65 +77,50 @@ export function MentionTrendCard({
 }: MentionTrendCardProps) {
   const [activeKeys, setActiveKeys] = useState<Set<string>>(() => new Set());
 
-  const { rows, engines } = useMemo(
-    () => buildMentionTrendRows(points),
-    [points]
+  const { rows, engines } = buildMentionTrendRows(points);
+  const series = mentionTrendSeries(engines).filter((entry) =>
+    rows.some((row) => {
+      const value = row[entry.key];
+      return typeof value === "number" && value > 0;
+    })
   );
-  const series = useMemo(
-    () =>
-      mentionTrendSeries(engines).filter((entry) =>
-        rows.some((row) => {
-          const value = row[entry.key];
-          return typeof value === "number" && value > 0;
-        })
-      ),
-    [engines, rows]
+  const allKeys = engines.map(chartKey);
+  const visibleKeys = series.map((entry) => entry.key);
+  const observedRows = rows.map((row) =>
+    allKeys.some((key) => typeof row[key] === "number")
+      ? row
+      : { ...row, [GEO_MENTION_TREND_TOTAL_KEY]: null }
   );
-  const allKeys = useMemo(() => engines.map(chartKey), [engines]);
-  const visibleKeys = useMemo(() => series.map((entry) => entry.key), [series]);
-  const chartRows = useMemo(() => {
-    const observedRows = rows.map((row) =>
-      allKeys.some((key) => typeof row[key] === "number")
-        ? row
-        : { ...row, [GEO_MENTION_TREND_TOTAL_KEY]: null }
-    );
-    const trend = fitMentionTrendLine(
-      observedRows,
-      GEO_MENTION_TREND_TOTAL_KEY
-    );
-    return rows.map((row, index) => {
-      const trendValue = trend[index];
-      return typeof trendValue === "number"
-        ? { ...row, [GEO_MENTION_TREND_LINE_KEY]: trendValue }
-        : row;
-    });
-  }, [allKeys, rows]);
-  const config = useMemo(() => {
-    const trendConfig: ChartConfig = {
-      [GEO_MENTION_TREND_TOTAL_KEY]: {
-        label: GEO_MENTION_TREND_TOTAL_LABEL,
-        colors: seriesColors(CHART_PRIMARY_COLOR),
-      },
-      [GEO_MENTION_TREND_LINE_KEY]: {
-        label: GEO_MENTION_TREND_LINE_LABEL,
-        colors: seriesColors(CHART_MUTED_COLOR),
-      },
+  const trend = fitMentionTrendLine(observedRows, GEO_MENTION_TREND_TOTAL_KEY);
+  const chartRows = rows.map((row, index) => {
+    const trendValue = trend[index];
+    return typeof trendValue === "number"
+      ? { ...row, [GEO_MENTION_TREND_LINE_KEY]: trendValue }
+      : row;
+  });
+  const config: ChartConfig = {
+    [GEO_MENTION_TREND_TOTAL_KEY]: {
+      label: GEO_MENTION_TREND_TOTAL_LABEL,
+      colors: seriesColors(CHART_PRIMARY_COLOR),
+    },
+    [GEO_MENTION_TREND_LINE_KEY]: {
+      label: GEO_MENTION_TREND_LINE_LABEL,
+      colors: seriesColors(CHART_MUTED_COLOR),
+    },
+  };
+  for (const [index, entry] of series.entries()) {
+    config[entry.key] = {
+      label: entry.label,
+      colors: accountSeriesColors(index),
+      indicatorHtml: engineIconHtml(entry.engine, false),
     };
-    for (const [index, entry] of series.entries()) {
-      trendConfig[entry.key] = {
-        label: entry.label,
-        colors: accountSeriesColors(index),
-        indicatorHtml: engineIconHtml(entry.engine, false),
-      };
-    }
-    return trendConfig;
-  }, [series]);
+  }
   const markIncompleteTail = hasIncompleteTail(rows);
   const sampledDays = sampledDayCount(rows, engines);
 
-  const handleToggle = useCallback((key: string) => {
+  const handleToggle = (key: string) => {
     setActiveKeys((previous) => toggleActiveSeries(previous, key));
-  }, []);
+  };
 
   const emptyMessage =
     sampledDays === 0

--- a/apps/dashboard/src/components/geo/mention-trend-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-trend-card.tsx
@@ -81,8 +81,18 @@ export function MentionTrendCard({
     () => buildMentionTrendRows(points),
     [points]
   );
-  const series = useMemo(() => mentionTrendSeries(engines), [engines]);
-  const allKeys = useMemo(() => series.map((entry) => entry.key), [series]);
+  const series = useMemo(
+    () =>
+      mentionTrendSeries(engines).filter((entry) =>
+        rows.some((row) => {
+          const value = row[entry.key];
+          return typeof value === "number" && value > 0;
+        })
+      ),
+    [engines, rows]
+  );
+  const allKeys = useMemo(() => engines.map(chartKey), [engines]);
+  const visibleKeys = useMemo(() => series.map((entry) => entry.key), [series]);
   const chartRows = useMemo(() => {
     const observedRows = rows.map((row) =>
       allKeys.some((key) => typeof row[key] === "number")
@@ -115,7 +125,7 @@ export function MentionTrendCard({
       trendConfig[entry.key] = {
         label: entry.label,
         colors: accountSeriesColors(index),
-        indicatorHtml: engineIconHtml(entry.engine),
+        indicatorHtml: engineIconHtml(entry.engine, false),
       };
     }
     return trendConfig;
@@ -210,7 +220,7 @@ export function MentionTrendCard({
             layout="activity"
             position="fixed"
             roundness="xl"
-            rowKeys={allKeys}
+            rowKeys={visibleKeys}
             valueFormatter={formatChartInteger}
           />
         </EChartsAreaChart>

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -8,8 +8,8 @@ import type {
   GeoCompetitor,
   GeoCompetitorKind,
   GeoCompetitorShareTimeseriesPoint,
-  GeoGroundedEngine,
   GeoGroundedProvider,
+  GeoGroundedProviderConfig,
   GeoIngestFramework,
   GeoIngestPackageManager,
   GeoJourneyPathKind,
@@ -269,56 +269,38 @@ const hasEnv = (name: string): boolean => {
   return typeof value === "string" && value.length > 0;
 };
 
-export const GEO_GROUNDED_ENGINES: readonly GeoGroundedEngine[] = [
+export const GEO_GROUNDED_PROVIDERS: readonly GeoGroundedProviderConfig[] = [
   {
-    key: "openai/gpt-5.4-grounded",
-    label: "ChatGPT",
-    model: "openai/gpt-5.4",
     provider: "gateway-openai",
     zdr: "some",
     envVar: null,
     isAvailable: () => true,
   },
   {
-    key: "anthropic/claude-sonnet-4.6-grounded",
-    label: "Claude Sonnet",
-    model: "anthropic/claude-sonnet-4.6",
     provider: "gateway-anthropic",
     zdr: "all",
     envVar: null,
     isAvailable: () => true,
   },
   {
-    key: "google/gemini-3-flash-grounded",
-    label: "Gemini",
-    model: "google/gemini-3-flash",
     provider: "gateway-google",
     zdr: "some",
     envVar: null,
     isAvailable: () => true,
   },
   {
-    key: "openai-direct-grounded",
-    label: "ChatGPT",
-    model: "gpt-5.4",
     provider: "direct-openai",
     zdr: "none",
     envVar: GEO_OPENAI_API_KEY_ENV,
     isAvailable: () => hasEnv(GEO_OPENAI_API_KEY_ENV),
   },
   {
-    key: "anthropic-direct-grounded",
-    label: "Claude Sonnet",
-    model: "claude-sonnet-4-6",
     provider: "direct-anthropic",
     zdr: "none",
     envVar: GEO_ANTHROPIC_API_KEY_ENV,
     isAvailable: () => hasEnv(GEO_ANTHROPIC_API_KEY_ENV),
   },
   {
-    key: "perplexity-sonar",
-    label: "Perplexity",
-    model: "sonar",
     provider: "direct-perplexity",
     zdr: "none",
     envVar: GEO_PERPLEXITY_API_KEY_ENV,
@@ -334,9 +316,21 @@ export const GEO_DIRECT_GROUNDED_PROVIDERS: ReadonlySet<GeoGroundedProvider> =
     "direct-perplexity",
   ]);
 
-const groundedEngineLabels = Object.fromEntries(
-  GEO_GROUNDED_ENGINES.map((engine) => [engine.key, engine.label])
-);
+// Decode historical records and queued tasks only; never used to select models.
+export const GEO_LEGACY_GROUNDED_MODELS: Readonly<Record<string, string>> = {
+  "openai-direct-grounded": "openai/gpt-5.4",
+  "anthropic-direct-grounded": "anthropic/claude-sonnet-4.6",
+  "perplexity-sonar": "perplexity/sonar",
+};
+
+const groundedEngineLabels: Record<string, string> = {
+  "openai/gpt-5.4-grounded": "GPT-5.4",
+  "anthropic/claude-sonnet-4.6-grounded": "Claude Sonnet 4.6",
+  "google/gemini-3-flash-grounded": "Gemini 3 Flash",
+  "openai-direct-grounded": "GPT-5.4",
+  "anthropic-direct-grounded": "Claude Sonnet 4.6",
+  "perplexity-sonar": "Sonar",
+};
 
 const catalogEngineLabels = Object.fromEntries(
   GEO_MODEL_CATALOG_SEED.map((entry) => [entry.id, entry.label])

--- a/packages/geo-core/src/geo/engines.ts
+++ b/packages/geo-core/src/geo/engines.ts
@@ -7,7 +7,6 @@ import { requireApiKey } from "@notra/utils/require-api-key";
 
 import {
   GEO_ANTHROPIC_API_KEY_ENV,
-  GEO_GROUNDED_ENGINES,
   GEO_GROUNDED_MAX_SEARCHES,
   GEO_OPENAI_API_KEY_ENV,
   GEO_PERPLEXITY_API_KEY_ENV,
@@ -78,27 +77,4 @@ export function buildGroundedInvocation(
       return { model: provider(engine.model), tools: {} };
     }
   }
-}
-
-const SUPERSEDED_BY_DIRECT: Partial<
-  Record<GeoGroundedEngine["provider"], GeoGroundedEngine["provider"]>
-> = {
-  "direct-openai": "gateway-openai",
-  "direct-anthropic": "gateway-anthropic",
-};
-
-export function resolveGroundedEngines(): GeoGroundedEngine[] {
-  const available = GEO_GROUNDED_ENGINES.filter((engine) =>
-    engine.isAvailable()
-  );
-
-  const superseded = new Set<GeoGroundedEngine["provider"]>();
-  for (const engine of available) {
-    const replaced = SUPERSEDED_BY_DIRECT[engine.provider];
-    if (replaced) {
-      superseded.add(replaced);
-    }
-  }
-
-  return available.filter((engine) => !superseded.has(engine.provider));
 }

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -85,6 +85,10 @@ import {
   resolveGeoZdrMode,
 } from "../utils/geo-engines";
 import {
+  resolveGroundedEngineByKey,
+  resolveGroundedEngines,
+} from "../utils/geo-grounded-engines";
+import {
   describeGeoError,
   flushGeoLogEffect,
   geoLogError,
@@ -98,7 +102,7 @@ import {
 } from "../utils/geo-scan";
 import { askCursorEngine } from "./cursor";
 import { geoSkip } from "./effect";
-import { buildGroundedInvocation, resolveGroundedEngines } from "./engines";
+import { buildGroundedInvocation } from "./engines";
 import {
   GeoEmptyAnswerError,
   GeoJudgeError,
@@ -685,10 +689,6 @@ function parseGeoClaimToken(
   });
 }
 
-function resolveGroundedEngineByKey(key: string): GeoGroundedEngine | null {
-  return resolveGroundedEngines().find((engine) => engine.key === key) ?? null;
-}
-
 /**
  * Loads the settings rows a scan run covers and returns the enabled project
  * ids in creation order. Also releases the phantom "scanning" stamp of rows
@@ -1041,7 +1041,7 @@ const buildGeoScanProjectPlan = Effect.fn("geo.buildScanProjectPlan")(
 
     const groundedEngines: { grounded: GeoGroundedEngine; zdr: GeoZdrMode }[] =
       [];
-    for (const grounded of resolveGroundedEngines()) {
+    for (const grounded of resolveGroundedEngines(settings.engines, catalog)) {
       const zdr = resolveGeoGroundedZdrMode(catalog, grounded, zdrPolicy);
       if (zdr === null) {
         yield* geoLogWarn({
@@ -1909,7 +1909,7 @@ const runGeoSequenceNowProgram = Effect.fn("geo.runSequenceNow")(function* (
 
   const groundedEngines: { grounded: GeoGroundedEngine; zdr: GeoZdrMode }[] =
     [];
-  for (const grounded of resolveGroundedEngines()) {
+  for (const grounded of resolveGroundedEngines(settings.engines, catalog)) {
     const zdr = resolveGeoGroundedZdrMode(catalog, grounded, zdrPolicy);
     if (zdr === null) {
       yield* geoLogWarn({

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -663,6 +663,11 @@ export interface GeoGroundedEngine {
   isAvailable: () => boolean;
 }
 
+export type GeoGroundedProviderConfig = Pick<
+  GeoGroundedEngine,
+  "provider" | "zdr" | "envVar" | "isAvailable"
+>;
+
 export interface GeoGroundedInvocation {
   model: LanguageModel;
   tools: ToolSet;

--- a/packages/geo-core/src/utils/geo-engine-family.ts
+++ b/packages/geo-core/src/utils/geo-engine-family.ts
@@ -1,10 +1,17 @@
-import { GEO_BRAND_LABELS, GEO_ENGINE_LABELS } from "../constants/geo";
+import {
+  GEO_BRAND_LABELS,
+  GEO_ENGINE_LABELS,
+  GEO_LEGACY_GROUNDED_MODELS,
+} from "../constants/geo";
 import { resolveEngineIconKey } from "./geo-engine-icon";
 
 export const GROUNDED_SUFFIX_PATTERN = /(-direct)?-grounded$/;
 
 export function engineModelOf(engine: string): string {
-  return engine.replace(GROUNDED_SUFFIX_PATTERN, "");
+  return (
+    GEO_LEGACY_GROUNDED_MODELS[engine] ??
+    engine.replace(GROUNDED_SUFFIX_PATTERN, "")
+  );
 }
 
 export function engineFamilyOf(engine: string): string {

--- a/packages/geo-core/src/utils/geo-grounded-engines.ts
+++ b/packages/geo-core/src/utils/geo-grounded-engines.ts
@@ -1,0 +1,63 @@
+import {
+  GEO_ENGINE_LABELS,
+  GEO_GROUNDED_PROVIDERS,
+  GEO_LEGACY_GROUNDED_MODELS,
+} from "../constants/geo";
+import type { GeoGroundedEngine, GeoModelCatalog } from "../types/geo";
+import { engineModelOf } from "./geo-engine-family";
+
+/** Reconstruct the exact model and route recorded by the scan planner. */
+export function resolveGroundedEngineByKey(
+  key: string
+): GeoGroundedEngine | null {
+  const legacyModel = GEO_LEGACY_GROUNDED_MODELS[key];
+  if (!legacyModel && !key.endsWith("-grounded")) {
+    return null;
+  }
+  const modelId = legacyModel ?? engineModelOf(key);
+  const separator = modelId.indexOf("/");
+  if (separator <= 0 || separator === modelId.length - 1) {
+    return null;
+  }
+  const providerId = modelId.slice(0, separator);
+  const direct = Boolean(legacyModel) || key.endsWith("-direct-grounded");
+  const provider = GEO_GROUNDED_PROVIDERS.find(
+    (entry) =>
+      entry.provider === `${direct ? "direct" : "gateway"}-${providerId}`
+  );
+  if (!provider?.isAvailable()) {
+    return null;
+  }
+  const slug = modelId.slice(separator + 1);
+  let model = modelId;
+  if (direct) {
+    model =
+      providerId === "anthropic" ? slug.replace(/(\d)\.(\d)/g, "$1-$2") : slug;
+  }
+  return {
+    ...provider,
+    key,
+    model,
+    label: GEO_ENGINE_LABELS[modelId] ?? GEO_ENGINE_LABELS[key] ?? modelId,
+  };
+}
+
+/** Web-search variants of explicitly selected models; never add other models. */
+export function resolveGroundedEngines(
+  selectedEngines: readonly string[],
+  catalog: GeoModelCatalog
+): GeoGroundedEngine[] {
+  return [...new Set(selectedEngines)].flatMap((modelId) => {
+    const model = catalog.models.find((entry) => entry.id === modelId);
+    if (!model) {
+      return [];
+    }
+    const direct = resolveGroundedEngineByKey(`${modelId}-direct-grounded`);
+    const engine =
+      direct ??
+      (model.gateways.includes("vercel")
+        ? resolveGroundedEngineByKey(`${modelId}-grounded`)
+        : null);
+    return engine ? [{ ...engine, label: model.label }] : [];
+  });
+}

--- a/packages/geo-core/tests/geo-grounded-engines.test.ts
+++ b/packages/geo-core/tests/geo-grounded-engines.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  GEO_MODEL_CATALOG_SEED,
+  GEO_MODEL_PROVIDERS,
+} from "../src/constants/geo-model-catalog";
+import type { GeoModelCatalog } from "../src/types/geo";
+import { engineModelOf } from "../src/utils/geo-engine-family";
+import {
+  resolveGroundedEngineByKey,
+  resolveGroundedEngines,
+} from "../src/utils/geo-grounded-engines";
+
+const catalog: GeoModelCatalog = {
+  providers: [...GEO_MODEL_PROVIDERS],
+  models: [...GEO_MODEL_CATALOG_SEED],
+};
+
+describe("selected grounded engines", () => {
+  test("only plans selected models, even when older models remain in the catalog", () => {
+    const selected = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-sol"];
+    const engines = resolveGroundedEngines(selected, catalog);
+    expect(engines.map((engine) => engineModelOf(engine.key)).join(",")).toBe(
+      selected.join(",")
+    );
+    expect(engines.map((engine) => engine.label).join(",")).toBe(
+      "Claude Sonnet 5,GPT-5.6 Sol"
+    );
+    expect(
+      engines.map((engine) => engine.model.split("/").at(-1)).join(",")
+    ).toBe("claude-sonnet-5,gpt-5.6-sol");
+    for (const engine of engines) {
+      expect(resolveGroundedEngineByKey(engine.key)?.model).toBe(engine.model);
+      expect(resolveGroundedEngineByKey(engine.key)?.provider).toBe(
+        engine.provider
+      );
+    }
+  });
+
+  test("empty or unsupported selections do not inject default search models", () => {
+    expect(resolveGroundedEngines([], catalog).length).toBe(0);
+    expect(resolveGroundedEngines(["unlisted/model"], catalog).length).toBe(0);
+    expect(resolveGroundedEngines(["moonshotai/kimi-k3"], catalog).length).toBe(
+      0
+    );
+  });
+
+  test("none of the six legacy web-search routes are added to a selection", () => {
+    const legacyKeys = [
+      "openai/gpt-5.4-grounded",
+      "anthropic/claude-sonnet-4.6-grounded",
+      "google/gemini-3-flash-grounded",
+      "openai-direct-grounded",
+      "anthropic-direct-grounded",
+      "perplexity-sonar",
+    ];
+    const engines = resolveGroundedEngines(
+      ["anthropic/claude-sonnet-5"],
+      catalog
+    );
+    for (const key of legacyKeys) {
+      expect(engines.some((engine) => engine.key === key)).toBe(false);
+    }
+    expect(engines.length).toBe(1);
+  });
+
+  test("deduplicates selected models", () => {
+    expect(
+      resolveGroundedEngines(
+        ["anthropic/claude-sonnet-5", "anthropic/claude-sonnet-5"],
+        catalog
+      ).length
+    ).toBe(1);
+  });
+
+  test("new catalog models work without adding version constants", () => {
+    const futureCatalog: GeoModelCatalog = {
+      providers: catalog.providers,
+      models: [
+        {
+          id: "google/gemini-test-version",
+          provider: "google",
+          label: "Gemini test version",
+          zdr: "all",
+          released: "2099-01-01",
+          default: false,
+          gateways: ["vercel"],
+        },
+      ],
+    };
+    const engine = resolveGroundedEngines(
+      ["google/gemini-test-version"],
+      futureCatalog
+    )[0];
+    expect(engine?.model).toBe("google/gemini-test-version");
+    expect(engine?.label).toBe("Gemini test version");
+    const openRouterCatalog: GeoModelCatalog = {
+      ...futureCatalog,
+      models: futureCatalog.models.map((model) => ({
+        ...model,
+        gateways: ["openrouter"],
+      })),
+    };
+    expect(
+      resolveGroundedEngines(["google/gemini-test-version"], openRouterCatalog)
+        .length
+    ).toBe(0);
+  });
+
+  test("queued keys preserve the exact model rather than using a default", () => {
+    expect(
+      resolveGroundedEngineByKey("anthropic/claude-sonnet-5-grounded")?.model
+    ).toBe("anthropic/claude-sonnet-5");
+    expect(
+      resolveGroundedEngineByKey("anthropic/claude-sonnet-4.6-grounded")?.model
+    ).toBe("anthropic/claude-sonnet-4.6");
+    expect(resolveGroundedEngineByKey("anthropic/claude-sonnet-5")).toBe(null);
+  });
+
+  test("historical direct results group under the actual model", () => {
+    expect(engineModelOf("anthropic-direct-grounded")).toBe(
+      "anthropic/claude-sonnet-4.6"
+    );
+    expect(engineModelOf("openai-direct-grounded")).toBe("openai/gpt-5.4");
+    expect(engineModelOf("perplexity-sonar")).toBe("perplexity/sonar");
+  });
+});


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Web-search scans now only run on explicitly selected models instead of a hardcoded list, and mention trend chart tooltips no longer show empty engines.

- Scans resolve grounded engines from the selected model IDs in the catalog; direct provider keys are preferred, gateway routes are used otherwise.
- Legacy web-search routes and their labels remain supported for decoding historical records and queued tasks, but are never added to a scan plan.
- The trend card filters out engines with no data and passes only visible keys to tooltip row rendering.

<sup>Written for commit 23b091df88d884c97bc48d02463a28f29e42b319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

