### PR TITLE
fix(api): prevent orphaned QStash schedules on patch failure

### DIFF
--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -35,11 +35,11 @@ import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
 import { buildCronExpression, createQstashSchedule } from "../utils/qstash";
-import { deleteQstashScheduleWithRetry } from "../utils/triggers";
 import {
   ORGANIZATION_SCHEDULE_PATH_REGEX,
   ORGANIZATION_SCHEDULES_PATH_REGEX,
 } from "../utils/regex";
+import { deleteQstashScheduleWithRetry } from "../utils/triggers";
 
 export const schedulesRoutes = createOpenApiApp();
 
@@ -676,18 +676,6 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
     return c.json({ error: "Duplicate schedule" }, 409);
   }
 
-  const existing = await db.query.contentTriggers.findFirst({
-    where: and(
-      eq(contentTriggers.id, scheduleId),
-      eq(contentTriggers.organizationId, orgId),
-      eq(contentTriggers.sourceType, "cron")
-    ),
-  });
-
-  if (!existing) {
-    return c.json({ error: "Schedule not found" }, 404);
-  }
-
   if (input.enabled) {
     const missingTargets = await ensureScheduleTargetsExist(
       db,
@@ -701,85 +689,51 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
     }
   }
 
-  const persistedName =
-    input.name.trim() || existing.name || DEFAULT_SCHEDULE_NAME;
-  const cronExpression = buildCronExpression(normalized.sourceConfig.cron);
-  const previousQstashScheduleId = existing.qstashScheduleId ?? null;
-  let qstashScheduleId: string | null = null;
-  // When a schedule already exists in QStash, reuse its ID so QStash upserts
-  // in place. This avoids the create-new + delete-old double-write that can
-  // leave duplicates (delete fails) or outages (create succeeds, DB fails).
-  const reuseQstashScheduleId =
-    input.enabled && previousQstashScheduleId !== null
-      ? previousQstashScheduleId
-      : null;
-
-  if (input.enabled) {
-    try {
-      qstashScheduleId = await createQstashSchedule(env, {
-        triggerId: scheduleId,
-        cron: cronExpression,
-        ...(reuseQstashScheduleId
-          ? { scheduleId: reuseQstashScheduleId }
-          : {}),
-      });
-    } catch (error) {
-      const mapped = mapQstashError(error);
-      if (mapped.status === 400) {
-        return c.json({ error: mapped.error }, 400);
-      }
-
-      return c.json({ error: mapped.error }, 500);
-    }
-
-    // QStash should upsert in place when a schedule ID is reused. If it
-    // minted a different ID instead, fail before the DB transaction: the
-    // previous schedule is untouched and the DB still points at it, so both
-    // schedules can never go live at once.
-    if (
-      reuseQstashScheduleId &&
-      qstashScheduleId !== reuseQstashScheduleId
-    ) {
-      try {
-        await deleteQstashScheduleWithRetry(env, qstashScheduleId);
-      } catch (cleanupError) {
-        logError(
-          `Failed to clean up unexpected QStash schedule ${qstashScheduleId} for schedule ${scheduleId}`,
-          cleanupError
-        );
-      }
-
-      logError(
-        `QStash returned unexpected schedule ID ${qstashScheduleId} for schedule ${scheduleId} (expected ${reuseQstashScheduleId})`,
-        new Error("QStash schedule ID rotation")
-      );
-      return c.json({ error: "Failed to update schedule" }, 500);
-    }
-  }
-
-  if (!input.enabled && previousQstashScheduleId) {
-    // Disable path: delete before the DB transaction so a failure stays
-    // retryable — the DB still points at the previous schedule. Delete is
-    // idempotent (404 counts as success), so if the DB transaction fails
-    // after this, retrying PATCH heals instead of orphaning.
-    try {
-      await deleteQstashScheduleWithRetry(env, previousQstashScheduleId);
-    } catch (error) {
-      logError(
-        `Failed to delete previous QStash schedule ${previousQstashScheduleId} for schedule ${scheduleId}`,
-        error
-      );
-      return c.json({ error: "Failed to update schedule" }, 500);
-    }
-  }
-
+  const affectedQstashIds = new Set<string>();
   let committed = false;
   try {
-    const schedule = await db.transaction(async (tx) => {
+    const response = await db.transaction(async (tx) => {
+      // Lock before reading or changing remote state. Concurrent PATCHes must
+      // observe the preceding request's committed configuration.
+      const [existing] = await tx
+        .select()
+        .from(contentTriggers)
+        .where(
+          and(
+            eq(contentTriggers.id, scheduleId),
+            eq(contentTriggers.organizationId, orgId),
+            eq(contentTriggers.sourceType, "cron")
+          )
+        )
+        .for("update");
+
+      if (!existing) {
+        return c.json({ error: "Schedule not found" }, 404);
+      }
+
+      let qstashScheduleId: string | null = null;
+      if (input.enabled) {
+        // Choose the ID before sending so even a lost response is recoverable.
+        qstashScheduleId = existing.qstashScheduleId ?? crypto.randomUUID();
+        affectedQstashIds.add(qstashScheduleId);
+        const returnedId = await createQstashSchedule(env, {
+          triggerId: scheduleId,
+          cron: buildCronExpression(normalized.sourceConfig.cron),
+          scheduleId: qstashScheduleId,
+        });
+        affectedQstashIds.add(returnedId);
+        if (returnedId !== qstashScheduleId) {
+          throw new Error("QStash returned an unexpected schedule ID");
+        }
+      } else if (existing.qstashScheduleId) {
+        affectedQstashIds.add(existing.qstashScheduleId);
+        await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
+      }
+
       const [updatedTrigger] = await tx
         .update(contentTriggers)
         .set({
-          name: persistedName,
+          name: input.name.trim() || existing.name || DEFAULT_SCHEDULE_NAME,
           sourceType: "cron",
           sourceConfig: normalized.sourceConfig,
           targets: normalized.targets,
@@ -817,73 +771,69 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
           },
         });
 
-      return serializeSchedule({
+      const schedule = serializeSchedule({
         ...updatedTrigger,
         lookbackWindow: input.lookbackWindow,
       });
+      return c.json({ schedule, organization }, 200);
     });
-
     committed = true;
-
-    // No post-commit deletes: enables upsert in place (previous === current,
-    // nothing to clean up) and disables delete before the transaction so a
-    // failure stays retryable. Deleting here would return success while both
-    // schedules are live, with the previous ID already lost to the DB.
-
-    return c.json({ schedule, organization }, 200);
+    return response;
   } catch (error) {
-    // Only clean up schedules created by this request. A reused (upserted)
-    // ID belongs to the previous generation — deleting it would disable a
-    // previously working schedule — so only delete when we minted a new ID.
-    const mintedNewSchedule =
-      !committed &&
-      qstashScheduleId !== null &&
-      qstashScheduleId !== previousQstashScheduleId;
-    if (mintedNewSchedule && qstashScheduleId) {
+    if (!committed && affectedQstashIds.size > 0) {
       try {
-        await deleteQstashScheduleWithRetry(env, qstashScheduleId);
-      } catch (cleanupError) {
+        await db.transaction(async (tx) => {
+          // The failed transaction released its lock. Re-read under a new lock:
+          // another request may have committed while recovery was waiting.
+          const [current] = await tx
+            .select()
+            .from(contentTriggers)
+            .where(
+              and(
+                eq(contentTriggers.id, scheduleId),
+                eq(contentTriggers.organizationId, orgId),
+                eq(contentTriggers.sourceType, "cron")
+              )
+            )
+            .for("update");
+          const currentQstashId = current?.enabled
+            ? current.qstashScheduleId
+            : null;
+
+          if (currentQstashId && current) {
+            const config = scheduleSourceConfigSchema.parse(
+              current.sourceConfig
+            );
+            const restoredId = await createQstashSchedule(env, {
+              triggerId: scheduleId,
+              cron: buildCronExpression(config.cron),
+              scheduleId: currentQstashId,
+            });
+            if (restoredId !== currentQstashId) {
+              await deleteQstashScheduleWithRetry(env, restoredId);
+              throw new Error("QStash returned an unexpected restoration ID");
+            }
+          }
+
+          for (const affectedId of affectedQstashIds) {
+            if (affectedId !== currentQstashId) {
+              await deleteQstashScheduleWithRetry(env, affectedId);
+            }
+          }
+        });
+      } catch (recoveryError) {
         logError(
-          `Failed to clean up replacement QStash schedule ${qstashScheduleId} for schedule ${scheduleId}`,
-          cleanupError
-        );
-      }
-    }
-    // If the DB transaction failed after QStash was already mutated, restore
-    // the previous remote state so the live schedule matches the committed
-    // DB config. Enable path: the reused ID now carries the rejected cron.
-    // Disable path: the previous ID was deleted before the transaction.
-    // Either way, re-creating the previous cron under the previous ID
-    // converges both systems; retrying PATCH still heals if this fails.
-    const previousScheduleToRestore =
-      reuseQstashScheduleId ??
-      (!input.enabled ? previousQstashScheduleId : null);
-    if (!committed && previousScheduleToRestore) {
-      const parsedPrevious = scheduleSourceConfigSchema.safeParse(
-        existing.sourceConfig
-      );
-      if (parsedPrevious.success) {
-        try {
-          await createQstashSchedule(env, {
-            triggerId: scheduleId,
-            cron: buildCronExpression(parsedPrevious.data.cron),
-            scheduleId: previousScheduleToRestore,
-          });
-        } catch (restoreError) {
-          logError(
-            `Failed to restore previous QStash schedule ${previousScheduleToRestore} for schedule ${scheduleId} after DB transaction failure; retry PATCH to heal`,
-            restoreError
-          );
-        }
-      } else {
-        logError(
-          `QStash schedule ${previousScheduleToRestore} for schedule ${scheduleId} was changed but the DB transaction failed and the previous config could not be parsed; retry PATCH to heal`,
-          error
+          `Failed to reconcile QStash schedules ${[...affectedQstashIds].join(", ")} for schedule ${scheduleId}; retry PATCH to heal`,
+          recoveryError
         );
       }
     }
 
     logError("Failed to update schedule", error);
+    const mapped = mapQstashError(error);
+    if (mapped.status === 400) {
+      return c.json({ error: mapped.error }, 400);
+    }
     return c.json({ error: "Failed to update schedule" }, 500);
   }
 });
@@ -909,33 +859,36 @@ schedulesRoutes.openapi(deleteScheduleRoute, async (c) => {
     QSTASH_TOKEN?: string;
     WORKFLOW_BASE_URL?: string;
   };
-  const existing = await db.query.contentTriggers.findFirst({
-    where: and(
-      eq(contentTriggers.id, scheduleId),
-      eq(contentTriggers.organizationId, orgId),
-      eq(contentTriggers.sourceType, "cron")
-    ),
-  });
-
-  if (!existing) {
-    return c.json({ error: "Schedule not found" }, 404);
-  }
-
-  if (existing.qstashScheduleId) {
-    // Fail closed: if QStash is down the DB row is kept so DELETE stays
-    // retryable. Deleting the DB first would orphan a live schedule with no
-    // record of its ID.
-    await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
-  }
-
-  await db
-    .delete(contentTriggers)
-    .where(
-      and(
-        eq(contentTriggers.id, scheduleId),
-        eq(contentTriggers.organizationId, orgId)
+  return db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(contentTriggers)
+      .where(
+        and(
+          eq(contentTriggers.id, scheduleId),
+          eq(contentTriggers.organizationId, orgId),
+          eq(contentTriggers.sourceType, "cron")
+        )
       )
-    );
+      .for("update");
 
-  return c.json({ id: scheduleId, organization }, 200);
+    if (!existing) {
+      return c.json({ error: "Schedule not found" }, 404);
+    }
+
+    if (existing.qstashScheduleId) {
+      await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
+    }
+
+    await tx
+      .delete(contentTriggers)
+      .where(
+        and(
+          eq(contentTriggers.id, scheduleId),
+          eq(contentTriggers.organizationId, orgId)
+        )
+      );
+
+    return c.json({ id: scheduleId, organization }, 200);
+  });
 });

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -731,6 +731,46 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
 
       return c.json({ error: mapped.error }, 500);
     }
