### PR TITLE
feat(geo): replace more models hint with scroll fade

### DIFF
--- a/apps/dashboard/src/components/geo/mention-rate-card.tsx
+++ b/apps/dashboard/src/components/geo/mention-rate-card.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { ArrowDown01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
+import { PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   GEO_EMPTY_PROMPT_RESULTS,
   GEO_EMPTY_TIMESERIES,
   GEO_FAMILY_STAT_TREND_HINT,
   GEO_MAX_ENGINES,
-  GEO_MENTION_HINT_BLEED_REM,
-  GEO_MENTION_HINT_HEIGHT_REM,
+  GEO_MENTION_FADE_HEIGHT_REM,
   GEO_MENTION_ROW_HEIGHT_REM,
   GEO_MENTION_SUMMARY_VISIBLE,
   GEO_MENTION_UNTRACKED_HINT,
@@ -33,13 +32,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
-import {
-  AnimatePresence,
-  domAnimation,
-  LazyMotion,
-  m,
-  useReducedMotion,
-} from "motion/react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -55,7 +47,6 @@ import {
 } from "@/components/instrument/instrument-module";
 import { GEO_TRAFFIC_HOVER_DELAY_MS } from "@/constants/geo-traffic-hover";
 import { trackEvent } from "@/lib/analytics/posthog-client";
-import { EASE_OUT } from "@/lib/ease";
 import {
   useGeoModelCatalog,
   useGeoSettingsEngineAdd,
@@ -63,32 +54,19 @@ import {
 import { useScrollOverflow } from "@/lib/hooks/use-scroll-overflow";
 import { cn } from "@/lib/utils";
 import type {
-  MentionMoreModelsHintProps,
   MentionProviderRowProps,
   MentionRateCardProps,
 } from "@/types/geo";
 import {
   buildMentionProviderRows,
-  mentionMoreModelsLabel,
   mentionOverviewTotals,
   mentionStatTrends,
   withTrackedMentionEngines,
 } from "@/utils/geo-charts";
 
-const HINT_TRANSITION = { duration: 0.2, ease: EASE_OUT } as const;
-const HINT_HIDDEN = { opacity: 0 } as const;
-const HINT_VISIBLE = { opacity: 1 } as const;
-const HINT_ROW_CLASS =
-  "group border-border bg-card text-foreground/70 hover:text-foreground focus-visible:ring-ring absolute inset-x-0 flex w-full cursor-pointer items-center justify-center gap-1.5 border-t text-xs transition-colors outline-none focus-visible:ring-2";
-const HINT_ROW_HOVER_CLASS =
-  "group-hover:bg-muted/50 pointer-events-none absolute inset-0 transition-colors";
 const ROW_STYLE = { height: `${GEO_MENTION_ROW_HEIGHT_REM}rem` } as const;
-const HINT_ROW_STYLE = {
-  top: `calc(${GEO_MENTION_SUMMARY_VISIBLE * GEO_MENTION_ROW_HEIGHT_REM}rem - 1px)`,
-  bottom: `-${GEO_MENTION_HINT_BLEED_REM}rem`,
-} as const;
 const LIST_STYLE = {
-  maxHeight: `${GEO_MENTION_SUMMARY_VISIBLE * GEO_MENTION_ROW_HEIGHT_REM + GEO_MENTION_HINT_HEIGHT_REM}rem`,
+  maxHeight: `${GEO_MENTION_SUMMARY_VISIBLE * GEO_MENTION_ROW_HEIGHT_REM + GEO_MENTION_FADE_HEIGHT_REM}rem`,
   scrollbarWidth: "none",
 } as const;
 
@@ -191,49 +169,6 @@ function ProviderRow({
   );
 }
 
-function MoreModelsHint({
-  count,
-  visible,
-  onClick,
-}: MentionMoreModelsHintProps) {
-  const reduceMotion = useReducedMotion();
-  const row = (
-    <button
-      aria-label={`Show ${mentionMoreModelsLabel(count)}`}
-      className={HINT_ROW_CLASS}
-      onClick={onClick}
-      style={HINT_ROW_STYLE}
-      type="button"
-    >
-      <span aria-hidden="true" className={HINT_ROW_HOVER_CLASS} />
-      <span className="relative">{mentionMoreModelsLabel(count)}</span>
-      <HugeiconsIcon className="relative" icon={ArrowDown01Icon} size={12} />
-    </button>
-  );
-
-  if (reduceMotion) {
-    return visible ? row : null;
-  }
-
-  return (
-    <LazyMotion features={domAnimation}>
-      <AnimatePresence initial={false}>
-        {visible ? (
-          <m.div
-            animate={HINT_VISIBLE}
-            exit={HINT_HIDDEN}
-            initial={HINT_HIDDEN}
-            key="more-models"
-            transition={HINT_TRANSITION}
-          >
-            {row}
-          </m.div>
-        ) : null}
-      </AnimatePresence>
-    </LazyMotion>
-  );
-}
-
 export function MentionRateCard({
   engines,
   settings,
@@ -297,7 +232,6 @@ export function MentionRateCard({
   );
   const overviewDelta = mentionStatTrends(timeseriesPoints).mentionDelta;
   const [selected, setSelected] = useState<GeoEngineFamily | null>(null);
-  const reduceMotion = useReducedMotion();
   const openFamily = (family: GeoEngineFamily) => {
     const row = ranked.find((entry) => entry.family.family === family.family);
     trackEvent(POSTHOG_EVENTS.GEO_ENGINE_FAMILY_OPENED, {
@@ -316,11 +250,7 @@ export function MentionRateCard({
       onSuccess: () => toast.success(`${name} added to tracking`),
     });
   };
-  const { ref, hiddenBelow, atEnd, scrollToEnd } =
-    useScrollOverflow<HTMLDivElement>(
-      ranked.length,
-      GEO_MENTION_HINT_HEIGHT_REM
-    );
+  const { ref, atEnd } = useScrollOverflow<HTMLDivElement>(ranked.length);
 
   return (
     <div className="relative h-full">
@@ -355,11 +285,15 @@ export function MentionRateCard({
                 <span>{GEO_PROVIDER_COLUMN_LABEL}</span>
                 <span>{GEO_PROVIDER_MENTIONS_COLUMN_LABEL}</span>
               </div>
-              <div className="relative flex-1">
+              <div className="relative">
                 <div
-                  className="border-border relative overflow-y-auto [&::-webkit-scrollbar]:hidden [&>button:last-of-type]:border-b-0"
+                  aria-label="Mentions by provider"
+                  className="border-border focus-visible:ring-ring relative overflow-y-auto overscroll-contain outline-none focus-visible:ring-2 [&::-webkit-scrollbar]:hidden [&>button:last-of-type]:border-b-0"
                   ref={ref}
+                  role="region"
                   style={LIST_STYLE}
+                  // oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- The scroll region must support keyboard scrolling, including when every row is disabled.
+                  tabIndex={0}
                 >
                   {ranked.map((row, index) => (
                     <ProviderRow
@@ -374,10 +308,13 @@ export function MentionRateCard({
                     />
                   ))}
                 </div>
-                <MoreModelsHint
-                  count={hiddenBelow}
-                  onClick={() => scrollToEnd(!reduceMotion)}
-                  visible={!atEnd && hiddenBelow > 0}
+                <div
+                  aria-hidden="true"
+                  className={cn(
+                    "from-card pointer-events-none absolute inset-x-0 bottom-0 bg-linear-to-t to-transparent transition-opacity duration-200 motion-reduce:transition-none",
+                    atEnd ? "opacity-0" : "opacity-100"
+                  )}
+                  style={{ height: `${GEO_MENTION_FADE_HEIGHT_REM}rem` }}
                 />
               </div>
             </div>

--- a/apps/dashboard/src/lib/hooks/use-scroll-overflow.ts
+++ b/apps/dashboard/src/lib/hooks/use-scroll-overflow.ts
@@ -2,50 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import type {
-  ScrollOverflow,
-  ScrollOverflowState,
-} from "@/types/scroll-overflow";
-
-const EDGE_TOLERANCE_PX = 1;
-const DEFAULT_ROOT_FONT_PX = 16;
-const INITIAL_STATE: ScrollOverflowState = { hiddenBelow: 0, atEnd: true };
-
-function remToPx(rem: number): number {
-  const rootSize = Number.parseFloat(
-    getComputedStyle(document.documentElement).fontSize
-  );
-  return rem * (Number.isFinite(rootSize) ? rootSize : DEFAULT_ROOT_FONT_PX);
-}
-
-function measureOverflow(
-  node: HTMLElement,
-  insetRem: number
-): ScrollOverflowState {
-  const atEnd =
-    node.scrollTop + node.clientHeight + EDGE_TOLERANCE_PX >= node.scrollHeight;
-  const visibleBottom = node.scrollTop + node.clientHeight - remToPx(insetRem);
-  let hiddenBelow = 0;
-  for (const child of node.children) {
-    if (!(child instanceof HTMLElement)) {
-      continue;
-    }
-    if (
-      child.offsetTop + child.offsetHeight >
-      visibleBottom + EDGE_TOLERANCE_PX
-    ) {
-      hiddenBelow += 1;
-    }
-  }
-  return { hiddenBelow, atEnd };
-}
+import type { ScrollOverflow } from "@/types/scroll-overflow";
 
 export function useScrollOverflow<T extends HTMLElement>(
-  itemCount: number,
-  insetRem = 0
+  itemCount: number
 ): ScrollOverflow<T> {
   const ref = useRef<T>(null);
-  const [state, setState] = useState<ScrollOverflowState>(INITIAL_STATE);
+  const [atEnd, setAtEnd] = useState(true);
 
   useEffect(() => {
     const node = ref.current;
@@ -53,7 +16,7 @@ export function useScrollOverflow<T extends HTMLElement>(
       return;
     }
     const measure = () => {
-      setState(measureOverflow(node, insetRem));
+      setAtEnd(node.scrollTop + node.clientHeight + 1 >= node.scrollHeight);
     };
     measure();
     node.addEventListener("scroll", measure, { passive: true });
@@ -63,18 +26,7 @@ export function useScrollOverflow<T extends HTMLElement>(
       node.removeEventListener("scroll", measure);
       observer.disconnect();
     };
-  }, [insetRem, itemCount]);
+  }, [itemCount]);
 
-  const scrollToEnd = (smooth: boolean) => {
-    const node = ref.current;
-    if (!node) {
-      return;
-    }
-    node.scrollTo({
-      top: node.scrollHeight,
-      behavior: smooth ? "smooth" : "auto",
-    });
-  };
-
-  return { ref, ...state, scrollToEnd };
+  return { ref, atEnd };
 }

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -580,12 +580,6 @@ export interface MentionProviderRowProps {
   tracking: boolean;
 }
 
-export interface MentionMoreModelsHintProps {
-  count: number;
-  visible: boolean;
-  onClick: () => void;
-}
-
 export interface MentionRateCardProps extends EngineFamilyBrandScope {
   engines: GeoOverviewEngine[];
   settings?: GeoSettings;

--- a/apps/dashboard/src/types/scroll-overflow.ts
+++ b/apps/dashboard/src/types/scroll-overflow.ts
@@ -1,13 +1,6 @@
 import type { RefObject } from "react";
 
-export interface ScrollOverflowState {
-  hiddenBelow: number;
-  atEnd: boolean;
-}
-
-export interface ScrollOverflow<
-  T extends HTMLElement,
-> extends ScrollOverflowState {
+export interface ScrollOverflow<T extends HTMLElement> {
   ref: RefObject<T | null>;
-  scrollToEnd: (smooth: boolean) => void;
+  atEnd: boolean;
 }

--- a/apps/dashboard/src/utils/geo-charts.ts
+++ b/apps/dashboard/src/utils/geo-charts.ts
@@ -689,10 +689,6 @@ export function buildMentionProviderRows(
     .sort(compareMentionProviderRows);
 }
 
-export function mentionMoreModelsLabel(count: number): string {
-  return count === 1 ? "1 more model" : `${count.toLocaleString()} more models`;
-}
-
 function sumFamilyWindow(
   days: readonly string[],
   byDay: ReadonlyMap<string, FamilyDayBucket>

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -989,8 +989,7 @@ export const GEO_MENTION_TREND_ALL_PROVIDERS_LABEL = "All Models";
 export const GEO_MENTION_ACTIVITY_LABEL = "Mention activity";
 export const GEO_MENTION_SUMMARY_VISIBLE = 5;
 export const GEO_MENTION_ROW_HEIGHT_REM = 2.75;
-export const GEO_MENTION_HINT_HEIGHT_REM = 2;
-export const GEO_MENTION_HINT_BLEED_REM = 1;
+export const GEO_MENTION_FADE_HEIGHT_REM = 2;
 export const GEO_MENTION_UNTRACKED_HINT =
   "These mentions come from earlier scans. Add the model back in GEO settings to keep tracking it.";
 export const GEO_PROVIDER_COLUMN_LABEL = "Provider";


### PR DESCRIPTION
### Description
Replace the “more models” button in the Mentions card with a scrollable list of all available providers. A theme-aware bottom gradient indicates additional content, disappears at the end, and returns when scrolling back up. Lists without overflow show no fade.

Supports keyboard scrolling and reduced-motion preferences. Removes the obsolete hint component and counting logic.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the "more models" button in the Mentions card with a scrollable list of all providers. A theme-aware bottom gradient indicates additional content, disappears at the end, and returns when scrolling back up; lists without overflow show no fade.

- The scroll region now supports keyboard scrolling and honors reduced-motion preferences.
- Removes the hint component, its label helper, and the overflow-counting logic.

<sup>Written for commit 716c2a26a95c1d00a97f652d0bfe92a2d56708d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

