### PR TITLE
fix(dashboard): improve references loading semantics

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/references-list.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/brand/identity/components/references-list.tsx
@@ -109,45 +109,53 @@ export function ReferencesList({
     onDialogOpenChange(open);
   };
 
+  let content = (
+    <div className="columns-1 gap-4 space-y-4 sm:columns-2">
+      {references.map((ref) => (
+        <ReferenceCard
+          isDeleting={deletingId === ref.id}
+          key={ref.id}
+          onDelete={handleDelete}
+          onUpdateApplicableTo={handleUpdateApplicableTo}
+          onUpdateNote={handleUpdateNote}
+          reference={ref}
+        />
+      ))}
+    </div>
+  );
+
+  if (isPending) {
+    content = (
+      <output>
+        <span className="sr-only">Loading references</span>
+        <div aria-hidden="true" className="grid gap-4 sm:grid-cols-2">
+          <Skeleton className="h-48 w-full rounded-xl" />
+          <Skeleton className="h-48 w-full rounded-xl" />
+        </div>
+      </output>
+    );
+  } else if (references.length === 0) {
+    content = (
+      <EmptyState
+        actionIcon={<HugeiconsIcon className="size-4" icon={Add01Icon} />}
+        actionLabel="Add Reference"
+        description="Add a tweet or writing sample so the AI can match your style."
+        onActionClick={() => onDialogOpenChange(true)}
+        preview={
+          <EmptyStateCardsPreview
+            columns={2}
+            count={EMPTY_STATE_CARD_COUNT.reference}
+            variant="reference"
+          />
+        }
+        title="No references yet"
+      />
+    );
+  }
+
   return (
     <div className="space-y-4">
-      {isPending ? (
-        <div role="status">
-          <span className="sr-only">Loading references</span>
-          <div aria-hidden="true" className="grid gap-4 sm:grid-cols-2">
-            <Skeleton className="h-48 w-full rounded-xl" />
-            <Skeleton className="h-48 w-full rounded-xl" />
-          </div>
-        </div>
-      ) : references.length === 0 ? (
-        <EmptyState
-          actionIcon={<HugeiconsIcon className="size-4" icon={Add01Icon} />}
-          actionLabel="Add Reference"
-          description="Add a tweet or writing sample so the AI can match your style."
-          onActionClick={() => onDialogOpenChange(true)}
-          preview={
-            <EmptyStateCardsPreview
-              columns={2}
-              count={EMPTY_STATE_CARD_COUNT.reference}
-              variant="reference"
-            />
-          }
-          title="No references yet"
-        />
-      ) : (
-        <div className="columns-1 gap-4 space-y-4 sm:columns-2">
-          {references.map((ref) => (
-            <ReferenceCard
-              isDeleting={deletingId === ref.id}
-              key={ref.id}
-              onDelete={handleDelete}
-              onUpdateApplicableTo={handleUpdateApplicableTo}
-              onUpdateNote={handleUpdateNote}
-              reference={ref}
-            />
-          ))}
-        </div>
-      )}
+      {content}
 
       <AddReferenceDialog
         initialStep={initialStep}


### PR DESCRIPTION
## Summary
- use the semantic `output` element for the references loading status
- replace the nested rendering ternary with explicit content branches

## Verification
- `bunx biome lint apps/dashboard/src/app/\(dashboard\)/\[slug\]/brand/identity/components/references-list.tsx`
- pre-commit formatting and knip checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps the references list loading status to the semantic `output` element and replaces the nested rendering ternary with explicit content branches.

<sup>Written for commit b09342692bf3cdf8f6e668159eed84ed12fabd40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

