### PR TITLE
fix(geo): isolate data and suggestions by selected project

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/layout.tsx
@@ -5,6 +5,8 @@ import { GeoUpgradeGate } from "@/components/geo/geo-upgrade-gate";
 import { GeoProjectQueryProvider } from "@/components/providers/geo-project-provider";
 import type { GeoLayoutProps } from "@/types/geo";
 
+import { GeoPageSkeleton } from "./skeleton";
+
 export default async function GeoLayout({
   children,
   modal,
@@ -14,8 +16,8 @@ export default async function GeoLayout({
   return (
     <>
       <GeoCatalogWarmer organizationSlug={slug} />
-      <Suspense fallback={children}>
-        <GeoProjectQueryProvider>
+      <Suspense fallback={<GeoPageSkeleton />}>
+        <GeoProjectQueryProvider key={slug}>
           <GeoUpgradeGate slug={slug}>
             {children}
             {modal}

--- a/apps/dashboard/src/components/providers/geo-project-provider.tsx
+++ b/apps/dashboard/src/components/providers/geo-project-provider.tsx
@@ -18,7 +18,7 @@ export function GeoProjectProvider({
 }: GeoProjectProviderProps) {
   const value = useMemo(() => ({ projectId }), [projectId]);
   return (
-    <GeoProjectContext.Provider value={value}>
+    <GeoProjectContext.Provider key={projectId ?? ""} value={value}>
       {children}
     </GeoProjectContext.Provider>
   );

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -1113,10 +1113,15 @@ function useInvalidateSuggestionQueries(organizationId: string) {
 }
 
 export function useGeoSuggestionAccept(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
   const invalidate = useInvalidateSuggestionQueries(organizationId);
   return useMutation({
     mutationFn: (input: GeoSuggestionIdInput) =>
-      dashboardOrpc.geo.suggestionAccept.call({ ...input, organizationId }),
+      dashboardOrpc.geo.suggestionAccept.call({
+        ...input,
+        organizationId,
+        projectId,
+      }),
     onSuccess: async () => {
       await invalidate();
       toast.success("Prompt added to tracking");
@@ -1128,10 +1133,14 @@ export function useGeoSuggestionAccept(organizationId: string) {
 }
 
 export function useGeoSuggestionsAcceptAll(organizationId: string) {
+  const { projectId } = useGeoProjectScope();
   const invalidate = useInvalidateSuggestionQueries(organizationId);
   return useMutation({
     mutationFn: () =>
-      dashboardOrpc.geo.suggestionsAcceptAll.call({ organizationId }),
+      dashboardOrpc.geo.suggestionsAcceptAll.call({
+        organizationId,
+        projectId,
+      }),
     onSuccess: async (result) => {
       await invalidate();
       toast.success(

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -24,7 +24,6 @@ import {
   geoAgentReadinessReports,
   geoPromptSuggestions,
   geoPrompts,
-  projects,
 } from "@notra/db/schema";
 import { GEO_SAMPLE_DATA_ENABLED } from "@notra/geo-core/constants/geo";
 import {
@@ -600,20 +599,6 @@ function getGscScheduleIdsForDisconnect(
       ].filter((scheduleId): scheduleId is string => scheduleId !== null)
     ),
   ];
-}
-
-async function requireDefaultProjectId(
-  organizationId: string
-): Promise<string> {
-  const row = await db.query.projects.findFirst({
-    columns: { id: true },
-    where: eq(projects.organizationId, organizationId),
-    orderBy: [asc(projects.createdAt)],
-  });
-  if (!row) {
-    throw badRequest("Configure your brand tracking settings first");
-  }
-  return row.id;
 }
 
 async function acceptSuggestionInTx(
@@ -1915,7 +1900,10 @@ export const geoRouter = {
         throw notFound("Suggestion not found");
       }
 
-      const projectId = await requireDefaultProjectId(input.organizationId);
+      const { projectId } = await runOrpcEffect(
+        requireGeoProject(input),
+        toGeoOrpcError
+      );
       const accepted = await db.transaction((tx) =>
         acceptSuggestionInTx(tx, input.organizationId, projectId, suggestion)
       );
@@ -1967,7 +1955,10 @@ export const geoRouter = {
         return { accepted: 0 };
       }
 
-      const projectId = await requireDefaultProjectId(input.organizationId);
+      const { projectId } = await runOrpcEffect(
+        requireGeoProject(input),
+        toGeoOrpcError
+      );
       await db.transaction(async (tx) => {
         for (const row of rows) {
           await acceptSuggestionInTx(tx, input.organizationId, projectId, row);

--- a/packages/geo-core/src/schemas/geo.ts
+++ b/packages/geo-core/src/schemas/geo.ts
@@ -515,7 +515,6 @@ export const geoWriterWorkflowPayloadSchema = object({
   runId: string().min(1),
 });
 
-export const geoSuggestionIdInputSchema = object({
-  organizationId: string().min(1),
+export const geoSuggestionIdInputSchema = geoOrganizationInputSchema.extend({
   suggestionId: string().min(1),
 });


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes geo data and suggestions so they're scoped to the selected project instead of the default project.

- Suggestion accept mutations now send the selected `projectId` instead of resolving the first project in the organization.
- The geo page shows a skeleton while the project is loading and remounts its provider when the project changes.
- Suggestion accept calls now require `projectId` in the input schema; callers must include it.

<sup>Written for commit 3af5ce9622119a2b5ad1e09b8248ac2455870a81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

