### PR TITLE
feat(github): support new publishing folders

### DIFF
--- a/apps/dashboard/src/components/content/github-publish-dialog-footer.tsx
+++ b/apps/dashboard/src/components/content/github-publish-dialog-footer.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ResponsiveDialogClose } from "@notra/ui/components/shared/responsive-dialog";
+import Link from "next/link";
+
+import { Button } from "@/components/button";
+import type { GitHubPublishDialogFooterProps } from "@/types/content/detail";
+
+export function GitHubPublishDialogFooter({
+  hasSelectedRepository,
+  isPublishing,
+  organizationSlug,
+  publishRecovery,
+  pullRequest,
+  selectedPublishingEnabled,
+}: GitHubPublishDialogFooterProps) {
+  const permissionsUrl =
+    publishRecovery?.code === "github_app_permissions_required"
+      ? publishRecovery.permissionsUrl
+      : undefined;
+  const showIntegrationRecovery = Boolean(
+    publishRecovery &&
+    (publishRecovery.publishingPaused ||
+      publishRecovery.code !== "github_app_permissions_required" ||
+      !publishRecovery.permissionsUrl)
+  );
+
+  return (
+    <>
+      <ResponsiveDialogClose
+        disabled={isPublishing}
+        render={<Button variant="outline" />}
+      >
+        Close
+      </ResponsiveDialogClose>
+      {showIntegrationRecovery ? (
+        <Button
+          nativeButton={false}
+          render={
+            <Link href={`/${organizationSlug}/integrations/github`}>
+              Open GitHub integration
+            </Link>
+          }
+        />
+      ) : null}
+      {permissionsUrl ? (
+        <Button
+          nativeButton={false}
+          render={
+            <a href={permissionsUrl} rel="noopener noreferrer" target="_blank">
+              Update permissions
+              <HugeiconsIcon className="size-4" icon={ArrowUpRight01Icon} />
+            </a>
+          }
+        />
+      ) : null}
+      {!publishRecovery && pullRequest ? (
+        <Button
+          nativeButton={false}
+          render={
+            <a
+              href={pullRequest.pullRequestUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Open pull request
+              <HugeiconsIcon className="size-4" icon={ArrowUpRight01Icon} />
+            </a>
+          }
+        />
+      ) : null}
+      {publishRecovery || pullRequest ? null : (
+        <Button
+          disabled={
+            isPublishing || !hasSelectedRepository || !selectedPublishingEnabled
+          }
+          type="submit"
+        >
+          {isPublishing ? "Creating draft PR…" : "Create draft PR"}
+        </Button>
+      )}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/content/github-publish-recovery-alert.tsx
+++ b/apps/dashboard/src/components/content/github-publish-recovery-alert.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@notra/ui/components/ui/alert";
+
+import { GITHUB_RECOVERY_COPY } from "@/constants/github";
+import type { GitHubPublishRecoveryAlertProps } from "@/types/content/detail";
+
+export function GitHubPublishRecoveryAlert({
+  publishRecovery,
+}: GitHubPublishRecoveryAlertProps) {
+  const recoveryCopy = GITHUB_RECOVERY_COPY[publishRecovery.code];
+
+  return (
+    <Alert variant="destructive">
+      <HugeiconsIcon icon={AlertCircleIcon} />
+      <AlertTitle>{recoveryCopy.title}</AlertTitle>
+      <AlertDescription>
+        <p>{recoveryCopy.description}</p>
+        {publishRecovery.publishingPaused ? (
+          <p>
+            Publishing was also paused after three failures. Resume it in the
+            GitHub integration after fixing this.
+          </p>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/dashboard/src/components/content/github-publish-repository-field.tsx
+++ b/apps/dashboard/src/components/content/github-publish-repository-field.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "@notra/ui/components/ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@notra/ui/components/ui/select";
+import Link from "next/link";
+
+import { Button } from "@/components/button";
+import type {
+  GitHubPublishRepositoryFieldProps,
+  GitHubPublishRepositoryStatusProps,
+} from "@/types/content/detail";
+import { formatGitHubRepositoryLabel } from "@/utils/github-publish-repositories";
+
+function GitHubPublishRepositoryStatus({
+  connectedRepositoryCount,
+  contentTypeLabel,
+  githubIntegrationHref,
+  integrationsLoadFailed,
+  isLoadingIntegrations,
+  onRetryIntegrations,
+  repositoriesCount,
+  selectedPublishingEnabled,
+  selectedRepository,
+}: GitHubPublishRepositoryStatusProps) {
+  if (integrationsLoadFailed) {
+    return (
+      <div
+        className="border-destructive/30 flex items-center justify-between gap-3 rounded-lg border p-3"
+        role="alert"
+      >
+        <p className="text-destructive text-sm">
+          Unable to load GitHub repositories.
+        </p>
+        <Button
+          onClick={onRetryIntegrations}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (isLoadingIntegrations) {
+    return null;
+  }
+
+  if (connectedRepositoryCount === 0) {
+    return (
+      <FieldDescription>
+        No enabled GitHub repositories are connected. Open the{" "}
+        <Link
+          className="underline underline-offset-4"
+          href={githubIntegrationHref}
+        >
+          GitHub integration
+        </Link>{" "}
+        to connect or enable one.
+      </FieldDescription>
+    );
+  }
+
+  if (selectedRepository && !selectedPublishingEnabled) {
+    return (
+      <FieldDescription>
+        {contentTypeLabel} publishing is off for this repository. Open the{" "}
+        <Link
+          className="underline underline-offset-4"
+          href={githubIntegrationHref}
+        >
+          GitHub integration
+        </Link>{" "}
+        to enable it.
+      </FieldDescription>
+    );
+  }
+
+  if (repositoriesCount === 0) {
+    return (
+      <FieldDescription>
+        These repositories need a default branch before they can publish to
+        GitHub.
+      </FieldDescription>
+    );
+  }
+
+  return null;
+}
+
+export function GitHubPublishRepositoryField({
+  connectedRepositoryCount,
+  contentLabel,
+  integrationsLoadFailed,
+  isLoadingIntegrations,
+  isPublishing,
+  onRepositoryChange,
+  onRetryIntegrations,
+  organizationSlug,
+  repositories,
+  selectedPublishingEnabled,
+  selectedRepository,
+}: GitHubPublishRepositoryFieldProps) {
+  const githubIntegrationHref = `/${organizationSlug}/integrations/github`;
+  const contentTypeLabel =
+    contentLabel === "blog post" ? "Blog post" : "Changelog";
+
+  return (
+    <div className="space-y-4 py-6">
+      <Field>
+        <FieldLabel htmlFor="github-publish-repository">Repository</FieldLabel>
+        <Select
+          disabled={
+            isPublishing || integrationsLoadFailed || repositories.length === 0
+          }
+          onValueChange={(value) => onRepositoryChange(value ?? "")}
+          value={selectedRepository?.id ?? ""}
+        >
+          <SelectTrigger className="w-full" id="github-publish-repository">
+            <SelectValue
+              placeholder={
+                isLoadingIntegrations
+                  ? "Loading repositories…"
+                  : "Select a repository"
+              }
+            >
+              {(value) => {
+                const repository =
+                  repositories.find((candidate) => candidate.id === value) ??
+                  selectedRepository;
+                if (!repository) {
+                  return "Select a repository";
+                }
+                return formatGitHubRepositoryLabel(repository);
+              }}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {repositories.map((repository) => (
+              <SelectItem key={repository.id} value={repository.id}>
+                {formatGitHubRepositoryLabel(repository)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <GitHubPublishRepositoryStatus
+          connectedRepositoryCount={connectedRepositoryCount}
+          contentTypeLabel={contentTypeLabel}
+          githubIntegrationHref={githubIntegrationHref}
+          integrationsLoadFailed={integrationsLoadFailed}
+          isLoadingIntegrations={isLoadingIntegrations}
+          onRetryIntegrations={onRetryIntegrations}
+          repositoriesCount={repositories.length}
+          selectedPublishingEnabled={selectedPublishingEnabled}
+          selectedRepository={selectedRepository}
+        />
+      </Field>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/content/github-publish-result-card.tsx
+++ b/apps/dashboard/src/components/content/github-publish-result-card.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ArrowUpRight01Icon, GitCommitIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Notra } from "@notra/ui/components/ui/svgs/notra";
+
+import type { GitHubPublishResultCardProps } from "@/types/content/detail";
+
+export function GitHubPublishResultCard({
+  pullRequest,
+  repositoryLabel,
+  title,
+}: GitHubPublishResultCardProps) {
+  const wasCreated = pullRequest.operation === "created";
+
+  return (
+    <div className="bg-muted/20 my-4 overflow-hidden rounded-lg border">
+      <div className="flex items-start gap-3 p-3">
+        <div className="ring-foreground/10 flex size-8 shrink-0 items-center justify-center rounded-lg bg-[#f6f3f1] p-1 ring-1">
+          <Notra className="size-full" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">docs: add {title}</p>
+          <p className="text-muted-foreground mt-1 truncate text-xs">
+            {repositoryLabel}#{pullRequest.pullRequestNumber} ·{" "}
+            {wasCreated ? "Created as draft" : "Updated"}
+          </p>
+        </div>
+        <a
+          aria-label={`Open pull request #${pullRequest.pullRequestNumber} on GitHub`}
+          className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          href={pullRequest.pullRequestUrl}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <HugeiconsIcon className="size-4" icon={ArrowUpRight01Icon} />
+        </a>
+      </div>
+
+      <div className="text-muted-foreground flex min-w-0 items-center gap-2 border-t px-3 py-2.5 text-xs">
+        <HugeiconsIcon className="size-4 shrink-0" icon={GitCommitIcon} />
+        <span className="truncate">
+          {wasCreated ? "Added" : "Updated"} {pullRequest.path}
+        </span>
+        <span aria-hidden="true">·</span>
+        <span className="max-w-32 truncate font-mono">
+          {pullRequest.branchName}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/content/publish-content-to-github-dialog.tsx
+++ b/apps/dashboard/src/components/content/publish-content-to-github-dialog.tsx
@@ -88,6 +88,14 @@ export function PublishContentToGitHubDialog({
     ? isGitHubContentPublishingEnabled(selectedRepository, contentType)
     : false;
 
+  const invalidateIntegrations = () => {
+    queryClient.invalidateQueries({
+      queryKey: dashboardOrpc.integrations.list.queryKey({
+        input: { organizationId },
+      }),
+    });
+  };
+
   const publishMutation = useMutation({
     mutationFn: async (targetRepositoryId: string) => {
       const saved = await onSave();
@@ -103,11 +111,7 @@ export function PublishContentToGitHubDialog({
       });
     },
     onSuccess: (result) => {
-      queryClient.invalidateQueries({
-        queryKey: dashboardOrpc.integrations.list.queryKey({
-          input: { organizationId },
-        }),
-      });
+      invalidateIntegrations();
       toast.success(
         result.operation === "created"
           ? "Draft pull request created"
@@ -115,18 +119,9 @@ export function PublishContentToGitHubDialog({
       );
     },
     onError: (error) => {
+      invalidateIntegrations();
       const recovery = getGitHubPublishRecovery(error);
       if (recovery) {
-        if (
-          recovery.code === "github_content_publishing_paused" ||
-          recovery.publishingPaused
-        ) {
-          queryClient.invalidateQueries({
-            queryKey: dashboardOrpc.integrations.list.queryKey({
-              input: { organizationId },
-            }),
-          });
-        }
         return;
       }
       toast.error(error.message || "Failed to create draft pull request");
@@ -315,8 +310,14 @@ export function PublishContentToGitHubDialog({
                 !selectedPublishingEnabled ? (
                   <FieldDescription>
                     {contentLabel === "blog post" ? "Blog post" : "Changelog"}{" "}
-                    publishing is off for this repository. Creating a draft PR
-                    will turn it on.
+                    publishing is off for this repository. Open the{" "}
+                    <Link
+                      className="underline underline-offset-4"
+                      href={`/${organizationSlug}/integrations/github`}
+                    >
+                      GitHub integration
+                    </Link>{" "}
+                    to enable it.
                   </FieldDescription>
                 ) : null}
                 {!integrationsQuery.isLoading &&
@@ -401,7 +402,11 @@ export function PublishContentToGitHubDialog({
             ) : null}
             {publishRecovery || pullRequest ? null : (
               <Button
-                disabled={publishMutation.isPending || !selectedRepository}
+                disabled={
+                  publishMutation.isPending ||
+                  !selectedRepository ||
+                  !selectedPublishingEnabled
+                }
                 type="submit"
               >
                 {publishMutation.isPending

--- a/apps/dashboard/src/components/content/publish-content-to-github-dialog.tsx
+++ b/apps/dashboard/src/components/content/publish-content-to-github-dialog.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import {
-  AlertCircleIcon,
-  ArrowUpRight01Icon,
-  GitCommitIcon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import {
   ResponsiveDialog,
-  ResponsiveDialogClose,
   ResponsiveDialogContent,
   ResponsiveDialogDescription,
   ResponsiveDialogFooter,
@@ -16,36 +9,80 @@ import {
   ResponsiveDialogTitle,
   ResponsiveDialogTrigger,
 } from "@notra/ui/components/shared/responsive-dialog";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@notra/ui/components/ui/alert";
-import {
-  Field,
-  FieldDescription,
-  FieldLabel,
-} from "@notra/ui/components/ui/field";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@notra/ui/components/ui/select";
 import { Github } from "@notra/ui/components/ui/svgs/github";
-import { Notra } from "@notra/ui/components/ui/svgs/notra";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import Link from "next/link";
 import { type FormEvent, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/button";
-import { GITHUB_RECOVERY_COPY } from "@/constants/github";
+import { GitHubPublishDialogFooter } from "@/components/content/github-publish-dialog-footer";
+import { GitHubPublishRecoveryAlert } from "@/components/content/github-publish-recovery-alert";
+import { GitHubPublishRepositoryField } from "@/components/content/github-publish-repository-field";
+import { GitHubPublishResultCard } from "@/components/content/github-publish-result-card";
 import { dashboardOrpc } from "@/lib/orpc/query";
-import type { PublishContentToGitHubDialogProps } from "@/types/content/detail";
+import type {
+  GitHubPublishDialogBodyProps,
+  PublishContentToGitHubDialogProps,
+} from "@/types/content/detail";
+import { getGitHubPublishDialogCopy } from "@/utils/github-publish-dialog";
 import { getGitHubPublishRecovery } from "@/utils/github-publish-recovery";
-import { isGitHubContentPublishingEnabled } from "@/utils/github-publish-repositories";
+import {
+  formatGitHubRepositoryLabel,
+  getGitHubPublishRepositoryLists,
+  isGitHubContentPublishingEnabled,
+} from "@/utils/github-publish-repositories";
+
+function GitHubPublishDialogBody({
+  contentLabel,
+  connectedRepositoryCount,
+  integrationsLoadFailed,
+  isLoadingIntegrations,
+  isPublishing,
+  onRepositoryChange,
+  onRetryIntegrations,
+  organizationSlug,
+  publishRecovery,
+  pullRequest,
+  repositories,
+  selectedPublishingEnabled,
+  selectedRepository,
+  title,
+}: GitHubPublishDialogBodyProps) {
+  if (pullRequest) {
+    return (
+      <GitHubPublishResultCard
+        pullRequest={pullRequest}
+        repositoryLabel={
+          selectedRepository
+            ? formatGitHubRepositoryLabel(selectedRepository)
+            : "Repository"
+        }
+        title={title}
+      />
+    );
+  }
+
+  return (
+    <>
+      <GitHubPublishRepositoryField
+        connectedRepositoryCount={connectedRepositoryCount}
+        contentLabel={contentLabel}
+        integrationsLoadFailed={integrationsLoadFailed}
+        isLoadingIntegrations={isLoadingIntegrations}
+        isPublishing={isPublishing}
+        onRepositoryChange={onRepositoryChange}
+        onRetryIntegrations={onRetryIntegrations}
+        organizationSlug={organizationSlug}
+        repositories={repositories}
+        selectedPublishingEnabled={selectedPublishingEnabled}
+        selectedRepository={selectedRepository}
+      />
+      {publishRecovery ? (
+        <GitHubPublishRecoveryAlert publishRecovery={publishRecovery} />
+      ) : null}
+    </>
+  );
+}
 
 export function PublishContentToGitHubDialog({
   contentId,
@@ -67,18 +104,8 @@ export function PublishContentToGitHubDialog({
       staleTime: 5 * 60 * 1000,
     })
   );
-
-  const connectedRepositories =
-    integrationsQuery.data?.integrations.flatMap((integration) =>
-      integration.type === "github" &&
-      integration.enabled &&
-      integration.repositories.length > 0
-        ? integration.repositories.filter((repository) => repository.enabled)
-        : []
-    ) ?? [];
-  const repositories = connectedRepositories.filter(
-    (repository) => repository.defaultBranch
-  );
+  const { connected, publishable: repositories } =
+    getGitHubPublishRepositoryLists(integrationsQuery.data?.integrations ?? []);
   const integrationsLoadFailed =
     integrationsQuery.isError && !integrationsQuery.data;
   const selectedRepository =
@@ -120,37 +147,15 @@ export function PublishContentToGitHubDialog({
     },
     onError: (error) => {
       invalidateIntegrations();
-      const recovery = getGitHubPublishRecovery(error);
-      if (recovery) {
+      if (getGitHubPublishRecovery(error)) {
         return;
       }
       toast.error(error.message || "Failed to create draft pull request");
     },
   });
   const pullRequest = publishMutation.data;
-  const pullRequestWasCreated = pullRequest?.operation === "created";
   const publishRecovery = getGitHubPublishRecovery(publishMutation.error);
-  const recoveryCopy = publishRecovery
-    ? GITHUB_RECOVERY_COPY[publishRecovery.code]
-    : null;
-  const showIntegrationRecovery =
-    publishRecovery &&
-    (publishRecovery.publishingPaused ||
-      publishRecovery.code !== "github_app_permissions_required" ||
-      !publishRecovery.permissionsUrl);
-  const showPermissionsRecovery =
-    publishRecovery?.code === "github_app_permissions_required" &&
-    Boolean(publishRecovery.permissionsUrl);
-  let dialogTitle = "Create a draft pull request";
-  let dialogDescription = `Notra creates a branch, adds the ${contentLabel} as Markdown, and opens a draft pull request against the repository's default branch.`;
-  if (pullRequest) {
-    dialogTitle = pullRequestWasCreated
-      ? "Draft pull request created"
-      : "Pull request updated";
-    dialogDescription = pullRequestWasCreated
-      ? `Notra added the ${contentLabel} and opened a draft pull request.`
-      : `Notra updated the ${contentLabel} in the existing pull request.`;
-  }
+  const copy = getGitHubPublishDialogCopy(contentLabel, pullRequest);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!publishMutation.isPending) {
@@ -177,243 +182,38 @@ export function PublishContentToGitHubDialog({
       <ResponsiveDialogContent className="sm:max-w-[600px]">
         <form onSubmit={handleSubmit}>
           <ResponsiveDialogHeader>
-            <ResponsiveDialogTitle>{dialogTitle}</ResponsiveDialogTitle>
+            <ResponsiveDialogTitle>{copy.title}</ResponsiveDialogTitle>
             <ResponsiveDialogDescription>
-              {dialogDescription}
+              {copy.description}
             </ResponsiveDialogDescription>
           </ResponsiveDialogHeader>
 
-          {pullRequest ? (
-            <div className="bg-muted/20 my-4 overflow-hidden rounded-lg border">
-              <div className="flex items-start gap-3 p-3">
-                <div className="ring-foreground/10 flex size-8 shrink-0 items-center justify-center rounded-lg bg-[#f6f3f1] p-1 ring-1">
-                  <Notra className="size-full" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">
-                    docs: add {title}
-                  </p>
-                  <p className="text-muted-foreground mt-1 truncate text-xs">
-                    {selectedRepository
-                      ? `${selectedRepository.owner}/${selectedRepository.repo}`
-                      : "Repository"}
-                    #{pullRequest.pullRequestNumber} ·{" "}
-                    {pullRequestWasCreated ? "Created as draft" : "Updated"}
-                  </p>
-                </div>
-                <a
-                  aria-label={`Open pull request #${pullRequest.pullRequestNumber} on GitHub`}
-                  className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors focus-visible:ring-2 focus-visible:outline-none"
-                  href={pullRequest.pullRequestUrl}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <HugeiconsIcon className="size-4" icon={ArrowUpRight01Icon} />
-                </a>
-              </div>
-
-              <div className="text-muted-foreground flex min-w-0 items-center gap-2 border-t px-3 py-2.5 text-xs">
-                <HugeiconsIcon
-                  className="size-4 shrink-0"
-                  icon={GitCommitIcon}
-                />
-                <span className="truncate">
-                  {pullRequestWasCreated ? "Added" : "Updated"}{" "}
-                  {pullRequest.path}
-                </span>
-                <span aria-hidden="true">·</span>
-                <span className="max-w-32 truncate font-mono">
-                  {pullRequest.branchName}
-                </span>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-4 py-6">
-              <Field>
-                <FieldLabel htmlFor="github-publish-repository">
-                  Repository
-                </FieldLabel>
-                <Select
-                  disabled={
-                    publishMutation.isPending ||
-                    integrationsLoadFailed ||
-                    repositories.length === 0
-                  }
-                  onValueChange={(value) => setRepositoryId(value ?? "")}
-                  value={selectedRepository?.id ?? ""}
-                >
-                  <SelectTrigger
-                    className="w-full"
-                    id="github-publish-repository"
-                  >
-                    <SelectValue
-                      placeholder={
-                        integrationsQuery.isLoading
-                          ? "Loading repositories…"
-                          : "Select a repository"
-                      }
-                    >
-                      {(value) => {
-                        const repository =
-                          repositories.find(
-                            (candidate) => candidate.id === value
-                          ) ?? selectedRepository;
-                        if (!repository) {
-                          return "Select a repository";
-                        }
-                        return `${repository.owner}/${repository.repo}`;
-                      }}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {repositories.map((repository) => (
-                      <SelectItem key={repository.id} value={repository.id}>
-                        {repository.owner}/{repository.repo}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {integrationsLoadFailed ? (
-                  <div
-                    className="border-destructive/30 flex items-center justify-between gap-3 rounded-lg border p-3"
-                    role="alert"
-                  >
-                    <p className="text-destructive text-sm">
-                      Unable to load GitHub repositories.
-                    </p>
-                    <Button
-                      onClick={() => integrationsQuery.refetch()}
-                      size="sm"
-                      type="button"
-                      variant="outline"
-                    >
-                      Retry
-                    </Button>
-                  </div>
-                ) : null}
-                {!integrationsQuery.isLoading &&
-                !integrationsLoadFailed &&
-                connectedRepositories.length === 0 ? (
-                  <FieldDescription>
-                    No enabled GitHub repositories are connected. Open the{" "}
-                    <Link
-                      className="underline underline-offset-4"
-                      href={`/${organizationSlug}/integrations/github`}
-                    >
-                      GitHub integration
-                    </Link>{" "}
-                    to connect or enable one.
-                  </FieldDescription>
-                ) : null}
-                {!integrationsQuery.isLoading &&
-                selectedRepository &&
-                !selectedPublishingEnabled ? (
-                  <FieldDescription>
-                    {contentLabel === "blog post" ? "Blog post" : "Changelog"}{" "}
-                    publishing is off for this repository. Open the{" "}
-                    <Link
-                      className="underline underline-offset-4"
-                      href={`/${organizationSlug}/integrations/github`}
-                    >
-                      GitHub integration
-                    </Link>{" "}
-                    to enable it.
-                  </FieldDescription>
-                ) : null}
-                {!integrationsQuery.isLoading &&
-                connectedRepositories.length > 0 &&
-                repositories.length === 0 ? (
-                  <FieldDescription>
-                    These repositories need a default branch before they can
-                    publish to GitHub.
-                  </FieldDescription>
-                ) : null}
-              </Field>
-              {publishRecovery ? (
-                <Alert variant="destructive">
-                  <HugeiconsIcon icon={AlertCircleIcon} />
-                  <AlertTitle>{recoveryCopy?.title}</AlertTitle>
-                  <AlertDescription>
-                    <p>{recoveryCopy?.description}</p>
-                    {publishRecovery.publishingPaused ? (
-                      <p>
-                        Publishing was also paused after three failures. Resume
-                        it in the GitHub integration after fixing this.
-                      </p>
-                    ) : null}
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-            </div>
-          )}
+          <GitHubPublishDialogBody
+            contentLabel={contentLabel}
+            connectedRepositoryCount={connected.length}
+            integrationsLoadFailed={integrationsLoadFailed}
+            isLoadingIntegrations={integrationsQuery.isLoading}
+            isPublishing={publishMutation.isPending}
+            onRepositoryChange={setRepositoryId}
+            onRetryIntegrations={() => integrationsQuery.refetch()}
+            organizationSlug={organizationSlug}
+            publishRecovery={publishRecovery}
+            pullRequest={pullRequest}
+            repositories={repositories}
+            selectedPublishingEnabled={selectedPublishingEnabled}
+            selectedRepository={selectedRepository}
+            title={title}
+          />
 
           <ResponsiveDialogFooter>
-            <ResponsiveDialogClose
-              disabled={publishMutation.isPending}
-              render={<Button variant="outline" />}
-            >
-              Close
-            </ResponsiveDialogClose>
-            {showIntegrationRecovery ? (
-              <Button
-                nativeButton={false}
-                render={
-                  <Link href={`/${organizationSlug}/integrations/github`}>
-                    Open GitHub integration
-                  </Link>
-                }
-              />
-            ) : null}
-            {showPermissionsRecovery && publishRecovery.permissionsUrl ? (
-              <Button
-                nativeButton={false}
-                render={
-                  <a
-                    href={publishRecovery.permissionsUrl}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Update permissions
-                    <HugeiconsIcon
-                      className="size-4"
-                      icon={ArrowUpRight01Icon}
-                    />
-                  </a>
-                }
-              />
-            ) : null}
-            {!publishRecovery && pullRequest ? (
-              <Button
-                nativeButton={false}
-                render={
-                  <a
-                    href={pullRequest.pullRequestUrl}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Open pull request
-                    <HugeiconsIcon
-                      className="size-4"
-                      icon={ArrowUpRight01Icon}
-                    />
-                  </a>
-                }
-              />
-            ) : null}
-            {publishRecovery || pullRequest ? null : (
-              <Button
-                disabled={
-                  publishMutation.isPending ||
-                  !selectedRepository ||
-                  !selectedPublishingEnabled
-                }
-                type="submit"
-              >
-                {publishMutation.isPending
-                  ? "Creating draft PR…"
-                  : "Create draft PR"}
-              </Button>
-            )}
+            <GitHubPublishDialogFooter
+              hasSelectedRepository={Boolean(selectedRepository)}
+              isPublishing={publishMutation.isPending}
+              organizationSlug={organizationSlug}
+              publishRecovery={publishRecovery}
+              pullRequest={pullRequest}
+              selectedPublishingEnabled={selectedPublishingEnabled}
+            />
           </ResponsiveDialogFooter>
         </form>
       </ResponsiveDialogContent>

--- a/apps/dashboard/src/components/content/publish-content-to-github-dialog.tsx
+++ b/apps/dashboard/src/components/content/publish-content-to-github-dialog.tsx
@@ -41,13 +41,11 @@ import { type FormEvent, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/button";
-import {
-  DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED,
-  GITHUB_RECOVERY_COPY,
-} from "@/constants/github";
+import { GITHUB_RECOVERY_COPY } from "@/constants/github";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { PublishContentToGitHubDialogProps } from "@/types/content/detail";
 import { getGitHubPublishRecovery } from "@/utils/github-publish-recovery";
+import { isGitHubContentPublishingEnabled } from "@/utils/github-publish-repositories";
 
 export function PublishContentToGitHubDialog({
   contentId,
@@ -78,24 +76,17 @@ export function PublishContentToGitHubDialog({
         ? integration.repositories.filter((repository) => repository.enabled)
         : []
     ) ?? [];
-  const outputEnabledRepositories = connectedRepositories.filter(
-    (repository) => {
-      const output = repository.outputs?.find(
-        (candidate) => candidate.outputType === contentType
-      );
-      return (
-        output?.enabled ?? DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED[contentType]
-      );
-    }
-  );
-  const repositories = outputEnabledRepositories.filter(
+  const repositories = connectedRepositories.filter(
     (repository) => repository.defaultBranch
   );
   const integrationsLoadFailed =
     integrationsQuery.isError && !integrationsQuery.data;
-  const selectedRepository = repositories.find(
-    (repository) => repository.id === repositoryId
-  );
+  const selectedRepository =
+    repositories.find((repository) => repository.id === repositoryId) ??
+    repositories[0];
+  const selectedPublishingEnabled = selectedRepository
+    ? isGitHubContentPublishingEnabled(selectedRepository, contentType)
+    : false;
 
   const publishMutation = useMutation({
     mutationFn: async (targetRepositoryId: string) => {
@@ -112,6 +103,11 @@ export function PublishContentToGitHubDialog({
       });
     },
     onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: dashboardOrpc.integrations.list.queryKey({
+          input: { organizationId },
+        }),
+      });
       toast.success(
         result.operation === "created"
           ? "Draft pull request created"
@@ -249,9 +245,12 @@ export function PublishContentToGitHubDialog({
                     repositories.length === 0
                   }
                   onValueChange={(value) => setRepositoryId(value ?? "")}
-                  value={repositoryId}
+                  value={selectedRepository?.id ?? ""}
                 >
-                  <SelectTrigger id="github-publish-repository">
+                  <SelectTrigger
+                    className="w-full"
+                    id="github-publish-repository"
+                  >
                     <SelectValue
                       placeholder={
                         integrationsQuery.isLoading
@@ -260,12 +259,14 @@ export function PublishContentToGitHubDialog({
                       }
                     >
                       {(value) => {
-                        const repository = repositories.find(
-                          (candidate) => candidate.id === value
-                        );
-                        return repository
-                          ? `${repository.owner}/${repository.repo}`
-                          : "Select a repository";
+                        const repository =
+                          repositories.find(
+                            (candidate) => candidate.id === value
+                          ) ?? selectedRepository;
+                        if (!repository) {
+                          return "Select a repository";
+                        }
+                        return `${repository.owner}/${repository.repo}`;
                       }}
                     </SelectValue>
                   </SelectTrigger>
@@ -310,22 +311,16 @@ export function PublishContentToGitHubDialog({
                   </FieldDescription>
                 ) : null}
                 {!integrationsQuery.isLoading &&
-                connectedRepositories.length > 0 &&
-                outputEnabledRepositories.length === 0 ? (
+                selectedRepository &&
+                !selectedPublishingEnabled ? (
                   <FieldDescription>
                     {contentLabel === "blog post" ? "Blog post" : "Changelog"}{" "}
-                    publishing is off. Open the{" "}
-                    <Link
-                      className="underline underline-offset-4"
-                      href={`/${organizationSlug}/integrations/github`}
-                    >
-                      GitHub integration
-                    </Link>{" "}
-                    to enable it.
+                    publishing is off for this repository. Creating a draft PR
+                    will turn it on.
                   </FieldDescription>
                 ) : null}
                 {!integrationsQuery.isLoading &&
-                outputEnabledRepositories.length > 0 &&
+                connectedRepositories.length > 0 &&
                 repositories.length === 0 ? (
                   <FieldDescription>
                     These repositories need a default branch before they can

--- a/apps/dashboard/src/components/integrations/github/github-directory-picker.tsx
+++ b/apps/dashboard/src/components/integrations/github/github-directory-picker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Add01Icon,
   ArrowRight01Icon,
   Folder01Icon,
   Loading03Icon,
@@ -22,38 +23,89 @@ import {
   CollapsibleTrigger,
 } from "@notra/ui/components/ui/collapsible";
 import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from "@notra/ui/components/ui/field";
+import { Input } from "@notra/ui/components/ui/input";
+import {
   RadioGroup,
   RadioGroupItem,
 } from "@notra/ui/components/ui/radio-group";
 import { cn } from "@notra/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
-import { type ReactNode, useId, useState } from "react";
+import { type FormEvent, type ReactNode, useId, useState } from "react";
 
 import { Button } from "@/components/button";
 import { dashboardOrpc } from "@/lib/orpc/query";
+import { repositoryContentDirectorySchema } from "@/schemas/integrations";
 import type {
+  GitHubDirectoryChoiceProps,
   GitHubDirectoryNodeProps,
   GitHubDirectoryPickerProps,
 } from "@/types/integrations/github";
+import { joinGitHubDirectory } from "@/utils/github-directory";
+
+function DirectoryChoice({
+  depth,
+  helper,
+  name,
+  path,
+}: GitHubDirectoryChoiceProps) {
+  const radioId = useId();
+
+  return (
+    <label
+      className="hover:bg-muted/60 flex min-h-10 cursor-pointer items-center gap-2 rounded-lg py-2 pe-2 text-sm"
+      htmlFor={radioId}
+      style={{ paddingInlineStart: `${depth * 16 + 12}px` }}
+    >
+      <RadioGroupItem id={radioId} value={path} />
+      <HugeiconsIcon
+        className="text-muted-foreground size-4 shrink-0"
+        icon={Folder01Icon}
+      />
+      <span className="min-w-0">
+        <span className="block truncate">{name}</span>
+        {helper ? (
+          <span className="text-muted-foreground block text-xs">{helper}</span>
+        ) : null}
+      </span>
+    </label>
+  );
+}
 
 function DirectoryNode({
   depth,
   excludedPath,
+  missing = false,
   name,
   open,
   organizationId,
   path,
   repositoryId,
 }: GitHubDirectoryNodeProps) {
+  const radioId = useId();
   const [expanded, setExpanded] = useState(false);
   const directoriesQuery = useQuery(
     dashboardOrpc.integrations.repositories.directories.list.queryOptions({
       input: { organizationId, repositoryId, directory: path },
-      enabled: open && expanded,
+      enabled: open && expanded && !missing,
       staleTime: 5 * 60 * 1000,
     })
   );
-  const radioId = useId();
+
+  if (missing) {
+    return (
+      <DirectoryChoice
+        depth={depth}
+        helper="This folder is not in the repository yet. It will be created when you publish."
+        name={name}
+        path={path}
+      />
+    );
+  }
   let directoryContent: ReactNode = directoriesQuery.data?.directories
     .filter((directory) => directory.path !== excludedPath)
     .map((directory) => (
@@ -78,6 +130,16 @@ function DirectoryNode({
         <HugeiconsIcon className="size-4 animate-spin" icon={Loading03Icon} />
         Loading…
       </output>
+    );
+  } else if (directoriesQuery.data?.exists === false) {
+    directoryContent = (
+      <p
+        className="text-muted-foreground py-2 text-sm"
+        style={{ paddingInlineStart: `${(depth + 1) * 16 + 44}px` }}
+      >
+        This folder is not in the repository yet. It will be created when you
+        publish.
+      </p>
     );
   } else if (directoriesQuery.isError) {
     directoryContent = (
@@ -139,8 +201,12 @@ export function GitHubDirectoryPicker({
   triggerId,
 }: GitHubDirectoryPickerProps) {
   const rootRadioId = useId();
+  const newFolderInputId = useId();
   const [open, setOpen] = useState(false);
   const [selectedDirectory, setSelectedDirectory] = useState(directory);
+  const [customDirectories, setCustomDirectories] = useState<string[]>([]);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [newFolderError, setNewFolderError] = useState<string | null>(null);
   const rootDirectoriesQuery = useQuery(
     dashboardOrpc.integrations.repositories.directories.list.queryOptions({
       input: { organizationId, repositoryId, directory: "" },
@@ -148,7 +214,19 @@ export function GitHubDirectoryPicker({
       staleTime: 5 * 60 * 1000,
     })
   );
-  let rootDirectoryContent: ReactNode = rootDirectoriesQuery.data?.directories
+  const rootDirectories = rootDirectoriesQuery.data?.directories ?? [];
+  const currentFolderMissing =
+    Boolean(directory) &&
+    !directory.includes("/") &&
+    rootDirectoriesQuery.isSuccess &&
+    !rootDirectories.some((rootDirectory) => rootDirectory.path === directory);
+  const extraDirectories = customDirectories.filter(
+    (path) =>
+      path !== "" &&
+      path !== directory &&
+      !rootDirectories.some((rootDirectory) => rootDirectory.path === path)
+  );
+  let rootDirectoryContent: ReactNode = rootDirectories
     .filter((rootDirectory) => rootDirectory.path !== directory)
     .map((rootDirectory) => (
       <DirectoryNode
@@ -188,6 +266,9 @@ export function GitHubDirectoryPicker({
     setOpen(nextOpen);
     if (nextOpen) {
       setSelectedDirectory(directory);
+      setCustomDirectories([]);
+      setNewFolderName("");
+      setNewFolderError(null);
     }
   };
 
@@ -198,6 +279,25 @@ export function GitHubDirectoryPicker({
     } catch {
       // The parent mutation keeps the dialog open and surfaces the error.
     }
+  };
+
+  const handleCreateFolder = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextDirectory = joinGitHubDirectory(selectedDirectory, newFolderName);
+    const parsed = repositoryContentDirectorySchema.safeParse(nextDirectory);
+    if (!parsed.success) {
+      setNewFolderError(
+        parsed.error.issues[0]?.message ?? "Enter a valid folder path"
+      );
+      return;
+    }
+
+    setSelectedDirectory(parsed.data);
+    setCustomDirectories((current) =>
+      current.includes(parsed.data) ? current : [...current, parsed.data]
+    );
+    setNewFolderName("");
+    setNewFolderError(null);
   };
 
   return (
@@ -230,7 +330,7 @@ export function GitHubDirectoryPicker({
             Choose {contentLabel.toLowerCase()} folder
           </ResponsiveDialogTitle>
           <ResponsiveDialogDescription>
-            {repositoryName}
+            {repositoryName}. Missing folders are created when you publish.
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
@@ -240,6 +340,7 @@ export function GitHubDirectoryPicker({
           onValueChange={(value) => {
             if (typeof value === "string") {
               setSelectedDirectory(value);
+              setNewFolderError(null);
             }
           }}
           value={selectedDirectory}
@@ -260,6 +361,7 @@ export function GitHubDirectoryPicker({
             <DirectoryNode
               depth={0}
               excludedPath={directory}
+              missing={currentFolderMissing}
               name={`${directory} (current folder)`}
               open={open}
               organizationId={organizationId}
@@ -268,8 +370,62 @@ export function GitHubDirectoryPicker({
             />
           ) : null}
 
+          {extraDirectories.map((path) => (
+            <DirectoryChoice
+              depth={0}
+              helper="This folder will be created when you publish."
+              key={path}
+              name={`${path} (new folder)`}
+              path={path}
+            />
+          ))}
+
           {rootDirectoryContent}
         </RadioGroup>
+
+        <form className="space-y-2" onSubmit={handleCreateFolder}>
+          <Field data-invalid={newFolderError ? true : undefined}>
+            <FieldLabel htmlFor={newFolderInputId}>New folder</FieldLabel>
+            <div className="flex gap-2">
+              <Input
+                aria-invalid={Boolean(newFolderError)}
+                autoComplete="off"
+                className="w-auto min-w-0 flex-1"
+                id={newFolderInputId}
+                onChange={(event) => {
+                  setNewFolderName(event.target.value);
+                  if (newFolderError) {
+                    setNewFolderError(null);
+                  }
+                }}
+                placeholder={
+                  selectedDirectory
+                    ? `Folder inside ${selectedDirectory}`
+                    : "e.g. changelogs"
+                }
+                value={newFolderName}
+              />
+              <Button
+                className="shrink-0"
+                disabled={!newFolderName.trim()}
+                size="sm"
+                type="submit"
+                variant="outline"
+              >
+                <HugeiconsIcon className="size-4" icon={Add01Icon} />
+                Add
+              </Button>
+            </div>
+            {newFolderError ? (
+              <FieldError>{newFolderError}</FieldError>
+            ) : (
+              <FieldDescription className="text-xs">
+                Added relative to the selected folder. It does not need to exist
+                in GitHub yet.
+              </FieldDescription>
+            )}
+          </Field>
+        </form>
 
         <ResponsiveDialogFooter>
           <ResponsiveDialogClose
@@ -278,11 +434,7 @@ export function GitHubDirectoryPicker({
           >
             Cancel
           </ResponsiveDialogClose>
-          <Button
-            disabled={isSaving || rootDirectoriesQuery.isLoading}
-            onClick={handleSave}
-            type="button"
-          >
+          <Button disabled={isSaving} onClick={handleSave} type="button">
             {isSaving ? "Saving…" : "Use folder"}
           </Button>
         </ResponsiveDialogFooter>

--- a/apps/dashboard/src/components/integrations/github/github-directory-picker.tsx
+++ b/apps/dashboard/src/components/integrations/github/github-directory-picker.tsx
@@ -42,10 +42,16 @@ import { dashboardOrpc } from "@/lib/orpc/query";
 import { repositoryContentDirectorySchema } from "@/schemas/integrations";
 import type {
   GitHubDirectoryChoiceProps,
+  GitHubDirectoryExtraChoicesProps,
+  GitHubDirectoryNewFolderFieldProps,
   GitHubDirectoryNodeProps,
+  GitHubDirectoryNodesProps,
+  GitHubDirectoryNodeStatusProps,
   GitHubDirectoryPickerProps,
+  GitHubDirectoryRootContentProps,
 } from "@/types/integrations/github";
 import {
+  isGitHubCurrentFolderMissing,
   joinGitHubDirectory,
   normalizeGitHubDirectorySegment,
 } from "@/utils/github-directory";
@@ -79,6 +85,206 @@ function DirectoryChoice({
   );
 }
 
+function DirectoryNodes({
+  depth,
+  directories,
+  excludedPath,
+  open,
+  organizationId,
+  repositoryId,
+}: GitHubDirectoryNodesProps) {
+  const nodes: ReactNode[] = [];
+
+  for (const directory of directories) {
+    if (directory.path === excludedPath) {
+      continue;
+    }
+
+    nodes.push(
+      <DirectoryNode
+        depth={depth}
+        excludedPath={excludedPath}
+        key={directory.path}
+        name={directory.name}
+        open={open}
+        organizationId={organizationId}
+        path={directory.path}
+        repositoryId={repositoryId}
+      />
+    );
+  }
+
+  return nodes;
+}
+
+function ExtraDirectoryChoices({
+  customDirectories,
+  directory,
+  rootDirectories,
+}: GitHubDirectoryExtraChoicesProps) {
+  const rootPaths = new Set<string>();
+  for (const rootDirectory of rootDirectories) {
+    rootPaths.add(rootDirectory.path);
+  }
+
+  const choices: ReactNode[] = [];
+  for (const path of customDirectories) {
+    if (path === "" || path === directory || rootPaths.has(path)) {
+      continue;
+    }
+
+    choices.push(
+      <DirectoryChoice
+        depth={0}
+        helper="This folder will be created when you publish."
+        key={path}
+        name={`${path} (new folder)`}
+        path={path}
+      />
+    );
+  }
+
+  return choices;
+}
+
+function DirectoryNodeStatus({
+  depth,
+  exists,
+  isError,
+  isLoading,
+}: GitHubDirectoryNodeStatusProps) {
+  const paddingInlineStart = `${(depth + 1) * 16 + 44}px`;
+
+  if (isLoading) {
+    return (
+      <output
+        className="text-muted-foreground flex h-10 items-center gap-2 text-sm"
+        style={{ paddingInlineStart }}
+      >
+        <HugeiconsIcon className="size-4 animate-spin" icon={Loading03Icon} />
+        Loading…
+      </output>
+    );
+  }
+
+  if (exists === false) {
+    return (
+      <p
+        className="text-muted-foreground py-2 text-sm"
+        style={{ paddingInlineStart }}
+      >
+        This folder is not in the repository yet. It will be created when you
+        publish.
+      </p>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p
+        className="text-destructive py-2 text-sm"
+        role="alert"
+        style={{ paddingInlineStart }}
+      >
+        Unable to load this folder.
+      </p>
+    );
+  }
+
+  return null;
+}
+
+function RootDirectoryContent({
+  directory,
+  isError,
+  isLoading,
+  open,
+  organizationId,
+  repositoryId,
+  rootDirectories,
+}: GitHubDirectoryRootContentProps) {
+  if (isLoading) {
+    return (
+      <output className="text-muted-foreground flex h-20 items-center justify-center gap-2 text-sm">
+        <HugeiconsIcon className="size-4 animate-spin" icon={Loading03Icon} />
+        Loading folders…
+      </output>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p
+        className="text-destructive px-3 py-6 text-center text-sm"
+        role="alert"
+      >
+        Unable to load repository folders.
+      </p>
+    );
+  }
+
+  return (
+    <DirectoryNodes
+      depth={0}
+      directories={rootDirectories}
+      excludedPath={directory}
+      open={open}
+      organizationId={organizationId}
+      repositoryId={repositoryId}
+    />
+  );
+}
+
+function GitHubDirectoryNewFolderField({
+  error,
+  inputId,
+  name,
+  onNameChange,
+  onSubmit,
+  selectedDirectory,
+}: GitHubDirectoryNewFolderFieldProps) {
+  return (
+    <form className="space-y-2" onSubmit={onSubmit}>
+      <Field data-invalid={error ? true : undefined}>
+        <FieldLabel htmlFor={inputId}>New folder</FieldLabel>
+        <div className="flex gap-2">
+          <Input
+            aria-invalid={Boolean(error)}
+            autoComplete="off"
+            className="w-auto min-w-0 flex-1"
+            id={inputId}
+            onChange={(event) => onNameChange(event.target.value)}
+            placeholder={
+              selectedDirectory
+                ? `Folder inside ${selectedDirectory}`
+                : "e.g. changelogs"
+            }
+            value={name}
+          />
+          <Button
+            className="shrink-0"
+            disabled={!normalizeGitHubDirectorySegment(name)}
+            size="sm"
+            type="submit"
+            variant="outline"
+          >
+            <HugeiconsIcon className="size-4" icon={Add01Icon} />
+            Add
+          </Button>
+        </div>
+        {error ? (
+          <FieldError>{error}</FieldError>
+        ) : (
+          <FieldDescription className="text-xs">
+            Added relative to the selected folder. It does not need to exist in
+            GitHub yet.
+          </FieldDescription>
+        )}
+      </Field>
+    </form>
+  );
+}
+
 function DirectoryNode({
   depth,
   excludedPath,
@@ -109,52 +315,27 @@ function DirectoryNode({
       />
     );
   }
-  let directoryContent: ReactNode = directoriesQuery.data?.directories
-    .filter((directory) => directory.path !== excludedPath)
-    .map((directory) => (
-      <DirectoryNode
+
+  const directoryContent =
+    directoriesQuery.isLoading ||
+    directoriesQuery.data?.exists === false ||
+    directoriesQuery.isError ? (
+      <DirectoryNodeStatus
+        depth={depth}
+        exists={directoriesQuery.data?.exists}
+        isError={directoriesQuery.isError}
+        isLoading={directoriesQuery.isLoading}
+      />
+    ) : (
+      <DirectoryNodes
         depth={depth + 1}
+        directories={directoriesQuery.data?.directories ?? []}
         excludedPath={excludedPath}
-        key={directory.path}
-        name={directory.name}
         open={open}
         organizationId={organizationId}
-        path={directory.path}
         repositoryId={repositoryId}
       />
-    ));
-
-  if (directoriesQuery.isLoading) {
-    directoryContent = (
-      <output
-        className="text-muted-foreground flex h-10 items-center gap-2 text-sm"
-        style={{ paddingInlineStart: `${(depth + 1) * 16 + 44}px` }}
-      >
-        <HugeiconsIcon className="size-4 animate-spin" icon={Loading03Icon} />
-        Loading…
-      </output>
     );
-  } else if (directoriesQuery.data?.exists === false) {
-    directoryContent = (
-      <p
-        className="text-muted-foreground py-2 text-sm"
-        style={{ paddingInlineStart: `${(depth + 1) * 16 + 44}px` }}
-      >
-        This folder is not in the repository yet. It will be created when you
-        publish.
-      </p>
-    );
-  } else if (directoriesQuery.isError) {
-    directoryContent = (
-      <p
-        className="text-destructive py-2 text-sm"
-        role="alert"
-        style={{ paddingInlineStart: `${(depth + 1) * 16 + 44}px` }}
-      >
-        Unable to load this folder.
-      </p>
-    );
-  }
 
   return (
     <Collapsible onOpenChange={setExpanded} open={expanded}>
@@ -218,49 +399,11 @@ export function GitHubDirectoryPicker({
     })
   );
   const rootDirectories = rootDirectoriesQuery.data?.directories ?? [];
-  const currentFolderMissing =
-    Boolean(directory) &&
-    !directory.includes("/") &&
-    rootDirectoriesQuery.isSuccess &&
-    !rootDirectories.some((rootDirectory) => rootDirectory.path === directory);
-  const extraDirectories = customDirectories.filter(
-    (path) =>
-      path !== "" &&
-      path !== directory &&
-      !rootDirectories.some((rootDirectory) => rootDirectory.path === path)
+  const currentFolderMissing = isGitHubCurrentFolderMissing(
+    directory,
+    rootDirectories,
+    rootDirectoriesQuery.isSuccess
   );
-  let rootDirectoryContent: ReactNode = rootDirectories
-    .filter((rootDirectory) => rootDirectory.path !== directory)
-    .map((rootDirectory) => (
-      <DirectoryNode
-        depth={0}
-        excludedPath={directory}
-        key={rootDirectory.path}
-        name={rootDirectory.name}
-        open={open}
-        organizationId={organizationId}
-        path={rootDirectory.path}
-        repositoryId={repositoryId}
-      />
-    ));
-
-  if (rootDirectoriesQuery.isLoading) {
-    rootDirectoryContent = (
-      <output className="text-muted-foreground flex h-20 items-center justify-center gap-2 text-sm">
-        <HugeiconsIcon className="size-4 animate-spin" icon={Loading03Icon} />
-        Loading folders…
-      </output>
-    );
-  } else if (rootDirectoriesQuery.isError) {
-    rootDirectoryContent = (
-      <p
-        className="text-destructive px-3 py-6 text-center text-sm"
-        role="alert"
-      >
-        Unable to load repository folders.
-      </p>
-    );
-  }
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (isSaving) {
@@ -379,62 +522,36 @@ export function GitHubDirectoryPicker({
             />
           ) : null}
 
-          {extraDirectories.map((path) => (
-            <DirectoryChoice
-              depth={0}
-              helper="This folder will be created when you publish."
-              key={path}
-              name={`${path} (new folder)`}
-              path={path}
-            />
-          ))}
+          <ExtraDirectoryChoices
+            customDirectories={customDirectories}
+            directory={directory}
+            rootDirectories={rootDirectories}
+          />
 
-          {rootDirectoryContent}
+          <RootDirectoryContent
+            directory={directory}
+            isError={rootDirectoriesQuery.isError}
+            isLoading={rootDirectoriesQuery.isLoading}
+            open={open}
+            organizationId={organizationId}
+            repositoryId={repositoryId}
+            rootDirectories={rootDirectories}
+          />
         </RadioGroup>
 
-        <form className="space-y-2" onSubmit={handleCreateFolder}>
-          <Field data-invalid={newFolderError ? true : undefined}>
-            <FieldLabel htmlFor={newFolderInputId}>New folder</FieldLabel>
-            <div className="flex gap-2">
-              <Input
-                aria-invalid={Boolean(newFolderError)}
-                autoComplete="off"
-                className="w-auto min-w-0 flex-1"
-                id={newFolderInputId}
-                onChange={(event) => {
-                  setNewFolderName(event.target.value);
-                  if (newFolderError) {
-                    setNewFolderError(null);
-                  }
-                }}
-                placeholder={
-                  selectedDirectory
-                    ? `Folder inside ${selectedDirectory}`
-                    : "e.g. changelogs"
-                }
-                value={newFolderName}
-              />
-              <Button
-                className="shrink-0"
-                disabled={!normalizeGitHubDirectorySegment(newFolderName)}
-                size="sm"
-                type="submit"
-                variant="outline"
-              >
-                <HugeiconsIcon className="size-4" icon={Add01Icon} />
-                Add
-              </Button>
-            </div>
-            {newFolderError ? (
-              <FieldError>{newFolderError}</FieldError>
-            ) : (
-              <FieldDescription className="text-xs">
-                Added relative to the selected folder. It does not need to exist
-                in GitHub yet.
-              </FieldDescription>
-            )}
-          </Field>
-        </form>
+        <GitHubDirectoryNewFolderField
+          error={newFolderError}
+          inputId={newFolderInputId}
+          name={newFolderName}
+          onNameChange={(value) => {
+            setNewFolderName(value);
+            if (newFolderError) {
+              setNewFolderError(null);
+            }
+          }}
+          onSubmit={handleCreateFolder}
+          selectedDirectory={selectedDirectory}
+        />
 
         <ResponsiveDialogFooter>
           <ResponsiveDialogClose

--- a/apps/dashboard/src/components/integrations/github/github-directory-picker.tsx
+++ b/apps/dashboard/src/components/integrations/github/github-directory-picker.tsx
@@ -45,7 +45,10 @@ import type {
   GitHubDirectoryNodeProps,
   GitHubDirectoryPickerProps,
 } from "@/types/integrations/github";
-import { joinGitHubDirectory } from "@/utils/github-directory";
+import {
+  joinGitHubDirectory,
+  normalizeGitHubDirectorySegment,
+} from "@/utils/github-directory";
 
 function DirectoryChoice({
   depth,
@@ -283,7 +286,13 @@ export function GitHubDirectoryPicker({
 
   const handleCreateFolder = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const nextDirectory = joinGitHubDirectory(selectedDirectory, newFolderName);
+    const folderName = normalizeGitHubDirectorySegment(newFolderName);
+    if (!folderName) {
+      setNewFolderError("Enter a folder name");
+      return;
+    }
+
+    const nextDirectory = joinGitHubDirectory(selectedDirectory, folderName);
     const parsed = repositoryContentDirectorySchema.safeParse(nextDirectory);
     if (!parsed.success) {
       setNewFolderError(
@@ -407,7 +416,7 @@ export function GitHubDirectoryPicker({
               />
               <Button
                 className="shrink-0"
-                disabled={!newFolderName.trim()}
+                disabled={!normalizeGitHubDirectorySegment(newFolderName)}
                 size="sm"
                 type="submit"
                 variant="outline"

--- a/apps/dashboard/src/components/integrations/github/github-publishing-settings.tsx
+++ b/apps/dashboard/src/components/integrations/github/github-publishing-settings.tsx
@@ -9,9 +9,12 @@ import {
 } from "@notra/ui/components/ui/card";
 import { Field, FieldLabel } from "@notra/ui/components/ui/field";
 import {
-  RadioGroup,
-  RadioGroupItem,
-} from "@notra/ui/components/ui/radio-group";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@notra/ui/components/ui/select";
 import { Github } from "@notra/ui/components/ui/svgs/github";
 import { Switch } from "@notra/ui/components/ui/switch";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -41,8 +44,11 @@ function GitHubContentPublishingSettings({
   repositories,
 }: GitHubContentPublishingSettingsProps) {
   const queryClient = useQueryClient();
+  const repositorySelectId = useId();
   const folderTriggerId = useId();
-  const [selectedRepositoryId, setSelectedRepositoryId] = useState("");
+  const [selectedRepositoryId, setSelectedRepositoryId] = useState(
+    repositories[0]?.id ?? ""
+  );
   const selectedRepository =
     repositories.find((repository) => repository.id === selectedRepositoryId) ??
     repositories[0];
@@ -61,7 +67,7 @@ function GitHubContentPublishingSettings({
         contentType,
       },
       enabled: Boolean(organizationId && repositoryId),
-      staleTime: 0,
+      staleTime: 5 * 60 * 1000,
     })
   );
   const directory =
@@ -160,35 +166,45 @@ function GitHubContentPublishingSettings({
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-5">
-        <RadioGroup
-          aria-label={`${contentLabel} repository`}
-          className="bg-muted flex max-w-full grid-cols-none gap-1 overflow-x-auto rounded-lg p-[3px]"
-          onValueChange={(value) => {
-            if (typeof value === "string") {
-              setSelectedRepositoryId(value);
-            }
-          }}
-          value={selectedRepository.id}
-        >
-          {repositories.map((repository) => {
-            const radioId = `${folderTriggerId}-${repository.id}`;
-            return (
-              <label
-                className="text-foreground/60 hover:text-foreground has-data-checked:bg-background has-data-checked:text-foreground has-[:focus-visible]:ring-ring flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-transparent px-2 text-sm font-medium transition-colors has-data-checked:shadow-sm has-[:focus-visible]:ring-2"
-                htmlFor={radioId}
-                key={repository.id}
-              >
-                <RadioGroupItem
-                  className="sr-only"
-                  id={radioId}
-                  value={repository.id}
-                />
-                <Github className="size-3.5" />
-                {repository.owner}/{repository.repo}
-              </label>
-            );
-          })}
-        </RadioGroup>
+        <Field className="max-w-xl">
+          <FieldLabel htmlFor={repositorySelectId}>Repository</FieldLabel>
+          <Select
+            onValueChange={(value) => {
+              if (typeof value === "string") {
+                setSelectedRepositoryId(value);
+              }
+            }}
+            value={selectedRepository.id}
+          >
+            <SelectTrigger className="w-full" id={repositorySelectId}>
+              <SelectValue placeholder="Select a repository">
+                {(value) => {
+                  const repository = repositories.find(
+                    (candidate) => candidate.id === value
+                  );
+                  return repository ? (
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Github className="size-3.5" />
+                      <span className="truncate">
+                        {repository.owner}/{repository.repo}
+                      </span>
+                    </span>
+                  ) : (
+                    "Select a repository"
+                  );
+                }}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent align="start" alignItemWithTrigger={false}>
+              {repositories.map((repository) => (
+                <SelectItem key={repository.id} value={repository.id}>
+                  <Github className="size-3.5" />
+                  {repository.owner}/{repository.repo}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
 
         <div className="flex max-w-xl items-center justify-between gap-4 rounded-lg border px-3 py-2.5">
           <div className="space-y-0.5">
@@ -239,6 +255,7 @@ function GitHubContentPublishingSettings({
               directory={directory}
               disabled={directoryQuery.isLoading}
               isSaving={directoryMutation.isPending}
+              key={selectedRepository.id}
               onSave={async (nextDirectory) => {
                 await directoryMutation.mutateAsync({
                   nextDirectory,

--- a/apps/dashboard/src/lib/orpc/routers/content.ts
+++ b/apps/dashboard/src/lib/orpc/routers/content.ts
@@ -41,7 +41,6 @@ import {
 } from "@/constants/content-preview";
 import {
   DEFAULT_GITHUB_CONTENT_DIRECTORIES,
-  DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED,
   GITHUB_CONTENT_PATH_MAX_LENGTH,
   GITHUB_INSTALLATION_ID_REGEX,
 } from "@/constants/github";
@@ -847,12 +846,6 @@ export const contentRouter = {
           }
         : null;
       if (!contentOutput) {
-        if (!DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED[input.contentType]) {
-          throw forbidden("GitHub content publishing is paused", {
-            code: "github_content_publishing_paused",
-          });
-        }
-
         await db
           .insert(repositoryOutputs)
           .values({
@@ -881,8 +874,15 @@ export const contentRouter = {
         throw internalServerError("Failed to configure GitHub publishing");
       }
       if (!contentOutput.enabled) {
-        throw forbidden("GitHub content publishing is paused", {
-          code: "github_content_publishing_paused",
+        await db
+          .update(repositoryOutputs)
+          .set({ enabled: true })
+          .where(eq(repositoryOutputs.id, contentOutput.id));
+        contentOutput = { ...contentOutput, enabled: true };
+        await clearGitHubPublishFailures({
+          organizationId: input.organizationId,
+          outputType: input.contentType,
+          repositoryId: integration.id,
         });
       }
       const outputConfig = repositoryContentDirectoryConfigSchema.safeParse(

--- a/apps/dashboard/src/lib/orpc/routers/content.ts
+++ b/apps/dashboard/src/lib/orpc/routers/content.ts
@@ -41,6 +41,7 @@ import {
 } from "@/constants/content-preview";
 import {
   DEFAULT_GITHUB_CONTENT_DIRECTORIES,
+  DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED,
   GITHUB_CONTENT_PATH_MAX_LENGTH,
   GITHUB_INSTALLATION_ID_REGEX,
 } from "@/constants/github";
@@ -846,6 +847,12 @@ export const contentRouter = {
           }
         : null;
       if (!contentOutput) {
+        if (!DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED[input.contentType]) {
+          throw forbidden("GitHub content publishing is paused", {
+            code: "github_content_publishing_paused",
+          });
+        }
+
         await db
           .insert(repositoryOutputs)
           .values({
@@ -874,15 +881,8 @@ export const contentRouter = {
         throw internalServerError("Failed to configure GitHub publishing");
       }
       if (!contentOutput.enabled) {
-        await db
-          .update(repositoryOutputs)
-          .set({ enabled: true })
-          .where(eq(repositoryOutputs.id, contentOutput.id));
-        contentOutput = { ...contentOutput, enabled: true };
-        await clearGitHubPublishFailures({
-          organizationId: input.organizationId,
-          outputType: input.contentType,
-          repositoryId: integration.id,
+        throw forbidden("GitHub content publishing is paused", {
+          code: "github_content_publishing_paused",
         });
       }
       const outputConfig = repositoryContentDirectoryConfigSchema.safeParse(

--- a/apps/dashboard/src/lib/orpc/routers/integrations.ts
+++ b/apps/dashboard/src/lib/orpc/routers/integrations.ts
@@ -920,22 +920,13 @@ export const integrationsRouter = {
                     : []
                 )
                 .sort((left, right) => left.name.localeCompare(right.name)),
+              exists: true,
             };
           } catch (error) {
-            if (
-              typeof error === "object" &&
-              error !== null &&
-              "status" in error &&
-              error.status === 404
-            ) {
-              throw notFound("Directory not found");
+            if (hasGitHubStatus(error, 404)) {
+              return { directories: [], exists: false };
             }
-            if (
-              typeof error === "object" &&
-              error !== null &&
-              "status" in error &&
-              (error.status === 401 || error.status === 403)
-            ) {
+            if (hasGitHubStatus(error, 401) || hasGitHubStatus(error, 403)) {
               throw forbidden("GitHub denied access to this repository");
             }
             throw error;

--- a/apps/dashboard/src/lib/orpc/routers/integrations.ts
+++ b/apps/dashboard/src/lib/orpc/routers/integrations.ts
@@ -924,6 +924,9 @@ export const integrationsRouter = {
             };
           } catch (error) {
             if (hasGitHubStatus(error, 404)) {
+              if (!input.directory) {
+                throw notFound("Repository contents not found");
+              }
               return { directories: [], exists: false };
             }
             if (hasGitHubStatus(error, 401) || hasGitHubStatus(error, 403)) {

--- a/apps/dashboard/src/types/content/detail.ts
+++ b/apps/dashboard/src/types/content/detail.ts
@@ -1,4 +1,9 @@
-import type { GitHubPublishContentType } from "@/types/integrations/github";
+import type { GitHubRepository } from "@/types/integrations";
+import type {
+  GitHubPublishContentType,
+  GitHubPublishPullRequestResult,
+  GitHubPublishRecovery,
+} from "@/types/integrations/github";
 
 export interface ContentDetailPageClientProps {
   contentId: string;
@@ -13,4 +18,66 @@ export interface PublishContentToGitHubDialogProps {
   organizationId: string;
   organizationSlug: string;
   title: string;
+}
+
+export interface GitHubPublishDialogBodyProps {
+  contentLabel: string;
+  connectedRepositoryCount: number;
+  integrationsLoadFailed: boolean;
+  isLoadingIntegrations: boolean;
+  isPublishing: boolean;
+  onRepositoryChange: (repositoryId: string) => void;
+  onRetryIntegrations: () => void;
+  organizationSlug: string;
+  publishRecovery: GitHubPublishRecovery | null;
+  pullRequest: GitHubPublishPullRequestResult | undefined;
+  repositories: GitHubRepository[];
+  selectedPublishingEnabled: boolean;
+  selectedRepository: GitHubRepository | undefined;
+  title: string;
+}
+
+export interface GitHubPublishResultCardProps {
+  pullRequest: GitHubPublishPullRequestResult;
+  repositoryLabel: string;
+  title: string;
+}
+
+export interface GitHubPublishRepositoryFieldProps {
+  connectedRepositoryCount: number;
+  contentLabel: string;
+  integrationsLoadFailed: boolean;
+  isLoadingIntegrations: boolean;
+  isPublishing: boolean;
+  onRepositoryChange: (repositoryId: string) => void;
+  onRetryIntegrations: () => void;
+  organizationSlug: string;
+  repositories: GitHubRepository[];
+  selectedPublishingEnabled: boolean;
+  selectedRepository: GitHubRepository | undefined;
+}
+
+export interface GitHubPublishRepositoryStatusProps {
+  connectedRepositoryCount: number;
+  contentTypeLabel: string;
+  githubIntegrationHref: string;
+  integrationsLoadFailed: boolean;
+  isLoadingIntegrations: boolean;
+  onRetryIntegrations: () => void;
+  repositoriesCount: number;
+  selectedPublishingEnabled: boolean;
+  selectedRepository: GitHubRepository | undefined;
+}
+
+export interface GitHubPublishRecoveryAlertProps {
+  publishRecovery: GitHubPublishRecovery;
+}
+
+export interface GitHubPublishDialogFooterProps {
+  isPublishing: boolean;
+  organizationSlug: string;
+  publishRecovery: GitHubPublishRecovery | null;
+  pullRequest: GitHubPublishPullRequestResult | undefined;
+  selectedPublishingEnabled: boolean;
+  hasSelectedRepository: boolean;
 }

--- a/apps/dashboard/src/types/integrations/github.ts
+++ b/apps/dashboard/src/types/integrations/github.ts
@@ -147,6 +147,11 @@ export interface GitHubDirectoryChoiceProps {
   path: string;
 }
 
+export interface GitHubDirectoryEntry {
+  name: string;
+  path: string;
+}
+
 export interface GitHubDirectoryNodeProps {
   depth: number;
   excludedPath?: string;
@@ -156,6 +161,47 @@ export interface GitHubDirectoryNodeProps {
   organizationId: string;
   path: string;
   repositoryId: string;
+}
+
+export interface GitHubDirectoryNodesProps {
+  depth: number;
+  directories: GitHubDirectoryEntry[];
+  excludedPath?: string;
+  open: boolean;
+  organizationId: string;
+  repositoryId: string;
+}
+
+export interface GitHubDirectoryExtraChoicesProps {
+  customDirectories: string[];
+  directory: string;
+  rootDirectories: GitHubDirectoryEntry[];
+}
+
+export interface GitHubDirectoryRootContentProps {
+  directory: string;
+  isError: boolean;
+  isLoading: boolean;
+  open: boolean;
+  organizationId: string;
+  repositoryId: string;
+  rootDirectories: GitHubDirectoryEntry[];
+}
+
+export interface GitHubDirectoryNewFolderFieldProps {
+  error: string | null;
+  inputId: string;
+  name: string;
+  onNameChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  selectedDirectory: string;
+}
+
+export interface GitHubDirectoryNodeStatusProps {
+  depth: number;
+  exists: boolean | undefined;
+  isError: boolean;
+  isLoading: boolean;
 }
 
 export interface ResolveGitHubContentPathParams {
@@ -184,6 +230,14 @@ export interface ValidateExistingGitHubBranchParams {
 }
 
 export type GitHubPullRequestOperation = "created" | "updated";
+
+export interface GitHubPublishPullRequestResult {
+  branchName: string;
+  operation: GitHubPullRequestOperation;
+  path: string;
+  pullRequestNumber: number;
+  pullRequestUrl: string;
+}
 
 export interface GitHubCreateCommitOnBranchResult {
   createCommitOnBranch: {

--- a/apps/dashboard/src/types/integrations/github.ts
+++ b/apps/dashboard/src/types/integrations/github.ts
@@ -140,9 +140,17 @@ export interface GitHubDirectoryPickerProps {
   triggerId?: string;
 }
 
+export interface GitHubDirectoryChoiceProps {
+  depth: number;
+  helper?: string;
+  name: string;
+  path: string;
+}
+
 export interface GitHubDirectoryNodeProps {
   depth: number;
   excludedPath?: string;
+  missing?: boolean;
   name: string;
   open: boolean;
   organizationId: string;

--- a/apps/dashboard/src/utils/github-directory.ts
+++ b/apps/dashboard/src/utils/github-directory.ts
@@ -1,3 +1,5 @@
+import type { GitHubDirectoryEntry } from "@/types/integrations/github";
+
 export function normalizeGitHubDirectorySegment(segment: string): string {
   return segment.trim().replace(/^\/+|\/+$/g, "");
 }
@@ -15,4 +17,18 @@ export function joinGitHubDirectory(parent: string, segment: string): string {
   }
 
   return `${normalizedParent}/${normalizedSegment}`;
+}
+
+export function isGitHubCurrentFolderMissing(
+  directory: string,
+  rootDirectories: GitHubDirectoryEntry[],
+  isSuccess: boolean
+): boolean {
+  if (!directory || directory.includes("/") || !isSuccess) {
+    return false;
+  }
+
+  return !rootDirectories.some(
+    (rootDirectory) => rootDirectory.path === directory
+  );
 }

--- a/apps/dashboard/src/utils/github-directory.ts
+++ b/apps/dashboard/src/utils/github-directory.ts
@@ -1,6 +1,10 @@
+export function normalizeGitHubDirectorySegment(segment: string): string {
+  return segment.trim().replace(/^\/+|\/+$/g, "");
+}
+
 export function joinGitHubDirectory(parent: string, segment: string): string {
-  const normalizedParent = parent.replace(/^\/+|\/+$/g, "");
-  const normalizedSegment = segment.trim().replace(/^\/+|\/+$/g, "");
+  const normalizedParent = normalizeGitHubDirectorySegment(parent);
+  const normalizedSegment = normalizeGitHubDirectorySegment(segment);
 
   if (!normalizedSegment) {
     return normalizedParent;

--- a/apps/dashboard/src/utils/github-directory.ts
+++ b/apps/dashboard/src/utils/github-directory.ts
@@ -1,0 +1,14 @@
+export function joinGitHubDirectory(parent: string, segment: string): string {
+  const normalizedParent = parent.replace(/^\/+|\/+$/g, "");
+  const normalizedSegment = segment.trim().replace(/^\/+|\/+$/g, "");
+
+  if (!normalizedSegment) {
+    return normalizedParent;
+  }
+
+  if (!normalizedParent) {
+    return normalizedSegment;
+  }
+
+  return `${normalizedParent}/${normalizedSegment}`;
+}

--- a/apps/dashboard/src/utils/github-publish-dialog.ts
+++ b/apps/dashboard/src/utils/github-publish-dialog.ts
@@ -1,0 +1,21 @@
+import type { GitHubPublishPullRequestResult } from "@/types/integrations/github";
+
+export function getGitHubPublishDialogCopy(
+  contentLabel: string,
+  pullRequest: GitHubPublishPullRequestResult | undefined
+) {
+  if (!pullRequest) {
+    return {
+      description: `Notra creates a branch, adds the ${contentLabel} as Markdown, and opens a draft pull request against the repository's default branch.`,
+      title: "Create a draft pull request",
+    };
+  }
+
+  const wasCreated = pullRequest.operation === "created";
+  return {
+    description: wasCreated
+      ? `Notra added the ${contentLabel} and opened a draft pull request.`
+      : `Notra updated the ${contentLabel} in the existing pull request.`,
+    title: wasCreated ? "Draft pull request created" : "Pull request updated",
+  };
+}

--- a/apps/dashboard/src/utils/github-publish-repositories.ts
+++ b/apps/dashboard/src/utils/github-publish-repositories.ts
@@ -2,6 +2,36 @@ import { DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED } from "@/constants/github";
 import type { GitHubRepository } from "@/types/integrations";
 import type { GitHubPublishContentType } from "@/types/integrations/github";
 
+export function getGitHubPublishRepositoryLists(
+  integrations: Array<{
+    enabled: boolean;
+    repositories: GitHubRepository[];
+    type?: string;
+  }>
+) {
+  const connected: GitHubRepository[] = [];
+  const publishable: GitHubRepository[] = [];
+
+  for (const integration of integrations) {
+    if (integration.type !== "github" || !integration.enabled) {
+      continue;
+    }
+
+    for (const repository of integration.repositories) {
+      if (!repository.enabled) {
+        continue;
+      }
+
+      connected.push(repository);
+      if (repository.defaultBranch) {
+        publishable.push(repository);
+      }
+    }
+  }
+
+  return { connected, publishable };
+}
+
 export function isGitHubContentPublishingEnabled(
   repository: GitHubRepository,
   contentType: GitHubPublishContentType
@@ -11,4 +41,10 @@ export function isGitHubContentPublishingEnabled(
   );
 
   return output?.enabled ?? DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED[contentType];
+}
+
+export function formatGitHubRepositoryLabel(
+  repository: Pick<GitHubRepository, "owner" | "repo">
+) {
+  return `${repository.owner}/${repository.repo}`;
 }

--- a/apps/dashboard/src/utils/github-publish-repositories.ts
+++ b/apps/dashboard/src/utils/github-publish-repositories.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED } from "@/constants/github";
+import type { GitHubRepository } from "@/types/integrations";
+import type { GitHubPublishContentType } from "@/types/integrations/github";
+
+export function isGitHubContentPublishingEnabled(
+  repository: GitHubRepository,
+  contentType: GitHubPublishContentType
+): boolean {
+  const output = repository.outputs?.find(
+    (candidate) => candidate.outputType === contentType
+  );
+
+  return output?.enabled ?? DEFAULT_GITHUB_CONTENT_OUTPUT_ENABLED[contentType];
+}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Users can now publish to GitHub folders that don't exist yet, and publishing to a repository with the content type disabled will automatically enable it instead of failing.

- The GitHub directory picker lets users select or create a new folder that will be created on publish.
- The publishing dialog now defaults to the first available repository and shows a message when publishing is off for the selected repository.
- Publishing settings replace the repository radio group with a select dropdown.
- Repository directory lookups return `exists: false` instead of a 404 error when a folder is missing.
- Creating a draft PR for a disabled output now enables it and clears publish failures.

<sup>Written for commit 14e48a5be7fc37b4450d0f7c2f63c66b42e9ad3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

