### PR TITLE
fix(geo): show own brand logo and readable name in engine brand ranking

### DIFF
--- a/apps/dashboard/src/components/geo/engine-family-sheet.tsx
+++ b/apps/dashboard/src/components/geo/engine-family-sheet.tsx
@@ -47,6 +47,7 @@ import { EngineIcon } from "@/components/geo/engine-icon";
 import { FamilyImproveCard } from "@/components/geo/family-improve-card";
 import { GeoModeIcon } from "@/components/geo/geo-mode-icon";
 import { GeoStatDelta } from "@/components/geo/geo-stat-delta";
+import { ProjectLogo } from "@/components/geo/project-logo";
 import { PromptDetailDialog } from "@/components/geo/prompt-detail-dialog";
 import { PromptOutcomeIcon } from "@/components/geo/prompt-outcome-icon";
 import { WriteDialog } from "@/components/geo/writer/write-dialog";
@@ -60,6 +61,7 @@ import {
   GEO_WRITE_DIALOG_ENTRIES,
 } from "@/constants/geo-analytics";
 import { TABLE_ROW_HEIGHT } from "@/constants/table";
+import { useGeoActiveProject } from "@/lib/hooks/use-geo-active-project";
 import { cn } from "@/lib/utils";
 import type { ChartConfig } from "@/types/charts";
 import type { WriteDialogInitialState } from "@/types/components/geo-writer";
@@ -337,20 +339,24 @@ function BrandRow({
 }) {
   const muted = row.mentions === 0;
   return (
-    <li className={cn(BRAND_ROW_CLASS, muted && "text-muted-foreground")}>
+    <li className={BRAND_ROW_CLASS}>
       <span className="text-muted-foreground text-right text-xs tabular-nums">
         {rank}
       </span>
       <span className="flex min-w-0 items-center gap-2">
-        <CompetitorLogo
-          className={cn("size-4", muted && "opacity-60")}
-          domain={
-            row.own
-              ? null
-              : findCompetitorDomain(scope.competitors ?? [], row.name)
-          }
-          name={row.name}
-        />
+        {row.own ? (
+          <ProjectLogo
+            className="size-4 shrink-0 rounded-sm"
+            domain={scope.ownDomain ?? null}
+            name={row.name}
+          />
+        ) : (
+          <CompetitorLogo
+            className="size-4 shrink-0"
+            domain={findCompetitorDomain(scope.competitors ?? [], row.name)}
+            name={row.name}
+          />
+        )}
         <span className={cn("truncate", row.own && "font-medium")}>
           {row.name}
         </span>
@@ -364,7 +370,12 @@ function BrandRow({
         max={max}
         value={row.share}
       />
-      <span className="text-right text-xs tabular-nums">
+      <span
+        className={cn(
+          "text-right text-xs tabular-nums",
+          muted && "text-muted-foreground"
+        )}
+      >
         {formatMentionRate(row.share)}
       </span>
     </li>
@@ -523,6 +534,7 @@ function EngineFamilySheetSession({
     organization = getOrganization(organizationSlug);
   }
   const organizationId = organization?.id ?? "";
+  const { domain: ownDomain } = useGeoActiveProject(organizationId);
   const canWrite = Boolean(organizationSlug) && Boolean(organizationId);
   const name = engineFamilyLabel(family.family);
   const selectedRow = selectedPromptId
@@ -537,6 +549,7 @@ function EngineFamilySheetSession({
     companyName,
     aliases,
     competitors,
+    ownDomain,
   };
   const brandRows = engineFamilyBrandRows(
     family.family,

--- a/apps/dashboard/src/components/geo/engine-family-sheet.tsx
+++ b/apps/dashboard/src/components/geo/engine-family-sheet.tsx
@@ -88,7 +88,10 @@ import {
   formatMentionRate,
   mentionTrendEmptyLabel,
 } from "@/utils/geo-charts";
-import { engineFamilyBrandRows } from "@/utils/geo-competitors";
+import {
+  engineFamilyBrandRows,
+  findOwnBrandDomain,
+} from "@/utils/geo-competitors";
 import { familyImproveInsight } from "@/utils/geo-family-improve";
 import { geoGapsEngineHref } from "@/utils/geo-paths";
 import {
@@ -534,7 +537,8 @@ function EngineFamilySheetSession({
     organization = getOrganization(organizationSlug);
   }
   const organizationId = organization?.id ?? "";
-  const { domain: ownDomain } = useGeoActiveProject(organizationId);
+  const { domain: projectDomain } = useGeoActiveProject(organizationId);
+  const ownDomain = projectDomain ?? findOwnBrandDomain(aliases ?? []);
   const canWrite = Boolean(organizationSlug) && Boolean(organizationId);
   const name = engineFamilyLabel(family.family);
   const selectedRow = selectedPromptId

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -616,6 +616,8 @@ export interface EngineFamilyBrandScope {
   companyName?: string | null;
   aliases?: readonly string[];
   competitors?: readonly GeoCompetitor[];
+  /** Own brand website domain, used to resolve the own-brand logo. */
+  ownDomain?: string | null;
 }
 
 export interface EngineRateTableProps extends EngineFamilyBrandScope {


### PR DESCRIPTION
In the engine family sheet's Brand Ranking, the user's own brand looked broken: it showed a generic letter avatar instead of the company logo, and the whole row was greyed out whenever the brand had zero mentions, so the "(You)" row was visibly different from every competitor row.

The own-brand row now resolves its logo from the active project's website domain (the same way the Competitors table does) and keeps the name in normal foreground weight. Only the share percentage is muted when the brand has no mentions, so "0%" still reads as a weak signal without making the row look disabled.

## Notes
- Adds an optional `ownDomain` to `EngineFamilyBrandScope`; the sheet fills it via `useGeoActiveProject`, so no call sites had to change.
- Verified with `bun run check` and `tsc --noEmit` (the only tsc error is the pre-existing `bun-types/test` config issue on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the engine family Brand Ranking so your own brand shows the project logo instead of a letter avatar, and only the 0% share is muted at zero mentions instead of the whole row.

- Resolves the own-brand logo from the active project's website domain, falling back to an alias domain when no website URL is set.
- Adds an optional `ownDomain` to `EngineFamilyBrandScope`; existing call sites don't need changes.

<sup>Written for commit ff103241618600cddbbbb94f42e54a6250ffd39e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

