### PR TITLE
fix(geo): show newest prompts first by default

### DIFF
--- a/apps/dashboard/src/components/geo/prompts-table.tsx
+++ b/apps/dashboard/src/components/geo/prompts-table.tsx
@@ -575,7 +575,6 @@ export function PromptsTable({
         className="rounded-2xl"
         columns={columns}
         data={rows}
-        defaultSort={{ key: "presence", direction: "desc" }}
         emptyState={
           prompts.length === 0
             ? geoScanEmptyMessage(

--- a/packages/geo-core/src/geo/gaps.ts
+++ b/packages/geo-core/src/geo/gaps.ts
@@ -12,7 +12,7 @@ import {
   posts,
 } from "@notra/db/schema";
 import type { GeoContentBriefStatus } from "@notra/db/types/geo-writer";
-import { and, asc, desc, eq, gte, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNotNull, sql } from "drizzle-orm";
 import { Effect } from "effect";
 
 import {
@@ -175,7 +175,7 @@ const loadMentionGapInputs = Effect.fn("geo.mentionGapInputs")(function* (
         .where(
           and(eq(geoPrompts.projectId, projectId), eq(geoPrompts.enabled, true))
         )
-        .orderBy(asc(geoPrompts.createdAt))
+        .orderBy(desc(geoPrompts.createdAt))
     ),
   ]);
 });

--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -29,7 +29,7 @@ import {
   queryGeoCheckTimeseries,
   toGeoCheckWindow,
 } from "@notra/db/utils/geo-checks";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { Effect } from "effect";
 
 import {
@@ -1280,7 +1280,7 @@ export const listGeoPrompts = Effect.fn("geo.promptsList")(function* (
       geoDb("prompts lookup failed", () =>
         db.query.geoPrompts.findMany({
           where: eq(geoPrompts.projectId, projectId),
-          orderBy: [asc(geoPrompts.createdAt)],
+          orderBy: [desc(geoPrompts.createdAt)],
         })
       ),
       geoDb("settings lookup failed", () =>


### PR DESCRIPTION
### Description
The Prompts table looked randomly ordered: the backend returned custom prompts
oldest-first with auto prompts appended, and the table's default sort
(Presence desc) left rows in an arbitrary-looking order whenever all presence
values are equal (e.g. before any scan data exists).

This makes "newest first" the default ordering:

- `listGeoPrompts` returns custom prompts ordered by `createdAt` desc;
  auto-generated prompts (no creation date) still follow after. This also
  applies to the public `listGeoPrompts` API endpoint, whose docs promise no
  specific order.
- The Prompts table drops its `defaultSort` on Presence, so the default view
  is newest first. Presence and all other columns stay sortable via the
  column header (asc → desc → back to default order).
- The Gaps list now breaks opportunity-score ties newest-first instead of
  oldest-first, consistent with the Prompts page.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Prompts table previously showed rows in an arbitrary-looking order, so this makes "newest first" the default view.

- `listGeoPrompts` now returns custom prompts ordered by `createdAt` desc; auto-generated prompts still follow after.
- The Prompts table no longer defaults to sorting by Presence, so the backend order is the default view; all columns remain sortable via the header.
- The Gaps list breaks opportunity-score ties newest-first, matching the Prompts page.

<sup>Written for commit c1bd6e267793a376b25b3a6f8ae8a287382daf39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

