### PR TITLE
fix(auth): smooth testimonial transitions and improve carousel controls

### DIFF
--- a/apps/dashboard/src/components/auth/testimonial-carousel.tsx
+++ b/apps/dashboard/src/components/auth/testimonial-carousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CarouselProgress } from "@notra/ui/components/ui/carousel-progress";
+import { cn } from "@notra/ui/lib/utils";
 import { useReducedMotion } from "motion/react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -14,7 +15,6 @@ export function TestimonialCarousel() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [progress, setProgress] = useState(0);
   const shouldReduceMotion = useReducedMotion();
-  const testimonial = AUTH_TESTIMONIALS[activeIndex];
 
   useEffect(() => {
     if (shouldReduceMotion) {
@@ -41,44 +41,51 @@ export function TestimonialCarousel() {
     return () => window.clearInterval(interval);
   }, [activeIndex, shouldReduceMotion]);
 
-  if (!testimonial) {
-    return null;
-  }
-
   return (
     <section
       aria-label="Customer testimonials"
       aria-roledescription="carousel"
       className="flex w-full max-w-xl flex-col gap-5"
     >
-      <div aria-live={shouldReduceMotion ? "polite" : "off"}>
-        <figure
-          aria-label={`Testimonial ${activeIndex + 1} of ${AUTH_TESTIMONIALS.length}`}
-          aria-roledescription="slide"
-          className="fade-in-0 slide-in-from-bottom-2 animate-in duration-slower flex min-h-[15rem] flex-col justify-between gap-5 rounded-3xl bg-white/10 p-7 shadow-[0_0_0_0.0625rem_rgba(255,255,255,0.2)] motion-reduce:animate-none"
-          key={activeIndex}
-        >
-          <blockquote className="text-base leading-relaxed text-white">
-            "{testimonial.quote}"
-          </blockquote>
-          <figcaption className="flex items-center gap-3">
-            <Image
-              alt={testimonial.name}
-              className="size-10 shrink-0 rounded-full object-cover"
-              height={40}
-              src={testimonial.avatarSrc}
-              width={40}
-            />
-            <div className="flex flex-col">
-              <span className="text-sm font-semibold text-white">
-                {testimonial.name}
-              </span>
-              <span className="text-sm text-violet-100/75">
-                {testimonial.role}
-              </span>
-            </div>
-          </figcaption>
-        </figure>
+      <div
+        aria-live={shouldReduceMotion ? "polite" : "off"}
+        className="grid min-h-[15rem] rounded-3xl bg-white/10 p-7 shadow-[0_0_0_0.0625rem_rgba(255,255,255,0.2)]"
+      >
+        {AUTH_TESTIMONIALS.map((testimonial, index) => (
+          <figure
+            aria-hidden={index !== activeIndex}
+            aria-label={`Testimonial ${index + 1} of ${AUTH_TESTIMONIALS.length}`}
+            aria-roledescription="slide"
+            className={cn(
+              "duration-slower col-start-1 row-start-1 flex flex-col justify-between gap-5 transition-opacity ease-in-out motion-reduce:transition-none",
+              index === activeIndex
+                ? "opacity-100"
+                : "pointer-events-none select-none opacity-0"
+            )}
+            key={testimonial.name}
+          >
+            <blockquote className="text-base leading-relaxed text-white">
+              "{testimonial.quote}"
+            </blockquote>
+            <figcaption className="flex items-center gap-3">
+              <Image
+                alt={testimonial.name}
+                className="size-10 shrink-0 rounded-full object-cover"
+                height={40}
+                src={testimonial.avatarSrc}
+                width={40}
+              />
+              <div className="flex flex-col">
+                <span className="text-sm font-semibold text-white">
+                  {testimonial.name}
+                </span>
+                <span className="text-sm text-violet-100/75">
+                  {testimonial.role}
+                </span>
+              </div>
+            </figcaption>
+          </figure>
+        ))}
       </div>
       <CarouselProgress
         activeIndex={activeIndex}

--- a/packages/ui/src/components/ui/carousel-progress.tsx
+++ b/packages/ui/src/components/ui/carousel-progress.tsx
@@ -22,7 +22,7 @@ function CarouselProgress({
   const progressWidth = Math.min(100, Math.max(0, progress));
 
   return (
-    <div className={cn("flex items-center justify-center gap-2", className)}>
+    <div className={cn("flex items-center justify-center", className)}>
       {labels.map((label, index) => {
         const isActive = index === activeIndex;
 
@@ -30,30 +30,37 @@ function CarouselProgress({
           <button
             aria-current={isActive ? "true" : undefined}
             aria-label={label}
-            className={cn(
-              "relative h-2 cursor-pointer rounded-full transition-all duration-slow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none",
-              isActive ? "w-12" : "w-2",
-              variant === "inverted"
-                ? isActive
-                  ? "bg-white/20"
-                  : "bg-white/40 hover:bg-white/60"
-                : isActive
-                  ? "bg-foreground/15"
-                  : "bg-foreground/20 hover:bg-foreground/40"
-            )}
+            className="group flex h-11 cursor-pointer items-center justify-center rounded-full px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             key={label}
             onClick={() => onSelect(index)}
             type="button"
           >
-            {isActive ? (
-              <span
-                className={cn(
-                  "absolute inset-y-0 left-0 rounded-full",
-                  variant === "inverted" ? "bg-white" : "bg-foreground/60"
-                )}
-                style={{ width: `${progressWidth}%` }}
-              />
-            ) : null}
+            <span
+              aria-hidden="true"
+              className={cn(
+                "pointer-events-none relative block h-2 overflow-hidden rounded-full transition-[width,background-color] duration-slow motion-reduce:transition-none",
+                isActive ? "w-12" : "w-2",
+                variant === "inverted"
+                  ? isActive
+                    ? "bg-white/20"
+                    : "bg-white/40 group-hover:bg-white/60"
+                  : isActive
+                    ? "bg-foreground/15"
+                    : "bg-foreground/20 group-hover:bg-foreground/40"
+              )}
+            >
+              {isActive ? (
+                <span
+                  className={cn(
+                    "absolute inset-y-0 left-0 min-w-2 rounded-full",
+                    variant === "inverted" ? "bg-white" : "bg-foreground/60"
+                  )}
+                  style={{
+                    width: `calc(${progressWidth}% + ${0.5 * (1 - progressWidth / 100)}rem)`,
+                  }}
+                />
+              ) : null}
+            </span>
           </button>
         );
       })}


### PR DESCRIPTION
### Description
Smooth out the login testimonial carousel by crossfading quote content while keeping the card background and height stable. Enlarge the pagination click targets and keep progress indicators rounded while growing continuously from the start.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths the login testimonial carousel by crossfading quotes while keeping the card background and height stable. Enlarges the pagination click targets and makes the progress indicator grow continuously from a rounded start.

<sup>Written for commit 06bf98e7a023a09c2633b676cbe9511b5fba8303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

