### PR TITLE
style: format Tailwind class ordering

### DIFF
--- a/apps/dashboard/src/components/geo/shelf/shelf-detail-dialog.tsx
+++ b/apps/dashboard/src/components/geo/shelf/shelf-detail-dialog.tsx
@@ -78,7 +78,7 @@ export function ShelfDetailDialog({
 
   return (
     <ResponsiveDialog onOpenChange={onOpenChange} open={open}>
-      <ResponsiveDialogContent className="max-h-[90vh] gap-8 overflow-x-hidden overflow-y-auto p-5 [scrollbar-gutter:stable] sm:max-w-3xl sm:p-6">
+      <ResponsiveDialogContent className="max-h-[90vh] [scrollbar-gutter:stable] gap-8 overflow-x-hidden overflow-y-auto p-5 sm:max-w-3xl sm:p-6">
         <ResponsiveDialogHeader className="gap-2">
           <ResponsiveDialogTitle className="text-xl font-semibold tracking-tight text-pretty">
             {row.title ?? row.domain}

--- a/apps/web/src/components/integrations/integrations-view.tsx
+++ b/apps/web/src/components/integrations/integrations-view.tsx
@@ -68,7 +68,7 @@ export function IntegrationsView({
                 Browse all
               </a>
             </div>
-            <div className="flex w-full max-w-[45rem] items-center gap-2.5 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <div className="flex w-full max-w-[45rem] [scrollbar-width:none] items-center gap-2.5 overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden">
               {categories.map((category) => {
                 const isActive = category.id === activeCategory;
                 return (


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders Tailwind arbitrary-value classes to match the project's class-ordering convention in the shelf detail dialog and integrations view. No behavior changes.

<sup>Written for commit a4719028a93dd5382e1e71dc7e16fc07832f4e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