+
+    // QStash should upsert in place when a schedule ID is reused. If it
+    // minted a different ID instead, fail before the DB transaction: the
+    // previous schedule is untouched and the DB still points at it, so both
+    // schedules can never go live at once.
+    if (
+      reuseQstashScheduleId &&
+      qstashScheduleId !== reuseQstashScheduleId
+    ) {
+      try {
+        await deleteQstashScheduleWithRetry(env, qstashScheduleId);
+      } catch (cleanupError) {
+        logError(
+          `Failed to clean up unexpected QStash schedule ${qstashScheduleId} for schedule ${scheduleId}`,
+          cleanupError
+        );
+      }
+
+      logError(
+        `QStash returned unexpected schedule ID ${qstashScheduleId} for schedule ${scheduleId} (expected ${reuseQstashScheduleId})`,
+        new Error("QStash schedule ID rotation")
+      );
+      return c.json({ error: "Failed to update schedule" }, 500);
+    }
+  }
+
+  if (!input.enabled && previousQstashScheduleId) {
+    // Disable path: delete before the DB transaction so a failure stays
+    // retryable — the DB still points at the previous schedule. Delete is
+    // idempotent (404 counts as success), so if the DB transaction fails
+    // after this, retrying PATCH heals instead of orphaning.
+    try {
+      await deleteQstashScheduleWithRetry(env, previousQstashScheduleId);
+    } catch (error) {
+      logError(
+        `Failed to delete previous QStash schedule ${previousQstashScheduleId} for schedule ${scheduleId}`,
+        error
+      );
+      return c.json({ error: "Failed to update schedule" }, 500);
+    }
   }
 
   let committed = false;
