### PR TITLE
perf(dashboard): stop prefetching every sidebar route on first paint

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/components/geo-tabs.tsx
@@ -202,11 +202,7 @@ export function GeoTabs({
           <TabSection active={revealActive} order={0}>
             <GeoPromptsPanel
               action={
-                <Link
-                  className={TAB_LINK_CLASS}
-                  href={promptsHref}
-                  prefetch={true}
-                >
+                <Link className={TAB_LINK_CLASS} href={promptsHref}>
                   All prompts
                 </Link>
               }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
@@ -58,6 +58,10 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
       : orgFromList;
   const organizationId = organization?.id ?? "";
   const geoRange = useGeoRange();
+  const [activeTab, setActiveTab] = useQueryState(
+    "tab",
+    parseAsStringLiteral(GEO_TAB_VALUES).withDefault(GEO_DEFAULT_TAB)
+  );
 
   const { data: settingsData, isPending: isSettingsPending } =
     useGeoSettings(organizationId);
@@ -66,7 +70,8 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
   const { data: prompts } = useGeoPrompts(organizationId);
   const { data: promptResults } = useGeoPromptResults(
     organizationId,
-    geoRange.query
+    geoRange.query,
+    activeTab === "prompts"
   );
   const { data: competitorShare } = useGeoCompetitorShare(
     organizationId,
@@ -79,7 +84,8 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
   );
   const { data: trafficJourneys } = useGeoTrafficJourneys(
     organizationId,
-    geoRange.query
+    geoRange.query,
+    activeTab === "journeys"
   );
   const startScan = useGeoStartScan(organizationId);
   const isScanning = useIsGeoScanning(organizationId);
@@ -90,11 +96,6 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
   useHotkey("R", () => setPreflightOpen(true), {
     enabled: !isScanning && !preflightOpen,
   });
-
-  const [activeTab, setActiveTab] = useQueryState(
-    "tab",
-    parseAsStringLiteral(GEO_TAB_VALUES).withDefault(GEO_DEFAULT_TAB)
-  );
 
   const reduceMotion = useReducedMotion();
   const [modulesVisible, setModulesVisible] = useState(false);

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/page-client.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import { GEO_DEFAULT_TAB, GEO_TAB_VALUES } from "@notra/geo-core/constants/geo";
-import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { Kbd } from "@notra/ui/components/ui/kbd";
-import { useHotkey } from "@tanstack/react-hotkeys";
 import { Loader2Icon } from "lucide-react";
-import { useReducedMotion } from "motion/react";
-import { parseAsStringLiteral, useQueryState } from "nuqs";
-import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/button";
 import { GeoRangePicker } from "@/components/geo/geo-range-picker";
@@ -15,29 +9,17 @@ import { GeoSetupEmpty } from "@/components/geo/geo-setup-empty";
 import { ScanPreflightDialog } from "@/components/geo/scan-preflight-dialog";
 import { PageContainer } from "@/components/layout/container";
 import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
-import { useOrganizationsContext } from "@/components/providers/organization-provider";
-import { trackEvent } from "@/lib/analytics/posthog-client";
-import {
-  useGeoCompetitorShare,
-  useGeoCompetitors,
-  useGeoLanguageShare,
-  useGeoOverview,
-  useGeoPromptResults,
-  useGeoPrompts,
-  useGeoSettings,
-  useGeoStartScan,
-  useGeoTimeseries,
-  useGeoTrafficJourneys,
-  useIsGeoScanning,
-} from "@/lib/hooks/use-geo";
+import { useGeoOverviewPage } from "@/lib/hooks/use-geo-overview-page";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
-import { useGeoRange } from "@/lib/hooks/use-geo-range";
-import type { GeoPageClientProps, GeoPageContentProps } from "@/types/geo";
+import type {
+  GeoOverviewLoadedProps,
+  GeoPageClientProps,
+  GeoPageContentProps,
+  GeoScanSpinnerProps,
+} from "@/types/geo";
 
 import { GeoTabs } from "./components/geo-tabs";
 import { GeoPageSkeleton } from "./skeleton";
-
-const MODULES_REVEAL_MS = 150;
 
 export default function PageClient({ organizationSlug }: GeoPageClientProps) {
   const [projectParam] = useGeoProjectQueryState();
@@ -50,105 +32,26 @@ export default function PageClient({ organizationSlug }: GeoPageClientProps) {
 }
 
 function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
-  const { getOrganization, activeOrganization } = useOrganizationsContext();
-  const orgFromList = getOrganization(organizationSlug);
-  const organization =
-    activeOrganization?.slug === organizationSlug
-      ? activeOrganization
-      : orgFromList;
-  const organizationId = organization?.id ?? "";
-  const geoRange = useGeoRange();
-  const [activeTab, setActiveTab] = useQueryState(
-    "tab",
-    parseAsStringLiteral(GEO_TAB_VALUES).withDefault(GEO_DEFAULT_TAB)
-  );
+  const page = useGeoOverviewPage(organizationSlug);
 
-  const { data: settingsData, isPending: isSettingsPending } =
-    useGeoSettings(organizationId);
-  const { data: overview } = useGeoOverview(organizationId, geoRange.query);
-  const { data: timeseries } = useGeoTimeseries(organizationId, geoRange.query);
-  const { data: prompts } = useGeoPrompts(organizationId);
-  const { data: promptResults } = useGeoPromptResults(
-    organizationId,
-    geoRange.query,
-    activeTab === "prompts"
-  );
-  const { data: competitorShare } = useGeoCompetitorShare(
-    organizationId,
-    geoRange.query
-  );
-  const { data: competitorList } = useGeoCompetitors(organizationId);
-  const { data: languageShare } = useGeoLanguageShare(
-    organizationId,
-    geoRange.query
-  );
-  const { data: trafficJourneys } = useGeoTrafficJourneys(
-    organizationId,
-    geoRange.query,
-    activeTab === "journeys"
-  );
-  const startScan = useGeoStartScan(organizationId);
-  const isScanning = useIsGeoScanning(organizationId);
-  const [preflightOpen, setPreflightOpen] = useState(false);
-  const enabledPromptCount =
-    prompts?.prompts.filter((prompt) => prompt.enabled).length ?? 0;
-
-  useHotkey("R", () => setPreflightOpen(true), {
-    enabled: !isScanning && !preflightOpen,
-  });
-
-  const reduceMotion = useReducedMotion();
-  const [modulesVisible, setModulesVisible] = useState(false);
-  const ready = !isSettingsPending;
-  const revealActive = ready && (Boolean(reduceMotion) || modulesVisible);
-
-  useEffect(() => {
-    if (!(ready && !reduceMotion)) {
-      return;
-    }
-    const timer = setTimeout(() => setModulesVisible(true), MODULES_REVEAL_MS);
-    return () => clearTimeout(timer);
-  }, [ready, reduceMotion]);
-
-  const overviewViewedRef = useRef(false);
-  const hasSettings = Boolean(settingsData?.settings);
-  const overviewLoaded = overview !== undefined;
-  const engineCount = overview?.engines.length ?? 0;
-  const rangePreset = geoRange.preset;
-
-  useEffect(() => {
-    if (
-      overviewViewedRef.current ||
-      !ready ||
-      (hasSettings && !overviewLoaded)
-    ) {
-      return;
-    }
-    overviewViewedRef.current = true;
-    trackEvent(POSTHOG_EVENTS.GEO_OVERVIEW_VIEWED, {
-      has_data: engineCount > 0,
-      has_settings: hasSettings,
-      range: rangePreset,
-      tab: activeTab,
-    });
-  }, [activeTab, engineCount, hasSettings, overviewLoaded, rangePreset, ready]);
-
-  if (isSettingsPending) {
+  if (page.status === "loading") {
     return <GeoPageSkeleton />;
   }
 
-  const settings = settingsData?.settings ?? null;
-
-  if (!settings) {
+  if (page.status === "empty") {
     return (
       <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
         <div className="w-full px-4 lg:px-6">
-          <GeoSetupEmpty organizationId={organizationId} page="overview" />
+          <GeoSetupEmpty organizationId={page.organizationId} page="overview" />
         </div>
       </PageContainer>
     );
   }
 
+  return <GeoOverviewLoaded page={page} />;
+}
+
+function GeoOverviewLoaded({ page }: GeoOverviewLoadedProps) {
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full space-y-6 px-4 lg:px-6">
@@ -156,19 +59,19 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
           <div className="space-y-1">
             <h1 className="text-3xl font-bold tracking-tight">GEO</h1>
             <p className="text-muted-foreground">
-              How AI engines talk about {settings.companyName}
+              How AI engines talk about {page.companyName}
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <GeoRangePicker control={geoRange} />
+            <GeoRangePicker control={page.geoRange} />
             <Button
               className="w-fit gap-2"
-              disabled={isScanning}
-              onClick={() => setPreflightOpen(true)}
+              disabled={page.isScanning}
+              onClick={page.onRunScan}
               size="sm"
             >
               <span className="inline-flex items-center gap-1.5">
-                {isScanning && <Loader2Icon className="size-4 animate-spin" />}
+                <GeoScanSpinner visible={page.isScanning} />
                 Run Scan
               </span>
               <Kbd className="hidden sm:inline-flex">R</Kbd>
@@ -176,38 +79,17 @@ function GeoPageContent({ organizationSlug }: GeoPageContentProps) {
           </div>
         </header>
 
-        <GeoTabs
-          activeTab={activeTab}
-          competitorPoints={competitorShare?.points ?? []}
-          competitorShareTimeseries={competitorShare?.timeseries ?? []}
-          competitors={competitorList?.competitors ?? []}
-          engines={overview?.engines ?? []}
-          isScanning={isScanning}
-          journeys={trafficJourneys?.journeys ?? []}
-          languagePoints={languageShare?.points ?? []}
-          onActiveTabChange={setActiveTab}
-          organizationId={organizationId}
-          organizationSlug={organizationSlug}
-          promptCount={prompts?.prompts.length ?? 0}
-          promptResults={promptResults?.results ?? []}
-          revealActive={revealActive}
-          settings={settings}
-          timeseriesPoints={timeseries?.points ?? []}
-        />
+        <GeoTabs {...page.tabs} />
       </div>
-      <ScanPreflightDialog
-        engines={settings.engines}
-        isPending={startScan.isPending}
-        languages={settings.languages}
-        lastScanAt={settings.lastScanAt}
-        onConfirm={() => {
-          startScan.mutate();
-          setPreflightOpen(false);
-        }}
-        onOpenChange={setPreflightOpen}
-        open={preflightOpen}
-        promptCount={enabledPromptCount}
-      />
+      <ScanPreflightDialog {...page.scanPreflight} />
     </PageContainer>
   );
+}
+
+function GeoScanSpinner({ visible }: GeoScanSpinnerProps) {
+  if (!visible) {
+    return null;
+  }
+
+  return <Loader2Icon className="size-4 animate-spin" />;
 }

--- a/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
+++ b/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
@@ -47,7 +47,6 @@ import {
 } from "@notra/ui/components/ui/sidebar";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -62,6 +61,7 @@ import { cn } from "@/lib/utils";
 import { getChatHistoryGroups } from "@/utils/chat-history-groups";
 
 import { SidebarLabel } from "./sidebar-label";
+import { SidebarNavLink } from "./sidebar-nav-link";
 
 export function ChatHistoryNav() {
   const { activeOrganization } = useOrganizationsContext();
@@ -254,17 +254,16 @@ export function ChatHistoryNav() {
                             />
                           </div>
                         ) : (
-                          <Link
+                          <SidebarNavLink
                             href={`/${slug}/chat/${session.chatId}`}
                             onFocus={() => prefetchChatHistory(session.chatId)}
                             onMouseEnter={() =>
                               prefetchChatHistory(session.chatId)
                             }
-                            prefetch={false}
                             replace={isOnChatRoute}
                           >
                             <span className="truncate">{session.title}</span>
-                          </Link>
+                          </SidebarNavLink>
                         )
                       }
                       tooltip={session.title}
@@ -357,14 +356,13 @@ export function ChatHistoryNav() {
               <SidebarMenuButton
                 className="cursor-pointer"
                 render={
-                  <Link
+                  <SidebarNavLink
                     href={`/${slug}/chat`}
-                    prefetch={false}
                     replace={isOnChatRoute}
                   >
                     <HugeiconsIcon icon={Add01Icon} />
                     <SidebarLabel>New chat</SidebarLabel>
-                  </Link>
+                  </SidebarNavLink>
                 }
                 tooltip="New chat"
               />

--- a/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
+++ b/apps/dashboard/src/components/dashboard/chat-history-nav.tsx
@@ -260,6 +260,7 @@ export function ChatHistoryNav() {
                             onMouseEnter={() =>
                               prefetchChatHistory(session.chatId)
                             }
+                            prefetch={false}
                             replace={isOnChatRoute}
                           >
                             <span className="truncate">{session.title}</span>
@@ -358,7 +359,7 @@ export function ChatHistoryNav() {
                 render={
                   <Link
                     href={`/${slug}/chat`}
-                    prefetch={true}
+                    prefetch={false}
                     replace={isOnChatRoute}
                   >
                     <HugeiconsIcon icon={Add01Icon} />

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -112,7 +112,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
               !isGuidelinesView
             }
             render={
-              <Link href={companyInfoHref} replace>
+              <Link href={companyInfoHref} prefetch={false} replace>
                 <HugeiconsIcon icon={CorporateIcon} />
                 <SidebarLabel>Company Info</SidebarLabel>
               </Link>
@@ -124,7 +124,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
           <SidebarMenuButton
             isActive={isGuidelinesView}
             render={
-              <Link href={guidelinesHref} replace>
+              <Link href={guidelinesHref} prefetch={false} replace>
                 <HugeiconsIcon icon={PaintBoardIcon} />
                 <SidebarLabel>Brand Guidelines</SidebarLabel>
               </Link>
@@ -136,7 +136,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
           <SidebarMenuButton
             isActive={isReferencesView}
             render={
-              <Link href={referencesHref} replace>
+              <Link href={referencesHref} prefetch={false} replace>
                 <HugeiconsIcon icon={Comment01Icon} />
                 <SidebarLabel>References</SidebarLabel>
                 {referenceCount > 0 ? (
@@ -153,7 +153,7 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
           <SidebarMenuButton
             isActive={isSitemapView}
             render={
-              <Link href={sitemapHref} replace>
+              <Link href={sitemapHref} prefetch={false} replace>
                 <HugeiconsIcon icon={GlobalIcon} />
                 <SidebarLabel>Sitemap</SidebarLabel>
                 {sitemapCount > 0 ? (

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -1,11 +1,5 @@
 "use client";
 
-import {
-  Comment01Icon,
-  CorporateIcon,
-  GlobalIcon,
-  PaintBoardIcon,
-} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   SidebarGroup,
@@ -15,87 +9,22 @@ import {
   SidebarMenuItem,
 } from "@notra/ui/components/ui/sidebar";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
-import { useSyncExternalStore } from "react";
 
-import { useOrganizationsContext } from "@/components/providers/organization-provider";
-import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
-import { useReferences } from "@/lib/hooks/use-brand-references";
-import { useSitemaps } from "@/lib/hooks/use-brand-sitemaps";
-import {
-  findSelectedBrandIdentity,
-  readStoredBrandIdentityId,
-} from "@/utils/brand-identity-selection";
+import { useNavBrandIdentity } from "@/lib/hooks/use-nav-brand-identity";
+import type {
+  NavBrandIdentityLinkProps,
+  NavBrandIdentityProps,
+  NavCountBadgeProps,
+} from "@/types/components/nav";
 
 import { SidebarLabel } from "./sidebar-label";
 
-function subscribeToStorage(onStoreChange: () => void) {
-  window.addEventListener("storage", onStoreChange);
-  return () => window.removeEventListener("storage", onStoreChange);
-}
+export function NavBrandIdentity({ slug }: NavBrandIdentityProps) {
+  const model = useNavBrandIdentity(slug);
 
-function getServerStoredVoiceId(): string | null {
-  return null;
-}
-
-export function NavBrandIdentity({ slug }: { slug: string }) {
-  const { activeOrganization } = useOrganizationsContext();
-  const organizationId = activeOrganization?.id ?? "";
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  const { data } = useBrandSettings(organizationId);
-  const voices = data?.voices ?? [];
-
-  const brandBasePath = `/${slug}/brand/identity`;
-  const isOnBrandPage = pathname === brandBasePath;
-  const voiceParam = searchParams.get("voice");
-  const currentView = searchParams.get("view");
-  const isReferencesView = isOnBrandPage && currentView === "references";
-  const isSitemapView = isOnBrandPage && currentView === "sitemap";
-  const isGuidelinesView = isOnBrandPage && currentView === "guidelines";
-
-  const storedVoiceId = useSyncExternalStore(
-    subscribeToStorage,
-    () => (organizationId ? readStoredBrandIdentityId(organizationId) : null),
-    getServerStoredVoiceId
-  );
-
-  const activeVoice = findSelectedBrandIdentity(
-    voices,
-    voiceParam,
-    storedVoiceId
-  );
-  const activeVoiceId = activeVoice?.id;
-
-  const { data: referencesData } = useReferences(
-    organizationId,
-    activeVoiceId ?? ""
-  );
-  const referenceCount = referencesData?.references.length ?? 0;
-
-  const { data: sitemapsData } = useSitemaps(
-    organizationId,
-    activeVoiceId ?? ""
-  );
-  const sitemapCount = sitemapsData?.sitemaps.length ?? 0;
-
-  if (!organizationId) {
+  if (!model) {
     return null;
   }
-
-  const companyInfoHref = activeVoiceId
-    ? `${brandBasePath}?voice=${activeVoiceId}`
-    : brandBasePath;
-  const referencesHref = activeVoiceId
-    ? `${brandBasePath}?voice=${activeVoiceId}&view=references`
-    : `${brandBasePath}?view=references`;
-  const sitemapHref = activeVoiceId
-    ? `${brandBasePath}?voice=${activeVoiceId}&view=sitemap`
-    : `${brandBasePath}?view=sitemap`;
-  const guidelinesHref = activeVoiceId
-    ? `${brandBasePath}?voice=${activeVoiceId}&view=guidelines`
-    : `${brandBasePath}?view=guidelines`;
 
   return (
     <SidebarGroup>
@@ -103,70 +32,44 @@ export function NavBrandIdentity({ slug }: { slug: string }) {
         <SidebarLabel>Brand Identity</SidebarLabel>
       </SidebarGroupLabel>
       <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            isActive={
-              isOnBrandPage &&
-              !isReferencesView &&
-              !isSitemapView &&
-              !isGuidelinesView
-            }
-            render={
-              <Link href={companyInfoHref} prefetch={false} replace>
-                <HugeiconsIcon icon={CorporateIcon} />
-                <SidebarLabel>Company Info</SidebarLabel>
-              </Link>
-            }
-            tooltip="Company Info"
-          />
-        </SidebarMenuItem>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            isActive={isGuidelinesView}
-            render={
-              <Link href={guidelinesHref} prefetch={false} replace>
-                <HugeiconsIcon icon={PaintBoardIcon} />
-                <SidebarLabel>Brand Guidelines</SidebarLabel>
-              </Link>
-            }
-            tooltip="Brand Guidelines"
-          />
-        </SidebarMenuItem>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            isActive={isReferencesView}
-            render={
-              <Link href={referencesHref} prefetch={false} replace>
-                <HugeiconsIcon icon={Comment01Icon} />
-                <SidebarLabel>References</SidebarLabel>
-                {referenceCount > 0 ? (
-                  <span className="text-muted-foreground ml-auto text-xs tabular-nums group-data-[collapsible=icon]:hidden">
-                    {referenceCount}
-                  </span>
-                ) : null}
-              </Link>
-            }
-            tooltip="References"
-          />
-        </SidebarMenuItem>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            isActive={isSitemapView}
-            render={
-              <Link href={sitemapHref} prefetch={false} replace>
-                <HugeiconsIcon icon={GlobalIcon} />
-                <SidebarLabel>Sitemap</SidebarLabel>
-                {sitemapCount > 0 ? (
-                  <span className="text-muted-foreground ml-auto text-xs tabular-nums group-data-[collapsible=icon]:hidden">
-                    {sitemapCount}
-                  </span>
-                ) : null}
-              </Link>
-            }
-            tooltip="Sitemap"
-          />
-        </SidebarMenuItem>
+        {model.items.map((item) => (
+          <NavBrandIdentityLink item={item} key={item.tab} />
+        ))}
       </SidebarMenu>
     </SidebarGroup>
+  );
+}
+
+function NavBrandIdentityLink({ item }: NavBrandIdentityLinkProps) {
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        isActive={item.isActive}
+        render={
+          <Link href={item.href} prefetch={false} replace>
+            <HugeiconsIcon icon={item.icon} />
+            <SidebarLabel>{item.label}</SidebarLabel>
+            <NavCountBadge count={item.count} />
+          </Link>
+        }
+        tooltip={item.label}
+      />
+    </SidebarMenuItem>
+  );
+}
+
+function NavCountBadge({ count }: NavCountBadgeProps) {
+  if (count === null) {
+    return null;
+  }
+
+  if (count <= 0) {
+    return null;
+  }
+
+  return (
+    <span className="text-muted-foreground ml-auto text-xs tabular-nums group-data-[collapsible=icon]:hidden">
+      {count}
+    </span>
   );
 }

--- a/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-brand-identity.tsx
@@ -8,7 +8,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@notra/ui/components/ui/sidebar";
-import Link from "next/link";
 
 import { useNavBrandIdentity } from "@/lib/hooks/use-nav-brand-identity";
 import type {
@@ -18,6 +17,7 @@ import type {
 } from "@/types/components/nav";
 
 import { SidebarLabel } from "./sidebar-label";
+import { SidebarNavLink } from "./sidebar-nav-link";
 
 export function NavBrandIdentity({ slug }: NavBrandIdentityProps) {
   const model = useNavBrandIdentity(slug);
@@ -46,11 +46,11 @@ function NavBrandIdentityLink({ item }: NavBrandIdentityLinkProps) {
       <SidebarMenuButton
         isActive={item.isActive}
         render={
-          <Link href={item.href} prefetch={false} replace>
+          <SidebarNavLink href={item.href} replace>
             <HugeiconsIcon icon={item.icon} />
             <SidebarLabel>{item.label}</SidebarLabel>
             <NavCountBadge count={item.count} />
-          </Link>
+          </SidebarNavLink>
         }
         tooltip={item.label}
       />

--- a/apps/dashboard/src/components/dashboard/nav-list.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-list.tsx
@@ -8,15 +8,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@notra/ui/components/ui/sidebar";
-import Link from "next/link";
 
-import { AGENT_FEEDBACK_NAV_LINK } from "@/constants/agent-feedback";
 import type { NavListProps } from "@/types/components/nav";
 import { geoNavHref, isGeoDashboardPath } from "@/utils/geo-paths";
 import { resolveNavItems } from "@/utils/nav";
 
 import { NavLockHint } from "./nav-lock-hint";
 import { SidebarLabel } from "./sidebar-label";
+import { SidebarNavLink } from "./sidebar-nav-link";
 
 export function NavList({
   links,
@@ -36,17 +35,12 @@ export function NavList({
     <SidebarMenu>
       {items.map((item) => {
         const isGeoItem = isGeoDashboardPath(item.link);
-        const prefetch =
-          isGeoItem || item.link === AGENT_FEEDBACK_NAV_LINK ? true : undefined;
         return (
           <SidebarMenuItem key={item.link}>
             <SidebarMenuButton
               isActive={item.link === activeLink}
               render={
-                <Link
-                  href={geoNavHref(slug, item.link, projectId)}
-                  prefetch={prefetch}
-                >
+                <SidebarNavLink href={geoNavHref(slug, item.link, projectId)}>
                   <HugeiconsIcon icon={item.icon} />
                   <SidebarLabel>{item.label}</SidebarLabel>
                   {item.badge && (
@@ -60,7 +54,7 @@ export function NavList({
                   {geoLocked && isGeoItem && (
                     <NavLockHint message={GEO_UPGRADE_TOOLTIP} />
                   )}
-                </Link>
+                </SidebarNavLink>
               }
               tooltip={item.label}
             />

--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -52,9 +52,8 @@ export function NavMain() {
       />
       {/*
         Both mode panels stay mounted so the swoosh has something to fade
-        between. Only the active one sits in flow — a stacked layout would
-        grow to whichever panel is taller, including while hidden async
-        content (recent posts, entitlements) settles.
+        between. Hidden Studio recent posts stay unfetched until that mode is
+        active so first paint does not wait on content.list.
       */}
       <SidebarSwap
         activeId={mode}
@@ -76,6 +75,7 @@ export function NavMain() {
             side: "right",
             children: (
               <NavStudio
+                loadRecent={mode === "studio"}
                 organizationId={activeOrganization.id}
                 pathname={navPathname}
                 slug={slug}

--- a/apps/dashboard/src/components/dashboard/nav-mode-primary-action.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-mode-primary-action.tsx
@@ -5,7 +5,6 @@ import { GEO_WRITER_NAV_LINK } from "@notra/geo-core/constants/geo";
 import { SidebarGroup } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import { useState } from "react";
 
 import { Button } from "@/components/button";
@@ -20,6 +19,8 @@ import {
 import { useHasGeoFeature } from "@/lib/hooks/use-plan";
 import type { NavModePrimaryActionProps } from "@/types/components/nav";
 import { geoNavHref } from "@/utils/geo-paths";
+
+import { SidebarNavLink } from "./sidebar-nav-link";
 
 const CreateContentDialog = dynamic(
   () =>
@@ -75,9 +76,8 @@ export function NavModePrimaryAction({
                   inert={geoActive ? undefined : true}
                   nativeButton={false}
                   render={
-                    <Link
+                    <SidebarNavLink
                       href={geoNavHref(slug, GEO_WRITER_NAV_LINK, projectId)}
-                      prefetch
                     />
                   }
                   size="sm"

--- a/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
@@ -9,7 +9,6 @@ import {
   SidebarMenuItem,
 } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
-import Link from "next/link";
 
 import {
   SIDEBAR_MODE_HOME_LINKS,
@@ -21,6 +20,7 @@ import type { NavModeSwitchProps, SidebarMode } from "@/types/components/nav";
 import { geoNavHref } from "@/utils/geo-paths";
 
 import { SidebarLabel } from "./sidebar-label";
+import { SidebarNavLink } from "./sidebar-nav-link";
 
 export function NavModeSwitch({
   mode,
@@ -52,7 +52,7 @@ export function NavModeSwitch({
           {SIDEBAR_MODES.map((option) => {
             const isActive = option.id === mode;
             return (
-              <Link
+              <SidebarNavLink
                 aria-current={isActive ? "page" : undefined}
                 title={`${option.label} · ${option.description}`}
                 className={cn(
@@ -68,11 +68,10 @@ export function NavModeSwitch({
                 )}
                 key={option.id}
                 onClick={() => handleModeSelect(option.id)}
-                prefetch={option.id === "geo"}
               >
                 <HugeiconsIcon className="size-3.5" icon={option.icon} />
                 {option.label}
-              </Link>
+              </SidebarNavLink>
             );
           })}
         </div>
@@ -83,18 +82,17 @@ export function NavModeSwitch({
             <SidebarMenuButton
               isActive={option.id === mode}
               render={
-                <Link
+                <SidebarNavLink
                   href={geoNavHref(
                     slug,
                     SIDEBAR_MODE_HOME_LINKS[option.id],
                     projectId
                   )}
                   onClick={() => handleModeSelect(option.id)}
-                  prefetch={option.id === "geo"}
                 >
                   <HugeiconsIcon icon={option.icon} />
                   <SidebarLabel>{option.label}</SidebarLabel>
-                </Link>
+                </SidebarNavLink>
               }
               tooltip={`${option.label} · ${option.description}`}
             />

--- a/apps/dashboard/src/components/dashboard/nav-recent-content.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-recent-content.tsx
@@ -9,7 +9,6 @@ import {
   SidebarMenuSkeleton,
 } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import {
@@ -25,16 +24,18 @@ import { usePosts } from "@/lib/hooks/use-posts";
 import type { NavRecentContentProps } from "@/types/components/nav";
 
 import { SidebarLabel } from "./sidebar-label";
+import { SidebarNavLink } from "./sidebar-nav-link";
 
 export function NavRecentContent({
   slug,
   organizationId,
+  enabled = true,
 }: NavRecentContentProps) {
   const pathname = usePathname();
-  const { data, isPending } = usePosts(organizationId, 1);
+  const { data, isPending } = usePosts(organizationId, 1, enabled);
   const posts = (data?.posts ?? []).slice(0, NAV_RECENT_LIMIT);
 
-  if (!isPending && posts.length === 0) {
+  if (!enabled || (!isPending && posts.length === 0)) {
     return null;
   }
 
@@ -57,7 +58,7 @@ export function NavRecentContent({
                   <SidebarMenuButton
                     isActive={pathname === href}
                     render={
-                      <Link href={href}>
+                      <SidebarNavLink href={href}>
                         <span
                           aria-hidden="true"
                           className={cn(
@@ -71,7 +72,7 @@ export function NavRecentContent({
                         <span className="text-muted-foreground ml-auto shrink-0 text-[0.625rem]">
                           {POST_STATUS_LABELS[post.status]}
                         </span>
-                      </Link>
+                      </SidebarNavLink>
                     }
                     size="sm"
                   />

--- a/apps/dashboard/src/components/dashboard/nav-settings.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-settings.tsx
@@ -7,7 +7,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
 } from "@notra/ui/components/ui/sidebar";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import {
@@ -18,6 +17,7 @@ import { useHasAiCreditsFeature } from "@/lib/hooks/use-plan";
 import type { NavSettingsProps } from "@/types/components/nav";
 
 import { SidebarLabel } from "./sidebar-label";
+import { SidebarNavLink } from "./sidebar-nav-link";
 
 export function NavSettings({ slug }: NavSettingsProps) {
   const pathname = usePathname();
@@ -40,10 +40,10 @@ export function NavSettings({ slug }: NavSettingsProps) {
               isActive={isActive(item.url)}
               key={item.label}
               render={
-                <Link href={`/${slug}/${item.url}`} prefetch={true} replace>
+                <SidebarNavLink href={`/${slug}/${item.url}`} replace>
                   <HugeiconsIcon icon={item.icon} />
                   <SidebarLabel>{item.label}</SidebarLabel>
-                </Link>
+                </SidebarNavLink>
               }
               tooltip={item.label}
             />
@@ -61,10 +61,10 @@ export function NavSettings({ slug }: NavSettingsProps) {
               isActive={isActive(item.url)}
               key={item.label}
               render={
-                <Link href={`/${slug}/${item.url}`} prefetch={true} replace>
+                <SidebarNavLink href={`/${slug}/${item.url}`} replace>
                   <HugeiconsIcon icon={item.icon} />
                   <SidebarLabel>{item.label}</SidebarLabel>
-                </Link>
+                </SidebarNavLink>
               }
               tooltip={item.label}
             />

--- a/apps/dashboard/src/components/dashboard/nav-studio.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-studio.tsx
@@ -19,7 +19,12 @@ import { CollapsibleSidebarGroup } from "./collapsible-nav-group";
 import { NavList } from "./nav-list";
 import { NavRecentContent } from "./nav-recent-content";
 
-export function NavStudio({ slug, organizationId, pathname }: NavStudioProps) {
+export function NavStudio({
+  slug,
+  organizationId,
+  pathname,
+  loadRecent = true,
+}: NavStudioProps) {
   const visibility = useNavVisibility();
   const activeLink = resolveActiveNavLink(pathname, slug, NAV_STUDIO_ALL_LINKS);
 
@@ -35,7 +40,11 @@ export function NavStudio({ slug, organizationId, pathname }: NavStudioProps) {
           />
         </SidebarGroupContent>
       </SidebarGroup>
-      <NavRecentContent organizationId={organizationId} slug={slug} />
+      <NavRecentContent
+        enabled={loadRecent}
+        organizationId={organizationId}
+        slug={slug}
+      />
       <CollapsibleSidebarGroup label={NAV_CATEGORY_LABELS.automation}>
         <NavList
           activeLink={activeLink}

--- a/apps/dashboard/src/components/dashboard/sidebar-nav-link.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-nav-link.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import type { ComponentProps } from "react";
+import { useState } from "react";
 
 /**
  * Sidebar destinations stay in the viewport (both GEO and Studio panels stay
- * mounted for the mode swoosh). Default Next.js prefetch would compile and
- * fetch every route on first paint. Prefetch only after the user aims at a
- * link.
+ * mounted for the mode swoosh). Viewport prefetch would compile and fetch
+ * every route on first paint. Keep prefetch off until hover or focus, then
+ * restore Link's default so Next.js prefetches the App Shell and keeps the
+ * cache in sync.
  */
 export function SidebarNavLink({
   href,
@@ -16,12 +17,10 @@ export function SidebarNavLink({
   onMouseEnter,
   ...props
 }: Omit<ComponentProps<typeof Link>, "prefetch">) {
-  const router = useRouter();
+  const [prefetch, setPrefetch] = useState<false | null>(false);
 
-  function prefetchRoute() {
-    if (typeof href === "string") {
-      router.prefetch(href);
-    }
+  function enablePrefetch() {
+    setPrefetch(null);
   }
 
   return (
@@ -29,14 +28,14 @@ export function SidebarNavLink({
       {...props}
       href={href}
       onFocus={(event) => {
-        prefetchRoute();
+        enablePrefetch();
         onFocus?.(event);
       }}
       onMouseEnter={(event) => {
-        prefetchRoute();
+        enablePrefetch();
         onMouseEnter?.(event);
       }}
-      prefetch={false}
+      prefetch={prefetch}
     />
   );
 }

--- a/apps/dashboard/src/components/dashboard/sidebar-nav-link.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-nav-link.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { ComponentProps } from "react";
+
+/**
+ * Sidebar destinations stay in the viewport (both GEO and Studio panels stay
+ * mounted for the mode swoosh). Default Next.js prefetch would compile and
+ * fetch every route on first paint. Prefetch only after the user aims at a
+ * link.
+ */
+export function SidebarNavLink({
+  href,
+  onFocus,
+  onMouseEnter,
+  ...props
+}: Omit<ComponentProps<typeof Link>, "prefetch">) {
+  const router = useRouter();
+
+  function prefetchRoute() {
+    if (typeof href === "string") {
+      router.prefetch(href);
+    }
+  }
+
+  return (
+    <Link
+      {...props}
+      href={href}
+      onFocus={(event) => {
+        prefetchRoute();
+        onFocus?.(event);
+      }}
+      onMouseEnter={(event) => {
+        prefetchRoute();
+        onMouseEnter?.(event);
+      }}
+      prefetch={false}
+    />
+  );
+}

--- a/apps/dashboard/src/components/geo/family-improve-card.tsx
+++ b/apps/dashboard/src/components/geo/family-improve-card.tsx
@@ -28,7 +28,6 @@ export function FamilyImproveCard({
             "shrink-0"
           )}
           href={gapsHref}
-          prefetch={true}
         >
           {GEO_FAMILY_IMPROVE_CTA_GAPS}
           <HugeiconsIcon data-icon="inline-end" icon={ArrowRight01Icon} />

--- a/apps/dashboard/src/components/geo/prompt-unseen-list.tsx
+++ b/apps/dashboard/src/components/geo/prompt-unseen-list.tsx
@@ -77,7 +77,6 @@ export function PromptUnseenList({
             <Link
               className={cn(buttonVariants({ size: "sm" }))}
               href={gapsHref}
-              prefetch={true}
             >
               {GEO_FAMILY_IMPROVE_CTA_GAPS}
             </Link>

--- a/apps/dashboard/src/constants/brand-identity.ts
+++ b/apps/dashboard/src/constants/brand-identity.ts
@@ -1,7 +1,14 @@
+import {
+  Comment01Icon,
+  CorporateIcon,
+  GlobalIcon,
+  PaintBoardIcon,
+} from "@hugeicons/core-free-icons";
 import { SUPPORTED_LANGUAGES } from "@notra/ai/constants/languages";
 import type { ToneProfile } from "@notra/ai/schemas/tone";
 
 import type { BrandTab } from "@/types/brand-identity";
+import type { NavBrandIdentityItemConfig } from "@/types/components/nav";
 
 export const AUTO_SAVE_DELAY = 2500;
 
@@ -32,6 +39,18 @@ export const BRAND_IDENTITY_TAB_VALUES = [
   "sitemap",
   "guidelines",
 ] as const satisfies readonly BrandTab[];
+
+export const BRAND_IDENTITY_NAV_ITEMS: readonly NavBrandIdentityItemConfig[] = [
+  { tab: "identity", label: "Company Info", icon: CorporateIcon },
+  { tab: "guidelines", label: "Brand Guidelines", icon: PaintBoardIcon },
+  {
+    tab: "references",
+    label: "References",
+    icon: Comment01Icon,
+    countKey: "references",
+  },
+  { tab: "sitemap", label: "Sitemap", icon: GlobalIcon, countKey: "sitemap" },
+];
 
 export const BRAND_TAB_HEADERS: Record<
   BrandTab,

--- a/apps/dashboard/src/constants/geo-overview.ts
+++ b/apps/dashboard/src/constants/geo-overview.ts
@@ -1,0 +1,1 @@
+export const GEO_MODULES_REVEAL_MS = 150;

--- a/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
@@ -117,7 +117,7 @@ export function useGeoOverviewPage(
   const { data: promptResults } = useGeoPromptResults(
     organizationId,
     geoRange.query,
-    activeTab === "prompts"
+    activeTab === "visibility" || activeTab === "prompts"
   );
   const { data: competitorShare } = useGeoCompetitorShare(
     organizationId,

--- a/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
@@ -1,0 +1,194 @@
+"use client";
+
+import { GEO_DEFAULT_TAB, GEO_TAB_VALUES } from "@notra/geo-core/constants/geo";
+import type { GeoTab } from "@notra/geo-core/types/geo";
+import { POSTHOG_EVENTS } from "@notra/posthog/events";
+import { useHotkey } from "@tanstack/react-hotkeys";
+import { useReducedMotion } from "motion/react";
+import { parseAsStringLiteral, useQueryState } from "nuqs";
+import { useEffect, useRef, useState } from "react";
+
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { GEO_MODULES_REVEAL_MS } from "@/constants/geo-overview";
+import { trackEvent } from "@/lib/analytics/posthog-client";
+import {
+  useGeoCompetitorShare,
+  useGeoCompetitors,
+  useGeoLanguageShare,
+  useGeoOverview,
+  useGeoPromptResults,
+  useGeoPrompts,
+  useGeoSettings,
+  useGeoStartScan,
+  useGeoTimeseries,
+  useGeoTrafficJourneys,
+  useIsGeoScanning,
+} from "@/lib/hooks/use-geo";
+import { useGeoRange } from "@/lib/hooks/use-geo-range";
+import type { GeoOverviewPageModel } from "@/types/geo";
+import { resolveOrganizationId } from "@/utils/geo-overview-organization";
+import {
+  countEnabledGeoPrompts,
+  toGeoOverviewReadyPage,
+} from "@/utils/geo-overview-page";
+
+function useGeoModulesReveal(ready: boolean): boolean {
+  const reduceMotion = useReducedMotion();
+  const [modulesVisible, setModulesVisible] = useState(false);
+
+  useEffect(() => {
+    if (!ready) {
+      return;
+    }
+    if (reduceMotion) {
+      return;
+    }
+    const timer = setTimeout(
+      () => setModulesVisible(true),
+      GEO_MODULES_REVEAL_MS
+    );
+    return () => clearTimeout(timer);
+  }, [ready, reduceMotion]);
+
+  if (!ready) {
+    return false;
+  }
+
+  return Boolean(reduceMotion) || modulesVisible;
+}
+
+function useGeoOverviewViewed(input: {
+  ready: boolean;
+  hasSettings: boolean;
+  overviewLoaded: boolean;
+  engineCount: number;
+  rangePreset: string;
+  activeTab: GeoTab;
+}) {
+  const overviewViewedRef = useRef(false);
+
+  useEffect(() => {
+    if (overviewViewedRef.current) {
+      return;
+    }
+    if (!input.ready) {
+      return;
+    }
+    if (input.hasSettings && !input.overviewLoaded) {
+      return;
+    }
+    overviewViewedRef.current = true;
+    trackEvent(POSTHOG_EVENTS.GEO_OVERVIEW_VIEWED, {
+      has_data: input.engineCount > 0,
+      has_settings: input.hasSettings,
+      range: input.rangePreset,
+      tab: input.activeTab,
+    });
+  }, [
+    input.activeTab,
+    input.engineCount,
+    input.hasSettings,
+    input.overviewLoaded,
+    input.rangePreset,
+    input.ready,
+  ]);
+}
+
+export function useGeoOverviewPage(
+  organizationSlug: string
+): GeoOverviewPageModel {
+  const { getOrganization, activeOrganization } = useOrganizationsContext();
+  const organizationId = resolveOrganizationId(
+    organizationSlug,
+    activeOrganization,
+    getOrganization(organizationSlug)
+  );
+  const geoRange = useGeoRange();
+  const [activeTab, setActiveTab] = useQueryState(
+    "tab",
+    parseAsStringLiteral(GEO_TAB_VALUES).withDefault(GEO_DEFAULT_TAB)
+  );
+
+  const { data: settingsData, isPending: isSettingsPending } =
+    useGeoSettings(organizationId);
+  const { data: overview } = useGeoOverview(organizationId, geoRange.query);
+  const { data: timeseries } = useGeoTimeseries(organizationId, geoRange.query);
+  const { data: prompts } = useGeoPrompts(organizationId);
+  const { data: promptResults } = useGeoPromptResults(
+    organizationId,
+    geoRange.query,
+    activeTab === "prompts"
+  );
+  const { data: competitorShare } = useGeoCompetitorShare(
+    organizationId,
+    geoRange.query
+  );
+  const { data: competitorList } = useGeoCompetitors(organizationId);
+  const { data: languageShare } = useGeoLanguageShare(
+    organizationId,
+    geoRange.query
+  );
+  const { data: trafficJourneys } = useGeoTrafficJourneys(
+    organizationId,
+    geoRange.query,
+    activeTab === "journeys"
+  );
+  const startScan = useGeoStartScan(organizationId);
+  const isScanning = useIsGeoScanning(organizationId);
+  const [preflightOpen, setPreflightOpen] = useState(false);
+  const settings = settingsData?.settings ?? null;
+  const ready = !isSettingsPending;
+  const revealActive = useGeoModulesReveal(ready);
+
+  useHotkey("R", () => setPreflightOpen(true), {
+    enabled: !isScanning && !preflightOpen,
+  });
+
+  useGeoOverviewViewed({
+    ready,
+    hasSettings: Boolean(settings),
+    overviewLoaded: overview !== undefined,
+    engineCount: overview?.engines.length ?? 0,
+    rangePreset: geoRange.preset,
+    activeTab,
+  });
+
+  if (isSettingsPending) {
+    return { status: "loading" };
+  }
+
+  if (!settings) {
+    return { status: "empty", organizationId };
+  }
+
+  return toGeoOverviewReadyPage({
+    organizationId,
+    organizationSlug,
+    settings,
+    geoRange,
+    activeTab,
+    onActiveTabChange: setActiveTab,
+    engines: overview?.engines,
+    timeseriesPoints: timeseries?.points,
+    competitorPoints: competitorShare?.points,
+    competitorShareTimeseries: competitorShare?.timeseries,
+    competitors: competitorList?.competitors,
+    languagePoints: languageShare?.points,
+    promptResults: promptResults?.results,
+    promptCount: prompts?.prompts.length,
+    journeys: trafficJourneys?.journeys,
+    isScanning,
+    revealActive,
+    scanPreflight: {
+      open: preflightOpen,
+      onOpenChange: setPreflightOpen,
+      onConfirm: () => {
+        startScan.mutate();
+        setPreflightOpen(false);
+      },
+      isPending: startScan.isPending,
+      promptCount: countEnabledGeoPrompts(prompts?.prompts),
+      lastScanAt: settings.lastScanAt,
+    },
+  });
+}

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -304,14 +304,15 @@ export function useGeoTimeseries(
 
 export function useGeoPromptResults(
   organizationId: string,
-  range?: GeoRangeQuery
+  range?: GeoRangeQuery,
+  enabled = true
 ) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoPromptResultsResponse>({
     ...dashboardOrpc.geo.promptResults.queryOptions({
       input: { organizationId, projectId, ...toGeoWindowInput(range) },
     }),
-    enabled: !!organizationId,
+    enabled: enabled && !!organizationId,
     placeholderData: keepPreviousData,
     meta: { errorMessage: "Failed to load prompt results" },
   });
@@ -754,14 +755,15 @@ export function useGeoTrafficPages(
 
 export function useGeoTrafficJourneys(
   organizationId: string,
-  range?: GeoRangeQuery
+  range?: GeoRangeQuery,
+  enabled = true
 ) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoTrafficJourneysResponse>({
     ...dashboardOrpc.geo.trafficJourneys.queryOptions({
       input: { organizationId, projectId, ...toGeoWindowInput(range) },
     }),
-    enabled: !!organizationId,
+    enabled: enabled && !!organizationId,
     placeholderData: keepPreviousData,
     meta: { errorMessage: "Failed to load AI journeys" },
   });

--- a/apps/dashboard/src/lib/hooks/use-nav-brand-identity.ts
+++ b/apps/dashboard/src/lib/hooks/use-nav-brand-identity.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useSyncExternalStore } from "react";
+
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
+import { useReferences } from "@/lib/hooks/use-brand-references";
+import { useSitemaps } from "@/lib/hooks/use-brand-sitemaps";
+import type { NavBrandIdentityModel } from "@/types/components/nav";
+import {
+  buildBrandIdentityNavItems,
+  resolveBrandIdentityNavView,
+} from "@/utils/brand-identity-nav";
+import {
+  findSelectedBrandIdentity,
+  readStoredBrandIdentityId,
+} from "@/utils/brand-identity-selection";
+
+function subscribeToStorage(onStoreChange: () => void) {
+  window.addEventListener("storage", onStoreChange);
+  return () => window.removeEventListener("storage", onStoreChange);
+}
+
+function getServerStoredVoiceId(): string | null {
+  return null;
+}
+
+export function useNavBrandIdentity(
+  slug: string
+): NavBrandIdentityModel | null {
+  const { activeOrganization } = useOrganizationsContext();
+  const organizationId = activeOrganization?.id ?? "";
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { data } = useBrandSettings(organizationId);
+  const voices = data?.voices ?? [];
+  const brandBasePath = `/${slug}/brand/identity`;
+  const storedVoiceId = useSyncExternalStore(
+    subscribeToStorage,
+    () => (organizationId ? readStoredBrandIdentityId(organizationId) : null),
+    getServerStoredVoiceId
+  );
+  const activeVoice = findSelectedBrandIdentity(
+    voices,
+    searchParams.get("voice"),
+    storedVoiceId
+  );
+  const activeVoiceId = activeVoice?.id;
+  const { data: referencesData } = useReferences(
+    organizationId,
+    activeVoiceId ?? ""
+  );
+  const { data: sitemapsData } = useSitemaps(
+    organizationId,
+    activeVoiceId ?? ""
+  );
+
+  if (!organizationId) {
+    return null;
+  }
+
+  return {
+    items: buildBrandIdentityNavItems({
+      basePath: brandBasePath,
+      voiceId: activeVoiceId,
+      activeView: resolveBrandIdentityNavView(
+        pathname,
+        brandBasePath,
+        searchParams.get("view")
+      ),
+      counts: {
+        references: referencesData?.references.length ?? 0,
+        sitemap: sitemapsData?.sitemaps.length ?? 0,
+      },
+    }),
+  };
+}

--- a/apps/dashboard/src/lib/hooks/use-posts.ts
+++ b/apps/dashboard/src/lib/hooks/use-posts.ts
@@ -9,7 +9,7 @@ import { useActiveProject } from "./use-active-project";
 
 const DEFAULT_PAGE_SIZE = 12;
 
-export function usePosts(organizationId: string, page: number) {
+export function usePosts(organizationId: string, page: number, enabled = true) {
   const { projectId, isResolved } = useActiveProject();
   return useQuery<PostsResponse>({
     ...dashboardOrpc.content.list.queryOptions({
@@ -20,7 +20,7 @@ export function usePosts(organizationId: string, page: number) {
         pageSize: DEFAULT_PAGE_SIZE,
       },
     }),
-    enabled: !!organizationId && isResolved,
+    enabled: enabled && !!organizationId && isResolved,
     meta: { errorMessage: "Failed to load content" },
   });
 }

--- a/apps/dashboard/src/types/components/nav.ts
+++ b/apps/dashboard/src/types/components/nav.ts
@@ -1,6 +1,8 @@
 import type { IconSvgElement } from "@hugeicons/react";
 import type { ReactNode } from "react";
 
+import type { BrandTab } from "@/types/brand-identity";
+
 export type SidebarMode = "geo" | "studio";
 
 export type NavGroupKey = "visibility" | "improve" | "automation" | "utility";
@@ -106,6 +108,40 @@ export interface NavSettingsItem {
 
 export interface NavSettingsProps {
   slug: string;
+}
+
+export interface NavBrandIdentityProps {
+  slug: string;
+}
+
+export type BrandIdentityNavCountKey = "references" | "sitemap";
+
+export interface NavBrandIdentityItemConfig {
+  tab: BrandTab;
+  label: string;
+  icon: IconSvgElement;
+  countKey?: BrandIdentityNavCountKey;
+}
+
+export interface NavBrandIdentityItem {
+  tab: BrandTab;
+  label: string;
+  icon: IconSvgElement;
+  href: string;
+  isActive: boolean;
+  count: number | null;
+}
+
+export interface NavBrandIdentityModel {
+  items: NavBrandIdentityItem[];
+}
+
+export interface NavBrandIdentityLinkProps {
+  item: NavBrandIdentityItem;
+}
+
+export interface NavCountBadgeProps {
+  count: number | null;
 }
 
 export interface NavLockHintProps {

--- a/apps/dashboard/src/types/components/nav.ts
+++ b/apps/dashboard/src/types/components/nav.ts
@@ -60,6 +60,8 @@ export interface NavStudioProps {
   organizationId: string;
   /** Route to resolve the active item against; may lead the real pathname. */
   pathname: string;
+  /** Skip recent-post fetching while the Studio panel is hidden. */
+  loadRecent?: boolean;
 }
 
 export interface NavModePrimaryActionProps {
@@ -72,6 +74,7 @@ export interface NavModePrimaryActionProps {
 export interface NavRecentContentProps {
   slug: string;
   organizationId: string;
+  enabled?: boolean;
 }
 
 export interface NavUtilityProps {

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -120,6 +120,37 @@ export interface GeoPageContentProps {
   organizationSlug: string;
 }
 
+export interface GeoOverviewPageEmpty {
+  status: "empty";
+  organizationId: string;
+}
+
+export interface GeoOverviewPageReady {
+  status: "ready";
+  organizationId: string;
+  organizationSlug: string;
+  companyName: string;
+  geoRange: GeoRangeControl;
+  isScanning: boolean;
+  revealActive: boolean;
+  tabs: GeoTabsProps;
+  scanPreflight: ScanPreflightDialogProps;
+  onRunScan: () => void;
+}
+
+export type GeoOverviewPageModel =
+  | { status: "loading" }
+  | GeoOverviewPageEmpty
+  | GeoOverviewPageReady;
+
+export interface GeoOverviewLoadedProps {
+  page: GeoOverviewPageReady;
+}
+
+export interface GeoScanSpinnerProps {
+  visible: boolean;
+}
+
 export interface GeoStatDeltaProps {
   delta: number | null;
   kind?: GeoStatDeltaKind;

--- a/apps/dashboard/src/utils/brand-identity-nav.ts
+++ b/apps/dashboard/src/utils/brand-identity-nav.ts
@@ -1,0 +1,90 @@
+import { BRAND_IDENTITY_NAV_ITEMS } from "@/constants/brand-identity";
+import type { BrandTab } from "@/types/brand-identity";
+import type {
+  BrandIdentityNavCountKey,
+  NavBrandIdentityItem,
+} from "@/types/components/nav";
+
+function buildBrandIdentityHref(
+  basePath: string,
+  voiceId: string | undefined,
+  view?: Exclude<BrandTab, "identity">
+): string {
+  const params = new URLSearchParams();
+
+  if (voiceId) {
+    params.set("voice", voiceId);
+  }
+
+  if (view) {
+    params.set("view", view);
+  }
+
+  const query = params.toString();
+  if (!query) {
+    return basePath;
+  }
+
+  return `${basePath}?${query}`;
+}
+
+export function resolveBrandIdentityNavView(
+  pathname: string,
+  brandBasePath: string,
+  viewParam: string | null
+): BrandTab | null {
+  if (pathname !== brandBasePath) {
+    return null;
+  }
+
+  if (
+    viewParam === "references" ||
+    viewParam === "sitemap" ||
+    viewParam === "guidelines"
+  ) {
+    return viewParam;
+  }
+
+  return "identity";
+}
+
+function navViewForHref(
+  tab: BrandTab
+): Exclude<BrandTab, "identity"> | undefined {
+  if (tab === "identity") {
+    return undefined;
+  }
+
+  return tab;
+}
+
+function navItemCount(
+  countKey: BrandIdentityNavCountKey | undefined,
+  counts: Record<BrandIdentityNavCountKey, number>
+): number | null {
+  if (!countKey) {
+    return null;
+  }
+
+  return counts[countKey];
+}
+
+export function buildBrandIdentityNavItems(input: {
+  basePath: string;
+  voiceId: string | undefined;
+  activeView: BrandTab | null;
+  counts: Record<BrandIdentityNavCountKey, number>;
+}): NavBrandIdentityItem[] {
+  return BRAND_IDENTITY_NAV_ITEMS.map((item) => ({
+    tab: item.tab,
+    label: item.label,
+    icon: item.icon,
+    href: buildBrandIdentityHref(
+      input.basePath,
+      input.voiceId,
+      navViewForHref(item.tab)
+    ),
+    isActive: input.activeView === item.tab,
+    count: navItemCount(item.countKey, input.counts),
+  }));
+}

--- a/apps/dashboard/src/utils/geo-overview-organization.ts
+++ b/apps/dashboard/src/utils/geo-overview-organization.ts
@@ -1,0 +1,11 @@
+export function resolveOrganizationId(
+  organizationSlug: string,
+  activeOrganization: { id: string; slug: string } | null | undefined,
+  orgFromList: { id: string } | undefined
+): string {
+  if (activeOrganization?.slug === organizationSlug) {
+    return activeOrganization.id;
+  }
+
+  return orgFromList?.id ?? "";
+}

--- a/apps/dashboard/src/utils/geo-overview-page.ts
+++ b/apps/dashboard/src/utils/geo-overview-page.ts
@@ -1,0 +1,98 @@
+import { GEO_EMPTY_COMPETITOR_SHARE_TIMESERIES } from "@notra/geo-core/constants/geo";
+import type {
+  GeoCompetitor,
+  GeoCompetitorSharePoint,
+  GeoCompetitorShareTimeseriesPoint,
+  GeoJourney,
+  GeoLanguageSharePoint,
+  GeoOverviewEngine,
+  GeoPromptResult,
+  GeoSettings,
+  GeoTab,
+  GeoTimeseriesPoint,
+  GeoTrackedPrompt,
+} from "@notra/geo-core/types/geo";
+
+import type {
+  GeoOverviewPageReady,
+  GeoRangeControl,
+  ScanPreflightDialogProps,
+} from "@/types/geo";
+
+export function countEnabledGeoPrompts(
+  prompts: readonly GeoTrackedPrompt[] | undefined
+): number {
+  if (!prompts) {
+    return 0;
+  }
+
+  return prompts.filter((prompt) => prompt.enabled).length;
+}
+
+export function toGeoOverviewReadyPage(input: {
+  organizationId: string;
+  organizationSlug: string;
+  settings: GeoSettings;
+  geoRange: GeoRangeControl;
+  activeTab: GeoTab;
+  onActiveTabChange: (tab: GeoTab) => void;
+  engines: GeoOverviewEngine[] | undefined;
+  timeseriesPoints: GeoTimeseriesPoint[] | undefined;
+  competitorPoints: GeoCompetitorSharePoint[] | undefined;
+  competitorShareTimeseries:
+    | readonly GeoCompetitorShareTimeseriesPoint[]
+    | undefined;
+  competitors: GeoCompetitor[] | undefined;
+  languagePoints: GeoLanguageSharePoint[] | undefined;
+  promptResults: GeoPromptResult[] | undefined;
+  promptCount: number | undefined;
+  journeys: GeoJourney[] | undefined;
+  isScanning: boolean;
+  revealActive: boolean;
+  scanPreflight: Omit<ScanPreflightDialogProps, "engines" | "languages">;
+}): GeoOverviewPageReady {
+  const engines = input.engines ?? [];
+  const timeseriesPoints = input.timeseriesPoints ?? [];
+  const competitorPoints = input.competitorPoints ?? [];
+  const competitorShareTimeseries =
+    input.competitorShareTimeseries ?? GEO_EMPTY_COMPETITOR_SHARE_TIMESERIES;
+  const competitors = input.competitors ?? [];
+  const languagePoints = input.languagePoints ?? [];
+  const promptResults = input.promptResults ?? [];
+  const journeys = input.journeys ?? [];
+  const promptCount = input.promptCount ?? 0;
+
+  return {
+    status: "ready",
+    organizationId: input.organizationId,
+    organizationSlug: input.organizationSlug,
+    companyName: input.settings.companyName,
+    geoRange: input.geoRange,
+    isScanning: input.isScanning,
+    revealActive: input.revealActive,
+    onRunScan: () => input.scanPreflight.onOpenChange(true),
+    tabs: {
+      activeTab: input.activeTab,
+      onActiveTabChange: input.onActiveTabChange,
+      organizationSlug: input.organizationSlug,
+      revealActive: input.revealActive,
+      settings: input.settings,
+      engines,
+      timeseriesPoints,
+      competitorPoints,
+      competitorShareTimeseries,
+      competitors,
+      languagePoints,
+      promptResults,
+      promptCount,
+      isScanning: input.isScanning,
+      journeys,
+      organizationId: input.organizationId,
+    },
+    scanPreflight: {
+      ...input.scanPreflight,
+      engines: input.settings.engines,
+      languages: input.settings.languages,
+    },
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Dashboard first paint was compiling and fetching every GEO/Studio/settings route because the sidebar keeps both mode panels mounted and every `Link` used `prefetch={true}`. With Next.js Partial Prefetching that is a full dynamic prefetch (auth layouts included), which showed up as ~250 requests in `next dev`.

Prefetch sidebar destinations only after hover or focus via `SidebarNavLink` (`prefetch={false}` until then, then restore Link’s default so Next owns App Shell prefetch). Skip Studio `content.list` until Studio mode is active, and skip GEO traffic journeys until the Journeys tab. Prompt-level results still load on Visibility and Prompts — Visibility cards drill into those rows.

In-page CTAs (All prompts, GAPS) drop `prefetch={true}` so they use App Router auto prefetch instead of an eager full prefetch. They are not forced to `prefetch={false}`.

This change was written with Cursor / an AI coding agent.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc085872-9c89-4b4d-846b-6a7bebf5d5e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc085872-9c89-4b4d-846b-6a7bebf5d5e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the dashboard sidebar from prefetching every route on first paint, cutting the initial request burst from ~250 requests. Routes now prefetch on hover or focus, and queries for hidden panels and inactive tabs are skipped until they're actually needed.

- Adds `SidebarNavLink`, which disables Next.js default prefetch and restores it on hover or focus, and applies it to all sidebar destinations including chat history and brand identity.
- Skips recent-post fetching while the Studio panel is hidden.
- Skips traffic journeys queries until their tab is active; GEO prompt results now load for both the visibility and prompts tabs so per-prompt cards render on the default view.
- Moves GEO overview and brand identity nav data loading into hooks and helpers so components only render resolved state.

<sup>Written for commit 0ae99acff36d1cc8241ceaa5c77f5e9330f064aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

