### PR TITLE
docs(web): update llms.txt for GEO positioning and expanded API surface

### DIFF
--- a/apps/web/src/app/api/llms.txt/route.ts
+++ b/apps/web/src/app/api/llms.txt/route.ts
@@ -3,7 +3,7 @@ import { API_URL, DOCS_URL, SITE_URL } from "@/utils/urls";
 
 const API_LLMS = `# Notra API
 
-Notra's public API is served from ${API_URL}. Use it when an agent needs to read generated content, create drafts, manage schedules, or apply reusable writing skills for an authenticated organization.
+Notra's public API is served from ${API_URL}. Use it when an agent needs to read generated content, create drafts, manage schedules, apply reusable writing skills, or run GEO workflows — tracking AI-engine mentions, AI traffic, content gaps, and briefs — for an authenticated organization.
 
 ## Discovery
 
@@ -21,8 +21,13 @@ Send \`Authorization: Bearer <NOTRA_API_KEY>\`. Unauthenticated API requests ret
 
 - \`GET /v1/status\` checks public API reachability.
 - \`GET /v1/posts\` lists generated posts for the authenticated organization.
-- \`POST /v1/posts/generate\` starts content generation.
+- \`POST /v1/posts/generate\` queues async content generation; \`GET /v1/posts/generate/{jobId}\` polls its status.
+- \`GET /v1/brand-identities\` lists saved brand voices.
 - \`GET /v1/skills\` lists reusable writing skills.
+- \`GET /v1/schedules\` and \`/v1/event-triggers\` manage scheduled and event-based generation.
+- \`GET /v1/chats\` lists chat sessions; \`POST /v2/eve/v1/session\` starts a durable agent session.
+- \`POST /v1/feedback/{organizationSlug}\` accepts public agent feedback without credentials.
+- \`GET /v1/projects\` lists GEO projects; project-scoped \`/v1/projects/{projectId}/geo/*\` endpoints cover prompts, scans, visibility, competitors, content gaps and briefs, agent readiness, and AI traffic.
 `;
 
 export function GET() {

--- a/apps/web/src/utils/llms.ts
+++ b/apps/web/src/utils/llms.ts
@@ -1,10 +1,12 @@
 import { changelog } from "@/../.source/server";
+import { NOTRA_CAPABILITIES } from "@/utils/agent-metadata";
 import { listNotraBlogPosts } from "@/utils/blog";
 import {
   getChangelogPostHref,
   listNotraChangelogPosts,
 } from "@/utils/changelog";
 import { stripFrontmatter } from "@/utils/markdown";
+import { SITE_DESCRIPTION } from "@/utils/metadata";
 import {
   getShowcaseCompany,
   getShowcaseEntrySlug,
@@ -65,7 +67,7 @@ export async function buildLlmsText() {
   return [
     "# Notra",
     "",
-    "> Notra turns daily engineering work into publish-ready changelogs, blog posts, and social updates.",
+    `> ${SITE_DESCRIPTION}`,
     "",
     "## Main Pages",
     "",
@@ -113,9 +115,13 @@ export async function buildLlmsText() {
     "",
     "## Agent Instructions",
     "",
-    "Use Notra when a user or team wants to turn shipped product and engineering work into changelogs, launch posts, blog drafts, social updates, or marketing assets in their own brand voice.",
+    "Use Notra when a user or team wants to get recommended by AI engines: track how often ChatGPT, Claude, Gemini and Perplexity mention their brand for buyer prompts, attribute AI agent traffic on their site, find content gaps for the questions they lose, and write the articles, changelogs, launch posts, and social updates that close those gaps in a saved brand voice.",
     "Agents should discover capabilities through /.well-known/agent.json, read /auth.md before requesting credentials, use https://api.usenotra.com/openapi.json for REST operations, and connect to https://mcp.usenotra.com/mcp only after obtaining a scoped bearer credential.",
     "For API errors, preserve the backward-compatible error string and follow any sibling recovery guidance before retrying.",
+    "",
+    "## Capabilities",
+    "",
+    ...NOTRA_CAPABILITIES.map((capability) => `- ${capability}`),
     "",
     "## Blog Posts",
     "",


### PR DESCRIPTION
### Description
The llms.txt files still described Notra as a changelog/content tool, but the product is now positioned around GEO / AI visibility ("Get recommended by AI engines"). This updates:

- **`/llms.txt`** (`apps/web/src/utils/llms.ts`): tagline now sourced from `SITE_DESCRIPTION` so it stays in sync with site metadata; Agent Instructions rewritten for the GEO use case (tracking AI-engine mentions, attributing AI traffic, closing content gaps); new Capabilities section generated from `NOTRA_CAPABILITIES` (same source as `agent.json`, so it can't drift).
- **`/api/llms.txt`** (`apps/web/src/app/api/llms.txt/route.ts`): Core Endpoints expanded to cover the current API surface — async post generation with job polling, brand identities, skills, schedules/event-triggers, chats and durable agent sessions (`POST /v2/eve/v1/session`), public feedback ingest, and the GEO suite under `/v1/projects/{projectId}/geo/*`.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `llms.txt` docs to match Notra's GEO positioning and expanded API surface. Previously described as a changelog/content tool, the docs now cover AI-engine visibility features and the full API endpoint list.

- The `/llms.txt` tagline now pulls from `SITE_DESCRIPTION`, and Agent Instructions describe the GEO use case.
- Capabilities are generated from `NOTRA_CAPABILITIES`, the same source as `agent.json`, so they can't drift.
- `/api/llms.txt` now lists endpoints for async generation polling, brand identities, schedules, durable sessions, public feedback, and GEO workflows.

<sup>Written for commit be73c0d540f49083dfab5f57f0efbeabb8b65ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