@@ -785,25 +825,10 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
 
     committed = true;
 
-    // Only the disable path (or an unexpected ID rotation) leaves a previous
-    // schedule to delete: upserts reuse the previous ID, so normally
-    // previous === current and there is nothing to clean up. A failed delete
-    // here is a phantom-fire risk only — the schedule workflow no-ops when
-    // the DB trigger is disabled/missing — so log with both IDs and keep
-    // the successful response.
-    if (
-      previousQstashScheduleId &&
-      previousQstashScheduleId !== qstashScheduleId
-    ) {
-      try {
-        await deleteQstashScheduleWithRetry(env, previousQstashScheduleId);
-      } catch (deleteError) {
-        logError(
-          `Failed to delete previous QStash schedule ${previousQstashScheduleId} for schedule ${scheduleId} (replacement ${qstashScheduleId ?? "none"})`,
-          deleteError
-        );
-      }
-    }
+    // No post-commit deletes: enables upsert in place (previous === current,
+    // nothing to clean up) and disables delete before the transaction so a
+    // failure stays retryable. Deleting here would return success while both
+    // schedules are live, with the previous ID already lost to the DB.
 
     return c.json({ schedule, organization }, 200);
   } catch (error) {
@@ -826,10 +851,39 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
     }
     if (!committed && reuseQstashScheduleId) {
       // Upsert succeeded but the DB transaction failed: QStash now has the
-      // new cron while the DB still has the old config. No orphan/duplicate,
-      // and retrying PATCH self-heals — log for visibility only.
+      // rejected cron while the DB still has the old config, and the
+      // schedule workflow fires at whatever cron is live. Restore the
+      // previous cron so the live schedule keeps the committed cadence;
+      // retrying PATCH still self-heals if the restore fails.
+      const parsedPrevious = scheduleSourceConfigSchema.safeParse(
+        existing.sourceConfig
+      );
+      if (parsedPrevious.success) {
+        try {
+          await createQstashSchedule(env, {
+            triggerId: scheduleId,
+            cron: buildCronExpression(parsedPrevious.data.cron),
+            scheduleId: reuseQstashScheduleId,
+          });
+        } catch (restoreError) {
+          logError(
+            `Failed to restore previous QStash schedule ${reuseQstashScheduleId} for schedule ${scheduleId} after DB transaction failure; DB config is stale until PATCH is retried`,
+            restoreError
+          );
+        }
+      } else {
+        logError(
+          `QStash schedule ${reuseQstashScheduleId} for schedule ${scheduleId} was upserted but the DB transaction failed and the previous config could not be parsed; DB config is stale until PATCH is retried`,
+          error
+        );
+      }
+    }
+    if (!committed && !input.enabled && previousQstashScheduleId) {
+      // Disable path: the previous schedule was already deleted before the
+      // transaction, so the DB still points at a deleted schedule. Delete is
+      // idempotent, so retrying PATCH heals.
       logError(
-        `QStash schedule ${reuseQstashScheduleId} for schedule ${scheduleId} was upserted but the DB transaction failed; DB config is stale until PATCH is retried`,
+        `Previous QStash schedule ${previousQstashScheduleId} for schedule ${scheduleId} was deleted but the DB transaction failed; retry PATCH to heal`,
         error
       );
     }

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -34,11 +34,8 @@ import { logError } from "../utils/logging";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
-import {
-  buildCronExpression,
-  createQstashSchedule,
-  deleteQstashSchedule,
-} from "../utils/qstash";
+import { buildCronExpression, createQstashSchedule } from "../utils/qstash";
+import { deleteQstashScheduleWithRetry } from "../utils/triggers";
 import {
   ORGANIZATION_SCHEDULE_PATH_REGEX,
   ORGANIZATION_SCHEDULES_PATH_REGEX,
@@ -628,7 +625,14 @@ schedulesRoutes.openapi(createScheduleRoute, async (c) => {
     return c.json({ schedule, organization }, 201);
   } catch (error) {
     if (qstashScheduleId) {
-      await deleteQstashSchedule(env, qstashScheduleId).catch(() => null);
+      try {
+        await deleteQstashScheduleWithRetry(env, qstashScheduleId);
+      } catch (cleanupError) {
+        logError(
+          `Failed to clean up replacement QStash schedule ${qstashScheduleId} for new schedule ${triggerId}`,
+          cleanupError
+        );
+      }
     }
 
     logError("Failed to create schedule", error);
@@ -702,12 +706,22 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
   const cronExpression = buildCronExpression(normalized.sourceConfig.cron);
   const previousQstashScheduleId = existing.qstashScheduleId ?? null;
   let qstashScheduleId: string | null = null;
+  // When a schedule already exists in QStash, reuse its ID so QStash upserts
+  // in place. This avoids the create-new + delete-old double-write that can
+  // leave duplicates (delete fails) or outages (create succeeds, DB fails).
+  const reuseQstashScheduleId =
+    input.enabled && previousQstashScheduleId !== null
+      ? previousQstashScheduleId
+      : null;
 
   if (input.enabled) {
     try {
       qstashScheduleId = await createQstashSchedule(env, {
         triggerId: scheduleId,
         cron: cronExpression,
+        ...(reuseQstashScheduleId
+          ? { scheduleId: reuseQstashScheduleId }
+          : {}),
       });
     } catch (error) {
       const mapped = mapQstashError(error);
@@ -771,20 +785,53 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
 
     committed = true;
 
-    if (previousQstashScheduleId) {
+    // Only the disable path (or an unexpected ID rotation) leaves a previous
+    // schedule to delete: upserts reuse the previous ID, so normally
+    // previous === current and there is nothing to clean up. A failed delete
+    // here is a phantom-fire risk only — the schedule workflow no-ops when
+    // the DB trigger is disabled/missing — so log with both IDs and keep
+    // the successful response.
+    if (
+      previousQstashScheduleId &&
+      previousQstashScheduleId !== qstashScheduleId
+    ) {
       try {
-        await deleteQstashSchedule(env, previousQstashScheduleId);
+        await deleteQstashScheduleWithRetry(env, previousQstashScheduleId);
       } catch (deleteError) {
-        // DB already points at the new schedule, so don't fail the request
-        // or clean up the new schedule — log for retry/cleanup instead.
-        logError("Failed to delete previous QStash schedule", deleteError);
+        logError(
+          `Failed to delete previous QStash schedule ${previousQstashScheduleId} for schedule ${scheduleId} (replacement ${qstashScheduleId ?? "none"})`,
+          deleteError
+        );
       }
     }
 
     return c.json({ schedule, organization }, 200);
   } catch (error) {
-    if (!committed && qstashScheduleId) {
-      await deleteQstashSchedule(env, qstashScheduleId).catch(() => null);
+    // Only clean up schedules created by this request. A reused (upserted)
+    // ID belongs to the previous generation — deleting it would disable a
+    // previously working schedule — so only delete when we minted a new ID.
+    const mintedNewSchedule =
+      !committed &&
+      qstashScheduleId !== null &&
+      qstashScheduleId !== previousQstashScheduleId;
+    if (mintedNewSchedule && qstashScheduleId) {
+      try {
+        await deleteQstashScheduleWithRetry(env, qstashScheduleId);
+      } catch (cleanupError) {
+        logError(
+          `Failed to clean up replacement QStash schedule ${qstashScheduleId} for schedule ${scheduleId}`,
+          cleanupError
+        );
+      }
+    }
+    if (!committed && reuseQstashScheduleId) {
+      // Upsert succeeded but the DB transaction failed: QStash now has the
+      // new cron while the DB still has the old config. No orphan/duplicate,
+      // and retrying PATCH self-heals — log for visibility only.
+      logError(
+        `QStash schedule ${reuseQstashScheduleId} for schedule ${scheduleId} was upserted but the DB transaction failed; DB config is stale until PATCH is retried`,
+        error
+      );
     }
 
     logError("Failed to update schedule", error);
@@ -826,7 +873,10 @@ schedulesRoutes.openapi(deleteScheduleRoute, async (c) => {
   }
 
   if (existing.qstashScheduleId) {
-    await deleteQstashSchedule(env, existing.qstashScheduleId);
+    // Fail closed: if QStash is down the DB row is kept so DELETE stays
+    // retryable. Deleting the DB first would orphan a live schedule with no
+    // record of its ID.
+    await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
   }
 
   await db

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -719,6 +719,7 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
     }
   }
 
+  let committed = false;
   try {
     const schedule = await db.transaction(async (tx) => {
       const [updatedTrigger] = await tx
@@ -768,13 +769,21 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
       });
     });
 
+    committed = true;
+
     if (previousQstashScheduleId) {
-      await deleteQstashSchedule(env, previousQstashScheduleId);
+      try {
+        await deleteQstashSchedule(env, previousQstashScheduleId);
+      } catch (deleteError) {
+        // DB already points at the new schedule, so don't fail the request
+        // or clean up the new schedule — log for retry/cleanup instead.
+        logError("Failed to delete previous QStash schedule", deleteError);
+      }
     }
 
     return c.json({ schedule, organization }, 200);
   } catch (error) {
-    if (qstashScheduleId) {
+    if (!committed && qstashScheduleId) {
       await deleteQstashSchedule(env, qstashScheduleId).catch(() => null);
     }
 

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -849,12 +849,16 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
         );
       }
     }
-    if (!committed && reuseQstashScheduleId) {
-      // Upsert succeeded but the DB transaction failed: QStash now has the
-      // rejected cron while the DB still has the old config, and the
-      // schedule workflow fires at whatever cron is live. Restore the
-      // previous cron so the live schedule keeps the committed cadence;
-      // retrying PATCH still self-heals if the restore fails.
+    // If the DB transaction failed after QStash was already mutated, restore
+    // the previous remote state so the live schedule matches the committed
+    // DB config. Enable path: the reused ID now carries the rejected cron.
+    // Disable path: the previous ID was deleted before the transaction.
+    // Either way, re-creating the previous cron under the previous ID
+    // converges both systems; retrying PATCH still heals if this fails.
+    const previousScheduleToRestore =
+      reuseQstashScheduleId ??
+      (!input.enabled ? previousQstashScheduleId : null);
+    if (!committed && previousScheduleToRestore) {
       const parsedPrevious = scheduleSourceConfigSchema.safeParse(
         existing.sourceConfig
       );
@@ -863,29 +867,20 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
           await createQstashSchedule(env, {
             triggerId: scheduleId,
             cron: buildCronExpression(parsedPrevious.data.cron),
-            scheduleId: reuseQstashScheduleId,
+            scheduleId: previousScheduleToRestore,
           });
         } catch (restoreError) {
           logError(
-            `Failed to restore previous QStash schedule ${reuseQstashScheduleId} for schedule ${scheduleId} after DB transaction failure; DB config is stale until PATCH is retried`,
+            `Failed to restore previous QStash schedule ${previousScheduleToRestore} for schedule ${scheduleId} after DB transaction failure; retry PATCH to heal`,
             restoreError
           );
         }
       } else {
         logError(
-          `QStash schedule ${reuseQstashScheduleId} for schedule ${scheduleId} was upserted but the DB transaction failed and the previous config could not be parsed; DB config is stale until PATCH is retried`,
+          `QStash schedule ${previousScheduleToRestore} for schedule ${scheduleId} was changed but the DB transaction failed and the previous config could not be parsed; retry PATCH to heal`,
           error
         );
       }
-    }
-    if (!committed && !input.enabled && previousQstashScheduleId) {
-      // Disable path: the previous schedule was already deleted before the
-      // transaction, so the DB still points at a deleted schedule. Delete is
-      // idempotent, so retrying PATCH heals.
-      logError(
-        `Previous QStash schedule ${previousQstashScheduleId} for schedule ${scheduleId} was deleted but the DB transaction failed; retry PATCH to heal`,
-        error
-      );
     }
 
     logError("Failed to update schedule", error);

--- a/apps/api/src/utils/triggers.ts
+++ b/apps/api/src/utils/triggers.ts
@@ -120,9 +120,7 @@ function isRetryableDeleteError(error: unknown) {
     return true;
   }
   const status = Number(match[1]);
-  return (
-    status === 408 || status === 425 || status === 429 || status >= 500
-  );
+  return status === 408 || status === 425 || status === 429 || status >= 500;
 }
 
 export async function deleteQstashScheduleWithRetry(
@@ -163,10 +161,7 @@ export async function deleteQstashSchedulesForTriggers(
     }
 
     try {
-      await deleteQstashScheduleWithRetry(
-        runtimeEnv,
-        trigger.qstashScheduleId
-      );
+      await deleteQstashScheduleWithRetry(runtimeEnv, trigger.qstashScheduleId);
     } catch (error) {
       logError(
         `Failed to delete qstash schedule ${trigger.qstashScheduleId}`,

--- a/apps/api/src/utils/triggers.ts
+++ b/apps/api/src/utils/triggers.ts
@@ -103,6 +103,56 @@ export async function disableTriggersAndDeleteIntegration(
   });
 }
 
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableDeleteError(error: unknown) {
+  // deleteQstashSchedule throws `...: <status> <body>` for HTTP failures and
+  // plain Errors for missing config/network failures. Only retry timeouts,
+  // rate limits, 5xx, and network failures — 401/403/400 will never succeed.
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("not configured")) {
+    return false;
+  }
+  const match = message.match(/:\s(\d{3})\b/);
+  if (!match) {
+    return true;
+  }
+  const status = Number(match[1]);
+  return (
+    status === 408 || status === 425 || status === 429 || status >= 500
+  );
+}
+
+export async function deleteQstashScheduleWithRetry(
+  runtimeEnv: { QSTASH_TOKEN?: string; WORKFLOW_BASE_URL?: string },
+  scheduleId: string,
+  attempts = 3
+) {
+  const totalAttempts = Math.max(1, Math.floor(attempts));
+  let lastError: unknown = new Error(
+    `Failed to delete QStash schedule ${scheduleId}`
+  );
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
+    try {
+      await deleteQstashSchedule(runtimeEnv, scheduleId);
+      return;
+    } catch (error) {
+      lastError = error;
+
+      if (attempt >= totalAttempts || !isRetryableDeleteError(error)) {
+        throw error;
+      }
+
+      await delay(200 * attempt);
+    }
+  }
+
+  throw lastError;
+}
+
 export async function deleteQstashSchedulesForTriggers(
   runtimeEnv: { QSTASH_TOKEN?: string; WORKFLOW_BASE_URL?: string },
   affectedTriggers: readonly { qstashScheduleId: string | null }[]
@@ -112,13 +162,16 @@ export async function deleteQstashSchedulesForTriggers(
       continue;
     }
 
-    await deleteQstashSchedule(runtimeEnv, trigger.qstashScheduleId).catch(
-      (error) => {
-        logError(
-          `Failed to delete qstash schedule ${trigger.qstashScheduleId}`,
-          error
-        );
-      }
-    );
+    try {
+      await deleteQstashScheduleWithRetry(
+        runtimeEnv,
+        trigger.qstashScheduleId
+      );
+    } catch (error) {
+      logError(
+        `Failed to delete qstash schedule ${trigger.qstashScheduleId}`,
+        error
+      );
+    }
   }
 }


### PR DESCRIPTION
Moves previous QStash schedule deletion after database transaction commit with error handling. Uses a committed flag to only clean up new schedule if DB transaction fails, while logging previous schedule deletion failures for retry rather than failing the request.

Closes #395