### PR TITLE
fix(web): match landing table corners to GEO dashboard

### DIFF
--- a/apps/dashboard/src/components/chat-input.tsx
+++ b/apps/dashboard/src/components/chat-input.tsx
@@ -112,9 +112,7 @@ const ChatInput = ({
     remainingChatCredits !== null &&
     remainingChatCredits > 0 &&
     remainingChatCredits <= 10;
-  const isUsageBlocked =
-    checkResult?.allowed === false &&
-    !chatIncludedInPlan;
+  const isUsageBlocked = checkResult?.allowed === false && !chatIncludedInPlan;
   const usageLimitError =
     externalError ??
     internalError ??

--- a/apps/dashboard/src/components/chat/chat-input.tsx
+++ b/apps/dashboard/src/components/chat/chat-input.tsx
@@ -645,9 +645,7 @@ export function ChatInputAdvanced({
     remainingChatCredits !== null &&
     remainingChatCredits > 0 &&
     remainingChatCredits <= 10;
-  const isUsageBlocked =
-    checkResult?.allowed === false &&
-    !chatIncludedInPlan;
+  const isUsageBlocked = checkResult?.allowed === false && !chatIncludedInPlan;
   const usageLimitError =
     externalError ??
     internalError ??

--- a/apps/dashboard/src/utils/development-autumn.ts
+++ b/apps/dashboard/src/utils/development-autumn.ts
@@ -38,7 +38,7 @@ function createDevelopmentAutumnCustomer() {
           maxPurchase: null,
           nextResetAt: null,
         },
-      ]),
+      ])
     ),
     flags: {},
   };

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -149,7 +149,7 @@ export default function LandingPage() {
   return (
     <div className="dark:bg-background flex w-full flex-col items-stretch justify-start overflow-x-clip bg-white">
       <LandingPageJsonLd />
-      <main className="flex w-full flex-col items-stretch justify-start">
+      <main className="landing-tables flex w-full flex-col items-stretch justify-start">
         <HeroSection />
         <p className="sr-only" id="agent-readable-summary">
           Notra is a GEO (Generative Engine Optimization) product. It asks AI

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -386,6 +386,22 @@
   }
 }
 
+.landing-tables [data-slot="table"] {
+  background: var(--muted);
+}
+
+.landing-tables [data-slot="table-body"] > tr:first-child {
+  background: transparent;
+
+  > td:first-child {
+    border-top-left-radius: var(--radius-2xl);
+  }
+
+  > td:last-child {
+    border-top-right-radius: var(--radius-2xl);
+  }
+}
+
 @keyframes orbitSpin {
   from {
     transform: translate(-50%, -50%) rotate(0deg);


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rounds the top corners of landing page tables so they match the GEO dashboard styling.

- Includes formatting-only cleanup in the dashboard chat input components and a development utility; no behavior changes there.

<sup>Written for commit 9da8929dd1fbfc573c0070683e0fa120b782eef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

