### PR TITLE
fix(geo): generate scan prompts from the project's own brand

### DIFF
--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -136,6 +136,7 @@ import {
   toTrackedPrompt,
 } from "./mappers";
 import { loadGeoModelCatalog } from "./model-catalog";
+import { loadGeoProjectBrand } from "./project-brand";
 import {
   ensureGeoProject,
   geoCheckScope,
@@ -1286,15 +1287,7 @@ export const listGeoPrompts = Effect.fn("geo.promptsList")(function* (
           where: eq(geoSettings.projectId, projectId),
         })
       ),
-      geoDb("brand lookup failed", () =>
-        db.query.brandSettings.findFirst({
-          columns: { companyDescription: true, audience: true },
-          where: and(
-            eq(brandSettings.organizationId, scope.organizationId),
-            eq(brandSettings.id, scope.brandSettingsId ?? "")
-          ),
-        })
-      ),
+      loadGeoProjectBrand({ organizationId: scope.organizationId, projectId }),
     ],
     { concurrency: "unbounded" }
   );

--- a/packages/geo-core/src/geo/project-brand.ts
+++ b/packages/geo-core/src/geo/project-brand.ts
@@ -1,0 +1,35 @@
+import { db } from "@notra/db/drizzle";
+import { brandSettings, projects } from "@notra/db/schema";
+import { and, eq } from "drizzle-orm";
+import { Effect } from "effect";
+
+import type { GeoScopeInput } from "../types/geo";
+import { geoDb } from "./effect";
+
+export const loadGeoProjectBrand = Effect.fn("geo.projectBrand")(function* (
+  scope: GeoScopeInput
+) {
+  const rows = yield* geoDb("project brand lookup failed", () =>
+    db
+      .select({
+        companyDescription: brandSettings.companyDescription,
+        audience: brandSettings.audience,
+      })
+      .from(projects)
+      .innerJoin(
+        brandSettings,
+        and(
+          eq(brandSettings.id, projects.brandSettingsId),
+          eq(brandSettings.organizationId, projects.organizationId)
+        )
+      )
+      .where(
+        and(
+          eq(projects.organizationId, scope.organizationId),
+          eq(projects.id, scope.projectId ?? "")
+        )
+      )
+      .limit(1)
+  );
+  return rows.at(0) ?? null;
+});

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -13,12 +13,7 @@ import {
   GEO_CHECK_GROUNDING_MAX_SOURCES,
 } from "@notra/db/constants/geo-checks";
 import { db } from "@notra/db/drizzle";
