### PR TITLE
feat(observability): trace AI call outcomes and GEO usage

### DIFF
--- a/packages/ai/src/router/lazy-model.ts
+++ b/packages/ai/src/router/lazy-model.ts
@@ -27,6 +27,8 @@ import type {
   RoutedModelContext,
   RouteMetadata,
 } from "@notra/ai/types/router";
+import { createModelCallTelemetry } from "@notra/ai/utils/model-call-telemetry";
+import { observeModelStream } from "@notra/ai/utils/observe-model-stream";
 
 import { otherGateway } from "./policy";
 import {
@@ -254,28 +256,60 @@ export class RoutedLanguageModel implements LanguageModelV3 {
     };
   }
 
-  doGenerate(
+  async doGenerate(
     options: LanguageModelV3CallOptions
   ): Promise<LanguageModelV3GenerateResult> {
-    return this.execute(options, async (route, params) => {
-      const result = await route.model.doGenerate(params);
-      return {
-        ...result,
-        providerMetadata: annotateProviderMetadata(
-          result.providerMetadata,
-          route
-        ),
-      };
+    const telemetry = createModelCallTelemetry({
+      logger: this.context.logger,
+      request: this.context.request,
+      operation: "generate",
+      signal: options.abortSignal,
     });
+    try {
+      const result = await this.execute(options, async (route, params) => {
+        telemetry.attempt(route);
+        const generated = await route.model.doGenerate(params);
+        return {
+          ...generated,
+          providerMetadata: annotateProviderMetadata(
+            generated.providerMetadata,
+            route
+          ),
+        };
+      });
+      telemetry.complete({ ...result, responseId: result.response?.id });
+      return result;
+    } catch (error) {
+      telemetry.fail(error);
+      throw error;
+    }
   }
 
-  doStream(
+  async doStream(
     options: LanguageModelV3CallOptions
   ): Promise<LanguageModelV3StreamResult> {
-    return this.execute(options, async (route, params) => {
-      const result = await route.model.doStream(params);
-      return { ...result, stream: annotateStream(result.stream, route) };
+    const telemetry = createModelCallTelemetry({
+      logger: this.context.logger,
+      request: this.context.request,
+      operation: "stream",
+      signal: options.abortSignal,
     });
+    try {
+      return await this.execute(options, async (route, params) => {
+        telemetry.attempt(route);
+        const result = await route.model.doStream(params);
+        return {
+          ...result,
+          stream: observeModelStream(
+            annotateStream(result.stream, route),
+            telemetry
+          ),
+        };
+      });
+    } catch (error) {
+      telemetry.fail(error);
+      throw error;
+    }
   }
 
   private getRoute(): Promise<ResolvedRoute> {

--- a/packages/ai/src/types/model-call-telemetry.ts
+++ b/packages/ai/src/types/model-call-telemetry.ts
@@ -1,0 +1,31 @@
+import type {
+  LanguageModelV3FinishReason,
+  LanguageModelV3Usage,
+} from "@ai-sdk/provider";
+import type {
+  ResolvedRoute,
+  RouteRequest,
+  RouterLogger,
+} from "@notra/ai/types/router";
+
+export interface ModelCallTelemetryOptions {
+  logger: RouterLogger;
+  request: RouteRequest;
+  operation: "generate" | "stream";
+  signal?: AbortSignal;
+}
+
+export interface ModelCallCompletion {
+  usage: LanguageModelV3Usage;
+  finishReason: LanguageModelV3FinishReason;
+  responseId?: string;
+}
+
+export interface ModelCallTelemetry {
+  attempt(route: ResolvedRoute): void;
+  firstChunk(): void;
+  complete(result: ModelCallCompletion): void;
+  fail(error: unknown): void;
+  abort(): void;
+  incomplete(): void;
+}

--- a/packages/ai/src/types/router.ts
+++ b/packages/ai/src/types/router.ts
@@ -168,7 +168,13 @@ export interface RouterPolicyConfig {
 }
 
 export interface RouterLogFields {
-  [key: string]: string | number | boolean | undefined | null;
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | undefined
+    | null
+    | Record<string, string | number | boolean | undefined | null>;
 }
 
 export interface RouterLogger {

--- a/packages/ai/src/utils/model-call-telemetry.ts
+++ b/packages/ai/src/utils/model-call-telemetry.ts
@@ -1,0 +1,143 @@
+import type {
+  ModelCallTelemetry,
+  ModelCallTelemetryOptions,
+} from "@notra/ai/types/model-call-telemetry";
+import type { ResolvedRoute, RouterLogFields } from "@notra/ai/types/router";
+
+/** One lifecycle per SDK model invocation, including any router fallback. */
+export function createModelCallTelemetry({
+  logger,
+  request,
+  operation,
+  signal,
+}: ModelCallTelemetryOptions): ModelCallTelemetry {
+  const callId = crypto.randomUUID();
+  const startedAt = performance.now();
+  let route: ResolvedRoute | undefined;
+  let attemptCount = 0;
+  let msToFirstChunk: number | undefined;
+  let finished = false;
+
+  function emit(
+    level: "info" | "warn" | "error",
+    event: string,
+    fields: RouterLogFields = {}
+  ) {
+    try {
+      logger[level](event, {
+        callId,
+        operation,
+        organizationId: request.organizationId,
+        requestedModel: request.modelId,
+        model: route?.decision.modelId ?? request.modelId,
+        gateway: route?.decision.gateway ?? request.gateway,
+        attemptCount,
+        fallbackFrom: route?.decision.fallbackFrom,
+        fallbackReason: route?.decision.fallbackReason,
+        zdrEnforced: route?.decision.zdrEnforced,
+        zdrRelaxed: route?.decision.zdrRelaxed,
+        ...fields,
+      });
+    } catch {
+      // Observability must not turn a provider success into a retry or failure.
+    }
+  }
+
+  function finish(
+    level: "info" | "warn" | "error",
+    event: string,
+    ai: Record<string, string | number | undefined> = {},
+    fields: RouterLogFields = {}
+  ) {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    signal?.removeEventListener("abort", abort);
+    const durationMs = Math.round(performance.now() - startedAt);
+    emit(level, event, {
+      durationMs,
+      ai: {
+        model: route?.decision.modelId ?? request.modelId,
+        msToFinish: durationMs,
+        msToFirstChunk,
+        ...ai,
+      },
+      ...fields,
+    });
+  }
+
+  function abort() {
+    finish("warn", "ai.call.aborted");
+  }
+
+  emit("info", "ai.call.started");
+  signal?.addEventListener("abort", abort, { once: true });
+  if (signal?.aborted) {
+    abort();
+  }
+
+  return {
+    attempt(nextRoute) {
+      route = nextRoute;
+      attemptCount += 1;
+    },
+    firstChunk() {
+      msToFirstChunk ??= Math.round(performance.now() - startedAt);
+    },
+    complete(result) {
+      if (finished) {
+        return;
+      }
+      const inputTokens = result.usage.inputTokens.total;
+      const outputTokens = result.usage.outputTokens.total;
+      const failed = result.finishReason.unified === "error";
+      finish(
+        failed ? "error" : "info",
+        failed ? "ai.call.failed" : "ai.call.completed",
+        {
+          inputTokens,
+          outputTokens,
+          totalTokens:
+            inputTokens !== undefined && outputTokens !== undefined
+              ? inputTokens + outputTokens
+              : undefined,
+          cacheReadTokens: result.usage.inputTokens.cacheRead,
+          reasoningTokens: result.usage.outputTokens.reasoning,
+          finishReason: result.finishReason.unified,
+          responseId: result.responseId,
+        },
+        failed ? { error: "Provider returned an error finish reason" } : {}
+      );
+    },
+    fail(error) {
+      if (
+        signal?.aborted ||
+        (error instanceof Error && error.name === "AbortError")
+      ) {
+        abort();
+        return;
+      }
+      finish(
+        "error",
+        "ai.call.failed",
+        {},
+        {
+          errorName: error instanceof Error ? error.name : typeof error,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
+    },
+    abort,
+    incomplete() {
+      finish(
+        "warn",
+        "ai.call.incomplete",
+        {},
+        {
+          error: "Stream closed without a finish event",
+        }
+      );
+    },
+  };
+}

--- a/packages/ai/src/utils/observe-model-stream.test.ts
+++ b/packages/ai/src/utils/observe-model-stream.test.ts
@@ -1,0 +1,242 @@
+import { spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, test } from "node:test";
+
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { createCaptureLogger } from "@notra/ai/router/test-helpers";
+
+import { createModelCallTelemetry } from "./model-call-telemetry";
+import { observeModelStream } from "./observe-model-stream";
+
+describe("stream terminal telemetry", () => {
+  let now: number;
+  let clock: ReturnType<typeof spyOn>;
+  let logger: ReturnType<typeof createCaptureLogger>;
+  let abortController: AbortController;
+  let source: ReadableStreamDefaultController<LanguageModelV3StreamPart>;
+  let reader: ReadableStreamDefaultReader<LanguageModelV3StreamPart>;
+  let cancelledWith: unknown;
+  let onPull: (() => void) | undefined;
+  let finish: LanguageModelV3StreamPart;
+
+  beforeEach(() => {
+    now = 0;
+    clock = spyOn(performance, "now").mockImplementation(() => now);
+    logger = createCaptureLogger();
+    abortController = new AbortController();
+    cancelledWith = undefined;
+    onPull = undefined;
+    const telemetry = createModelCallTelemetry({
+      logger,
+      request: { modelId: "test-model", organizationId: "org-test" },
+      operation: "stream",
+      signal: abortController.signal,
+    });
+    const stream = new ReadableStream<LanguageModelV3StreamPart>(
+      {
+        start(controller) {
+          source = controller;
+        },
+        pull() {
+          onPull?.();
+        },
+        cancel(reason) {
+          cancelledWith = reason;
+        },
+      },
+      { highWaterMark: 0 }
+    );
+    reader = observeModelStream(stream, telemetry).getReader();
+    finish = {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: { total: 11, noCache: 8, cacheRead: 3, cacheWrite: 0 },
+        outputTokens: { total: 7, text: 5, reasoning: 2 },
+      },
+    };
+  });
+
+  afterEach(() => {
+    clock.mockRestore();
+  });
+
+  test("finish records usage and first-content timing once, even after a later abort", async () => {
+    source.enqueue({ type: "response-metadata", id: "response-test" });
+    await reader.read();
+    now = 10;
+    source.enqueue({ type: "text-delta", id: "text", delta: "" });
+    await reader.read();
+    now = 20;
+    source.enqueue({
+      type: "reasoning-delta",
+      id: "reasoning",
+      delta: "first",
+    });
+    await reader.read();
+    now = 40;
+    source.enqueue({ type: "text-delta", id: "text", delta: "second" });
+    await reader.read();
+    assert.equal(logger.entries.length, 1);
+    now = 60;
+    source.enqueue(finish);
+    assert.equal((await reader.read()).value, finish);
+    now = 80;
+    source.close();
+    assert.equal((await reader.read()).done, true);
+    abortController.abort();
+    await reader.cancel();
+
+    assert.deepEqual(
+      logger.entries.map((entry) => entry.event),
+      ["ai.call.started", "ai.call.completed"]
+    );
+    const [start, terminal] = logger.entries;
+    assert.equal(terminal?.level, "info");
+    assert.ok(typeof start?.fields?.callId === "string");
+    assert.equal(terminal?.fields?.callId, start.fields.callId);
+    assert.equal(terminal?.fields?.organizationId, "org-test");
+    assert.equal(terminal?.fields?.durationMs, 60);
+    assert.deepEqual(terminal?.fields?.ai, {
+      model: "test-model",
+      msToFinish: 60,
+      msToFirstChunk: 20,
+      inputTokens: 11,
+      outputTokens: 7,
+      totalTokens: 18,
+      cacheReadTokens: 3,
+      reasoningTokens: 2,
+      finishReason: "stop",
+      responseId: "response-test",
+    });
+  });
+
+  test("an error chunk stays failed when a finish chunk arrives later", async () => {
+    const error = new Error("provider failed");
+    now = 40;
+    source.enqueue({ type: "error", error });
+    assert.deepEqual((await reader.read()).value, { type: "error", error });
+    now = 60;
+    source.enqueue(finish);
+    assert.equal((await reader.read()).value, finish);
+    source.close();
+    await reader.read();
+
+    assert.deepEqual(
+      logger.entries.map((entry) => entry.event),
+      ["ai.call.started", "ai.call.failed"]
+    );
+    const terminal = logger.entries[1];
+    assert.equal(terminal?.level, "error");
+    assert.equal(terminal?.fields?.error, error.message);
+    assert.equal(terminal?.fields?.durationMs, 40);
+    assert.deepEqual(terminal?.fields?.ai, {
+      model: "test-model",
+      msToFinish: 40,
+      msToFirstChunk: undefined,
+    });
+  });
+
+  test("a transport error is rethrown and records one failure", async () => {
+    const error = new Error("connection lost");
+    now = 30;
+    source.error(error);
+    await assert.rejects(reader.read(), (caught) => caught === error);
+    now = 50;
+    abortController.abort();
+
+    assert.deepEqual(
+      logger.entries.map((entry) => entry.event),
+      ["ai.call.started", "ai.call.failed"]
+    );
+    const terminal = logger.entries[1];
+    assert.equal(terminal?.level, "error");
+    assert.equal(terminal?.fields?.error, error.message);
+    assert.equal(terminal?.fields?.durationMs, 30);
+    assert.deepEqual(terminal?.fields?.ai, {
+      model: "test-model",
+      msToFinish: 30,
+      msToFirstChunk: undefined,
+    });
+  });
+
+  test("finishless EOF records incomplete without inventing usage or first-content timing", async () => {
+    now = 10;
+    source.close();
+    assert.equal((await reader.read()).done, true);
+    now = 20;
+    abortController.abort();
+
+    assert.deepEqual(
+      logger.entries.map((entry) => entry.event),
+      ["ai.call.started", "ai.call.incomplete"]
+    );
+    const terminal = logger.entries[1];
+    assert.equal(terminal?.level, "warn");
+    assert.equal(
+      terminal?.fields?.error,
+      "Stream closed without a finish event"
+    );
+    assert.equal(terminal?.fields?.durationMs, 10);
+    assert.deepEqual(terminal?.fields?.ai, {
+      model: "test-model",
+      msToFinish: 10,
+      msToFirstChunk: undefined,
+    });
+  });
+
+  test("cancelling an outstanding read reaches the upstream and records one abort", async () => {
+    now = 20;
+    source.enqueue({ type: "text-delta", id: "text", delta: "first" });
+    await reader.read();
+    const upstreamRead = new Promise<void>((resolve) => {
+      onPull = resolve;
+    });
+    const pending = reader.read();
+    await upstreamRead;
+    now = 60;
+    const reason = new Error("consumer stopped");
+    await reader.cancel(reason);
+    assert.equal((await pending).done, true);
+    assert.equal(cancelledWith, reason);
+    now = 80;
+    abortController.abort();
+
+    assert.deepEqual(
+      logger.entries.map((entry) => entry.event),
+      ["ai.call.started", "ai.call.aborted"]
+    );
+    const terminal = logger.entries[1];
+    assert.equal(terminal?.level, "warn");
+    assert.equal(terminal?.fields?.error, undefined);
+    assert.equal(terminal?.fields?.durationMs, 60);
+    assert.deepEqual(terminal?.fields?.ai, {
+      model: "test-model",
+      msToFinish: 60,
+      msToFirstChunk: 20,
+    });
+  });
+
+  test("an abort signal records an unconsumed stream once despite subsequent cancellation", async () => {
+    now = 25;
+    abortController.abort();
+    now = 50;
+    const reason = new Error("cleanup");
+    await reader.cancel(reason);
+    assert.equal(cancelledWith, reason);
+
+    assert.deepEqual(
+      logger.entries.map((entry) => entry.event),
+      ["ai.call.started", "ai.call.aborted"]
+    );
+    const terminal = logger.entries[1];
+    assert.equal(terminal?.level, "warn");
+    assert.equal(terminal?.fields?.error, undefined);
+    assert.equal(terminal?.fields?.durationMs, 25);
+    assert.deepEqual(terminal?.fields?.ai, {
+      model: "test-model",
+      msToFinish: 25,
+      msToFirstChunk: undefined,
+    });
+  });
+});

--- a/packages/ai/src/utils/observe-model-stream.ts
+++ b/packages/ai/src/utils/observe-model-stream.ts
@@ -1,0 +1,56 @@
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { ModelCallTelemetry } from "@notra/ai/types/model-call-telemetry";
+
+/** Observes consumption without buffering ahead or changing provider chunks. */
+export function observeModelStream(
+  stream: ReadableStream<LanguageModelV3StreamPart>,
+  telemetry: ModelCallTelemetry
+): ReadableStream<LanguageModelV3StreamPart> {
+  const reader = stream.getReader();
+  let responseId: string | undefined;
+  return new ReadableStream<LanguageModelV3StreamPart>(
+    {
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            telemetry.incomplete();
+            reader.releaseLock();
+            controller.close();
+            return;
+          }
+          if (value.type === "response-metadata") {
+            responseId = value.id;
+          }
+          if (
+            (value.type === "text-delta" ||
+              value.type === "reasoning-delta" ||
+              value.type === "tool-input-delta") &&
+            value.delta.length > 0
+          ) {
+            telemetry.firstChunk();
+          }
+          if (value.type === "error") {
+            telemetry.fail(value.error);
+          } else if (value.type === "finish") {
+            telemetry.complete({ ...value, responseId });
+          }
+          controller.enqueue(value);
+        } catch (error) {
+          telemetry.fail(error);
+          reader.releaseLock();
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        telemetry.abort();
+        try {
+          await reader.cancel(reason);
+        } finally {
+          reader.releaseLock();
+        }
+      },
+    },
+    { highWaterMark: 0 }
+  );
+}

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -158,6 +158,7 @@ function checkFailureFields(
     projectId: context.projectId,
     scanId: context.scanId,
     engine: task.engine,
+    runId: context.runId,
     promptId: task.prompt.id,
     language: task.language,
     grounded: task.grounded !== null,
@@ -176,6 +177,7 @@ function sequenceFailureFields(
     projectId: context.projectId,
     scanId: context.scanId,
     engine,
+    runId: context.runId,
     promptId: sequencePromptId(sequence.id),
     sequenceId: sequence.id,
     language: DEFAULT_LANGUAGE,
@@ -1070,6 +1072,7 @@ const buildGeoScanProjectPlan = Effect.fn("geo.buildScanProjectPlan")(
               organizationId,
               projectId: settingsRow.projectId,
               scanId,
+              runId,
               language,
               grounded: false,
             })
@@ -1198,6 +1201,7 @@ const buildGeoScanCheckContext = Effect.fn("geo.buildScanCheckContext")(
       organizationId: context.organizationId,
       projectId: context.projectId,
       scanId: context.scanId,
+      runId: context.runId,
       catalog,
       capturedAt: new Date(),
       companyName: context.companyName,
@@ -1237,6 +1241,7 @@ export const runGeoScanTaskBatch = Effect.fn("geo.runScanTaskBatch")(function* (
         projectId: context.projectId,
         scanId: context.scanId,
         engine: planned.engine,
+        runId: context.runId,
         promptId: planned.prompt.id,
         language: planned.language,
         grounded: true,
@@ -1288,6 +1293,7 @@ export const runGeoScanTaskBatch = Effect.fn("geo.runScanTaskBatch")(function* (
       projectId: context.projectId,
       scanId: context.scanId,
       engine: summary.engine,
+      runId: context.runId,
       attempted: summary.attempted,
       failed: summary.failed,
     });
@@ -1494,8 +1500,10 @@ export const finalizeGeoScanProject = Effect.fn("geo.finalizeScanProject")(
     ).pipe(
       geoSkip("scan row finish failed", {
         event: "geo.scan.stamp_failed",
+        organizationId: context.organizationId,
         projectId: context.projectId,
         scanId: context.scanId,
+        runId: context.runId,
         stamp: status,
       })
     );
@@ -1506,7 +1514,10 @@ export const finalizeGeoScanProject = Effect.fn("geo.finalizeScanProject")(
           ? markGeoScanFinished(context.projectId, claimedAt).pipe(
               geoSkip("scan finish stamp failed", {
                 event: "geo.scan.stamp_failed",
+                organizationId: context.organizationId,
                 projectId: context.projectId,
+                scanId: context.scanId,
+                runId: context.runId,
                 stamp: "finished",
               })
             )
@@ -1526,6 +1537,7 @@ export const finalizeGeoScanProject = Effect.fn("geo.finalizeScanProject")(
       checks: totals.checks,
       mentions: totals.mentions,
       droppedChecks: totals.dropped,
+      usage: totals.usage,
       durationMs: Date.now() - context.startedAtMs,
     });
     yield* flushGeoLogEffect;
@@ -1963,6 +1975,7 @@ const runGeoSequenceNowProgram = Effect.fn("geo.runSequenceNow")(function* (
           organizationId: scope.organizationId,
           projectId,
           scanId,
+          runId,
           catalog,
           capturedAt: new Date(),
           companyName: settings.companyName,

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -609,6 +609,7 @@ export interface GeoCheckContext {
   organizationId: string;
   projectId: string;
   scanId: string;
+  runId: string;
   capturedAt: Date;
   companyName: string;
   aliases: string[];


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end tracing for AI model calls and GEO scan runs so observability can capture call outcomes, token usage, and timing without changing routing or stream behavior.

**AI call observability**
- Each model invocation logs `started`, `attempted`, `completed`, `failed`, `aborted`, and `incomplete` events.
- Logs include attempt count, fallback and ZDR decisions, token usage, duration, time to first chunk, and finish reason.
- Streams are observed without buffering or altering provider chunks, and aborts or stream errors are reported.

**GEO usage tracking**
- `runId` is added to the GEO check context and included in failure and completion logs.
- Scan completion logs now report token usage totals, and stamp-failure logs include organization and run IDs.

<sup>Written for commit 081dc909a755c7a9df23d9d97d18fb41bfff48c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

