### PR TITLE
feat(geo): render OpenCode answers in the TUI with staggered search replay

### DIFF
--- a/apps/dashboard/src/app/design-system/opencode/page-client.tsx
+++ b/apps/dashboard/src/app/design-system/opencode/page-client.tsx
@@ -5,6 +5,7 @@ import { OpencodeComposer } from "@notra/ui/components/brainless/opencode/openco
 import { OpencodeLogo } from "@notra/ui/components/brainless/opencode/opencode-logo";
 import { OpencodeMessage } from "@notra/ui/components/brainless/opencode/opencode-message";
 import { OpencodeSidebar } from "@notra/ui/components/brainless/opencode/opencode-sidebar";
+import { OpencodeSources } from "@notra/ui/components/brainless/opencode/opencode-sources";
 import { OPENCODE_COLORS } from "@notra/ui/constants/brainless-opencode";
 import { cn } from "@notra/ui/lib/utils";
 import type { ReactNode } from "react";
@@ -13,6 +14,7 @@ import { DesignSystemSectionHeader } from "@/components/design-system/design-sys
 import {
   OPENCODE_STORY_ACTIVITIES,
   OPENCODE_STORY_SESSION,
+  OPENCODE_STORY_SOURCES,
 } from "@/constants/design-system-opencode";
 
 function OpencodeSurface({
@@ -65,6 +67,7 @@ export function DesignSystemOpencodeCatalog() {
                     <OpencodeActivity key={activity.id} {...activity} />
                   ))}
                 </div>
+                <OpencodeSources sources={OPENCODE_STORY_SOURCES} />
                 <OpencodeMessage>{session.resultMessage}</OpencodeMessage>
               </div>
               <OpencodeComposer
