### PR TITLE
fix(geo): stop article planning failing with "No output generated" and show which action is running

### DIFF
--- a/apps/dashboard/src/components/geo/writer/write-dialog.tsx
+++ b/apps/dashboard/src/components/geo/writer/write-dialog.tsx
@@ -41,7 +41,7 @@ import {
 } from "@notra/ui/components/ui/select";
 import { Textarea } from "@notra/ui/components/ui/textarea";
 import { cn } from "@notra/ui/lib/utils";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { AnimatePresence, LazyMotion, m, useReducedMotion } from "motion/react";
 import { useRouter } from "next/navigation";
 import {
   type ComponentProps,
@@ -91,8 +91,13 @@ import { WriteSitemapSection } from "./write-sitemap-section";
 
 const MANUAL_PROMPT_VALUE = "manual";
 const FOOTER_STATUS_TRANSITION = { duration: 0.18, ease: "easeOut" } as const;
+const loadMotionFeatures = () =>
+  import("@/lib/motion-features").then((mod) => mod.default);
 
 type WriteAction = keyof typeof GEO_WRITE_ACTION_PENDING;
+
+const sectionMeta = (id: WriteDialogSectionId) =>
+  GEO_WRITE_DIALOG_SECTIONS.find((item) => item.id === id);
 
 export function WriteDialog({
   open,
@@ -142,7 +147,6 @@ function WriteDialogForm({
     useState<WriteDialogSectionId>("prompt");
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [pendingAction, setPendingAction] = useState<WriteAction | null>(null);
-  const reduceMotion = useReducedMotion();
   const openedRef = useRef(false);
   const initialSourceKind = initial?.sourceKind ?? "manual";
   const hasInitialTopic = Boolean(initial?.topic);
@@ -302,6 +306,7 @@ function WriteDialogForm({
 
   const allCompetitorsSelected =
     competitors.length > 0 && competitorIds.length === competitors.length;
+  const selectedCompetitorIds = new Set(competitorIds);
 
   const canSubmit =
     topic.trim().length >= GEO_WRITER_TOPIC_MIN_LENGTH &&
@@ -316,9 +321,8 @@ function WriteDialogForm({
       return;
     }
     setPendingAction(action);
-    let result: Awaited<ReturnType<typeof planMutation.mutateAsync>>;
-    try {
-      result = await planMutation.mutateAsync({
+    const result = await planMutation
+      .mutateAsync({
         topic: trimmed,
         autoApprove: action === "write",
         contentSubtype,
@@ -328,58 +332,14 @@ function WriteDialogForm({
         sourceKind,
         sourceId,
         existingPageUrl,
-      });
-    } finally {
-      setPendingAction(null);
-    }
+      })
+      .finally(() => setPendingAction(null));
     onOpenChange(false);
     if (result.postId) {
       router.push(geoContentPath(organizationSlug, result.postId));
       return;
     }
     router.push(withGeoProject(`/${organizationSlug}/geo/gaps`, projectId));
-  };
-
-  const sectionMeta = (id: WriteDialogSectionId) =>
-    GEO_WRITE_DIALOG_SECTIONS.find((item) => item.id === id);
-
-  const renderSectionHeader = (
-    id: WriteDialogSectionId,
-    description: string,
-    htmlFor?: string
-  ) => {
-    const meta = sectionMeta(id);
-    if (!meta) {
-      return null;
-    }
-    const heading = (
-      <>
-        <HugeiconsIcon
-          className="text-muted-foreground size-4"
-          icon={meta.icon}
-          strokeWidth={1.8}
-        />
-        <span>{meta.label}</span>
-        {meta.required ? <span className="text-destructive">*</span> : null}
-      </>
-    );
-    return (
-      <div className="space-y-1">
-        {htmlFor ? (
-          <Label
-            className="flex items-center gap-2 text-base font-semibold"
-            htmlFor={htmlFor}
-          >
-            {heading}
-          </Label>
-        ) : (
-          <h3 className="flex items-center gap-2 text-base font-semibold">
-            {heading}
-          </h3>
-        )}
-        <p className="text-muted-foreground text-sm">{description}</p>
-      </div>
-    );
   };
 
   return (
@@ -458,11 +418,11 @@ function WriteDialogForm({
                 data-section="prompt"
               >
                 <div className="flex flex-wrap items-start justify-between gap-2">
-                  {renderSectionHeader(
-                    "prompt",
-                    "Pick a tracked prompt or write your own. The article answers this question.",
-                    `${fieldId}-topic`
-                  )}
+                  <WriteSectionHeader
+                    description="Pick a tracked prompt or write your own. The article answers this question."
+                    htmlFor={`${fieldId}-topic`}
+                    id="prompt"
+                  />
                   {promptBadgeLabel ? (
                     <Badge className="shrink-0 font-normal" variant="outline">
                       {promptBadgeLabel}
@@ -537,7 +497,10 @@ function WriteDialogForm({
                 className="scroll-mt-2 space-y-4 px-6 py-6"
                 data-section="type"
               >
-                {renderSectionHeader("type", recommendation.reason)}
+                <WriteSectionHeader
+                  description={recommendation.reason}
+                  id="type"
+                />
                 <div className="grid gap-3 sm:grid-cols-2">
                   {GEO_WRITE_CONTENT_SUBTYPES.map((option) => (
                     <WriteOptionCard
@@ -567,11 +530,11 @@ function WriteDialogForm({
                 className="scroll-mt-2 space-y-4 px-6 py-6"
                 data-section="brand"
               >
-                {renderSectionHeader(
-                  "brand",
-                  "The brand whose voice and facts the article uses.",
-                  voices.length > 0 ? `${fieldId}-brand` : undefined
-                )}
+                <WriteSectionHeader
+                  description="The brand whose voice and facts the article uses."
+                  htmlFor={voices.length > 0 ? `${fieldId}-brand` : undefined}
+                  id="brand"
+                />
                 {voices.length === 0 ? (
                   <p className="border-border text-muted-foreground rounded-lg border border-dashed px-3 py-2.5 text-sm">
                     No brand identities yet. The writer will use your GEO
@@ -611,10 +574,10 @@ function WriteDialogForm({
                 className="scroll-mt-2 space-y-4 px-6 py-6"
                 data-section="sitemap"
               >
-                {renderSectionHeader(
-                  "sitemap",
-                  "The writer links to real pages from the brand identity's sitemap."
-                )}
+                <WriteSectionHeader
+                  description="The writer links to real pages from the brand identity's sitemap."
+                  id="sitemap"
+                />
                 <WriteSitemapSection
                   brandIdentityHref={`/${organizationSlug}/brand/identity`}
                   brandVoiceId={brandVoiceId}
@@ -633,10 +596,10 @@ function WriteDialogForm({
                 data-section="competitors"
               >
                 <div className="flex items-start justify-between gap-3">
-                  {renderSectionHeader(
-                    "competitors",
-                    "Competitors the article can mention when it compares options."
-                  )}
+                  <WriteSectionHeader
+                    description="Competitors the article can mention when it compares options."
+                    id="competitors"
+                  />
                   {competitors.length > 0 ? (
                     <button
                       className="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer text-xs transition-colors"
@@ -662,7 +625,7 @@ function WriteDialogForm({
                 ) : (
                   <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
                     {competitors.map((competitor) => {
-                      const selected = competitorIds.includes(competitor.id);
+                      const selected = selectedCompetitorIds.has(competitor.id);
                       return (
                         <WriteOptionCard
                           compact
@@ -697,59 +660,122 @@ function WriteDialogForm({
             </div>
           </div>
 
-          <div className={GEO_WRITE_PANEL_FOOTER_CLASS}>
-            <div
-              className={cn(
-                GEO_WRITE_PANEL_FOOTER_ROW_CLASS,
-                "justify-between gap-3 px-4"
-              )}
-            >
-              <AnimatePresence initial={false} mode="wait">
-                <motion.p
-                  animate={{ opacity: 1, y: 0 }}
-                  aria-live="polite"
-                  className={cn(
-                    "hidden min-w-0 truncate text-xs sm:block",
-                    pendingAction ? "text-foreground" : "text-muted-foreground"
-                  )}
-                  exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
-                  initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
-                  key={pendingAction ?? "help"}
-                  transition={FOOTER_STATUS_TRANSITION}
-                >
-                  {pendingAction
-                    ? GEO_WRITE_ACTION_PENDING[pendingAction].status
-                    : `${GEO_WRITE_ACTION_HELP.plan} ${GEO_WRITE_ACTION_HELP.write}`}
-                </motion.p>
-              </AnimatePresence>
-              <div className="flex shrink-0 gap-2">
-                <WriteActionButton
-                  action="plan"
-                  disabled={!canSubmit}
-                  onClick={() => {
-                    handleSubmit("plan").catch(() => undefined);
-                  }}
-                  pendingAction={pendingAction}
-                  variant="outline"
-                >
-                  Plan
-                </WriteActionButton>
-                <WriteActionButton
-                  action="write"
-                  disabled={!canSubmit}
-                  onClick={() => {
-                    handleSubmit("write").catch(() => undefined);
-                  }}
-                  pendingAction={pendingAction}
-                >
-                  Write
-                </WriteActionButton>
-              </div>
-            </div>
-          </div>
+          <WriteDialogFooter
+            canSubmit={canSubmit}
+            onSubmit={(action) => {
+              handleSubmit(action).catch(() => undefined);
+            }}
+            pendingAction={pendingAction}
+          />
         </div>
       </div>
     </ResponsiveDialogContent>
+  );
+}
+
+function WriteSectionHeader({
+  id,
+  description,
+  htmlFor,
+}: {
+  id: WriteDialogSectionId;
+  description: string;
+  htmlFor?: string;
+}) {
+  const meta = sectionMeta(id);
+  if (!meta) {
+    return null;
+  }
+  const heading = (
+    <>
+      <HugeiconsIcon
+        className="text-muted-foreground size-4"
+        icon={meta.icon}
+        strokeWidth={1.8}
+      />
+      <span>{meta.label}</span>
+      {meta.required ? <span className="text-destructive">*</span> : null}
+    </>
+  );
+  return (
+    <div className="space-y-1">
+      {htmlFor ? (
+        <Label
+          className="flex items-center gap-2 text-base font-semibold"
+          htmlFor={htmlFor}
+        >
+          {heading}
+        </Label>
+      ) : (
+        <h3 className="flex items-center gap-2 text-base font-semibold">
+          {heading}
+        </h3>
+      )}
+      <p className="text-muted-foreground text-sm">{description}</p>
+    </div>
+  );
+}
+
+function WriteDialogFooter({
+  canSubmit,
+  onSubmit,
+  pendingAction,
+}: {
+  canSubmit: boolean;
+  onSubmit: (action: WriteAction) => void;
+  pendingAction: WriteAction | null;
+}) {
+  const reduceMotion = useReducedMotion();
+  const statusText = pendingAction
+    ? GEO_WRITE_ACTION_PENDING[pendingAction].status
+    : `${GEO_WRITE_ACTION_HELP.plan} ${GEO_WRITE_ACTION_HELP.write}`;
+  return (
+    <div className={GEO_WRITE_PANEL_FOOTER_CLASS}>
+      <div
+        className={cn(
+          GEO_WRITE_PANEL_FOOTER_ROW_CLASS,
+          "justify-between gap-3 px-4"
+        )}
+      >
+        <LazyMotion features={loadMotionFeatures} strict>
+          <AnimatePresence initial={false} mode="wait">
+            <m.p
+              animate={{ opacity: 1, y: 0 }}
+              aria-live="polite"
+              className={cn(
+                "hidden min-w-0 truncate text-xs sm:block",
+                pendingAction ? "text-foreground" : "text-muted-foreground"
+              )}
+              exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
+              initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
+              key={pendingAction ?? "help"}
+              transition={FOOTER_STATUS_TRANSITION}
+            >
+              {statusText}
+            </m.p>
+          </AnimatePresence>
+        </LazyMotion>
+        <div className="flex shrink-0 gap-2">
+          <WriteActionButton
+            action="plan"
+            disabled={!canSubmit}
+            onClick={() => onSubmit("plan")}
+            pendingAction={pendingAction}
+            variant="outline"
+          >
+            Plan
+          </WriteActionButton>
+          <WriteActionButton
+            action="write"
+            disabled={!canSubmit}
+            onClick={() => onSubmit("write")}
+            pendingAction={pendingAction}
+          >
+            Write
+          </WriteActionButton>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/apps/dashboard/src/components/geo/writer/write-dialog.tsx
+++ b/apps/dashboard/src/components/geo/writer/write-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Loading03Icon,
   SidebarLeft01Icon,
   SidebarRight01Icon,
 } from "@hugeicons/core-free-icons";
@@ -40,8 +41,10 @@ import {
 } from "@notra/ui/components/ui/select";
 import { Textarea } from "@notra/ui/components/ui/textarea";
 import { cn } from "@notra/ui/lib/utils";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useRouter } from "next/navigation";
 import {
+  type ComponentProps,
   type ReactNode,
   useEffect,
   useId,
@@ -56,6 +59,7 @@ import { useGeoProjectScope } from "@/components/providers/geo-project-provider"
 import { GEO_WRITE_DIALOG_ENTRIES } from "@/constants/geo-analytics";
 import {
   GEO_WRITE_ACTION_HELP,
+  GEO_WRITE_ACTION_PENDING,
   GEO_WRITE_CONTENT_SUBTYPES,
   GEO_WRITE_DIALOG_SECTIONS,
   GEO_WRITE_EDIT_NOTE,
@@ -86,6 +90,9 @@ import { WriteSectionSidebar } from "./write-section-sidebar";
 import { WriteSitemapSection } from "./write-sitemap-section";
 
 const MANUAL_PROMPT_VALUE = "manual";
+const FOOTER_STATUS_TRANSITION = { duration: 0.18, ease: "easeOut" } as const;
+
+type WriteAction = keyof typeof GEO_WRITE_ACTION_PENDING;
 
 export function WriteDialog({
   open,
@@ -134,6 +141,8 @@ function WriteDialogForm({
   const [activeSection, setActiveSection] =
     useState<WriteDialogSectionId>("prompt");
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [pendingAction, setPendingAction] = useState<WriteAction | null>(null);
+  const reduceMotion = useReducedMotion();
   const openedRef = useRef(false);
   const initialSourceKind = initial?.sourceKind ?? "manual";
   const hasInitialTopic = Boolean(initial?.topic);
@@ -298,7 +307,7 @@ function WriteDialogForm({
     topic.trim().length >= GEO_WRITER_TOPIC_MIN_LENGTH &&
     !planMutation.isPending;
 
-  const handleSubmit = async (autoApprove: boolean) => {
+  const handleSubmit = async (action: WriteAction) => {
     const trimmed = topic.trim();
     if (
       trimmed.length < GEO_WRITER_TOPIC_MIN_LENGTH ||
@@ -306,17 +315,23 @@ function WriteDialogForm({
     ) {
       return;
     }
-    const result = await planMutation.mutateAsync({
-      topic: trimmed,
-      autoApprove,
-      contentSubtype,
-      brandVoiceIds: brandVoiceId ? [brandVoiceId] : [],
-      competitorIds,
-      sitemapId: effectiveSitemapId ?? undefined,
-      sourceKind,
-      sourceId,
-      existingPageUrl,
-    });
+    setPendingAction(action);
+    let result: Awaited<ReturnType<typeof planMutation.mutateAsync>>;
+    try {
+      result = await planMutation.mutateAsync({
+        topic: trimmed,
+        autoApprove: action === "write",
+        contentSubtype,
+        brandVoiceIds: brandVoiceId ? [brandVoiceId] : [],
+        competitorIds,
+        sitemapId: effectiveSitemapId ?? undefined,
+        sourceKind,
+        sourceId,
+        existingPageUrl,
+      });
+    } finally {
+      setPendingAction(null);
+    }
     onOpenChange(false);
     if (result.postId) {
       router.push(geoContentPath(organizationSlug, result.postId));
@@ -689,32 +704,80 @@ function WriteDialogForm({
                 "justify-between gap-3 px-4"
               )}
             >
-              <p className="text-muted-foreground hidden min-w-0 truncate text-xs sm:block">
-                {GEO_WRITE_ACTION_HELP.plan} {GEO_WRITE_ACTION_HELP.write}
-              </p>
+              <AnimatePresence initial={false} mode="wait">
+                <motion.p
+                  animate={{ opacity: 1, y: 0 }}
+                  aria-live="polite"
+                  className={cn(
+                    "hidden min-w-0 truncate text-xs sm:block",
+                    pendingAction ? "text-foreground" : "text-muted-foreground"
+                  )}
+                  exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
+                  initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
+                  key={pendingAction ?? "help"}
+                  transition={FOOTER_STATUS_TRANSITION}
+                >
+                  {pendingAction
+                    ? GEO_WRITE_ACTION_PENDING[pendingAction].status
+                    : `${GEO_WRITE_ACTION_HELP.plan} ${GEO_WRITE_ACTION_HELP.write}`}
+                </motion.p>
+              </AnimatePresence>
               <div className="flex shrink-0 gap-2">
-                <Button
+                <WriteActionButton
+                  action="plan"
                   disabled={!canSubmit}
                   onClick={() => {
-                    handleSubmit(false).catch(() => undefined);
+                    handleSubmit("plan").catch(() => undefined);
                   }}
+                  pendingAction={pendingAction}
                   variant="outline"
                 >
-                  {planMutation.isPending ? "Planning…" : "Plan"}
-                </Button>
-                <Button
+                  Plan
+                </WriteActionButton>
+                <WriteActionButton
+                  action="write"
                   disabled={!canSubmit}
                   onClick={() => {
-                    handleSubmit(true).catch(() => undefined);
+                    handleSubmit("write").catch(() => undefined);
                   }}
+                  pendingAction={pendingAction}
                 >
                   Write
-                </Button>
+                </WriteActionButton>
               </div>
             </div>
           </div>
         </div>
       </div>
     </ResponsiveDialogContent>
+  );
+}
+
+function WriteActionButton({
+  action,
+  pendingAction,
+  children,
+  ...props
+}: Omit<ComponentProps<typeof Button>, "children"> & {
+  action: WriteAction;
+  pendingAction: WriteAction | null;
+  children: ReactNode;
+}) {
+  const isPending = pendingAction === action;
+  return (
+    <Button aria-busy={isPending} {...props}>
+      {isPending ? (
+        <>
+          <HugeiconsIcon
+            aria-hidden="true"
+            className="size-4 animate-spin"
+            icon={Loading03Icon}
+          />
+          {GEO_WRITE_ACTION_PENDING[action].label}
+        </>
+      ) : (
+        children
+      )}
+    </Button>
   );
 }

--- a/apps/dashboard/src/constants/geo-writer.ts
+++ b/apps/dashboard/src/constants/geo-writer.ts
@@ -71,6 +71,18 @@ export const GEO_WRITE_ACTION_HELP = {
   write: "Write plans and drafts the article in one step.",
 } as const;
 
+export const GEO_WRITE_ACTION_PENDING = {
+  plan: {
+    label: "Planning…",
+    status: "Planning the brief. You review it before anything is drafted.",
+  },
+  write: {
+    label: "Writing…",
+    status:
+      "Planning the brief, then drafting the article. This takes about a minute.",
+  },
+} as const;
+
 export const GEO_WRITE_EDIT_NOTE =
   "Editing the text creates a custom variant that is no longer linked to the tracked prompt.";
 

--- a/packages/ai/src/agents/geo-writer.ts
+++ b/packages/ai/src/agents/geo-writer.ts
@@ -54,6 +54,7 @@ import { db } from "@notra/db/drizzle";
 import { posts } from "@notra/db/schema";
 import {
   generateText,
+  type FinishReason,
   type LanguageModelUsage,
   NoObjectGeneratedError,
   Output,
@@ -115,6 +116,34 @@ interface PlannerFailure {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
+}
+
+/**
+ * `result.output` throws when the model did not finish with `stop`, so an
+ * unfinished response has to be described before the output is read. A
+ * `length` finish means the brief hit the token budget; the truncated JSON is
+ * handed back to the model so the repair attempt can shorten it.
+ */
+function describeUnfinishedPlan(
+  finishReason: FinishReason,
+  text: string,
+  usage: LanguageModelUsage
+): PlannerFailure {
+  const previousOutput = text.trim() || undefined;
+  if (finishReason === "length") {
+    return {
+      errors: [
+        `The brief was cut off before it was complete (finish reason: length, ${usage.outputTokens ?? "unknown"} output tokens, limit ${GEO_WRITER_PLANNER_MAX_TOKENS}). Keep every field short and stay within the item limits.`,
+      ],
+      previousOutput,
+    };
+  }
+  return {
+    errors: [
+      `The planner stopped before returning a brief (finish reason: ${finishReason}).`,
+    ],
+    previousOutput,
+  };
 }
 
 function describePlannerFailure(error: unknown): PlannerFailure {
@@ -191,6 +220,19 @@ export async function generateGeoContentBrief(
         }),
       });
       usage = mergeTokenUsage(usage, toTokenUsage(result.usage));
+      if (result.finishReason !== "stop") {
+        const failure = describeUnfinishedPlan(
+          result.finishReason,
+          result.text,
+          result.usage
+        );
+        lastError = failure.errors.join("; ");
+        prompt = `${basePrompt}\n\n${buildGeoPlannerRepairPrompt({
+          errors: failure.errors,
+          previousOutput: failure.previousOutput,
+        })}`;
+        continue;
+      }
       const parsed = geoContentBriefSchema.safeParse(result.output);
       if (parsed.success) {
         return { brief: stripDashes(parsed.data), usage };

--- a/packages/ai/src/constants/geo-writer.ts
+++ b/packages/ai/src/constants/geo-writer.ts
@@ -7,6 +7,9 @@ export const GEO_BRIEF_MAX_TITLE_LENGTH = 120;
 export const GEO_BRIEF_MIN_SECTIONS = 3;
 export const GEO_BRIEF_MAX_SECTIONS = 8;
 export const GEO_BRIEF_MAX_CLAIMS = 5;
+/** Targets the planner aims for; the MAX_* values above are hard ceilings. */
+export const GEO_BRIEF_TARGET_MAX_SECTIONS = 6;
+export const GEO_BRIEF_TARGET_MAX_CLAIMS = 3;
 export const GEO_BRIEF_MAX_QUESTIONS = 8;
 export const GEO_BRIEF_MAX_LINKS = 6;
 export const GEO_BRIEF_MAX_CHECKLIST = 8;

--- a/packages/ai/src/constants/models.ts
+++ b/packages/ai/src/constants/models.ts
@@ -1,7 +1,7 @@
 export const AGENT_DEFAULT_MODEL = "anthropic/claude-sonnet-5";
 
 export const GEO_WRITER_MODEL = "anthropic/claude-opus-5";
-export const GEO_WRITER_PLANNER_MAX_TOKENS = 6000;
+export const GEO_WRITER_PLANNER_MAX_TOKENS = 8000;
 export const GEO_WRITER_PLANNER_TEMPERATURE = 0.3;
 export const GEO_WRITER_PLANNER_REPAIR_ATTEMPTS = 1;
 export const GEO_WRITER_HUMANIZER_MAX_TOKENS = 8000;

--- a/packages/ai/src/constants/models.ts
+++ b/packages/ai/src/constants/models.ts
@@ -1,7 +1,7 @@
 export const AGENT_DEFAULT_MODEL = "anthropic/claude-sonnet-5";
 
 export const GEO_WRITER_MODEL = "anthropic/claude-opus-5";
-export const GEO_WRITER_PLANNER_MAX_TOKENS = 2500;
+export const GEO_WRITER_PLANNER_MAX_TOKENS = 6000;
 export const GEO_WRITER_PLANNER_TEMPERATURE = 0.3;
 export const GEO_WRITER_PLANNER_REPAIR_ATTEMPTS = 1;
 export const GEO_WRITER_HUMANIZER_MAX_TOKENS = 8000;

--- a/packages/ai/src/prompts/geo_writer/planner.ts
+++ b/packages/ai/src/prompts/geo_writer/planner.ts
@@ -1,4 +1,11 @@
 import {
+  GEO_BRIEF_MAX_CHECKLIST,
+  GEO_BRIEF_MAX_CLAIMS,
+  GEO_BRIEF_MAX_EVIDENCE_ITEMS,
+  GEO_BRIEF_MAX_LINKS,
+  GEO_BRIEF_MAX_QUESTIONS,
+  GEO_BRIEF_MAX_SECTIONS,
+  GEO_BRIEF_MIN_SECTIONS,
   GEO_PLANNER_MAX_EVIDENCE_ENGINES,
   GEO_PLANNER_MAX_EVIDENCE_EXCERPT_CHARS,
   GEO_PLANNER_MAX_EVIDENCE_SOURCES,
@@ -48,6 +55,12 @@ export function buildGeoPlannerSystem(): string {
     ${GEO_WRITING_RULES}
 
     ${prohibitedLanguage}
+
+    Hard limits (the brief is rejected when any is exceeded):
+    - ${GEO_BRIEF_MIN_SECTIONS} to ${GEO_BRIEF_MAX_SECTIONS} sections, at most ${GEO_BRIEF_MAX_CLAIMS} claims per section.
+    - At most ${GEO_BRIEF_MAX_QUESTIONS} FAQ questions, ${GEO_BRIEF_MAX_LINKS} internal links, and ${GEO_BRIEF_MAX_CHECKLIST} checklist items.
+    - At most ${GEO_BRIEF_MAX_EVIDENCE_ITEMS} items each in competitorsToCounter, sourcesToReference, and missingCoverage.
+    - Keep every string to one or two short sentences. The whole brief must stay compact.
 
     Output rules:
     - Never use em dashes or en dashes anywhere. Use commas, periods, or parentheses.
@@ -221,7 +234,7 @@ export function buildGeoPlannerRepairPrompt(input: {
   previousOutput?: string;
 }): string {
   return dedent`
-    Your previous brief did not match the required structure. Fix these problems and return the complete brief again:
+    Your previous brief was not accepted. Fix these problems and return the complete brief again, within the hard limits:
     ${input.errors.map((error) => `- ${error}`).join("\n")}
     ${
       input.previousOutput

--- a/packages/ai/src/prompts/geo_writer/planner.ts
+++ b/packages/ai/src/prompts/geo_writer/planner.ts
@@ -6,6 +6,8 @@ import {
   GEO_BRIEF_MAX_QUESTIONS,
   GEO_BRIEF_MAX_SECTIONS,
   GEO_BRIEF_MIN_SECTIONS,
+  GEO_BRIEF_TARGET_MAX_CLAIMS,
+  GEO_BRIEF_TARGET_MAX_SECTIONS,
   GEO_PLANNER_MAX_EVIDENCE_ENGINES,
   GEO_PLANNER_MAX_EVIDENCE_EXCERPT_CHARS,
   GEO_PLANNER_MAX_EVIDENCE_SOURCES,
@@ -43,7 +45,7 @@ export function buildGeoPlannerSystem(): string {
     How to build the brief:
     - Pick ONE target prompt: the exact question a buyer would type into an AI assistant. Prefer a provided content gap prompt when the topic matches one.
     - Every article is a blog post. Choose the subtype that fits the intent: guide, comparison, listicle, how-to, faq, or alternatives. If the user already chose one, keep it.
-    - Write 3 to 6 sections. Each section gets a heading, a one-sentence goal, and 1 to 3 concrete, checkable claims the writer must support.
+    - Aim for ${GEO_BRIEF_MIN_SECTIONS} to ${GEO_BRIEF_TARGET_MAX_SECTIONS} sections. Each section gets a heading, a one-sentence goal, and 1 to ${GEO_BRIEF_TARGET_MAX_CLAIMS} concrete, checkable claims the writer must support. More is allowed only up to the hard limits below.
     - List the questions the FAQ must answer directly.
     - Choose internal links ONLY from the provided sitemap pages. Copy each URL exactly as listed. If no sitemap pages are provided, return an empty internalLinks array. Never invent paths, subdomains, or query strings.
     - The acceptance checklist mirrors the GEO writing rules below, adapted to this article.
@@ -56,8 +58,8 @@ export function buildGeoPlannerSystem(): string {
 
     ${prohibitedLanguage}
 
-    Hard limits (the brief is rejected when any is exceeded):
-    - ${GEO_BRIEF_MIN_SECTIONS} to ${GEO_BRIEF_MAX_SECTIONS} sections, at most ${GEO_BRIEF_MAX_CLAIMS} claims per section.
+    Hard limits (ceilings, not targets; the brief is rejected when any is exceeded):
+    - Never fewer than ${GEO_BRIEF_MIN_SECTIONS} or more than ${GEO_BRIEF_MAX_SECTIONS} sections, never more than ${GEO_BRIEF_MAX_CLAIMS} claims per section.
     - At most ${GEO_BRIEF_MAX_QUESTIONS} FAQ questions, ${GEO_BRIEF_MAX_LINKS} internal links, and ${GEO_BRIEF_MAX_CHECKLIST} checklist items.
     - At most ${GEO_BRIEF_MAX_EVIDENCE_ITEMS} items each in competitorsToCounter, sourcesToReference, and missingCoverage.
     - Keep every string to one or two short sentences. The whole brief must stay compact.


### PR DESCRIPTION
### Description
Writing an article from GEO failed with "Failed to plan the article: No output generated." (seen twice in production today on `/rpc/geo/writerPlan`). The AI SDK only fills `result.output` when the model finishes with `stop`; the planner read it blindly, so every run that hit the 2500 output-token cap (Opus 5 briefs with up to 8 sections, FAQ, links, checklist and evidence lists) blew up with that message, and the repair attempt got the same useless error and failed identically.

The planner now checks the finish reason before reading the output. On `length` it hands the truncated JSON back to the repair attempt with a "keep it compact" instruction, the budget is raised to 6000 tokens, and the system prompt states the brief's hard item limits so Opus stays inside the schema. The error message now includes finish reason and token count, so the next incident is diagnosable from the logs.

Also in the write dialog: both buttons shared one pending flag, so pressing **Write** showed "Planning…" on the **Plan** button. The dialog now remembers which action was pressed, shows spinner + "Planning…" / "Writing…" on that button, and fades the footer help text into a status line ("Planning the brief, then drafting the article. This takes about a minute."). Respects reduced motion, announced via `aria-live`.

### Screenshot/Recording (if applicable)

### Notes
- Not verified end-to-end against the Vercel gateway: the local gateway key has no credits and the prod key is Sensitive. A partial OpenRouter run confirmed Opus 5 returns a complete brief once the budget is larger, and that it exceeds the item limits without the new prompt caps.
- `bun run check`, `bun run format`, and `tsc --noEmit` for `packages/ai` and `apps/dashboard` pass.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did (written with Claude Code)

</details>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GEO article planning failing with "No output generated" when the planner hit the output-token cap, and fixes the write dialog showing "Planning…" on the Plan button when Write was pressed.

**Bug Fixes**
- The planner checks the finish reason before reading the output; truncated briefs go back to the repair attempt, the budget is raised to 8000 tokens, and the system prompt names the brief's section and claim targets alongside the hard item limits.
- Planner errors now include the finish reason and token count so the next incident is diagnosable from logs.
- The dialog tracks which action was pressed and shows the spinner and "Planning…"/"Writing…" on that button, with the footer help text replaced by an animated status line.

**Refactors**
- The dialog now uses `promise.finally` instead of `try/finally`, lazy-loads motion via `LazyMotion` with the shared feature loader, and extracts the section header and footer into components.

<sup>Written for commit 4836c4409a766aeeddcaeab29ac7bcb1ae332290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



