### PR TITLE
fix(dashboard): add missing loading states

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/references-list.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/references-list.tsx
@@ -2,6 +2,7 @@
 
 import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -33,7 +34,7 @@ export function ReferencesList({
   dialogOpen,
   onDialogOpenChange,
 }: ReferencesListProps) {
-  const { data } = useReferences(organizationId, voiceId);
+  const { data, isPending } = useReferences(organizationId, voiceId);
   const deleteMutation = useDeleteReference(organizationId, voiceId);
   const updateMutation = useUpdateReference(organizationId, voiceId);
   const searchParams = useSearchParams();
@@ -110,7 +111,15 @@ export function ReferencesList({
 
   return (
     <div className="space-y-4">
-      {references.length === 0 ? (
+      {isPending ? (
+        <div role="status">
+          <span className="sr-only">Loading references</span>
+          <div aria-hidden="true" className="grid gap-4 sm:grid-cols-2">
+            <Skeleton className="h-48 w-full rounded-xl" />
+            <Skeleton className="h-48 w-full rounded-xl" />
+          </div>
+        </div>
+      ) : references.length === 0 ? (
         <EmptyState
           actionIcon={<HugeiconsIcon className="size-4" icon={Add01Icon} />}
           actionLabel="Add Reference"

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/@modal/(.)competitors/[competitor]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/@modal/(.)competitors/[competitor]/page.tsx
@@ -5,6 +5,7 @@ import { Suspense } from "react";
 
 import { CompetitorDetailView } from "@/components/geo/competitor-detail-view";
 import { CompetitorModal } from "@/components/geo/competitor-modal";
+import { StatusSpinner } from "@/components/geo/status-spinner";
 
 function PageContent() {
   const { slug, competitor } = useParams<{
@@ -22,7 +23,19 @@ function PageContent() {
 
 export default function Page() {
   return (
-    <Suspense fallback={null}>
+    <Suspense
+      fallback={
+        <CompetitorModal title="Competitor">
+          <div
+            className="flex items-center justify-center gap-2 py-12"
+            role="status"
+          >
+            <StatusSpinner />
+            <span>Loading competitor</span>
+          </div>
+        </CompetitorModal>
+      }
+    >
       <PageContent />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/[competitor]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/competitors/[competitor]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 
 import { CompetitorDetailView } from "@/components/geo/competitor-detail-view";
+import { StatusSpinner } from "@/components/geo/status-spinner";
 import { PageContainer } from "@/components/layout/container";
 
 export const metadata: Metadata = {
@@ -34,7 +35,17 @@ function Page({
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="w-full px-4 lg:px-6">
-        <Suspense fallback={null}>
+        <Suspense
+          fallback={
+            <div
+              className="flex items-center justify-center gap-2 py-12"
+              role="status"
+            >
+              <StatusSpinner />
+              <span>Loading competitor</span>
+            </div>
+          }
+        >
           <PageContent params={params} />
         </Suspense>
       </div>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/success/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/success/page.tsx
@@ -4,6 +4,7 @@ import { Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Confetti } from "@neoconfetti/react";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { cn } from "@notra/ui/lib/utils";
 import { useCustomer } from "autumn-js/react";
 import Link from "next/link";
@@ -125,7 +126,20 @@ function BillingSuccessPageContent() {
 
 export default function BillingSuccessPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense
+      fallback={
+        <div
+          className="flex flex-1 flex-col items-center justify-center gap-6 px-4"
+          role="status"
+        >
+          <span className="sr-only">Loading billing confirmation</span>
+          <Skeleton aria-hidden="true" className="size-12 rounded-full" />
+          <Skeleton aria-hidden="true" className="h-10 w-full max-w-sm" />
+          <Skeleton aria-hidden="true" className="h-12 w-full max-w-md" />
+          <Skeleton aria-hidden="true" className="h-11 w-64" />
+        </div>
+      }
+    >
       <BillingSuccessPageContent />
     </Suspense>
   );


### PR DESCRIPTION
### Description
Adds missing loading states across the dashboard:

- Show skeletons while brand references load instead of prematurely displaying “No references yet”.
- Replace blank Suspense fallbacks on competitor detail pages and modals with a visible loading indicator.
- Add a skeleton fallback to the billing confirmation page.
- Include accessible status announcements for loading states.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing loading states across the dashboard so users get feedback instead of blank screens or premature empty states.

- Shows skeleton placeholders while brand references load, replacing the premature “No references yet” state.
- Replaces blank Suspense fallbacks on competitor detail pages and modals with a visible loading spinner.
- Adds a skeleton fallback to the billing confirmation page.
- Includes accessible status announcements for all new loading states.

<sup>Written for commit 48ad5f7f02b7eee7e5cf99cff3cf005646ca0225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

