### PR TITLE
fix(web): remove purple mega menu hover in dark mode

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -116,7 +116,7 @@ function MegaCard({
   onSelect: () => void;
 }) {
   const className =
-    "flex h-52.5 w-52 shrink-0 cursor-pointer flex-col items-stretch justify-between rounded-2xl border border-[#1E1E1E1A] bg-[#C8B2EE40] p-6 shadow-[0_0_0_0.0625rem_#ECECEC,0_0.0625rem_0.125rem_#28282814] transition-[background,border-color] hover:bg-[linear-gradient(180deg,#C8B2EE40_0%,#C8B2EE66_100%)] dark:border-white/10 dark:bg-white/5 dark:shadow-none dark:hover:bg-white/10";
+    "flex h-52.5 w-52 shrink-0 cursor-pointer flex-col items-stretch justify-between rounded-2xl border border-[#1E1E1E1A] bg-[#C8B2EE40] p-6 shadow-[0_0_0_0.0625rem_#ECECEC,0_0.0625rem_0.125rem_#28282814] transition-[background,border-color] hover:bg-[linear-gradient(180deg,#C8B2EE40_0%,#C8B2EE66_100%)] dark:border-white/10 dark:bg-white/5 dark:shadow-none dark:hover:bg-white/10 dark:hover:bg-none";
   const body = (
     <>
       <span className="flex size-8 shrink-0 items-center justify-center leading-none [&_svg]:block">


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dark mode mega menu hover showing a purple tint instead of the intended neutral background by overriding the hover background.

<sup>Written for commit c58d74583714e339509ea3e28d5714149020df0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

