### PR TITLE
fix(web): load author portraits in OG images

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -21,6 +21,9 @@ const nextConfig: NextConfig = {
   },
   transpilePackages: ["@notra/ui", "@notra/email", "@notra/kiwi"],
   serverExternalPackages: ["@remotion/bundler", "@remotion/renderer"],
+  outputFileTracingIncludes: {
+    "/blog/**/opengraph-image*": ["./public/blog/authors/**/*"],
+  },
   rewrites: async () => {
     return [
       {

--- a/apps/web/src/app/(site)/(blog)/blog/author/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/(site)/(blog)/blog/author/[slug]/opengraph-image.tsx
@@ -92,7 +92,11 @@ export default async function Image({ params }: BlogAuthorPageProps) {
           alt=""
           height={180}
           src={authorImage}
-          style={{ borderRadius: "9999px" }}
+          style={{
+            borderRadius: authorImageDataUrl ? "9999px" : 0,
+            objectFit: authorImageDataUrl ? "cover" : "contain",
+            flexShrink: 0,
+          }}
           width={180}
         />
         <div style={{ display: "flex", flexDirection: "column" }}>

--- a/apps/web/src/utils/og.ts
+++ b/apps/web/src/utils/og.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
 const GOOGLE_FONT_URL_REGEX =
   /src: url\((.+)\) format\('(opentype|truetype)'\)/;
 
@@ -39,11 +42,16 @@ export async function loadImageAsDataUrl(url: string | null) {
     return null;
   }
   try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      return null;
+    let input: Buffer;
+    if (url.startsWith("/")) {
+      input = await readFile(join(process.cwd(), "public", url));
+    } else {
+      const response = await fetch(url);
+      if (!response.ok) {
+        return null;
+      }
+      input = Buffer.from(await response.arrayBuffer());
     }
-    const input = Buffer.from(await response.arrayBuffer());
     const { default: sharp } = await import("sharp");
     const png = await sharp(input).png().toBuffer();
     return `data:image/png;base64,${png.toString("base64")}`;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes author portraits not appearing in generated OG images for blog author pages.

Author portraits are now loaded from the local filesystem instead of fetched over HTTP, and Next.js config includes the portrait directory in the serverless bundle. When an author has no portrait, the placeholder image is no longer clipped to a circle.

- **Bug Fixes**
  - Reads local author portraits directly from disk via `readFile` now that they no longer resolve over HTTP.
  - Adds `outputFileTracingIncludes` so portrait files ship with the serverless build.
  - If you're missing the portrait image, the fallback now shows full-width instead of cropped into a circle.

<sup>Written for commit ddd5dadede95d9a734c4bb08aa1f63ac7560d168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

