### PR TITLE
fix(web): simplify sponsor links and add Vercel

### DIFF
--- a/apps/web/src/components/contributors/sponsors.tsx
+++ b/apps/web/src/components/contributors/sponsors.tsx
@@ -18,28 +18,19 @@ export function Sponsors({ sponsors }: SponsorsProps) {
         </p>
       </div>
 
-      <div className="mx-auto flex w-full max-w-4xl flex-wrap items-stretch justify-center gap-4">
+      <div className="mx-auto flex w-full max-w-4xl flex-wrap items-center justify-center gap-12 sm:gap-16">
         {sponsors.map((sponsor) => (
           <Link
-            className="group flex flex-col items-center gap-4 rounded-2xl border border-[#1E1E1E14] bg-[#C8B2EE1F] px-8 py-6 transition-colors hover:bg-[#C8B2EE33] dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/[0.06]"
+            className="text-foreground focus-visible:ring-ring flex flex-col items-center gap-4 rounded-sm transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:ring-offset-4 focus-visible:outline-none"
             href={sponsor.url}
             key={sponsor.name}
             rel="noopener noreferrer"
             target="_blank"
           >
-            <sponsor.logo
-              aria-label={sponsor.name}
-              className="h-10 w-auto"
-              role="img"
-            />
-            <div className="flex flex-col items-center gap-1 text-center">
-              <span className="text-foreground font-sans text-sm font-medium">
-                {sponsor.name}
-              </span>
-              <span className="text-muted-foreground max-w-[16rem] text-xs leading-5">
-                {sponsor.description}
-              </span>
-            </div>
+            <sponsor.logo aria-hidden="true" className="h-10 w-auto" />
+            <span className="font-sans text-sm font-medium">
+              {sponsor.name}
+            </span>
           </Link>
         ))}
       </div>

--- a/apps/web/src/lib/sponsors/constants.ts
+++ b/apps/web/src/lib/sponsors/constants.ts
@@ -1,20 +1,22 @@
 import { Neon } from "@notra/ui/components/ui/svgs/neon";
 import { Upstash } from "@notra/ui/components/ui/svgs/upstash";
+import { Vercel } from "@notra/ui/components/ui/svgs/vercel";
 import type { Sponsor } from "~types/sponsors";
 
 export const SPONSORS: Sponsor[] = [
   {
     name: "Upstash",
     url: "https://upstash.com",
-    description:
-      "Serverless data platform for Redis, Kafka, QStash, and Sandboxes.",
     logo: Upstash,
   },
   {
     name: "Neon",
     url: "https://neon.com",
-    description:
-      "Serverless Postgres with branching, autoscaling, and bottomless storage.",
     logo: Neon,
+  },
+  {
+    name: "Vercel",
+    url: "https://vercel.com",
+    logo: Vercel,
   },
 ];

--- a/apps/web/src/styles/ui-sources.css
+++ b/apps/web/src/styles/ui-sources.css
@@ -128,6 +128,7 @@
 @source "../../../../packages/ui/src/components/ui/svgs/timpi.tsx";
 @source "../../../../packages/ui/src/components/ui/svgs/twitter.tsx";
 @source "../../../../packages/ui/src/components/ui/svgs/upstash.tsx";
+@source "../../../../packages/ui/src/components/ui/svgs/vercel.tsx";
 @source "../../../../packages/ui/src/components/ui/svgs/webflow.tsx";
 @source "../../../../packages/ui/src/components/ui/svgs/xiaomi.tsx";
 @source "../../../../packages/ui/src/components/ui/svgs/youCom.tsx";

--- a/apps/web/types/sponsors.ts
+++ b/apps/web/types/sponsors.ts
@@ -3,7 +3,6 @@ import type { ComponentType, SVGProps } from "react";
 export interface Sponsor {
   name: string;
   url: string;
-  description: string;
   logo: ComponentType<SVGProps<SVGSVGElement>>;
 }
 


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies sponsor cards on the contributors page to show only the logo and name, and adds Vercel to the sponsor list.

- Removes sponsor descriptions, card borders, and background fill; now uses hover opacity and a visible focus ring.
- Adds `Vercel` sponsor and includes its logo in the UI source path.
- Removes the required `description` field from the `Sponsor` type.

<sup>Written for commit 7973d8daa0120cba0b73fa067d97ffd8306ee13d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