@@ -129,14 +132,18 @@ export function DesignSystemOpencodeCatalog() {
 
       <section className="scroll-mt-10 space-y-6" id="opencode-activity">
         <DesignSystemSectionHeader
-          description="User and assistant turns plus orange reasoning and muted tool activity."
+          description="User and assistant turns plus orange reasoning, muted tool activity, and cited sources."
           id="opencode-activity"
           title="Messages & activity"
         />
         <OpencodeSurface className="p-5 sm:p-6">
           <div className="space-y-5">
             <OpencodeMessage from="user">{session.userMessage}</OpencodeMessage>
-            <OpencodeMessage>{session.assistantMessage}</OpencodeMessage>
+            <OpencodeMessage
+              search={<OpencodeSources sources={OPENCODE_STORY_SOURCES} />}
+            >
+              {session.assistantMessage}
+            </OpencodeMessage>
             {OPENCODE_STORY_ACTIVITIES.map((activity) => (
               <OpencodeActivity key={activity.id} {...activity} />
             ))}

--- a/apps/dashboard/src/components/geo/conversation-replay-thread.tsx
+++ b/apps/dashboard/src/components/geo/conversation-replay-thread.tsx
@@ -99,11 +99,15 @@ function ReplayTurn({
   const sources = replaySources(turn);
   const hasRecordedSearch =
     turn.searchQueries.length > 0 || turn.sources.length > 0;
-  const hasSearchChrome = skin === "perplexity" || hasRecordedSearch;
+  const hasSearchChrome =
+    skin === "perplexity" || skin === "opencode" || hasRecordedSearch;
   const showSearch =
     hasSearchChrome && (showAnswer || (skin === "opencode" && showThinking));
   let searchQueries: readonly string[] = turn.searchQueries;
-  if (searchQueries.length === 0 && skin === "perplexity") {
+  if (
+    searchQueries.length === 0 &&
+    (skin === "perplexity" || skin === "opencode")
+  ) {
     searchQueries = [turn.prompt];
   }
 

--- a/apps/dashboard/src/components/geo/conversation-replay-thread.tsx
+++ b/apps/dashboard/src/components/geo/conversation-replay-thread.tsx
@@ -99,7 +99,9 @@ function ReplayTurn({
   const sources = replaySources(turn);
   const hasRecordedSearch =
     turn.searchQueries.length > 0 || turn.sources.length > 0;
-  const showSearch = skin === "perplexity" || hasRecordedSearch;
+  const hasSearchChrome = skin === "perplexity" || hasRecordedSearch;
+  const showSearch =
+    hasSearchChrome && (showAnswer || (skin === "opencode" && showThinking));
   let searchQueries: readonly string[] = turn.searchQueries;
   if (searchQueries.length === 0 && skin === "perplexity") {
     searchQueries = [turn.prompt];
@@ -114,9 +116,10 @@ function ReplayTurn({
         <GeoSkinMessage
           from="assistant"
           search={
-            showSearch && showAnswer ? (
+            showSearch ? (
               <GeoAnswerSearch
                 queries={searchQueries}
+                sequential={isCurrent}
                 skin={skin}
                 sources={sources}
               />

--- a/apps/dashboard/src/components/geo/geo-answer-search.tsx
+++ b/apps/dashboard/src/components/geo/geo-answer-search.tsx
@@ -3,8 +3,10 @@
 import type { GeoChatSkin } from "@notra/geo-core/types/geo";
 import { getReferenceDomain } from "@notra/geo-core/utils/reference-display";
 import { ClaudeChatSources } from "@notra/ui/components/brainless/claude-chat/claude-chat-sources";
+import { OpencodeSources } from "@notra/ui/components/brainless/opencode/opencode-sources";
 import { PerplexitySearch } from "@notra/ui/components/brainless/perplexity/perplexity-search";
 import type { PerplexitySearchSource } from "@notra/ui/types/perplexity";
+import { useReducedMotion } from "motion/react";
 
 import { getSafeReferenceSourceUrl } from "@/utils/reference-source-url";
 
@@ -191,11 +193,15 @@ export function GeoAnswerSearch({
   skin,
   sources,
   queries = EMPTY_QUERIES,
+  sequential = false,
 }: {
   skin: GeoChatSkin;
   sources: readonly PerplexitySearchSource[];
   queries?: readonly string[];
+  sequential?: boolean;
 }) {
+  const reducedMotion = Boolean(useReducedMotion());
+
   if (skin === "perplexity") {
     return (
       <PerplexitySearch
@@ -212,6 +218,17 @@ export function GeoAnswerSearch({
 
   if (skin === "gemini") {
     return <GeminiCitedSearch queries={queries} sources={sources} />;
+  }
+
+  if (skin === "opencode") {
+    return (
+      <OpencodeSources
+        queries={queries}
+        reducedMotion={reducedMotion}
+        sequential={sequential}
+        sources={sources}
+      />
+    );
   }
 
   return <ChatgptCitedSearch queries={queries} sources={sources} />;

--- a/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
+++ b/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
@@ -185,11 +185,15 @@ export function GeoPromptAnswerThread({
   const reducedMotion = useReducedMotion();
   const progress = useAnswerReplay(replayTurns, 1, Boolean(reducedMotion));
   const sources = threadSources(result, answer);
+  const searchQueries =
+    result.searchQueries.length > 0 || skin !== "opencode"
+      ? result.searchQueries
+      : [prompt];
   const hasRecordedSearch =
-    result.searchQueries.length > 0 || result.sources.length > 0;
+    searchQueries.length > 0 || result.sources.length > 0;
   const search = hasRecordedSearch ? (
     <GeoAnswerSearch
-      queries={result.searchQueries}
+      queries={searchQueries}
       sequential={progress !== null}
       skin={skin}
       sources={sources}

--- a/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
+++ b/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
@@ -134,6 +134,8 @@ function ThreadMessages({
   const answerDone = progress === null;
   const showThinking = stage === "thinking";
   const showAnswer = answerDone || stage === "typing";
+  const showSearch =
+    Boolean(search) && (showAnswer || (skin === "opencode" && showThinking));
   const answerText = stage === "typing" ? (progress?.typed ?? "") : answer;
 
   return (
@@ -147,7 +149,7 @@ function ThreadMessages({
             answerDone ? assistantActions(answerText, sources) : undefined
           }
           from="assistant"
-          search={showAnswer ? search : undefined}
+          search={showSearch ? search : undefined}
           skin={skin}
         >
           {showThinking ? (
@@ -188,6 +190,7 @@ export function GeoPromptAnswerThread({
   const search = hasRecordedSearch ? (
     <GeoAnswerSearch
       queries={result.searchQueries}
+      sequential={progress !== null}
       skin={skin}
       sources={sources}
     />

--- a/apps/dashboard/src/components/geo/geo-skin-message.tsx
+++ b/apps/dashboard/src/components/geo/geo-skin-message.tsx
@@ -3,6 +3,7 @@
 import { ChatgptMessage } from "@notra/ui/components/brainless/chatgpt/chatgpt-message";
 import { ClaudeChatMessage } from "@notra/ui/components/brainless/claude-chat/claude-chat-message";
 import { GeminiMessage } from "@notra/ui/components/brainless/gemini/gemini-message";
+import { OpencodeMessage } from "@notra/ui/components/brainless/opencode/opencode-message";
 import { PerplexityMessage } from "@notra/ui/components/brainless/perplexity/perplexity-message";
 
 import type { GeoSkinMessageProps } from "@/types/geo";
@@ -33,6 +34,13 @@ export function GeoSkinMessage({
       <PerplexityMessage actions={actions} from={from} search={search}>
         {children}
       </PerplexityMessage>
+    );
+  }
+  if (skin === "opencode") {
+    return (
+      <OpencodeMessage actions={actions} from={from} search={search}>
+        {children}
+      </OpencodeMessage>
     );
   }
   return (

--- a/apps/dashboard/src/components/geo/prompts-table.tsx
+++ b/apps/dashboard/src/components/geo/prompts-table.tsx
@@ -7,6 +7,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+  GEO_PRESENCE_LABELS,
   GEO_PROMPT_AUTO_MANAGED_HINT,
   GEO_PROMPT_AUTO_MANAGED_LABEL,
   GEO_PROMPT_INTENT_LABELS,
@@ -14,9 +15,9 @@ import {
   PROMPTS_TABLE_HEIGHT,
   PROMPTS_TABLE_ROW_HEIGHT,
 } from "@notra/geo-core/constants/geo";
+import type { GeoPresenceStatus } from "@notra/geo-core/types/geo";
 import { collectPromptTags } from "@notra/geo-core/utils/geo-prompt-tags";
 import { geoScanEmptyMessage } from "@notra/geo-core/utils/geo-scan";
-import { PresenceBadge } from "@notra/ui/components/geo/presence-badge";
 import { TruncateWithTooltip } from "@notra/ui/components/shared/truncate-with-tooltip";
 import { Badge } from "@notra/ui/components/ui/badge";
 import { Input } from "@notra/ui/components/ui/input";
@@ -75,6 +76,26 @@ import {
 
 const PROMPT_NOUNS = { singular: "prompt", plural: "prompts" } as const;
 const PROMPT_ACTIONS_WIDTH = "13rem";
+const PRESENCE_TITLES: Record<GeoPresenceStatus, string> = {
+  "training-data": "Named in the model, not only in live search",
+  "retrieval-only": "Mentioned in Search only: found live, not in the model",
+  invisible: "No engine mentions you on this prompt yet",
+};
+
+function PromptPresenceCell({ status }: { status: GeoPresenceStatus | null }) {
+  if (!status) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+  const label = GEO_PRESENCE_LABELS[status];
+  if (!label) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+  return (
+    <span className="text-muted-foreground" title={PRESENCE_TITLES[status]}>
+      {label}
+    </span>
+  );
+}
 
 function PromptTagChips({ tags }: PromptTagChipsProps) {
   if (tags.length === 0) {
@@ -325,19 +346,20 @@ export function PromptsTable({
       key: "intent",
       header: GEO_PROMPT_TAGS_COPY.intentColumn,
       width: "7.5rem",
+      minWidth: "7.5rem",
       sortable: true,
       cell: (row) => (
-        <Badge className="font-normal" variant="outline">
+        <span className="text-muted-foreground">
           {GEO_PROMPT_INTENT_LABELS[row.intent]}
-        </Badge>
+        </span>
       ),
       sortValue: (row) => GEO_PROMPT_INTENT_LABELS[row.intent],
     },
     {
       key: "tags",
       header: GEO_PROMPT_TAGS_COPY.column,
-      width: "12rem",
-      minWidth: "8rem",
+      width: "8rem",
+      minWidth: "7rem",
       sortable: true,
       cell: (row) => <PromptTagChips tags={row.tags} />,
       sortValue: (row) => row.tags.join(" "),
@@ -345,20 +367,17 @@ export function PromptsTable({
     {
       key: "presence",
       header: "Presence",
-      width: "8.5rem",
+      width: "7.5rem",
+      minWidth: "7.5rem",
       sortable: true,
-      cell: (row) =>
-        row.presence ? (
-          <PresenceBadge status={row.presence} />
-        ) : (
-          <span className="text-muted-foreground">-</span>
-        ),
+      cell: (row) => <PromptPresenceCell status={row.presence} />,
       sortValue: (row) => promptPresenceSortValue(row.presence),
     },
     {
       key: "engines",
       header: "Engines",
-      width: "7rem",
+      width: "5.5rem",
+      minWidth: "5.5rem",
       sortable: true,
       cell: (row) =>
         row.total === 0 ? (
@@ -373,7 +392,8 @@ export function PromptsTable({
     {
       key: "bestPosition",
       header: "Best",
-      width: "5.5rem",
+      width: "4.5rem",
+      minWidth: "4.5rem",
       sortable: true,
       cell: (row) =>
         row.bestPosition === null ? (

--- a/apps/dashboard/src/constants/design-system-opencode.ts
+++ b/apps/dashboard/src/constants/design-system-opencode.ts
@@ -1,3 +1,5 @@
+import type { OpencodeSource } from "@notra/ui/types/brainless-opencode";
+
 import type {
   OpencodeStoryActivity,
   OpencodeStorySession,
@@ -52,6 +54,44 @@ export const OPENCODE_STORY_SESSION: OpencodeStorySession = {
     { name: "linear", status: "Connected" },
   ],
 };
+
+export const OPENCODE_STORY_SOURCES: OpencodeSource[] = [
+  {
+    title: "ChatGPT",
+    domain: "chatgpt.com",
+    url: "https://chatgpt.com/",
+  },
+  {
+    title: "Claude",
+    domain: "claude.ai",
+    url: "https://claude.ai/",
+  },
+  {
+    title: "Jasper",
+    domain: "jasper.ai",
+    url: "https://www.jasper.ai/",
+  },
+  {
+    title: "Canva",
+    domain: "canva.com",
+    url: "https://www.canva.com/",
+  },
+  {
+    title: "Adobe",
+    domain: "adobe.com",
+    url: "https://www.adobe.com/",
+  },
+  {
+    title: "Descript",
+    domain: "descript.com",
+    url: "https://www.descript.com/",
+  },
+  {
+    title: "Gemini",
+    domain: "support.google.com",
+    url: "https://support.google.com/",
+  },
+];
 
 export const OPENCODE_STORY_ACTIVITIES: OpencodeStoryActivity[] = [
   {

--- a/apps/dashboard/src/utils/geo-chat-skin.test.ts
+++ b/apps/dashboard/src/utils/geo-chat-skin.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { geoChatSkin } from "./geo-chat-skin";
+
+describe("geoChatSkin", () => {
+  test("maps OpenCode engines onto the OpenCode mock instead of ChatGPT", () => {
+    expect(geoChatSkin("opencode/gpt-5.6-sol-medium")).toBe("opencode");
+    expect(geoChatSkin("opencode")).toBe("opencode");
+  });
+
+  test("keeps the existing engine skins", () => {
+    expect(geoChatSkin("anthropic/claude-sonnet-5")).toBe("claude");
+    expect(geoChatSkin("google/gemini-3-flash")).toBe("gemini");
+    expect(geoChatSkin("perplexity/sonar")).toBe("perplexity");
+    expect(geoChatSkin("openai/gpt-5.4")).toBe("chatgpt");
+  });
+});

--- a/apps/dashboard/src/utils/geo-chat-skin.ts
+++ b/apps/dashboard/src/utils/geo-chat-skin.ts
@@ -12,5 +12,8 @@ export function geoChatSkin(engine: string): GeoChatSkin {
   if (key === "perplexity") {
     return "perplexity";
   }
+  if (key === "opencode") {
+    return "opencode";
+  }
   return "chatgpt";
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "test": "bun test src/router"
+    "test": "bun test src/router src/utils/geo-opencode-sources.test.ts"
   },
   "dependencies": {
     "@ai-sdk/gateway": "3.0.132",

--- a/packages/ai/src/constants/geo-opencode.ts
+++ b/packages/ai/src/constants/geo-opencode.ts
@@ -17,7 +17,8 @@ export const GEO_OPENCODE_MILLISECOND_TIMESTAMP_MINIMUM = 1_000_000_000_000;
 export const GEO_OPENCODE_HTTP_URL_PATTERN = /https?:\/\/[^\s<>"'`]+/giu;
 export const GEO_OPENCODE_MARKDOWN_LINK_HREF_PATTERN =
   /\[(?:[^\]]*)\]\((https?:\/\/[^\s)]+)\)/giu;
-export const GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN = /[)*.,;:\]}]+$/u;
+export const GEO_OPENCODE_MARKDOWN_BOLD_AFFIX_PATTERN = /\)\*+$/u;
+export const GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN = /[),.;:\]}]+$/u;
 
 export const GEO_OPENCODE_BOX_API_KEY_ENV = "UPSTASH_BOX_API_KEY";
 export const GEO_OPENCODE_MODEL_API_KEY_ENV = "OPENROUTER_API_KEY";

--- a/packages/ai/src/constants/geo-opencode.ts
+++ b/packages/ai/src/constants/geo-opencode.ts
@@ -15,7 +15,9 @@ export const GEO_OPENCODE_STALE_BOX_AGE_MS = 30 * 60 * 1000;
 export const GEO_OPENCODE_MILLISECONDS_PER_SECOND = 1000;
 export const GEO_OPENCODE_MILLISECOND_TIMESTAMP_MINIMUM = 1_000_000_000_000;
 export const GEO_OPENCODE_HTTP_URL_PATTERN = /https?:\/\/[^\s<>"'`]+/giu;
-export const GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN = /[),.;:\]}]+$/u;
+export const GEO_OPENCODE_MARKDOWN_LINK_HREF_PATTERN =
+  /\[(?:[^\]]*)\]\((https?:\/\/[^\s)]+)\)/giu;
+export const GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN = /[)*.,;:\]}]+$/u;
 
 export const GEO_OPENCODE_BOX_API_KEY_ENV = "UPSTASH_BOX_API_KEY";
 export const GEO_OPENCODE_MODEL_API_KEY_ENV = "OPENROUTER_API_KEY";

--- a/packages/ai/src/utils/geo-opencode-sources.test.ts
+++ b/packages/ai/src/utils/geo-opencode-sources.test.ts
@@ -32,4 +32,21 @@ describe("extractHttpUrls", () => {
       })
     ).toEqual(["https://www.copy.ai/"]);
   });
+
+  test("keeps a trailing asterisk that is part of the URL", () => {
+    expect(extractHttpUrls("https://example.com/search?q=*")).toEqual([
+      "https://example.com/search?q=*",
+    ]);
+  });
+
+  test("preserves first-seen URL order when markdown citations follow a bare URL", () => {
+    const later = Array.from(
+      { length: 20 },
+      (_, index) => `**[source ${index}](https://later.example/${index})**`
+    ).join(" ");
+
+    expect(extractHttpUrls(`https://first.example/ ${later}`)[0]).toBe(
+      "https://first.example/"
+    );
+  });
 });

--- a/packages/ai/src/utils/geo-opencode-sources.test.ts
+++ b/packages/ai/src/utils/geo-opencode-sources.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractHttpUrls } from "./geo-opencode-sources";
+
+describe("extractHttpUrls", () => {
+  test("strips markdown-link closers and bold markers from cited URLs", () => {
+    expect(
+      extractHttpUrls(
+        "**[Anthropic](https://www.anthropic.com/claude)** and **[Jasper](https://www.jasper.ai/)**"
+      )
+    ).toEqual(["https://www.anthropic.com/claude", "https://www.jasper.ai/"]);
+  });
+
+  test("strips leftover )** from a bare URL scrape", () => {
+    expect(extractHttpUrls("https://chatgpt.com/)**")).toEqual([
+      "https://chatgpt.com/",
+    ]);
+  });
+
+  test("keeps ordinary URLs unchanged", () => {
+    expect(
+      extractHttpUrls("See https://writesonic.com/docs for details")
+    ).toEqual(["https://writesonic.com/docs"]);
+  });
+
+  test("walks nested tool payloads", () => {
+    expect(
+      extractHttpUrls({
+        output: {
+          links: ["**[Copy.ai](https://www.copy.ai/)**"],
+        },
+      })
+    ).toEqual(["https://www.copy.ai/"]);
+  });
+});

--- a/packages/ai/src/utils/geo-opencode-sources.ts
+++ b/packages/ai/src/utils/geo-opencode-sources.ts
@@ -1,14 +1,14 @@
 import {
   GEO_OPENCODE_HTTP_URL_PATTERN,
+  GEO_OPENCODE_MARKDOWN_BOLD_AFFIX_PATTERN,
   GEO_OPENCODE_MARKDOWN_LINK_HREF_PATTERN,
   GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN,
 } from "@notra/ai/constants/geo-opencode";
 
 function normalizeHttpUrl(value: string): string | null {
-  const trimmed = value.replace(
-    GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN,
-    ""
-  );
+  const trimmed = value
+    .replace(GEO_OPENCODE_MARKDOWN_BOLD_AFFIX_PATTERN, "")
+    .replace(GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN, "");
   try {
     const url = new URL(trimmed);
     return url.protocol === "http:" || url.protocol === "https:"
@@ -20,14 +20,14 @@ function normalizeHttpUrl(value: string): string | null {
 }
 
 function collectHttpUrlsFromString(value: string, urls: Set<string>): void {
-  for (const match of value.matchAll(GEO_OPENCODE_MARKDOWN_LINK_HREF_PATTERN)) {
-    const url = normalizeHttpUrl(match[1] ?? "");
+  for (const match of value.matchAll(GEO_OPENCODE_HTTP_URL_PATTERN)) {
+    const url = normalizeHttpUrl(match[0]);
     if (url) {
       urls.add(url);
     }
   }
-  for (const match of value.matchAll(GEO_OPENCODE_HTTP_URL_PATTERN)) {
-    const url = normalizeHttpUrl(match[0]);
+  for (const match of value.matchAll(GEO_OPENCODE_MARKDOWN_LINK_HREF_PATTERN)) {
+    const url = normalizeHttpUrl(match[1] ?? "");
     if (url) {
       urls.add(url);
     }

--- a/packages/ai/src/utils/geo-opencode-sources.ts
+++ b/packages/ai/src/utils/geo-opencode-sources.ts
@@ -1,5 +1,6 @@
 import {
   GEO_OPENCODE_HTTP_URL_PATTERN,
+  GEO_OPENCODE_MARKDOWN_LINK_HREF_PATTERN,
   GEO_OPENCODE_TRAILING_URL_PUNCTUATION_PATTERN,
 } from "@notra/ai/constants/geo-opencode";
 
@@ -18,18 +19,28 @@ function normalizeHttpUrl(value: string): string | null {
   }
 }
 
+function collectHttpUrlsFromString(value: string, urls: Set<string>): void {
+  for (const match of value.matchAll(GEO_OPENCODE_MARKDOWN_LINK_HREF_PATTERN)) {
+    const url = normalizeHttpUrl(match[1] ?? "");
+    if (url) {
+      urls.add(url);
+    }
+  }
+  for (const match of value.matchAll(GEO_OPENCODE_HTTP_URL_PATTERN)) {
+    const url = normalizeHttpUrl(match[0]);
+    if (url) {
+      urls.add(url);
+    }
+  }
+}
+
 export function extractHttpUrls(value: unknown): string[] {
   const urls = new Set<string>();
   const visited = new Set<object>();
 
   const visit = (current: unknown): void => {
     if (typeof current === "string") {
-      for (const match of current.matchAll(GEO_OPENCODE_HTTP_URL_PATTERN)) {
-        const url = normalizeHttpUrl(match[0]);
-        if (url) {
-          urls.add(url);
-        }
-      }
+      collectHttpUrlsFromString(current, urls);
       return;
     }
     if (typeof current !== "object" || current === null) {

--- a/packages/geo-core/package.json
+++ b/packages/geo-core/package.json
@@ -13,7 +13,8 @@
     "./csv/*": "./src/csv/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test tests"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.84",

--- a/packages/geo-core/src/constants/geo-sample.ts
+++ b/packages/geo-core/src/constants/geo-sample.ts
@@ -1,6 +1,7 @@
 import type { GeoCheckSource } from "@notra/db/types/geo-checks";
 
 import type { GeoCompetitorSeed } from "../types/geo";
+import { GEO_OPENCODE_ENGINE_ID } from "./geo";
 
 export const GEO_SAMPLE_DAYS = 30;
 export const GEO_SAMPLE_PROJECT_NAME = "Notra demo";
@@ -17,6 +18,7 @@ export const GEO_SAMPLE_ENGINES: readonly {
   { engine: "anthropic/claude-sonnet-4.6", mentionRate: 0.48 },
   { engine: "google/gemini-3-flash-grounded", mentionRate: 0.41 },
   { engine: "google/gemini-3-flash", mentionRate: 0.35 },
+  { engine: GEO_OPENCODE_ENGINE_ID, mentionRate: 0.64 },
 ];
 
 export const GEO_SAMPLE_GROUNDED_ENGINES: readonly string[] = [
@@ -28,6 +30,7 @@ export const GEO_SAMPLE_GROUNDED_ENGINES: readonly string[] = [
 export const GEO_SAMPLE_SEARCH_ENGINES: readonly string[] = [
   ...GEO_SAMPLE_GROUNDED_ENGINES,
   "perplexity-sonar",
+  GEO_OPENCODE_ENGINE_ID,
 ];
 
 export const GEO_SAMPLE_SEARCH_QUERY_SUFFIXES: readonly string[] = [
@@ -41,6 +44,44 @@ export const GEO_SAMPLE_SEARCH_QUERY_MIN = 2;
 export const GEO_SAMPLE_SEARCH_QUERY_MAX = 3;
 export const GEO_SAMPLE_SOURCE_MIN = 2;
 export const GEO_SAMPLE_SOURCE_MAX = 4;
+
+export const GEO_SAMPLE_OPENCODE_SOURCES: readonly GeoCheckSource[] = [
+  {
+    title: "ChatGPT",
+    url: "https://chatgpt.com/",
+    domain: "chatgpt.com",
+  },
+  {
+    title: "Claude",
+    url: "https://claude.ai/",
+    domain: "claude.ai",
+  },
+  {
+    title: "Jasper",
+    url: "https://www.jasper.ai/",
+    domain: "jasper.ai",
+  },
+  {
+    title: "Canva",
+    url: "https://www.canva.com/",
+    domain: "canva.com",
+  },
+  {
+    title: "Adobe",
+    url: "https://www.adobe.com/",
+    domain: "adobe.com",
+  },
+  {
+    title: "Descript",
+    url: "https://www.descript.com/",
+    domain: "descript.com",
+  },
+  {
+    title: "Gemini",
+    url: "https://support.google.com/",
+    domain: "support.google.com",
+  },
+];
 
 export const GEO_SAMPLE_SOURCES: readonly GeoCheckSource[] = [
   {

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -958,6 +958,7 @@ export const AI_TRAFFIC_CONFIDENCE_LABELS: Record<string, string> = {
 };
 
 export const GEO_PRESENCE_LABELS: Record<string, string> = {
+  "training-data": "In model",
   "retrieval-only": `${GEO_SEARCH_LABEL} only`,
   invisible: "Invisible",
 };
@@ -1110,6 +1111,7 @@ export const GEO_CHAT_SKIN_SURFACE: Record<GeoChatSkin, string> = {
   chatgpt: "bg-background",
   gemini: "bg-white dark:bg-[#1f1f1f]",
   perplexity: "bg-white dark:bg-[#111]",
+  opencode: "bg-[#fdfdfd]",
 };
 
 export const GEO_TAB_BREADCRUMB_LABELS: Record<string, string> = {

--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -849,14 +849,7 @@ export const loadGeoPromptResults = Effect.fn("geo.promptResults")(function* (
       competitors: row.competitors,
       excerpt: row.excerpt,
       searchQueries: row.grounding.queries,
-      sources:
-        row.grounding.sources.length > 0
-          ? row.grounding.sources
-          : row.sources.map((source) => ({
-              title: source.title ?? source.url,
-              url: source.url,
-              domain: "",
-            })),
+      sources: geoAnswerSourcesFor(row.grounding, row.sources),
       finishReason: row.finishReason,
       promptTokens: row.promptTokens,
       outputTokens: row.outputTokens,

--- a/packages/geo-core/src/geo/sample-data.ts
+++ b/packages/geo-core/src/geo/sample-data.ts
@@ -18,6 +18,7 @@ import {
 } from "@notra/db/schema";
 import type {
   GeoCheckGrounding,
+  GeoCheckSource,
   GeoCheckWrite,
 } from "@notra/db/types/geo-checks";
 import { insertGeoMentionChecks } from "@notra/db/utils/geo-checks";
@@ -26,6 +27,7 @@ import { Effect } from "effect";
 
 import {
   GEO_EXCERPT_MAX_LENGTH,
+  GEO_OPENCODE_ENGINE_ID,
   GEO_SAMPLE_DATA_ENABLED,
 } from "../constants/geo";
 import {
@@ -35,6 +37,7 @@ import {
   GEO_SAMPLE_ENGINES,
   GEO_SAMPLE_GROUNDED_ENGINES,
   GEO_SAMPLE_LANGUAGES,
+  GEO_SAMPLE_OPENCODE_SOURCES,
   GEO_SAMPLE_PROJECT_NAME,
   GEO_SAMPLE_PROMPTS,
   GEO_SAMPLE_REFERRALS,
@@ -152,16 +155,18 @@ function sampleSearchQueries(seed: string, prompt: string): string[] {
   return queries;
 }
 
-function sampleSources(seed: string): GeoCheckGrounding["sources"] {
+function sampleSources(
+  seed: string,
+  pool: readonly GeoCheckSource[] = GEO_SAMPLE_SOURCES
+): GeoCheckGrounding["sources"] {
   const count = rangeCount(
     `${seed}-sources`,
     GEO_SAMPLE_SOURCE_MIN,
-    GEO_SAMPLE_SOURCE_MAX
+    Math.min(GEO_SAMPLE_SOURCE_MAX, pool.length)
   );
-  const offset = hashInt(`${seed}-source-offset`) % GEO_SAMPLE_SOURCES.length;
+  const offset = hashInt(`${seed}-source-offset`) % pool.length;
   return Array.from({ length: count }, (_, index) => {
-    const source =
-      GEO_SAMPLE_SOURCES[(offset + index) % GEO_SAMPLE_SOURCES.length];
+    const source = pool[(offset + index) % pool.length];
     return source ? { ...source } : null;
   }).filter((source) => source !== null);
 }
@@ -171,6 +176,12 @@ function sampleGrounding(
   engine: string,
   prompt: string
 ): GeoCheckGrounding {
+  if (engine === GEO_OPENCODE_ENGINE_ID) {
+    return {
+      queries: sampleSearchQueries(seed, prompt),
+      sources: [...GEO_SAMPLE_OPENCODE_SOURCES],
+    };
+  }
   if (!GEO_SAMPLE_SEARCH_ENGINES.includes(engine)) {
     return EMPTY_GEO_CHECK_GROUNDING;
   }

--- a/packages/geo-core/src/geo/sequences.ts
+++ b/packages/geo-core/src/geo/sequences.ts
@@ -11,6 +11,7 @@ import type {
   GeoSequencesResponse,
   GeoSequenceUpdateInput,
 } from "../types/geo";
+import { geoAnswerSourcesFor } from "../utils/geo-answer-sources";
 import { geoDb } from "./effect";
 import {
   GeoSequenceCreateFailedError,
@@ -146,14 +147,7 @@ export const loadGeoSequenceResults = Effect.fn("geo.sequenceResults")(
         sentiment: row.sentiment,
         excerpt: row.excerpt,
         searchQueries: row.grounding.queries,
-        sources:
-          row.grounding.sources.length > 0
-            ? row.grounding.sources
-            : row.sources.map((source) => ({
-                title: source.title ?? source.url,
-                url: source.url,
-                domain: "",
-              })),
+        sources: geoAnswerSourcesFor(row.grounding, row.sources),
         finishReason: row.finishReason,
         promptTokens: row.promptTokens,
         outputTokens: row.outputTokens,

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -1081,7 +1081,12 @@ export type EngineIconKey =
   | "agent"
   | "cli";
 
-export type GeoChatSkin = "claude" | "chatgpt" | "gemini" | "perplexity";
+export type GeoChatSkin =
+  | "claude"
+  | "chatgpt"
+  | "gemini"
+  | "perplexity"
+  | "opencode";
 
 export interface EngineIconRule {
   key: EngineIconKey;

--- a/packages/geo-core/src/utils/geo-answer-sources.ts
+++ b/packages/geo-core/src/utils/geo-answer-sources.ts
@@ -1,35 +1,51 @@
 import type { GeoAnswerSource } from "../types/geo";
 import { getReferenceDomain } from "./reference-display";
 
+const CITED_SOURCE_MARKDOWN_AFFIX_PATTERN = /\)?\*+$/u;
+
 export interface GeoStoredAnswerSource {
   url: string;
   title: string | null;
+}
+
+function citedSourceUrl(url: string): string {
+  return url.replace(CITED_SOURCE_MARKDOWN_AFFIX_PATTERN, "");
 }
 
 export function geoAnswerSourcesFor(
   grounding: { sources: readonly GeoAnswerSource[] },
   stored: readonly GeoStoredAnswerSource[]
 ): GeoAnswerSource[] {
-  if (grounding.sources.length > 0) {
-    return grounding.sources.map((source) => ({
-      title: source.title,
-      url: source.url,
-      domain: source.domain,
-    }));
-  }
   const seen = new Set<string>();
   const sources: GeoAnswerSource[] = [];
-  for (const source of stored) {
-    const domain = getReferenceDomain(source.url);
-    if (!domain || seen.has(source.url)) {
-      continue;
+
+  const addSource = (
+    title: string | null,
+    url: string,
+    domain: string | null
+  ): void => {
+    const href = citedSourceUrl(url);
+    const sourceDomain = domain ?? getReferenceDomain(href);
+    if (!sourceDomain || seen.has(href)) {
+      return;
     }
-    seen.add(source.url);
+    seen.add(href);
     sources.push({
-      title: source.title?.trim() || domain,
-      url: source.url,
-      domain,
+      title: title?.trim() || sourceDomain,
+      url: href,
+      domain: sourceDomain,
     });
+  };
+
+  if (grounding.sources.length > 0) {
+    for (const source of grounding.sources) {
+      addSource(source.title, source.url, source.domain);
+    }
+    return sources;
+  }
+
+  for (const source of stored) {
+    addSource(source.title, source.url, null);
   }
   return sources;
 }

--- a/packages/geo-core/src/utils/geo-answer-sources.ts
+++ b/packages/geo-core/src/utils/geo-answer-sources.ts
@@ -1,7 +1,7 @@
 import type { GeoAnswerSource } from "../types/geo";
 import { getReferenceDomain } from "./reference-display";
 
-const CITED_SOURCE_MARKDOWN_AFFIX_PATTERN = /\)?\*+$/u;
+const CITED_SOURCE_MARKDOWN_AFFIX_PATTERN = /\)\*+$/u;
 
 export interface GeoStoredAnswerSource {
   url: string;
@@ -25,15 +25,16 @@ export function geoAnswerSourcesFor(
     domain: string | null
   ): void => {
     const href = citedSourceUrl(url);
-    const sourceDomain = domain ?? getReferenceDomain(href);
-    if (!sourceDomain || seen.has(href)) {
+    if (seen.has(href)) {
       return;
     }
+    const resolvedDomain =
+      domain && domain.length > 0 ? domain : getReferenceDomain(href);
     seen.add(href);
     sources.push({
-      title: title?.trim() || sourceDomain,
+      title: title?.trim() || resolvedDomain || href,
       url: href,
-      domain: sourceDomain,
+      domain: resolvedDomain ?? "",
     });
   };
 

--- a/packages/geo-core/tests/geo-answer-sources.test.ts
+++ b/packages/geo-core/tests/geo-answer-sources.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { geoAnswerSourcesFor } from "../src/utils/geo-answer-sources";
+
+describe("geoAnswerSourcesFor", () => {
+  test("strips markdown leftovers from stored OpenCode source URLs", () => {
+    expect(
+      geoAnswerSourcesFor(
+        {
+          sources: [
+            {
+              title: "anthropic.com",
+              url: "https://www.anthropic.com/claude)**",
+              domain: "anthropic.com",
+            },
+            {
+              title: "jasper.ai",
+              url: "https://www.jasper.ai/)**",
+              domain: "jasper.ai",
+            },
+          ],
+        },
+        []
+      )
+    ).toEqual([
+      {
+        title: "anthropic.com",
+        url: "https://www.anthropic.com/claude",
+        domain: "anthropic.com",
+      },
+      {
+        title: "jasper.ai",
+        url: "https://www.jasper.ai/",
+        domain: "jasper.ai",
+      },
+    ]);
+  });
+
+  test("does not treat a Wikipedia path parenthesis as markdown junk", () => {
+    expect(
+      geoAnswerSourcesFor({ sources: [] }, [
+        {
+          title: null,
+          url: "https://en.wikipedia.org/wiki/Answer_(law)",
+        },
+      ])
+    ).toEqual([
+      {
+        title: "en.wikipedia.org",
+        url: "https://en.wikipedia.org/wiki/Answer_(law)",
+        domain: "en.wikipedia.org",
+      },
+    ]);
+  });
+});

--- a/packages/geo-core/tests/geo-answer-sources.test.ts
+++ b/packages/geo-core/tests/geo-answer-sources.test.ts
@@ -5,23 +5,16 @@ import { geoAnswerSourcesFor } from "../src/utils/geo-answer-sources";
 describe("geoAnswerSourcesFor", () => {
   test("strips markdown leftovers from stored OpenCode source URLs", () => {
     expect(
-      geoAnswerSourcesFor(
+      geoAnswerSourcesFor({ sources: [] }, [
         {
-          sources: [
-            {
-              title: "anthropic.com",
-              url: "https://www.anthropic.com/claude)**",
-              domain: "anthropic.com",
-            },
-            {
-              title: "jasper.ai",
-              url: "https://www.jasper.ai/)**",
-              domain: "jasper.ai",
-            },
-          ],
+          title: "anthropic.com",
+          url: "https://www.anthropic.com/claude)**",
         },
-        []
-      )
+        {
+          title: "jasper.ai",
+          url: "https://www.jasper.ai/)**",
+        },
+      ])
     ).toEqual([
       {
         title: "anthropic.com",
@@ -49,6 +42,63 @@ describe("geoAnswerSourcesFor", () => {
         title: "en.wikipedia.org",
         url: "https://en.wikipedia.org/wiki/Answer_(law)",
         domain: "en.wikipedia.org",
+      },
+    ]);
+  });
+
+  test("keeps a trailing asterisk that is part of the URL", () => {
+    expect(
+      geoAnswerSourcesFor({ sources: [] }, [
+        {
+          title: "Wildcard search",
+          url: "https://example.com/search?q=*",
+        },
+      ])
+    ).toEqual([
+      {
+        title: "Wildcard search",
+        url: "https://example.com/search?q=*",
+        domain: "example.com",
+      },
+    ]);
+  });
+
+  test("keeps grounding sources whose domain cannot be derived", () => {
+    expect(
+      geoAnswerSourcesFor(
+        {
+          sources: [
+            {
+              title: "Internal note",
+              url: "not-a-url",
+              domain: "",
+            },
+          ],
+        },
+        []
+      )
+    ).toEqual([
+      {
+        title: "Internal note",
+        url: "not-a-url",
+        domain: "",
+      },
+    ]);
+  });
+
+  test("keeps stored sources whose URL is not http(s)", () => {
+    expect(
+      geoAnswerSourcesFor({ sources: [] }, [
+        {
+          title: null,
+          url: "/relative/path",
+        },
+      ])
+    ).toEqual([
+      {
+        title: "/relative/path",
+        url: "/relative/path",
+        domain: "",
       },
     ]);
   });

--- a/packages/ui/src/components/brainless/opencode/opencode-message.tsx
+++ b/packages/ui/src/components/brainless/opencode/opencode-message.tsx
@@ -4,6 +4,8 @@ import { cn } from "@notra/ui/lib/utils";
 
 export function OpencodeMessage({
   from = "assistant",
+  search,
+  actions,
   className,
   children,
 }: OpencodeMessageProps) {
@@ -26,11 +28,15 @@ export function OpencodeMessage({
   }
 
   return (
-    <div
-      className={cn("font-mono text-[13px] leading-[1.65]", className)}
-      style={{ color: OPENCODE_COLORS.foreground }}
-    >
-      {children}
+    <div className={cn("flex w-full flex-col items-start gap-3", className)}>
+      {search}
+      <div
+        className="max-w-full font-mono text-[13px] leading-[1.65]"
+        style={{ color: OPENCODE_COLORS.foreground }}
+      >
+        {children}
+      </div>
+      {actions}
     </div>
   );
 }

--- a/packages/ui/src/components/brainless/opencode/opencode-sources.tsx
+++ b/packages/ui/src/components/brainless/opencode/opencode-sources.tsx
@@ -16,7 +16,7 @@ import type {
 import type { CSSProperties } from "react";
 import { useEffect, useState } from "react";
 
-const MARKDOWN_URL_AFFIX_PATTERN = /\)?\*+$/u;
+const MARKDOWN_URL_AFFIX_PATTERN = /\)\*+$/u;
 const EMPTY_QUERIES: readonly string[] = [];
 
 const ENTER_CLASS =
@@ -57,7 +57,7 @@ function SourceRow({
   style?: CSSProperties;
 }) {
   const href = sourceHref(source.url);
-  const urlLabel = source.url ? citedSourceUrl(source.url) : source.domain;
+  const urlLabel = source.url ? citedSourceUrl(source.url) : source.title;
   const row = (
     <>
       <span

--- a/packages/ui/src/components/brainless/opencode/opencode-sources.tsx
+++ b/packages/ui/src/components/brainless/opencode/opencode-sources.tsx
@@ -167,11 +167,11 @@ export function OpencodeSources({
 
   return (
     <div className={cn("flex w-full flex-col gap-2 font-mono", className)}>
-      {visibleQueries.map((query, index) => (
+      {visibleQueries.map((query) => (
         <OpencodeActivity
           className={shouldSequence ? ENTER_CLASS : undefined}
           detail={`query=${query}`}
-          key={`${index}-${query}`}
+          key={query}
           kind="tool"
           label="websearch"
         />

--- a/packages/ui/src/components/brainless/opencode/opencode-sources.tsx
+++ b/packages/ui/src/components/brainless/opencode/opencode-sources.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { OpencodeActivity } from "@notra/ui/components/brainless/opencode/opencode-activity";
+import {
+  OPENCODE_COLORS,
+  OPENCODE_SEARCH_HEADER_MS,
+  OPENCODE_SEARCH_QUERY_MS,
+  OPENCODE_SEARCH_SOURCES_MS,
+  OPENCODE_SEARCH_STAGGER_MS,
+} from "@notra/ui/constants/brainless-opencode";
+import { cn } from "@notra/ui/lib/utils";
+import type {
+  OpencodeSource,
+  OpencodeSourcesProps,
+} from "@notra/ui/types/brainless-opencode";
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
+
+const MARKDOWN_URL_AFFIX_PATTERN = /\)?\*+$/u;
+const EMPTY_QUERIES: readonly string[] = [];
+
+const ENTER_CLASS =
+  "translate-y-0 opacity-100 transition-[opacity,transform] duration-slow ease-emphasized starting:translate-y-1 starting:opacity-0 motion-reduce:transition-none motion-reduce:starting:translate-y-0 motion-reduce:starting:opacity-100";
+
+function citedSourceUrl(url: string): string {
+  return url.replace(MARKDOWN_URL_AFFIX_PATTERN, "");
+}
+
+function sourceHref(url: string | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+  try {
+    const parsed = new URL(citedSourceUrl(url));
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function SourceRow({
+  source,
+  className,
+  style,
+}: {
+  source: OpencodeSource;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const href = sourceHref(source.url);
+  const urlLabel = source.url ? citedSourceUrl(source.url) : source.domain;
+  const row = (
+    <>
+      <span
+        className="min-w-0 truncate"
+        style={{ color: OPENCODE_COLORS.foreground }}
+      >
+        {source.domain}
+      </span>
+      <span
+        className="min-w-0 truncate"
+        style={{ color: OPENCODE_COLORS.muted }}
+      >
+        {urlLabel}
+      </span>
+    </>
+  );
+
+  return (
+    <li className={className} style={style}>
+      {href ? (
+        <a
+          aria-label={`Open ${source.title} on ${source.domain}`}
+          className="grid grid-cols-[minmax(0,9.5rem)_minmax(0,1fr)] items-baseline gap-3 rounded-sm text-[12px] leading-5 outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--opencode-purple)]/60"
+          href={href}
+          rel="noopener noreferrer"
+          style={
+            {
+              color: OPENCODE_COLORS.foreground,
+              "--opencode-purple": OPENCODE_COLORS.purple,
+            } as CSSProperties
+          }
+          target="_blank"
+        >
+          {row}
+        </a>
+      ) : (
+        <p className="grid grid-cols-[minmax(0,9.5rem)_minmax(0,1fr)] items-baseline gap-3 text-[12px] leading-5">
+          {row}
+        </p>
+      )}
+    </li>
+  );
+}
+
+export function OpencodeSources({
+  sources,
+  queries = EMPTY_QUERIES,
+  sequential = false,
+  reducedMotion = false,
+  className,
+}: OpencodeSourcesProps) {
+  const shouldSequence = sequential && !reducedMotion;
+  const [progress, setProgress] = useState({
+    queries: 0,
+    sources: false,
+  });
+
+  const visibleQueryCount = shouldSequence ? progress.queries : queries.length;
+  const showSources = shouldSequence ? progress.sources : sources.length > 0;
+
+  useEffect(() => {
+    if (!shouldSequence) {
+      return;
+    }
+
+    let cancelled = false;
+    setProgress({ queries: 0, sources: false });
+
+    async function run() {
+      await wait(OPENCODE_SEARCH_HEADER_MS);
+      if (cancelled) {
+        return;
+      }
+
+      for (let index = 0; index < queries.length; index += 1) {
+        if (cancelled) {
+          return;
+        }
+        setProgress((current) => ({ ...current, queries: index + 1 }));
+        await wait(OPENCODE_SEARCH_QUERY_MS);
+      }
+
+      if (cancelled || sources.length === 0) {
+        return;
+      }
+
+      await wait(OPENCODE_SEARCH_SOURCES_MS);
+      if (!cancelled) {
+        setProgress((current) => ({ ...current, sources: true }));
+      }
+    }
+
+    run().catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldSequence, queries, sources.length]);
+
+  if (sources.length === 0 && queries.length === 0) {
+    return null;
+  }
+
+  const countLabel =
+    sources.length === 1 ? "1 cited source" : `${sources.length} cited sources`;
+  const visibleQueries = queries.slice(0, visibleQueryCount);
+
+  return (
+    <div className={cn("flex w-full flex-col gap-2 font-mono", className)}>
+      {visibleQueries.map((query, index) => (
+        <OpencodeActivity
+          className={shouldSequence ? ENTER_CLASS : undefined}
+          detail={`query=${query}`}
+          key={`${index}-${query}`}
+          kind="tool"
+          label="websearch"
+        />
+      ))}
+      {showSources ? (
+        <div className="flex flex-col gap-1.5">
+          <p
+            className={cn(
+              "text-[12px] leading-5",
+              shouldSequence && ENTER_CLASS
+            )}
+            style={{ color: OPENCODE_COLORS.muted }}
+          >
+            {countLabel}
+          </p>
+          <ul className="flex flex-col gap-1">
+            {sources.map((source, index) => (
+              <SourceRow
+                className={shouldSequence ? ENTER_CLASS : undefined}
+                key={source.url ?? `${source.domain}-${source.title}`}
+                source={source}
+                style={
+                  shouldSequence
+                    ? {
+                        transitionDelay: `${(index + 1) * OPENCODE_SEARCH_STAGGER_MS}ms`,
+                      }
+                    : undefined
+                }
+              />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/geo/geo-prompt-answer-thread.tsx
+++ b/packages/ui/src/components/geo/geo-prompt-answer-thread.tsx
@@ -214,7 +214,9 @@ function OpencodeAnswerThread({
       <OpencodeMessage from="user">{prompt}</OpencodeMessage>
       <OpencodeMessage
         search={
-          sources.length > 0 ? <OpencodeSources sources={sources} /> : undefined
+          sources.length > 0 ? (
+            <OpencodeSources queries={[prompt]} sources={sources} />
+          ) : undefined
         }
         from="assistant"
       >

--- a/packages/ui/src/components/geo/geo-prompt-answer-thread.tsx
+++ b/packages/ui/src/components/geo/geo-prompt-answer-thread.tsx
@@ -10,6 +10,9 @@ import { ClaudeChatMessage } from "@notra/ui/components/brainless/claude-chat/cl
 import { GeminiActions } from "@notra/ui/components/brainless/gemini/gemini-actions";
 import { GeminiComposer } from "@notra/ui/components/brainless/gemini/gemini-composer";
 import { GeminiMessage } from "@notra/ui/components/brainless/gemini/gemini-message";
+import { OpencodeComposer } from "@notra/ui/components/brainless/opencode/opencode-composer";
+import { OpencodeMessage } from "@notra/ui/components/brainless/opencode/opencode-message";
+import { OpencodeSources } from "@notra/ui/components/brainless/opencode/opencode-sources";
 import { PerplexityActions } from "@notra/ui/components/brainless/perplexity/perplexity-actions";
 import { PerplexityComposer } from "@notra/ui/components/brainless/perplexity/perplexity-composer";
 import { PerplexityMessage } from "@notra/ui/components/brainless/perplexity/perplexity-message";
@@ -37,6 +40,7 @@ const SKIN_SURFACE: Record<GeoChatSkin, string> = {
   chatgpt: "bg-background",
   gemini: "bg-white dark:bg-[#1f1f1f]",
   perplexity: "bg-white dark:bg-[#111]",
+  opencode: "bg-[#fdfdfd]",
 };
 
 function ignoreFollowUp(_text: string): void {
@@ -194,6 +198,36 @@ function PerplexityAnswerThread({
   );
 }
 
+function OpencodeAnswerThread({
+  prompt,
+  excerpt,
+  mentioned,
+}: {
+  prompt: string;
+  excerpt: string;
+  mentioned: boolean;
+}) {
+  const sources = perplexitySourcesFromExcerpt(excerpt);
+
+  return (
+    <>
+      <OpencodeMessage from="user">{prompt}</OpencodeMessage>
+      <OpencodeMessage
+        search={
+          sources.length > 0 ? <OpencodeSources sources={sources} /> : undefined
+        }
+        from="assistant"
+      >
+        <AssistantBody
+          excerpt={excerpt}
+          mentioned={mentioned}
+          skin="opencode"
+        />
+      </OpencodeMessage>
+    </>
+  );
+}
+
 function SkinComposer({ engine, skin }: { engine: string; skin: GeoChatSkin }) {
   if (skin === "claude") {
     return (
@@ -224,6 +258,9 @@ function SkinComposer({ engine, skin }: { engine: string; skin: GeoChatSkin }) {
         placeholder="Ask a follow-up"
       />
     );
+  }
+  if (skin === "opencode") {
+    return <OpencodeComposer placeholder='Ask anything... "Draft a launch post"' />;
   }
   return (
     <ChatgptComposer
@@ -269,6 +306,15 @@ function ThreadMessages({
   if (skin === "perplexity") {
     return (
       <PerplexityAnswerThread
+        excerpt={excerpt}
+        mentioned={mentioned}
+        prompt={prompt}
+      />
+    );
+  }
+  if (skin === "opencode") {
+    return (
+      <OpencodeAnswerThread
         excerpt={excerpt}
         mentioned={mentioned}
         prompt={prompt}

--- a/packages/ui/src/components/geo/presence-badge.tsx
+++ b/packages/ui/src/components/geo/presence-badge.tsx
@@ -5,7 +5,6 @@ import { GEO_PRESENCE_LABELS } from "@notra/ui/constants/geo";
 import type { GeoPresenceStatus, PresenceBadgeProps } from "@notra/ui/types/geo";
 
 const PRESENCE_TITLES: Partial<Record<GeoPresenceStatus, string>> = {
-  "training-data": "Named in the model, not only in live search",
   "retrieval-only": "Mentioned in Search only: found live, not in the model",
   invisible: "No engine mentions you on this prompt yet",
 };

--- a/packages/ui/src/components/geo/presence-badge.tsx
+++ b/packages/ui/src/components/geo/presence-badge.tsx
@@ -5,6 +5,7 @@ import { GEO_PRESENCE_LABELS } from "@notra/ui/constants/geo";
 import type { GeoPresenceStatus, PresenceBadgeProps } from "@notra/ui/types/geo";
 
 const PRESENCE_TITLES: Partial<Record<GeoPresenceStatus, string>> = {
+  "training-data": "Named in the model, not only in live search",
   "retrieval-only": "Mentioned in Search only: found live, not in the model",
   invisible: "No engine mentions you on this prompt yet",
 };

--- a/packages/ui/src/constants/brainless-opencode.ts
+++ b/packages/ui/src/constants/brainless-opencode.ts
@@ -8,3 +8,12 @@ export const OPENCODE_COLORS = {
   orange: "#e48600",
   green: "#00a861",
 } as const;
+
+/** Beat before the first tool line during a replay. */
+export const OPENCODE_SEARCH_HEADER_MS = 140;
+/** Cadence between sequential tool lines. */
+export const OPENCODE_SEARCH_QUERY_MS = 280;
+/** Delay between cited-source rows. */
+export const OPENCODE_SEARCH_STAGGER_MS = 56;
+/** Pause after the last query before the sources block. */
+export const OPENCODE_SEARCH_SOURCES_MS = 160;

--- a/packages/ui/src/constants/geo.ts
+++ b/packages/ui/src/constants/geo.ts
@@ -1,6 +1,7 @@
 export const GEO_SEARCH_LABEL = "Search";
 
 export const GEO_PRESENCE_LABELS: Record<string, string> = {
+  "training-data": "In model",
   "retrieval-only": `${GEO_SEARCH_LABEL} only`,
   invisible: "Invisible",
 };

--- a/packages/ui/src/lib/geo-answer-font.ts
+++ b/packages/ui/src/lib/geo-answer-font.ts
@@ -6,8 +6,17 @@ const CLAUDE_MARKDOWN_FONT =
 const SANS_MARKDOWN_FONT =
   "font-sans [&_h1]:font-sans [&_h2]:font-sans [&_h3]:font-sans [&_p]:font-sans [&_li]:font-sans";
 
+const OPENCODE_MARKDOWN_FONT =
+  "font-mono text-[13px] leading-[1.65] [&_h1]:font-mono [&_h2]:font-mono [&_h3]:font-mono [&_p]:font-mono [&_li]:font-mono";
+
 export function geoAnswerMarkdownFontClass(skin: GeoChatSkin): string {
-  return skin === "claude" ? CLAUDE_MARKDOWN_FONT : SANS_MARKDOWN_FONT;
+  if (skin === "claude") {
+    return CLAUDE_MARKDOWN_FONT;
+  }
+  if (skin === "opencode") {
+    return OPENCODE_MARKDOWN_FONT;
+  }
+  return SANS_MARKDOWN_FONT;
 }
 
 export function geoAnswerEmptyClassName(skin: GeoChatSkin): string {
@@ -16,6 +25,9 @@ export function geoAnswerEmptyClassName(skin: GeoChatSkin): string {
   }
   if (skin === "perplexity") {
     return "font-sans text-[17.5px] leading-[1.75]";
+  }
+  if (skin === "opencode") {
+    return "font-mono text-[13px] leading-[1.65]";
   }
   return "text-[15px] leading-7";
 }
@@ -26,6 +38,9 @@ export function geoAnswerThinkingClassName(skin: GeoChatSkin): string {
   }
   if (skin === "perplexity") {
     return "font-sans text-[17.5px]";
+  }
+  if (skin === "opencode") {
+    return "font-mono text-[13px]";
   }
   return "text-[15px]";
 }

--- a/packages/ui/src/lib/geo-chat-skin.ts
+++ b/packages/ui/src/lib/geo-chat-skin.ts
@@ -12,5 +12,8 @@ export function geoChatSkin(engine: string): GeoChatSkin {
   if (key === "perplexity") {
     return "perplexity";
   }
+  if (key === "opencode") {
+    return "opencode";
+  }
   return "chatgpt";
 }

--- a/packages/ui/src/types/brainless-opencode.ts
+++ b/packages/ui/src/types/brainless-opencode.ts
@@ -33,6 +33,8 @@ export interface OpencodeLogoProps {
 
 export interface OpencodeMessageProps {
   from?: "user" | "assistant";
+  search?: React.ReactNode;
+  actions?: React.ReactNode;
   className?: string;
   children: React.ReactNode;
 }
@@ -52,5 +54,19 @@ export interface OpencodeSidebarProps {
   servers?: OpencodeMcpServer[];
   cwd?: string;
   version?: string;
+  className?: string;
+}
+
+export interface OpencodeSource {
+  title: string;
+  domain: string;
+  url?: string;
+}
+
+export interface OpencodeSourcesProps {
+  sources: readonly OpencodeSource[];
+  queries?: readonly string[];
+  sequential?: boolean;
+  reducedMotion?: boolean;
   className?: string;
 }

--- a/packages/ui/src/types/geo.ts
+++ b/packages/ui/src/types/geo.ts
@@ -88,7 +88,12 @@ export interface ParsedModelId {
   slug: string;
 }
 
-export type GeoChatSkin = "claude" | "chatgpt" | "gemini" | "perplexity";
+export type GeoChatSkin =
+  | "claude"
+  | "chatgpt"
+  | "gemini"
+  | "perplexity"
+  | "opencode";
 
 export interface GeoAnswerResult {
   engine: string;


### PR DESCRIPTION
### Description
OpenCode GEO answers were falling back to ChatGPT chrome, markdown-bold citations left `)**` on source URLs, and replay dumped every tool line at once.

This PR maps OpenCode to its own TUI skin, strips leftover markdown from cited URLs, and staggers tool queries then sources during replay (with reduced-motion as an instant path).

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenCode GEO answers no longer fall back to ChatGPT chrome: they render in the OpenCode TUI skin, and replay staggers search queries then cited sources instead of showing every tool line at once.

**New Features**
- The OpenCode skin is now wired into the composer and design-system catalog.
- New `OpencodeSources` component renders query tool lines and cited sources; only the current replay turn staggers, and reduced-motion skips the animation.
- OpenCode search appears during the thinking stage, while other skins keep waiting for the answer.

**Bug Fixes**
- Source cleanup strips only the `)**` bold leftover, so URLs ending in `*` or containing parentheses stay intact.
- Sources without a resolvable domain now show the URL as their title instead of being dropped.
- URL extraction handles markdown links and nested tool payloads.
- Replay falls back to the prompt as the search query when OpenCode results record none.
- Prompts table labels `training-data` as "In model", uses plain text for intent and presence, and tightens column widths.

<sup>Written for commit ea2bfa41f6295aaa2041e5fc58df0d992b1ffb50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

