### PR TITLE
fix(dashboard): exclude generated workflow bundles from Knip

### DIFF
--- a/apps/dashboard/.gitignore
+++ b/apps/dashboard/.gitignore
@@ -3,3 +3,6 @@
 
 certificates
 .vercel
+
+# Generated Workflow SDK route bundles
+/src/app/.well-known/workflow/


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Excludes generated Workflow SDK route bundles from Knip so they no longer get flagged as unused files.

<sup>Written for commit ad3fc9a47197bc9b91a76b7352f3e0ad033cb088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

