### PR TITLE
fix: resolve code quality formatting failures

### DIFF
--- a/apps/dashboard/src/components/auth/testimonial-carousel.tsx
+++ b/apps/dashboard/src/components/auth/testimonial-carousel.tsx
@@ -60,7 +60,7 @@ export function TestimonialCarousel() {
               "duration-slower col-start-1 row-start-1 flex flex-col justify-between gap-5 transition-opacity ease-in-out motion-reduce:transition-none",
               index === activeIndex
                 ? "opacity-100"
-                : "pointer-events-none select-none opacity-0"
+                : "pointer-events-none opacity-0 select-none"
             )}
             key={testimonial.name}
           >

--- a/apps/web/src/components/integrations/integrations-view.tsx
+++ b/apps/web/src/components/integrations/integrations-view.tsx
@@ -68,7 +68,7 @@ export function IntegrationsView({
                 Browse all
               </a>
             </div>
-            <div className="flex w-full max-w-[45rem] [scrollbar-width:none] items-center gap-2.5 overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden">
+            <div className="flex w-full max-w-[45rem] items-center gap-2.5 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               {categories.map((category) => {
                 const isActive = category.id === activeCategory;
                 return (


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code quality formatting failures by reordering Tailwind utility classes in the testimonial carousel and integrations view. No behavior changes.

<sup>Written for commit 9d63d98198408cb0ebd0a6c3d1aeab7f7a4f6511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

