### PR TITLE
feat(web): redirect signed-in homepage visitors to dashboard

### DIFF
--- a/apps/web/src/app/(landing)/home/page.tsx
+++ b/apps/web/src/app/(landing)/home/page.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from "../page";

--- a/apps/web/src/app/(landing)/landing/page.tsx
+++ b/apps/web/src/app/(landing)/landing/page.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from "../page";

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -333,6 +333,17 @@ export function Navbar({ variant }: NavbarProps = {}) {
 
   const { isAuthenticated, isResolved } = useDashboardSession();
   useNavbarAuthHotkeys({ isAuthenticated, isResolved });
+
+  useEffect(() => {
+    if (pathname === "/" && isResolved && isAuthenticated) {
+      window.location.replace(
+        process.env.NODE_ENV === "development"
+          ? "http://localhost:3000/callback"
+          : AUTH_DASHBOARD_URL
+      );
+    }
+  }, [pathname, isResolved, isAuthenticated]);
+
   const reduceMotion = useReducedMotion();
   const { scrollY } = useScroll();
   const [scrolled, setScrolled] = useState(false);


### PR DESCRIPTION
### Description
Signed-in users should go straight to the dashboard when opening `/`, while still being able to visit the marketing site intentionally.

Expected behavior:
- `/`: redirect to the dashboard after the existing session check confirms the user is signed in.
- `/home` and `/landing`: always show the landing page, including for signed-in users. These are intentional exceptions, not missing redirects. Do not add them to the redirect condition or redirect them to `/`.
- `/pricing` and all other subpages: remain accessible regardless of login state.
- Signed-out visitors, or visitors whose session check fails, stay on the landing page.

The redirect runs client-side through the existing Navbar session check, which calls the dashboard session endpoint with credentials included. It uses `location.replace`, so the redirected homepage does not remain in browser history. The landing page may appear briefly while the session resolves.

Validation: `git diff --check` passed. Lint and type checks could not run because dependencies are missing in this worktree. React Doctor ran a full scan instead of a changed-scope comparison, so it did not establish a regression result. Browser testing is still pending.

AI assistance was used to implement this change.

### Screenshot/Recording (if applicable)
No recording attached.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Signed-in visitors to `/` now leave the landing page for the dashboard flow instead of seeing the landing page. The redirect waits for session resolution, uses the local callback in development and `AUTH_DASHBOARD_URL` elsewhere, and replaces the current history entry.

- Adds `/home` and `/landing` routes that reuse the existing landing page and metadata.

<sup>Written for commit 03d3607cc4901e121055d3232204c9bfc1cc88c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

