### PR TITLE
fix(web): separate auth and theme keyboard shortcuts

### DIFF
--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -4,6 +4,7 @@ import { Moon02Icon, Sun02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@notra/ui/components/ui/button";
 import { SPRING } from "@notra/ui/lib/motion";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import {
   AnimatePresence,
   domAnimation,
@@ -72,6 +73,8 @@ export function ThemeToggle() {
     setTheme(isDark ? "light" : "dark");
   }
 
+  useHotkey("D", handleToggle, { enabled: mounted });
+
   let ariaLabel = "Toggle theme";
   if (mounted && isDark) {
     ariaLabel = "Switch to light mode";
@@ -82,6 +85,7 @@ export function ThemeToggle() {
   return (
     <LazyMotion features={domAnimation} strict>
       <Button
+        aria-keyshortcuts="d"
         aria-label={ariaLabel}
         aria-pressed={mounted ? isDark : undefined}
         className="text-foreground h-9 w-9 overflow-visible rounded-lg p-0"

--- a/apps/web/src/constants/auth.ts
+++ b/apps/web/src/constants/auth.ts
@@ -3,4 +3,4 @@ export const AUTH_SIGNUP_URL = "https://app.usenotra.com/signup";
 export const AUTH_DASHBOARD_URL = "https://app.usenotra.com/callback";
 
 export const AUTH_SIGNIN_HOTKEY = "L";
-export const AUTH_APP_HOTKEY = "D";
+export const AUTH_APP_HOTKEY = "S";

--- a/apps/web/src/lib/auth/use-navbar-auth-hotkeys.ts
+++ b/apps/web/src/lib/auth/use-navbar-auth-hotkeys.ts
@@ -35,6 +35,6 @@ export function useNavbarAuthHotkeys({
       }
       startSignup(NAVBAR_HOTKEY_SIGNUP_SOURCE);
     },
-    { enabled: isResolved, conflictBehavior: "replace" }
+    { enabled: isResolved }
   );
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates the auth and theme keyboard shortcuts so they no longer collide. The theme toggle now uses D, and the auth app shortcut moves from D to S.

- Theme toggle announces the shortcut via `aria-keyshortcuts`.
- The auth hotkey no longer overrides conflicting registered hotkeys.

<sup>Written for commit 96d218245956c5cafb1ddcbec07cf2bf3c0d85e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

