### PR TITLE
refactor(dashboard): switch schedules page to shared dual-tone table

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/page-client.tsx
@@ -2,9 +2,6 @@
 
 import {
   Add01Icon,
-  ArrowDown01Icon,
-  ArrowUp01Icon,
-  ArrowUpDownIcon,
   Delete02Icon,
   Edit02Icon,
   MoreVerticalIcon,
@@ -24,6 +21,7 @@ import {
   ResponsiveAlertDialogHeader,
   ResponsiveAlertDialogTitle,
 } from "@notra/ui/components/shared/responsive-alert-dialog";
+import { TruncateWithTooltip } from "@notra/ui/components/shared/truncate-with-tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,14 +30,6 @@ import {
   DropdownMenuTrigger,
 } from "@notra/ui/components/ui/dropdown-menu";
 import { Kbd } from "@notra/ui/components/ui/kbd";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@notra/ui/components/ui/table";
 import {
   Tabs,
   TabsContent,
@@ -66,6 +56,7 @@ import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
 import { EmptyStateTablePreview } from "@/components/empty-state-preview";
 import { PageContainer } from "@/components/layout/container";
+import { Table, type TableColumn } from "@/components/motion/table";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   EMPTY_STATE_TABLE_COLUMNS,
@@ -75,7 +66,9 @@ import { useCreateFromSuggestion } from "@/lib/hooks/use-onboarding";
 import { dashboardOrpc } from "@/lib/orpc/query";
 import type { BrandSettings } from "@/types/hooks/brand-analysis";
 import type { Trigger } from "@/types/triggers/triggers";
+import { formatRelative } from "@/utils/format-relative";
 import { getOutputTypeLabel, OutputTypeIcon } from "@/utils/output-types";
+import { tableHeightFor } from "@/utils/table";
 
 import { SchedulePageSkeleton } from "./skeleton";
 
@@ -97,14 +90,6 @@ function formatFrequency(cron?: Trigger["sourceConfig"]["cron"]) {
   return `Daily @ ${time}`;
 }
 
-function formatDate(dateString: string) {
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date(dateString));
-}
-
 function normalizeIntegrationError(error: unknown): Error {
   const errorWithCode = error as Error & { code?: string };
   if (
@@ -119,16 +104,6 @@ function normalizeIntegrationError(error: unknown): Error {
     return integrationError;
   }
   return error instanceof Error ? error : new Error(String(error));
-}
-
-function getSortIcon(isSorted: false | "asc" | "desc") {
-  if (isSorted === "asc") {
-    return ArrowUp01Icon;
-  }
-  if (isSorted === "desc") {
-    return ArrowDown01Icon;
-  }
-  return ArrowUpDownIcon;
 }
 
 interface PageClientProps {
@@ -653,6 +628,8 @@ export default function PageClient({ organizationSlug }: PageClientProps) {
   );
 }
 
+const SCHEDULE_TABLE_ROW_HEIGHT = 48;
+
 function ScheduleTable({
   triggers,
   repositoryMap,
@@ -686,166 +663,176 @@ function ScheduleTable({
   updatingTriggerId?: string;
   runningTriggerId?: string;
 }) {
-  const sortedTriggers = (() => {
-    if (createdSortOrder === false) {
-      return triggers;
-    }
-    return [...triggers].sort((a, b) => {
-      const createdAtA = new Date(a.createdAt).getTime();
-      const createdAtB = new Date(b.createdAt).getTime();
+  const columns: TableColumn<Trigger>[] = [
+    {
+      key: "name",
+      header: "Name",
+      width: "1fr",
+      minWidth: "4rem",
+      cell: (trigger) => (
+        <TruncateWithTooltip className="text-sm font-medium">
+          {trigger.name ?? "Untitled Schedule"}
+        </TruncateWithTooltip>
+      ),
+    },
+    {
+      key: "schedule",
+      header: "Schedule",
+      width: "10rem",
+      cell: (trigger) => (
+        <TruncateWithTooltip className="text-muted-foreground">
+          {formatFrequency(trigger.sourceConfig.cron)}
+        </TruncateWithTooltip>
+      ),
+    },
+    {
+      key: "identity",
+      header: "Identity",
+      width: "5.5rem",
+      cell: (trigger) => {
+        const explicitBrandVoiceId = trigger.outputConfig?.brandVoiceId;
+        const brandVoice = explicitBrandVoiceId
+          ? brandVoiceMap[explicitBrandVoiceId]
+          : defaultBrandVoice;
+        return (
+          <span className="text-muted-foreground">
+            <BrandVoiceCell
+              isDefault={!explicitBrandVoiceId}
+              voice={brandVoice}
+            />
+          </span>
+        );
+      },
+    },
+    {
+      key: "output",
+      header: "Output",
+      width: "8.5rem",
+      cell: (trigger) => (
+        <span className="text-muted-foreground flex items-center gap-1.5 capitalize">
+          <OutputTypeIcon
+            className="size-3.5"
+            outputType={trigger.outputType}
+          />
+          {getOutputTypeLabel(trigger.outputType)}
+        </span>
+      ),
+    },
+    {
+      key: "sources",
+      header: "Sources",
+      width: "5.5rem",
+      cell: (trigger) => (
+        <span className="text-muted-foreground">
+          <SourcesCell
+            repositoryIds={trigger.targets.repositoryIds}
+            repositoryMap={repositoryMap}
+          />
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      width: "5rem",
+      cell: (trigger) => <TriggerStatusBadge enabled={trigger.enabled} />,
+    },
+    {
+      key: "createdAt",
+      header: "Created",
+      sortable: true,
+      sortValue: (trigger) => new Date(trigger.createdAt).getTime(),
+      width: "6.5rem",
+      cell: (trigger) => (
+        <span className="text-muted-foreground whitespace-nowrap tabular-nums">
+          {formatRelative(trigger.createdAt)}
+        </span>
+      ),
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      width: "3.5rem",
+      minWidth: "3.5rem",
+      cell: (trigger) => {
+        const isThisUpdating = isUpdating && updatingTriggerId === trigger.id;
+        const isThisRunning = isRunning && runningTriggerId === trigger.id;
 
-      return createdSortOrder === "desc"
-        ? createdAtB - createdAtA
-        : createdAtA - createdAtB;
-    });
-  })();
-
-  const sortIcon = getSortIcon(createdSortOrder);
-
-  if (triggers.length === 0) {
-    return (
-      <div className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
-        No schedules in this category.
-      </div>
-    );
-  }
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  aria-label={`Actions for ${trigger.name ?? "schedule"}`}
+                  disabled={isThisUpdating || isThisRunning}
+                  size="icon"
+                  variant="ghost"
+                >
+                  {isThisUpdating || isThisRunning ? (
+                    <Loader2Icon className="size-4 animate-spin" />
+                  ) : (
+                    <HugeiconsIcon
+                      className="text-muted-foreground size-4"
+                      icon={MoreVerticalIcon}
+                    />
+                  )}
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onEdit(trigger)}>
+                <HugeiconsIcon className="size-4" icon={Edit02Icon} />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={isRunning || !trigger.enabled}
+                onClick={() => onRunNow(trigger.id)}
+              >
+                <HugeiconsIcon className="size-4" icon={PlayCircleIcon} />
+                Run now
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={isUpdating}
+                onClick={() => onToggle(trigger)}
+              >
+                <HugeiconsIcon
+                  className="size-4"
+                  icon={trigger.enabled ? PauseIcon : PlayIcon}
+                />
+                {trigger.enabled ? "Pause" : "Enable"}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={isDeleting}
+                onClick={() => onDelete(trigger.id)}
+                variant="destructive"
+              >
+                <HugeiconsIcon className="size-4" icon={Delete02Icon} />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        );
+      },
+    },
+  ];
 
   return (
-    <div className="border-border/80 border-b-border/40 bg-muted/80 overflow-hidden rounded-lg border shadow-2xs">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Schedule</TableHead>
-            <TableHead>Identity</TableHead>
-            <TableHead>Output</TableHead>
-            <TableHead>Sources</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>
-              <Button
-                className="-ml-4"
-                onClick={() =>
-                  onSortCreatedChange(
-                    createdSortOrder === "asc" ? "desc" : "asc"
-                  )
-                }
-                variant="ghost"
-              >
-                Created At
-                <HugeiconsIcon className="ml-2 size-4" icon={sortIcon} />
-              </Button>
-            </TableHead>
-            <TableHead className="w-12" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sortedTriggers.map((trigger) => {
-            const isThisUpdating =
-              isUpdating && updatingTriggerId === trigger.id;
-            const isThisRunning = isRunning && runningTriggerId === trigger.id;
-
-            const explicitBrandVoiceId = trigger.outputConfig?.brandVoiceId;
-            const hasExplicitVoice = !!explicitBrandVoiceId;
-            const brandVoice = explicitBrandVoiceId
-              ? brandVoiceMap[explicitBrandVoiceId]
-              : defaultBrandVoice;
-
-            return (
-              <TableRow key={trigger.id}>
-                <TableCell>
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium">
-                      {trigger.name ?? "Untitled Schedule"}
-                    </p>
-                  </div>
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {formatFrequency(trigger.sourceConfig.cron)}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  <BrandVoiceCell
-                    isDefault={!hasExplicitVoice}
-                    voice={brandVoice}
-                  />
-                </TableCell>
-                <TableCell className="text-muted-foreground capitalize">
-                  <span className="flex items-center gap-1.5">
-                    <OutputTypeIcon
-                      className="size-3.5"
-                      outputType={trigger.outputType}
-                    />
-                    {getOutputTypeLabel(trigger.outputType)}
-                  </span>
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  <SourcesCell
-                    repositoryIds={trigger.targets.repositoryIds}
-                    repositoryMap={repositoryMap}
-                  />
-                </TableCell>
-                <TableCell>
-                  <TriggerStatusBadge enabled={trigger.enabled} />
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {formatDate(trigger.createdAt)}
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      className="hover:bg-accent flex size-8 cursor-pointer items-center justify-center rounded-md disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={isThisUpdating || isThisRunning}
-                    >
-                      {isThisUpdating || isThisRunning ? (
-                        <Loader2Icon className="text-muted-foreground size-4 animate-spin" />
-                      ) : (
-                        <HugeiconsIcon
-                          className="text-muted-foreground size-4"
-                          icon={MoreVerticalIcon}
-                        />
-                      )}
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => onEdit(trigger)}>
-                        <HugeiconsIcon className="size-4" icon={Edit02Icon} />
-                        Edit
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={isRunning || !trigger.enabled}
-                        onClick={() => onRunNow(trigger.id)}
-                      >
-                        <HugeiconsIcon
-                          className="size-4"
-                          icon={PlayCircleIcon}
-                        />
-                        Run now
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={isUpdating}
-                        onClick={() => onToggle(trigger)}
-                      >
-                        <HugeiconsIcon
-                          className="size-4"
-                          icon={trigger.enabled ? PauseIcon : PlayIcon}
-                        />
-                        {trigger.enabled ? "Pause" : "Enable"}
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        disabled={isDeleting}
-                        onClick={() => onDelete(trigger.id)}
-                        variant="destructive"
-                      >
-                        <HugeiconsIcon className="size-4" icon={Delete02Icon} />
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+    <Table
+      className="rounded-2xl"
+      columns={columns}
+      data={triggers}
+      emptyState="No schedules in this category."
+      getRowId={(trigger) => trigger.id}
+      height={tableHeightFor(triggers.length, SCHEDULE_TABLE_ROW_HEIGHT)}
+      onSortChange={(next) => onSortCreatedChange(next?.direction ?? false)}
+      rowHeight={SCHEDULE_TABLE_ROW_HEIGHT}
+      sort={
+        createdSortOrder
+          ? { key: "createdAt", direction: createdSortOrder }
+          : null
+      }
+    />
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/skeleton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/automation/schedules/skeleton.tsx
@@ -1,34 +1,14 @@
 "use client";
 
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
-import { useId } from "react";
+
+import { GeoTableSkeleton } from "@/components/geo/skeleton-parts";
 
 export function SchedulePageSkeleton() {
-  const id = useId();
   return (
     <div className="space-y-4">
       <Skeleton className="h-10 w-48" />
-      <div className="space-y-3">
-        <div className="border-border/80 border-b-border/40 bg-muted/80 overflow-hidden rounded-lg border shadow-2xs">
-          <div className="bg-background space-y-3 rounded-t-lg p-4">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div
-                className="flex items-center gap-4 py-2"
-                key={`${id}-row-${i}`}
-              >
-                <Skeleton className="h-8 w-8 rounded-lg" />
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-4 w-24" />
-                <Skeleton className="h-5 w-16 rounded-full" />
-                <Skeleton className="h-4 w-20" />
-                <div className="ml-auto">
-                  <Skeleton className="h-8 w-8 rounded-md" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
+      <GeoTableSkeleton rows={5} />
     </div>
   );
 }


### PR DESCRIPTION
### Description
Switches the Schedules page to the shared dual-tone table (`@/components/motion/table`) used across the rest of the app (Content, API Keys, GEO tables), replacing the one-off table wrapper.

- Columns defined via `TableColumn<Trigger>[]`; "Created" sorting now uses the built-in sortable header (asc → desc → cleared) instead of a custom button
- "Created" shows relative dates ("5 days ago") matching the Content page; Name/Schedule truncate with a tooltip on hover
- Row actions column matches the API Keys pattern (ghost icon button + dropdown)
- Empty tab state renders inside the table surface; the loading skeleton now uses the shared `GeoTableSkeleton`
- Column widths budgeted to fit without horizontal scrolling from ~1280px viewport width

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the Schedules page to use the shared dual-tone table, replacing the one-off table wrapper.

**Refactors**
- Columns are now defined via `TableColumn<Trigger>[]`; sorting uses the built-in sortable header (asc → desc → cleared) instead of a custom button.
- "Created" shows relative dates (e.g., "5 days ago"); name and schedule truncate with a tooltip on hover.
- Row actions match the API Keys pattern (ghost icon button + dropdown).
- Empty state renders inside the table surface; loading skeleton uses the shared `GeoTableSkeleton`.
- Column widths are budgeted to avoid horizontal scrolling from ~1280px viewport width.

<sup>Written for commit 9a676db02950aeddd9a6e9ef2311729bce8e87a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

