### PR TITLE
fix(web): refresh shared UI sources for OpenCode components

### DIFF
--- a/apps/web/src/styles/ui-sources.css
+++ b/apps/web/src/styles/ui-sources.css
@@ -17,6 +17,10 @@
 @source "../../../../packages/ui/src/components/brainless/gemini/gemini-composer.tsx";
 @source "../../../../packages/ui/src/components/brainless/gemini/gemini-message.tsx";
 @source "../../../../packages/ui/src/components/brainless/gemini/gemini-model-selector.tsx";
+@source "../../../../packages/ui/src/components/brainless/opencode/opencode-activity.tsx";
+@source "../../../../packages/ui/src/components/brainless/opencode/opencode-composer.tsx";
+@source "../../../../packages/ui/src/components/brainless/opencode/opencode-message.tsx";
+@source "../../../../packages/ui/src/components/brainless/opencode/opencode-sources.tsx";
 @source "../../../../packages/ui/src/components/brainless/perplexity/perplexity-actions.tsx";
 @source "../../../../packages/ui/src/components/brainless/perplexity/perplexity-composer.tsx";
 @source "../../../../packages/ui/src/components/brainless/perplexity/perplexity-favicon.tsx";
@@ -134,6 +138,7 @@
 @source "../../../../packages/ui/src/components/ui/textarea.tsx";
 @source "../../../../packages/ui/src/components/ui/title-card.tsx";
 @source "../../../../packages/ui/src/components/ui/tooltip.tsx";
+@source "../../../../packages/ui/src/constants/brainless-opencode.ts";
 @source "../../../../packages/ui/src/constants/chatgpt-models.ts";
 @source "../../../../packages/ui/src/constants/claude-chat-models.ts";
 @source "../../../../packages/ui/src/constants/command-tabs.ts";
@@ -156,6 +161,7 @@
 @source "../../../../packages/ui/src/lib/motion.ts";
 @source "../../../../packages/ui/src/lib/perplexity-model.ts";
 @source "../../../../packages/ui/src/lib/utils.ts";
+@source "../../../../packages/ui/src/types/brainless-opencode.ts";
 @source "../../../../packages/ui/src/types/chatgpt.ts";
 @source "../../../../packages/ui/src/types/claude-chat.ts";
 @source "../../../../packages/ui/src/types/gemini.ts";


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode component and constant sources to the Tailwind CSS scanner so their styles are included in the web app build.

<sup>Written for commit 38fe40fab5446cab1a43c154bf3fbec3545e28af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

