### PR TITLE
fix(content): show queued prompts in the content agent composer

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/content/[id]/page-client.tsx
@@ -64,7 +64,7 @@ import remend from "remend";
 import { toast } from "sonner";
 
 import ChatInput from "@/components/chat-input";
-import { ChatQueue, type QueuedMessage } from "@/components/chat/chat-queue";
+import type { QueuedMessage } from "@/components/chat/chat-queue";
 import { getContentTypeLabel } from "@/components/content/content-card";
 import { ContentChatActivityPanel } from "@/components/content/content-chat-activity-panel";
 import { ContentPlanView } from "@/components/content/content-plan-view";
@@ -1162,13 +1162,7 @@ export default function PageClient({
 
   const renderChatComposer = () => (
     <>
-      <ChatQueue
-        messages={queuedMessages}
-        onEdit={handleEditQueued}
-        onRemove={handleRemoveQueued}
-      />
       <ChatInput
-        connectedTop={queuedMessages.length > 0}
         context={context}
         disabled={isChatDisabled}
         error={chatError}
@@ -1176,7 +1170,9 @@ export default function PageClient({
         onAddContext={handleAddContext}
         onClearError={() => setChatError(null)}
         onClearSelection={clearSelection}
+        onEditQueued={handleEditQueued}
         onRemoveContext={handleRemoveContext}
+        onRemoveQueued={handleRemoveQueued}
         onSend={handleAiEdit}
         onStop={handleStop}
         onValueChange={setChatInputValue}
@@ -1187,6 +1183,7 @@ export default function PageClient({
             ? CONTENT_PLAN_CHAT_PLACEHOLDER
             : undefined
         }
+        queuedMessages={queuedMessages}
         selection={selection}
         value={chatInputValue}
       />

--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -79,6 +79,9 @@ const ChatInput = ({
   onClearError,
   connectedTop = false,
   placeholder,
+  queuedMessages = [],
+  onEditQueued,
+  onRemoveQueued,
 }: ChatInputProps) => {
   const contextPickerId = useId();
   const [isFocused, setIsFocused] = useState(false);
@@ -288,7 +291,9 @@ const ChatInput = ({
   if (isInputLocked) {
     contextPickerDisabledReason = "Context is unavailable right now.";
   }
-  const hasContextChips = context.length > 0 || Boolean(selection);
+  const hasQueuedChips = queuedMessages.length > 0;
+  const hasContextChips =
+    context.length > 0 || Boolean(selection) || hasQueuedChips;
   const showComposerNudge =
     hasContextChips || shouldShowLowCredits || Boolean(usageLimitError);
   let sendTooltip = "Enter to send. Shift+Enter for a new line.";
@@ -333,6 +338,24 @@ const ChatInput = ({
           >
             {hasContextChips ? (
               <>
+                {queuedMessages.map((message) => (
+                  <Composer.Chip
+                    className="hover:border-border hover:bg-background w-full border-solid border-transparent bg-transparent transition-colors"
+                    editLabel="Edit queued message"
+                    key={message.id}
+                    label={message.text}
+                    labelClassName="min-w-0 flex-1 max-w-none"
+                    onEdit={
+                      onEditQueued ? () => onEditQueued(message) : undefined
+                    }
+                    onRemove={
+                      onRemoveQueued
+                        ? () => onRemoveQueued(message.id)
+                        : undefined
+                    }
+                    removeLabel="Remove from queue"
+                  />
+                ))}
                 <ChatInputContextRow
                   context={context}
                   onClearSelection={onClearSelection}

--- a/apps/dashboard/src/components/chat/chat-queue.tsx
+++ b/apps/dashboard/src/components/chat/chat-queue.tsx
@@ -2,7 +2,7 @@
 
 import type { ContextItem, TextSelection } from "@notra/ai/types/chat";
 import { SPRING } from "@notra/ui/lib/motion";
-import { AnimatePresence, m, useReducedMotion } from "motion/react";
+import { AnimatePresence, LazyMotion, m, useReducedMotion } from "motion/react";
 
 import { MessageAuthorAvatar } from "@/components/chat/message-author-avatar";
 import { Composer } from "@/components/composer/composer-shell";
@@ -26,6 +26,12 @@ interface ChatQueueProps {
 }
 
 const INSTANT = { duration: 0 } as const;
+// `m.*` components only animate once motion features are loaded. Loading
+// them here keeps the queue working in hosts without their own LazyMotion
+// boundary.
+const loadMotionFeatures = () =>
+  import("@/lib/motion-features").then((mod) => mod.default);
+
 export function ChatQueue({
   messages,
   onEdit,
@@ -39,52 +45,54 @@ export function ChatQueue({
   const itemTransition = reduceMotion ? INSTANT : SPRING.snappy;
 
   return (
-    <AnimatePresence initial={false}>
-      {hasMessages && (
-        <m.div
-          animate={{ height: "auto", opacity: 1, y: 0 }}
-          aria-label="Queued messages"
-          className="border-border bg-muted overflow-hidden rounded-t-[14px] border border-b-0 px-2.5 pt-1.5 pb-1"
-          exit={{ height: 0, opacity: 0, y: 12 }}
-          initial={{ height: 0, opacity: 0, y: 12 }}
-          transition={containerTransition}
-        >
-          <div className="flex flex-wrap items-center gap-1.5">
-            <AnimatePresence initial={false}>
-              {messages.map((message) => (
-                <m.div
-                  animate={{ opacity: 1, scale: 1 }}
-                  className="max-w-full"
-                  exit={{ opacity: 0, scale: 0.96 }}
-                  initial={{ opacity: 0, scale: 0.96 }}
-                  key={message.id}
-                  layout={!reduceMotion}
-                  transition={itemTransition}
-                >
-                  <Composer.Chip
-                    editLabel="Edit queued message"
-                    icon={
-                      showAuthorAvatars && message.authorUserId ? (
-                        <MessageAuthorAvatar
-                          author={
-                            authorsById?.get(message.authorUserId) ??
-                            unknownChatMessageAuthor(message.authorUserId)
-                          }
-                          size="sm"
-                        />
-                      ) : undefined
-                    }
-                    label={message.text}
-                    onEdit={() => onEdit(message)}
-                    onRemove={() => onRemove(message.id)}
-                    removeLabel="Remove from queue"
-                  />
-                </m.div>
-              ))}
-            </AnimatePresence>
-          </div>
-        </m.div>
-      )}
-    </AnimatePresence>
+    <LazyMotion features={loadMotionFeatures} strict>
+      <AnimatePresence initial={false}>
+        {hasMessages && (
+          <m.div
+            animate={{ height: "auto", opacity: 1, y: 0 }}
+            aria-label="Queued messages"
+            className="border-border bg-muted overflow-hidden rounded-t-[14px] border border-b-0 px-2.5 pt-1.5 pb-1"
+            exit={{ height: 0, opacity: 0, y: 12 }}
+            initial={{ height: 0, opacity: 0, y: 12 }}
+            transition={containerTransition}
+          >
+            <div className="flex flex-wrap items-center gap-1.5">
+              <AnimatePresence initial={false}>
+                {messages.map((message) => (
+                  <m.div
+                    animate={{ opacity: 1, scale: 1 }}
+                    className="max-w-full"
+                    exit={{ opacity: 0, scale: 0.96 }}
+                    initial={{ opacity: 0, scale: 0.96 }}
+                    key={message.id}
+                    layout={!reduceMotion}
+                    transition={itemTransition}
+                  >
+                    <Composer.Chip
+                      editLabel="Edit queued message"
+                      icon={
+                        showAuthorAvatars && message.authorUserId ? (
+                          <MessageAuthorAvatar
+                            author={
+                              authorsById?.get(message.authorUserId) ??
+                              unknownChatMessageAuthor(message.authorUserId)
+                            }
+                            size="sm"
+                          />
+                        ) : undefined
+                      }
+                      label={message.text}
+                      onEdit={() => onEdit(message)}
+                      onRemove={() => onRemove(message.id)}
+                      removeLabel="Remove from queue"
+                    />
+                  </m.div>
+                ))}
+              </AnimatePresence>
+            </div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </LazyMotion>
   );
 }

--- a/apps/dashboard/src/components/composer/composer-shell.tsx
+++ b/apps/dashboard/src/components/composer/composer-shell.tsx
@@ -101,12 +101,17 @@ function ComposerChip({
   editLabel,
   onClick,
   pending = false,
+  className,
+  labelClassName,
 }: ComposerChipProps) {
+  const labelClasses = cn("max-w-[12rem] truncate", labelClassName);
+
   return (
     <span
       className={cn(
         "border-foreground/25 bg-background text-foreground inline-flex max-w-full items-center gap-1.5 rounded-md border border-dashed py-1 pr-1 pl-1.5 text-xs",
-        pending ? "border-foreground/15 text-muted-foreground" : null
+        pending ? "border-foreground/15 text-muted-foreground" : null,
+        className
       )}
     >
       {onClick ? (
@@ -117,12 +122,12 @@ function ComposerChip({
           type="button"
         >
           {icon}
-          <span className="max-w-[12rem] truncate">{label}</span>
+          <span className={labelClasses}>{label}</span>
         </button>
       ) : (
         <>
           {icon}
-          <span className="max-w-[12rem] truncate">{label}</span>
+          <span className={labelClasses}>{label}</span>
         </>
       )}
       {onEdit ? (

--- a/apps/dashboard/src/types/components/chat-input.ts
+++ b/apps/dashboard/src/types/components/chat-input.ts
@@ -4,6 +4,7 @@ import type {
   TextSelection,
 } from "@notra/ai/types/chat";
 
+import type { QueuedMessage } from "@/components/chat/chat-queue";
 import type { GitHubRepository } from "@/types/integrations";
 
 export type ChatModelProvider = "anthropic" | "openai" | "auto";
@@ -35,6 +36,9 @@ export interface ChatInputProps {
   onClearError?: () => void;
   connectedTop?: boolean;
   placeholder?: string;
+  queuedMessages?: QueuedMessage[];
+  onEditQueued?: (message: QueuedMessage) => void;
+  onRemoveQueued?: (id: string) => void;
 }
 
 export type EnabledRepo = GitHubRepository & { integrationId: string };

--- a/apps/dashboard/src/types/components/composer.ts
+++ b/apps/dashboard/src/types/components/composer.ts
@@ -22,6 +22,8 @@ export interface ComposerChipProps {
   editLabel?: string;
   onClick?: () => void;
   pending?: boolean;
+  className?: string;
+  labelClassName?: string;
 }
 
 export interface ComposerToolbarProps {


### PR DESCRIPTION
Queuing a message in the content agent panel while the agent was running made the prompt disappear: it was stored, but never shown, so it looked like it had been lost.

The queue's animated wrapper needs Motion's LazyMotion features to animate in, and the content page never provided them, so the queue stayed collapsed at zero height and zero opacity. `ChatQueue` now loads the features itself. Queued prompts in the content agent are rendered inside the composer's top area, like mention and context chips, as full-width rows that only show an outline on hover.

## Notes
- The chat page keeps its existing queue strip unchanged; it already provided LazyMotion, so the fix is a no-op there.
- `Composer.Chip` gained optional `className` / `labelClassName` props so the queued rows can stretch to full width without changing the compact context chips.
- Verified in the dev server with a mocked streaming response: second message is queued and visible, and is sent automatically once the first response finishes.
- Typecheck, oxlint and oxfmt pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes queued prompts in the content agent composer being invisible: they were stored but never rendered, so they appeared lost. The queue's animated wrapper requires Motion's LazyMotion features, which the content page never provided, so the queue stayed collapsed at zero height and opacity. `ChatQueue` now loads the features itself, and queued prompts render inside the composer's top area as full-width rows that only show an outline on hover.

**Notes**
- The chat page keeps its existing queue strip unchanged; it already provided LazyMotion.
- `Composer.Chip` gained optional `className` / `labelClassName` props so queued rows can stretch full width without changing the compact context chips.

<sup>Written for commit 94a507db8833a91187d5d657519216b386199d79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