-import {
-  brandSettings,
-  geoPromptSequences,
-  geoPrompts,
-  geoSettings,
-} from "@notra/db/schema";
+import { geoPromptSequences, geoPrompts, geoSettings } from "@notra/db/schema";
 import type {
   GeoCheckSourceItem,
   GeoCheckWrite,
@@ -127,6 +122,7 @@ import {
 import { extractGrounding } from "./grounding";
 import { toGeoSettings } from "./mappers";
 import { loadGeoModelCatalog } from "./model-catalog";
+import { loadGeoProjectBrand } from "./project-brand";
 import { requireGeoProject } from "./projects";
 import {
   buildGeoPrompts,
@@ -1022,17 +1018,9 @@ const buildGeoScanProjectPlan = Effect.fn("geo.buildScanProjectPlan")(
     const catalog = yield* loadGeoModelCatalog(organizationId);
     const settings = toGeoSettings(settingsRow, catalog);
 
-    const brand = yield* Effect.tryPromise({
-      try: () =>
-        db.query.brandSettings.findFirst({
-          columns: { companyDescription: true, audience: true },
-          where: and(
-            eq(brandSettings.organizationId, organizationId),
-            eq(brandSettings.isDefault, true)
-          ),
-        }),
-      catch: (cause) =>
-        new GeoScanError({ message: "Failed to load brand settings", cause }),
+    const brand = yield* loadGeoProjectBrand({
+      organizationId,
+      projectId: settingsRow.projectId,
     });
 
     const customRows = yield* Effect.tryPromise({

--- a/packages/geo-core/tests/scan-lifecycle.test.ts
+++ b/packages/geo-core/tests/scan-lifecycle.test.ts
@@ -9,7 +9,7 @@ import {
 } from "bun:test";
 import assert from "node:assert/strict";
 
-import { geoScans } from "@notra/db/schema";
+import { brandSettings, geoScans } from "@notra/db/schema";
 import { eq } from "drizzle-orm";
 import { Effect, Exit } from "effect";
 
@@ -19,6 +19,7 @@ import {
   GEO_SCAN_STALE_MS,
 } from "../src/constants/geo";
 import { GeoWorkflowService } from "../src/deps";
+import { buildGeoPrompts } from "../src/geo/prompts";
 import type { GeoWorkflowServiceShape } from "../src/types/deps";
 import {
   initializeDatabase,
@@ -43,6 +44,7 @@ mock.module("@notra/ai/utils/geo-opencode-box", () => ({
 }));
 
 const { runGeoScanCronSweep } = await import("../src/geo/scan-schedule");
+const { loadGeoProjectBrand } = await import("../src/geo/project-brand");
 const { startClaimedGeoScanRun } = await import("../src/geo/scan-handoff");
 const {
   claimGeoScanRun,
@@ -82,6 +84,80 @@ beforeEach(async () => {
   );
   cleanupBoxes.mockReset();
   cleanupBoxes.mockImplementation(async () => undefined);
+});
+
+describe("scan project brand context", () => {
+  test("generates prompts from the selected project's brand, not the default brand", async () => {
+    const emailScope = await seedProject("email-sdk");
+    const botScope = await seedProject("akeru-bot");
+    await testDb
+      .update(brandSettings)
+      .set({
+        isDefault: true,
+        companyDescription: "sending transactional emails",
+        audience: "email developers",
+      })
+      .where(eq(brandSettings.id, "brand-email-sdk"));
+    await testDb
+      .update(brandSettings)
+      .set({
+        companyDescription: "moderating Discord communities",
+        audience: "community moderators",
+      })
+      .where(eq(brandSettings.id, "brand-akeru-bot"));
+
+    const emailBrand = await Effect.runPromise(loadGeoProjectBrand(emailScope));
+    const botBrand = await Effect.runPromise(loadGeoProjectBrand(botScope));
+    expect(emailBrand?.companyDescription).toBe("sending transactional emails");
+    expect(botBrand).toEqual({
+      companyDescription: "moderating Discord communities",
+      audience: "community moderators",
+    });
+    const prompts = buildGeoPrompts(
+      { companyName: "Akeru Bot", aliases: [] },
+      botBrand
+    );
+    expect(prompts.length).toBeGreaterThan(0);
+    for (const prompt of prompts) {
+      expect(prompt.text).toContain("discord");
+      expect(prompt.text).not.toContain("email");
+    }
+    expect(
+      prompts.find((prompt) => prompt.id === "audience-specific")?.text
+    ).toContain("community moderators");
+  });
+
+  test("never falls back to another brand for missing context or a foreign project", async () => {
+    const scope = await seedProject("selected");
+    await seedProject("default");
+    await testDb
+      .update(brandSettings)
+      .set({
+        isDefault: true,
+        companyDescription: "sending transactional emails",
+      })
+      .where(eq(brandSettings.id, "brand-default"));
+    expect(await Effect.runPromise(loadGeoProjectBrand(scope))).toEqual({
+      companyDescription: null,
+      audience: null,
+    });
+    expect(
+      await Effect.runPromise(
+        loadGeoProjectBrand({
+          organizationId: "other-org",
+          projectId: scope.projectId,
+        })
+      )
+    ).toBeNull();
+    expect(
+      await Effect.runPromise(
+        loadGeoProjectBrand({
+          organizationId: scope.organizationId,
+          projectId: "missing",
+        })
+      )
+    ).toBeNull();
+  });
 });
 
 describe("scheduled GEO scans", () => {


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates GEO scan prompts from the project's own brand settings instead of the organization's default brand. Previously, prompts used either the scope's `brandSettingsId` or the org-level default brand, which could produce prompts for the wrong product. Now brand context is always resolved through the project, and if a project has no brand settings, prompts are generated without brand context rather than falling back to another brand.

<sup>Written for commit ba11f05554afa09489b1a6e2ca78ffe20a9fda09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

