### PR TITLE
style(dashboard): refresh workspace chrome

### DIFF
--- a/apps/dashboard/src/components/dashboard/app-sidebar.tsx
+++ b/apps/dashboard/src/components/dashboard/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
+  SidebarRail,
   useSidebar,
 } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
@@ -162,6 +163,7 @@ export function DashboardSidebar({
       <SidebarFooter>
         <OrgSelector />
       </SidebarFooter>
+      <SidebarRail />
       <SidebarResizeHandle
         onWidthChange={onWidthChange}
         onWidthChangeEnd={onWidthChangeEnd}

--- a/apps/dashboard/src/components/dashboard/chat-topbar-title.tsx
+++ b/apps/dashboard/src/components/dashboard/chat-topbar-title.tsx
@@ -179,7 +179,7 @@ export function ChatTopbarTitle({ chatId }: ChatTopbarTitleProps) {
               <DropdownMenu onOpenChange={setIsMenuOpen} open={isMenuOpen}>
                 <DropdownMenuTrigger
                   className={cn(
-                    "text-foreground hover:bg-accent focus-visible:bg-accent flex max-w-[20ch] min-w-0 cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 text-sm no-underline outline-hidden transition-colors hover:no-underline sm:max-w-[40ch]",
+                    "text-foreground hover:bg-accent focus-visible:bg-accent flex max-w-[20ch] min-w-0 cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 text-sm font-medium no-underline outline-hidden transition-colors hover:no-underline sm:max-w-[40ch]",
                     (isRenaming || isPinning) && "opacity-70"
                   )}
                   onDoubleClick={(event) => {

--- a/apps/dashboard/src/components/dashboard/content-topbar-title.tsx
+++ b/apps/dashboard/src/components/dashboard/content-topbar-title.tsx
@@ -13,7 +13,7 @@ export function ContentTopbarTitle({ contentId }: ContentTopbarTitleProps) {
   const title = data?.content.title;
 
   return (
-    <BreadcrumbPage className="block min-w-0 truncate">
+    <BreadcrumbPage className="block min-w-0 truncate font-medium">
       {title ?? "Content"}
     </BreadcrumbPage>
   );

--- a/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard/dashboard-shell.tsx
@@ -4,8 +4,7 @@ import { SidebarInset, SidebarProvider } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
 import { useReducedMotion } from "motion/react";
 import dynamic from "next/dynamic";
-import { usePathname } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { SubscriptionGate } from "@/components/billing/subscription-gate";
@@ -58,9 +57,6 @@ export function DashboardShell({
   const shellStyle: DashboardShellStyle = {
     "--eve-banner-height": visible ? EVE_BANNER_HEIGHT : "0rem",
   };
-  const pathname = usePathname();
-  const mainScrollRef = useRef<HTMLDivElement>(null);
-  const [mainScrolled, setMainScrolled] = useState(false);
   const {
     finishSidebarResize,
     setSidebarWidth,
@@ -72,22 +68,6 @@ export function DashboardShell({
   useEffect(() => {
     setDismissingOrganizationId(null);
   }, [organizationId]);
-
-  useEffect(() => {
-    const el = mainScrollRef.current;
-    if (!el) {
-      return;
-    }
-
-    const sync = () => {
-      const next = el.scrollTop > 0;
-      setMainScrolled((current) => (current === next ? current : next));
-    };
-
-    sync();
-    el.addEventListener("scroll", sync, { passive: true });
-    return () => el.removeEventListener("scroll", sync);
-  }, [pathname]);
 
   const handleStart = () => {
     if (!organizationId || starting) {
@@ -128,7 +108,7 @@ export function DashboardShell({
 
   return (
     <div
-      className="flex h-svh flex-col overflow-hidden overscroll-none"
+      className="bg-sidebar flex h-svh flex-col overflow-hidden overscroll-none"
       style={shellStyle}
     >
       {bannerAvailable || dismissing ? (
@@ -167,10 +147,7 @@ export function DashboardShell({
         style={sidebarStyle}
       >
         <DashboardSidebar
-          className={cn(
-            "transition-[left,right,width,top,height] [transition-duration:var(--sidebar-duration),var(--sidebar-duration),var(--sidebar-duration),200ms,200ms] [transition-timing-function:var(--sidebar-ease),var(--sidebar-ease),var(--sidebar-ease),ease-out,ease-out] motion-reduce:transition-none md:top-(--eve-banner-height) md:h-[calc(100svh-var(--eve-banner-height))]",
-            visible && "md:pt-0!"
-          )}
+          className="transition-[left,right,width,top,height] [transition-duration:var(--sidebar-duration),var(--sidebar-duration),var(--sidebar-duration),200ms,200ms] [transition-timing-function:var(--sidebar-ease),var(--sidebar-ease),var(--sidebar-ease),ease-out,ease-out] motion-reduce:transition-none md:top-(--eve-banner-height) md:h-[calc(100svh-var(--eve-banner-height))]"
           onWidthChange={setSidebarWidth}
           onWidthChangeEnd={finishSidebarResize}
           onWidthChangeStart={startSidebarResize}
@@ -178,28 +155,11 @@ export function DashboardShell({
           variant="inset"
           width={sidebarWidth}
         />
-        <SidebarInset
-          className={cn(
-            "border-sidebar-border min-h-0 min-w-0 overflow-hidden",
-            visible && "md:mt-0! md:rounded-t-none! md:border-t-0!"
-          )}
-        >
+        <SidebarInset className="min-h-0 min-w-0 overflow-hidden">
           <SiteHeader />
           <RestoreSidebarHome />
-          <div className="bg-muted relative flex min-h-0 flex-1 flex-col">
-            <div
-              className="scrollbar-stable scrollbar-floating border-sidebar-border bg-background @container/main -mx-px flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto overscroll-contain rounded-t-2xl border border-b-0"
-              ref={mainScrollRef}
-            >
-              <SubscriptionGate>{children}</SubscriptionGate>
-            </div>
-            <div
-              aria-hidden
-              className={cn(
-                "from-background duration-normal pointer-events-none absolute -inset-x-px top-px z-10 h-12 rounded-t-[calc(1rem-1px)] bg-linear-to-b from-20% to-transparent transition-opacity ease-out motion-reduce:transition-none",
-                mainScrolled ? "opacity-100" : "opacity-0"
-              )}
-            />
+          <div className="scrollbar-stable @container/main flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto overscroll-contain">
+            <SubscriptionGate>{children}</SubscriptionGate>
           </div>
         </SidebarInset>
         <div className="contents" id={RIGHT_PANEL_PORTAL_ID} />

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -20,6 +20,7 @@ import {
   BreadcrumbSeparator,
 } from "@notra/ui/components/ui/breadcrumb";
 import { Kbd, KbdGroup } from "@notra/ui/components/ui/kbd";
+import { Separator } from "@notra/ui/components/ui/separator";
 import { useIsApplePlatform } from "@notra/ui/hooks/use-is-apple-platform";
 import { cn } from "@notra/ui/lib/utils";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -201,7 +202,9 @@ export function SiteHeader() {
         }
 
         if (isCollectionDetail && isLast) {
-          return <BreadcrumbPage>{label}</BreadcrumbPage>;
+          return (
+            <BreadcrumbPage className="font-medium">{label}</BreadcrumbPage>
+          );
         }
 
         if (isClickable) {
@@ -209,7 +212,9 @@ export function SiteHeader() {
         }
 
         if (isLast) {
-          return <BreadcrumbPage>{label}</BreadcrumbPage>;
+          return (
+            <BreadcrumbPage className="font-medium">{label}</BreadcrumbPage>
+          );
         }
 
         return <span>{label}</span>;
@@ -275,7 +280,7 @@ export function SiteHeader() {
               key={`${id}-geo-item-${segment}`}
             >
               {isLast ? (
-                <BreadcrumbPage className="block truncate">
+                <BreadcrumbPage className="block truncate font-medium">
                   {label}
                 </BreadcrumbPage>
               ) : (
@@ -289,7 +294,7 @@ export function SiteHeader() {
             <HugeiconsIcon icon={ArrowRight01Icon} />
           </BreadcrumbSeparator>,
           <BreadcrumbItem className="min-w-0" key={`${id}-geo-tab`}>
-            <BreadcrumbPage className="block truncate">
+            <BreadcrumbPage className="block truncate font-medium">
               {geoTabLabel}
             </BreadcrumbPage>
           </BreadcrumbItem>,
@@ -317,19 +322,23 @@ export function SiteHeader() {
   })();
 
   return (
-    <header className="bg-muted flex h-12 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-      <div className="grid h-full w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-4 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
-        <div className="flex h-full min-w-0 items-center gap-2 overflow-hidden">
-          <SidebarToggle className="-mx-1.5" />
+    <header className="relative flex h-12 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+      <div className="grid h-full w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 px-4 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] lg:gap-2 lg:px-6">
+        <div className="flex min-w-0 items-center gap-1 overflow-hidden lg:gap-2">
+          <SidebarToggle className="-ml-1" />
+          <Separator
+            className="mx-2 h-4 self-center data-[orientation=vertical]:h-4 data-[orientation=vertical]:self-center"
+            orientation="vertical"
+          />
           <Breadcrumb className="min-w-0">
-            <BreadcrumbList className="min-w-0 flex-nowrap gap-2">
+            <BreadcrumbList className="text-foreground min-w-0 flex-nowrap gap-2 text-sm font-medium">
               {breadcrumbs}
             </BreadcrumbList>
           </Breadcrumb>
         </div>
         <button
           aria-label="Search"
-          className="bg-background/60 text-muted-foreground hover:bg-muted/60 @container/search hidden h-8 w-48 cursor-pointer items-center justify-center gap-2 rounded-lg border px-2 text-sm transition-colors md:flex lg:w-64 xl:w-80 @[8rem]/search:justify-start @[8rem]/search:px-3"
+          className="text-muted-foreground hover:bg-muted/50 @container/search hidden h-8 w-48 cursor-pointer items-center justify-center gap-2 rounded-lg border bg-transparent px-2 text-sm transition-colors md:flex lg:w-64 xl:w-80 @[8rem]/search:justify-start @[8rem]/search:px-3"
           onClick={() => setCommandPaletteOpen(true)}
           type="button"
         >

--- a/apps/dashboard/src/components/dashboard/nav-user.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-user.tsx
@@ -92,7 +92,7 @@ export function NavUser() {
                 className="rounded-lg"
                 src={getUserAvatarUrl(user.image, user.email)}
               />
-              <AvatarFallback className="bg-foreground/10 text-foreground flex items-center justify-center rounded-lg text-[0.6875rem] leading-none font-medium">
+              <AvatarFallback className="bg-sidebar-accent text-sidebar-foreground flex items-center justify-center rounded-lg text-[0.6875rem] leading-none font-medium">
                 <span className="-translate-y-px">{userInitial}</span>
               </AvatarFallback>
             </Avatar>
@@ -114,7 +114,7 @@ export function NavUser() {
                   className="rounded-lg"
                   src={getUserAvatarUrl(user.image, user.email)}
                 />
-                <AvatarFallback className="bg-foreground/10 text-foreground flex items-center justify-center rounded-lg text-xs leading-none font-medium">
+                <AvatarFallback className="bg-sidebar-accent text-sidebar-foreground flex items-center justify-center rounded-lg text-xs leading-none font-medium">
                   <span className="-translate-y-px">{userInitial}</span>
                 </AvatarFallback>
               </Avatar>

--- a/apps/dashboard/src/components/dashboard/sidebar-brand-header.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-brand-header.tsx
@@ -7,7 +7,7 @@ import { SidebarLabel } from "./sidebar-label";
 export function SidebarBrandHeader() {
   return (
     <div className="flex h-8 items-center gap-2 px-2 group-data-[collapsible=icon]:px-0">
-      <div className="flex size-7 shrink-0 items-center justify-center rounded-lg dark:bg-[#F6F3F1]">
+      <div className="bg-background flex size-7 shrink-0 items-center justify-center rounded-lg">
         <Notra className="size-7 dark:size-5" />
       </div>
       <SidebarLabel className="text-base font-semibold">Notra</SidebarLabel>

--- a/apps/dashboard/src/components/dashboard/sidebar-project-switcher.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-project-switcher.tsx
@@ -138,11 +138,11 @@ export function SidebarProjectSwitcher() {
                   <ProjectLogo
                     className="size-7 rounded-lg"
                     domain={activeDomain}
-                    fallbackClassName="bg-background p-1 ring-1 ring-foreground/10"
+                    fallbackClassName="bg-sidebar-accent rounded-lg"
                     name={activeProject.name}
                   />
                   <div className="grid min-w-0 flex-1 leading-tight">
-                    <SidebarLabel className="truncate text-sm font-semibold">
+                    <SidebarLabel className="truncate text-sm font-medium">
                       {activeProject.name}
                     </SidebarLabel>
                     {activeDomain ? (

--- a/apps/dashboard/src/components/dashboard/sidebar-toggle.tsx
+++ b/apps/dashboard/src/components/dashboard/sidebar-toggle.tsx
@@ -22,7 +22,10 @@ export function SidebarToggle({
     <Button
       aria-expanded={isOpen}
       aria-label={isOpen ? "Hide sidebar" : "Show sidebar"}
-      className={cn("cursor-pointer", className)}
+      className={cn(
+        "hover:bg-muted aria-expanded:hover:bg-muted dark:hover:bg-muted/50 dark:aria-expanded:hover:bg-muted/50 cursor-pointer bg-transparent aria-expanded:bg-transparent",
+        className
+      )}
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
       onClick={(event) => {

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -3,15 +3,7 @@
 @source "../../../../packages/ui/src/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";
 
-/* Status and GEO colour tokens come from @notra/ui/status.css via globals.css. */
-
-:root {
-  --sidebar: hsl(0 0% 100%);
-}
-
-.dark {
-  --sidebar: hsl(233 7% 8%);
-}
+/* Status, GEO, and sidebar tokens come from @notra/ui via globals.css. */
 
 @theme inline {
   --font-sans: var(--font-inter);


### PR DESCRIPTION
### Description
Refresh the dashboard workspace chrome so navigation and content surfaces have a consistent visual hierarchy.

The sidebar now uses shared tokens and an interaction rail, while the header, breadcrumbs, avatars, and project switcher have matching typography, borders, and hover treatments. The simplified shell removes the inset content frame and its scroll-shadow behavior.

### Screenshot/Recording (if applicable)
Not included.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I disclosed AI assistance used to prepare this PR

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the dashboard workspace chrome so navigation and content surfaces share a consistent visual hierarchy.

The sidebar, header, breadcrumbs, avatars, and project switcher now use shared `@notra/ui` tokens with matching typography, borders, and hover treatments.

**Refactors**
- Removes the inset content frame and its scroll-shadow behavior; content now fills the area below the header.
- Drops local sidebar token overrides so the shell inherits tokens from `@notra/ui`.

<sup>Written for commit 732581dd26133ebbe4eb22e32f128297b37499e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

