### PR TITLE
fix(geo): simplify AI traffic layout and prevent tooltip clipping

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/traffic/skeleton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/traffic/skeleton.tsx
@@ -25,17 +25,16 @@ export function GeoTrafficSkeleton() {
         </header>
         <div className="flex flex-col gap-6">
           <div className="border-border bg-card overflow-hidden rounded-2xl border">
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="bg-muted/40 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
               {GEO_TRAFFIC_FUNNEL_STAGES.map((stage) => (
                 <div
-                  className="border-border space-y-2 border-b px-5 py-4 last:border-b-0 sm:odd:border-r sm:nth-[n+3]:border-b-0 lg:border-r lg:border-b-0 lg:last:border-r-0"
+                  className="border-border space-y-3 border-b px-5 py-5 last:border-b-0 sm:px-6 sm:odd:border-r sm:nth-[n+3]:border-b-0 lg:border-r lg:border-b-0 lg:last:border-r-0"
                   key={stage.key}
                 >
-                  <Skeleton className="h-3 w-24" />
-                  <Skeleton className="h-2.5 w-40" />
-                  <div className="flex items-baseline gap-2">
-                    <Skeleton className="h-9 w-16" />
-                    <Skeleton className="h-5 w-10 rounded-full" />
+                  <Skeleton className="h-6 w-32" />
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-9 w-20" />
+                    <Skeleton className="h-7 w-12 rounded-md" />
                   </div>
                 </div>
               ))}

--- a/apps/dashboard/src/components/geo/ai-traffic-log-card.tsx
+++ b/apps/dashboard/src/components/geo/ai-traffic-log-card.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { PauseIcon, PlayIcon, QuotesIcon } from "@hugeicons/core-free-icons";
+import {
+  ArrowDown01Icon,
+  PauseIcon,
+  PlayIcon,
+  QuotesIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   GEO_CITATIONS_LIVE_INTERVAL_MS,
@@ -13,12 +18,12 @@ import {
 import type { GeoTrafficLogFilters } from "@notra/geo-core/types/geo";
 import {
   formatGeoTrafficFilterLabel,
-  formatGeoTrafficRequestCount,
   isGeoTrafficCitationsOnly,
   toggleGeoTrafficCitationsOnly,
   toggleGeoTrafficFilterValue,
 } from "@notra/geo-core/utils/ai-traffic";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
+import { Button } from "@notra/ui/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -27,7 +32,6 @@ import {
 } from "@notra/ui/components/ui/dropdown-menu";
 import { type ReactNode, useState } from "react";
 
-import { Button } from "@/components/button";
 import { CitationsTable } from "@/components/geo/citations-table";
 import { GeoTableSkeleton } from "@/components/geo/skeleton-parts";
 import {
@@ -38,7 +42,6 @@ import { TRAFFIC_LOG_FILTER_KINDS } from "@/constants/geo-analytics";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import { useGeoTrafficLog } from "@/lib/hooks/use-geo";
 import { useTablePagination } from "@/lib/hooks/use-table-pagination";
-import { cn } from "@/lib/utils";
 import type { AiTrafficLogCardProps } from "@/types/geo";
 import { paginatedTableHeightFor } from "@/utils/table";
 
@@ -61,11 +64,6 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
     isReady: !isPending,
   });
   const citationsOnly = isGeoTrafficCitationsOnly(filters.categories);
-  let readout: string | undefined;
-  if (!isPending) {
-    readout =
-      total === 0 ? "no visits yet" : formatGeoTrafficRequestCount(total);
-  }
 
   let body: ReactNode;
   if (isPending) {
@@ -91,15 +89,22 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
   }
 
   const filterRow = (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-wrap items-center gap-1.5">
       <DropdownMenu>
-        <DropdownMenuTrigger render={<Button size="sm" variant="outline" />}>
+        <DropdownMenuTrigger render={<Button size="sm" variant="ghost" />}>
           {formatGeoTrafficFilterLabel(
             "All visitors",
             "visitors",
             filters.visitorTypes,
             GEO_TRAFFIC_LOG_VISITOR_OPTIONS
           )}
+          <HugeiconsIcon
+            aria-hidden="true"
+            className="text-muted-foreground"
+            data-icon="inline-end"
+            icon={ArrowDown01Icon}
+            strokeWidth={2}
+          />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
           {GEO_TRAFFIC_LOG_VISITOR_OPTIONS.map((option) => (
@@ -128,13 +133,20 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu>
-        <DropdownMenuTrigger render={<Button size="sm" variant="outline" />}>
+        <DropdownMenuTrigger render={<Button size="sm" variant="ghost" />}>
           {formatGeoTrafficFilterLabel(
             "All purposes",
             "purposes",
             filters.categories,
             GEO_TRAFFIC_LOG_PURPOSE_OPTIONS
           )}
+          <HugeiconsIcon
+            aria-hidden="true"
+            className="text-muted-foreground"
+            data-icon="inline-end"
+            icon={ArrowDown01Icon}
+            strokeWidth={2}
+          />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
           {GEO_TRAFFIC_LOG_PURPOSE_OPTIONS.map((option) => (
@@ -164,7 +176,6 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
       </DropdownMenu>
       <Button
         aria-pressed={citationsOnly}
-        className={cn(citationsOnly && "bg-muted")}
         onClick={() => {
           pagination.setPage(1);
           setFilters((previous) => ({
@@ -173,9 +184,10 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
           }));
         }}
         size="sm"
-        variant="outline"
+        variant={citationsOnly ? "secondary" : "ghost"}
       >
         <HugeiconsIcon
+          aria-hidden="true"
           data-icon="inline-start"
           icon={QuotesIcon}
           strokeWidth={2}
@@ -184,30 +196,29 @@ export function AiTrafficLogCard({ organizationId }: AiTrafficLogCardProps) {
       </Button>
       {total > 0 && (
         <Button
+          aria-label={live ? "Live updates: Pause" : "Paused updates: Resume"}
+          className="ml-1"
           onClick={() => {
             trackEvent(POSTHOG_EVENTS.TRAFFIC_LIVE_TOGGLED, { live: !live });
             setLive((current) => !current);
           }}
           size="sm"
-          variant="outline"
+          variant="ghost"
         >
           <HugeiconsIcon
+            aria-hidden="true"
             data-icon="inline-start"
             icon={live ? PauseIcon : PlayIcon}
             strokeWidth={2}
           />
-          {live ? "Pause live updates" : "Resume live updates"}
+          {live ? "Live" : "Paused"}
         </Button>
       )}
     </div>
   );
 
   return (
-    <InstrumentSection
-      action={filterRow}
-      eyebrow="Recent AI requests"
-      readout={readout}
-    >
+    <InstrumentSection action={filterRow} eyebrow="Recent AI requests">
       {body}
     </InstrumentSection>
   );

--- a/apps/dashboard/src/components/geo/traffic-hero.tsx
+++ b/apps/dashboard/src/components/geo/traffic-hero.tsx
@@ -16,6 +16,7 @@ import {
   trafficVisitDelta,
 } from "@notra/geo-core/utils/ai-traffic";
 import { todayIsoDate } from "@notra/geo-core/utils/day-label";
+import { Button } from "@notra/ui/components/ui/button";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -48,7 +49,7 @@ const HERO_CHART_OPTIONS = {
 const TRAFFIC_TREND_STROKE_WIDTH = 1.5;
 
 const HERO_METRIC_CELL_CLASS =
-  "border-border border-b px-5 py-4 last:border-b-0 sm:odd:border-r sm:nth-[n+3]:border-b-0 lg:border-r lg:border-b-0 lg:last:border-r-0";
+  "border-border flex min-w-0 flex-col gap-3 border-b px-5 py-5 last:border-b-0 sm:px-6 sm:odd:border-r sm:nth-[n+3]:border-b-0 lg:border-r lg:border-b-0 lg:last:border-r-0";
 
 function metricDelta(
   current: number | null,
@@ -63,29 +64,37 @@ function metricDelta(
 function TrafficHeroMetric({ metric, settingsHref }: TrafficHeroMetricProps) {
   return (
     <div className={HERO_METRIC_CELL_CLASS}>
-      <p className="text-muted-foreground text-xs">{metric.label}</p>
-      <p className="text-muted-foreground/70 text-[0.6875rem] leading-snug">
-        {metric.description}
+      <p className="text-foreground/75 text-base leading-6 font-semibold tracking-tight">
+        {metric.label}
       </p>
       {metric.value === null ? (
-        <div className="mt-2 flex flex-col gap-1">
-          <span className="text-muted-foreground text-lg leading-none font-medium">
+        <div className="flex items-center gap-3 self-start">
+          <span
+            aria-hidden="true"
+            className="text-muted-foreground/40 text-4xl leading-none font-semibold tracking-tight tabular-nums"
+          >
+            0
+          </span>
+          <span className="sr-only">
             {GEO_TRAFFIC_CONVERSIONS_NOT_CONFIGURED_LABEL}
           </span>
-          <Link
-            className="text-primary text-xs underline-offset-4 hover:underline"
-            href={settingsHref}
+          <Button
+            nativeButton={false}
+            render={<Link href={settingsHref} />}
+            size="sm"
+            title={GEO_TRAFFIC_CONVERSIONS_SETUP_LABEL}
+            variant="outline"
           >
-            {GEO_TRAFFIC_CONVERSIONS_SETUP_LABEL}
-          </Link>
+            Set up
+          </Button>
         </div>
       ) : (
-        <div className="mt-2 flex items-baseline gap-2">
-          <span className="text-3xl leading-none font-semibold tracking-tight tabular-nums">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 self-start">
+          <span className="text-4xl leading-none font-semibold tracking-tight tabular-nums">
             {metric.value.toLocaleString()}
           </span>
           <GeoStatDelta
-            className="mb-0.5"
+            className="rounded-md px-2 py-1.5 text-xs leading-4 [&>span]:hidden"
             delta={metric.delta}
             hint={GEO_TRAFFIC_STAT_TREND_HINT}
             label={metric.label}
@@ -180,13 +189,11 @@ export function TrafficHero({
   const anyVisible = providerSeries.some((entry) => !hiddenKeys.has(entry.key));
 
   return (
-    <div>
+    <div className="border-border bg-card overflow-hidden rounded-2xl border">
       <div
         className={cn(
           "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
-          showTrend
-            ? "border-border bg-muted rounded-t-2xl border border-b-0 pb-5"
-            : "border-border bg-card overflow-hidden rounded-2xl border"
+          showTrend && "bg-muted/40"
         )}
       >
         {metrics.map((metric) => (
@@ -198,7 +205,7 @@ export function TrafficHero({
         ))}
       </div>
       {showTrend ? (
-        <div className="border-border bg-card -mt-5 rounded-2xl border p-4">
+        <div className="border-border border-t p-4">
           <EChartsAreaChart
             animation={false}
             chartOptions={HERO_CHART_OPTIONS}
@@ -232,6 +239,7 @@ export function TrafficHero({
               <EChartsAreaChart.ActiveDot variant="border" />
             </EChartsAreaChart.Area>
             <EChartsAreaChart.Tooltip
+              confine={false}
               hideZeros
               layout="bars"
               position="fixed"

--- a/apps/dashboard/src/components/geo/traffic-hero.tsx
+++ b/apps/dashboard/src/components/geo/traffic-hero.tsx
@@ -71,9 +71,10 @@ function TrafficHeroMetric({ metric, settingsHref }: TrafficHeroMetricProps) {
         <div className="flex items-center gap-3 self-start">
           <span
             aria-hidden="true"
-            className="text-muted-foreground/40 text-4xl leading-none font-semibold tracking-tight tabular-nums"
+            className="text-muted-foreground text-4xl leading-none font-semibold tracking-tight"
+            title={GEO_TRAFFIC_CONVERSIONS_NOT_CONFIGURED_LABEL}
           >
-            0
+            —
           </span>
           <span className="sr-only">
             {GEO_TRAFFIC_CONVERSIONS_NOT_CONFIGURED_LABEL}

--- a/apps/dashboard/src/components/geo/traffic-page-sources-cell.tsx
+++ b/apps/dashboard/src/components/geo/traffic-page-sources-cell.tsx
@@ -26,15 +26,6 @@ export function TrafficPageSourcesCell({ group }: TrafficPageSourcesCellProps) {
     return null;
   }
 
-  if (group.sources.length === 1) {
-    return (
-      <span className="flex min-w-0 items-center gap-2 text-sm">
-        <EngineIcon engine={first.source} />
-        <span className="truncate">{formatGeoSource(first.source)}</span>
-      </span>
-    );
-  }
-
   const visible = group.sources.slice(0, GEO_TRAFFIC_PAGE_SOURCE_ICON_LIMIT);
   const overflow = group.sources.length - visible.length;
   const sourcesLabel = trafficPageSourcesLabel(group);
@@ -66,9 +57,6 @@ export function TrafficPageSourcesCell({ group }: TrafficPageSourcesCellProps) {
               +{overflow}
             </span>
           ) : null}
-        </span>
-        <span className="text-muted-foreground truncate text-sm">
-          {sourcesLabel}
         </span>
       </HoverCardTrigger>
       <TrafficBreakdownCard

--- a/apps/dashboard/src/components/geo/traffic-pages-card.tsx
+++ b/apps/dashboard/src/components/geo/traffic-pages-card.tsx
@@ -94,10 +94,10 @@ export function TrafficPagesCard({
 
         return (
           <span className="flex items-center justify-end gap-2">
-            <GeoStatDelta delta={delta} />
             <span className="text-sm tabular-nums">
               {row.visits.toLocaleString()}
             </span>
+            <GeoStatDelta delta={delta} />
           </span>
         );
       },


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AI traffic layout consistency and tooltip clipping across the geo dashboard, and makes unconfigured conversion goals visually distinct from a measured zero.

- Unifies the traffic hero and metric cells into a single card container with larger, bolder values and consistent spacing.
- Shows an em dash with a "Set up" button when conversion goals aren't configured, instead of displaying them as zero.
- Switches traffic log filter buttons to ghost style, shortens the live toggle label to "Live"/"Paused", and removes the total-request readout from the log card header.
- Removes the redundant single-source label in `TrafficPageSourcesCell` and replaces the duplicate "Set up" text with a compact button.
- Allows the chart tooltip to render outside its container so it is no longer clipped.
- Shows visit counts before the change badges in the traffic pages table.

<sup>Written for commit eeec640b2d10edf8f258f57823e425d5ab552e92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

