### PR TITLE
fix(dashboard): persist last organization across browser sessions

### DIFF
--- a/apps/dashboard/src/lib/organizations/actions.ts
+++ b/apps/dashboard/src/lib/organizations/actions.ts
@@ -390,7 +390,10 @@ export async function createOrganizationAction(
           () => cookies(),
           "Failed to access cookies"
         );
-        cookieStore.set(LAST_VISITED_ORGANIZATION_COOKIE, slug, { path: "/" });
+        cookieStore.set(LAST_VISITED_ORGANIZATION_COOKIE, slug, {
+          path: "/",
+          maxAge: LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE,
+        });
       }
 
       return organization;
@@ -470,6 +473,7 @@ export async function updateOrganizationAction(
         ) {
           cookieStore.set(LAST_VISITED_ORGANIZATION_COOKIE, organization.slug, {
             path: "/",
+            maxAge: LAST_VISITED_ORGANIZATION_COOKIE_MAX_AGE,
           });
         }
       }


### PR DESCRIPTION
### Description
Persist the last-used organization cookie for 30 days when creating an organization or updating its slug, matching the existing organization-switch behavior. This prevents these actions from replacing the saved preference with a session-only cookie.


### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the last-used organization cookie so it persists across browser sessions after creating an organization or updating its slug. Previously these actions set a session-only cookie, overriding the saved preference; now they set the same 30-day max age used when switching organizations.

<sup>Written for commit 5a37cd3d9e8322e0aa53aecddc7ab2919e953482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

