### PR TITLE
fix(web): allow dashboard session probe in marketing CSP

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,13 +6,16 @@ import type { NextConfig } from "next";
 
 import { SHOWCASE_COMPANIES } from "./src/utils/showcase";
 import { SOCIAL_LINKS } from "./src/utils/social-links";
-import { SITE_URL } from "./src/utils/urls";
+import { APP_URL, SITE_URL } from "./src/utils/urls";
 
 const SHOWCASE_COMPANY_SLUGS = SHOWCASE_COMPANIES.map(
   (company) => company.slug
 );
 
 const C15T_BACKEND_URL = "https://notra-prod-notra.inth.app";
+
+const DASHBOARD_SESSION_ORIGIN =
+  process.env.NODE_ENV === "development" ? "http://localhost:3000" : APP_URL;
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -130,7 +133,7 @@ const nextConfig: NextConfig = {
             "style-src 'self' 'unsafe-inline'",
             "font-src 'self'",
             "img-src 'self' data: blob: databuddy.cc *.databuddy.cc avatars.githubusercontent.com cdn.contentport.io media.brand.dev *.r2.dev cdn.usenotra.com pbs.twimg.com abs.twimg.com",
-            "connect-src 'self' databuddy.cc *.databuddy.cc *.inth.app *.c15t.com *.c15t.dev",
+            `connect-src 'self' databuddy.cc *.databuddy.cc *.inth.app *.c15t.com *.c15t.dev ${DASHBOARD_SESSION_ORIGIN}`,
             "frame-src https://challenges.cloudflare.com",
             "frame-ancestors 'none'",
             "object-src 'none'",

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -684,7 +684,10 @@ export function Navbar({ variant }: NavbarProps = {}) {
 
               <div className="flex flex-1 items-center justify-end gap-2 lg:gap-3">
                 <ThemeToggle />
-                <DesktopAuthActions isAuthenticated={isAuthenticated} />
+                <DesktopAuthActions
+                  isAuthenticated={isAuthenticated}
+                  isResolved={isResolved}
+                />
                 <button
                   aria-controls="mobile-navigation"
                   aria-expanded={isOpen}
@@ -723,7 +726,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
 }
 
 function MobileNav({ onNavigate }: { onNavigate: () => void }) {
-  const { isAuthenticated } = useDashboardSession();
+  const { isAuthenticated, isResolved } = useDashboardSession();
 
   return (
     <div className="flex flex-col gap-3">
@@ -774,7 +777,7 @@ function MobileNav({ onNavigate }: { onNavigate: () => void }) {
         })}
       </nav>
       <div className="flex flex-col gap-2 border-t border-[#1E1E1E14] pt-3 dark:border-white/10">
-        {isAuthenticated ? (
+        {isResolved && isAuthenticated ? (
           <Link
             className="cta-gradient-primary font-display rounded-full px-3 py-2.5 text-center text-sm font-medium tracking-[-0.015em] text-white"
             href={AUTH_DASHBOARD_URL}
@@ -782,7 +785,7 @@ function MobileNav({ onNavigate }: { onNavigate: () => void }) {
           >
             Dashboard
           </Link>
-        ) : (
+        ) : isResolved ? (
           <>
             <Link
               className="font-display rounded-md px-3 py-2 text-center text-sm tracking-[-0.015em] text-[#1E1E1E] hover:bg-[#C8B2EE26] dark:text-neutral-300 dark:hover:bg-white/6"
@@ -808,7 +811,14 @@ function MobileNav({ onNavigate }: { onNavigate: () => void }) {
 const SIGNUP_BUTTON_CLASS =
   "corner-squircle inline-flex h-8 items-center gap-1.5 rounded-[1rem] bg-white ps-2.5 pe-1.5 font-display text-sm leading-[1.14] font-semibold tracking-[-0.015em] text-[#1E1E1E] shadow-[0_0_0_1px_#ececec,0_1px_2px_#28282814] outline-none transition-[opacity,transform,box-shadow] duration-fast ease-out hover:opacity-90 focus-visible:ring-[3px] focus-visible:ring-ring/50 active:scale-[0.96] supports-[corner-shape:round]:rounded-[1.25rem] dark:bg-white";
 
-function DesktopAuthActions({ isAuthenticated }: NavbarAuthActionsProps) {
+function DesktopAuthActions({
+  isAuthenticated,
+  isResolved,
+}: NavbarAuthActionsProps) {
+  if (!isResolved) {
+    return <div aria-hidden="true" className="hidden h-8 lg:block" />;
+  }
+
   if (isAuthenticated) {
     return (
       <div className="hidden items-center gap-3 lg:flex">

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -716,7 +716,11 @@ export function Navbar({ variant }: NavbarProps = {}) {
               initial={{ opacity: 0, y: -6 }}
               transition={enterExitTransition}
             >
-              <MobileNav onNavigate={() => setIsOpen(false)} />
+              <MobileNav
+                isAuthenticated={isAuthenticated}
+                isResolved={isResolved}
+                onNavigate={() => setIsOpen(false)}
+              />
             </m.div>
           )}
         </AnimatePresence>
@@ -725,9 +729,11 @@ export function Navbar({ variant }: NavbarProps = {}) {
   );
 }
 
-function MobileNav({ onNavigate }: { onNavigate: () => void }) {
-  const { isAuthenticated, isResolved } = useDashboardSession();
-
+function MobileNav({
+  isAuthenticated,
+  isResolved,
+  onNavigate,
+}: NavbarAuthActionsProps & { onNavigate: () => void }) {
   return (
     <div className="flex flex-col gap-3">
       <nav className="flex flex-col gap-1">
@@ -777,34 +783,54 @@ function MobileNav({ onNavigate }: { onNavigate: () => void }) {
         })}
       </nav>
       <div className="flex flex-col gap-2 border-t border-[#1E1E1E14] pt-3 dark:border-white/10">
-        {isResolved && isAuthenticated ? (
-          <Link
-            className="cta-gradient-primary font-display rounded-full px-3 py-2.5 text-center text-sm font-medium tracking-[-0.015em] text-white"
-            href={AUTH_DASHBOARD_URL}
-            onClick={onNavigate}
-          >
-            Dashboard
-          </Link>
-        ) : isResolved ? (
-          <>
-            <Link
-              className="font-display rounded-md px-3 py-2 text-center text-sm tracking-[-0.015em] text-[#1E1E1E] hover:bg-[#C8B2EE26] dark:text-neutral-300 dark:hover:bg-white/6"
-              href={AUTH_SIGNIN_URL}
-              onClick={onNavigate}
-            >
-              Sign In
-            </Link>
-            <TrackedSignupLink
-              className="cta-gradient-primary font-display rounded-full px-3 py-2.5 text-center text-sm font-medium tracking-[-0.015em] text-white"
-              onClick={onNavigate}
-              source={NAVBAR_MOBILE_SIGNUP_SOURCE}
-            >
-              Sign Up
-            </TrackedSignupLink>
-          </>
-        )}
+        <MobileAuthActions
+          isAuthenticated={isAuthenticated}
+          isResolved={isResolved}
+          onNavigate={onNavigate}
+        />
       </div>
     </div>
+  );
+}
+
+function MobileAuthActions({
+  isAuthenticated,
+  isResolved,
+  onNavigate,
+}: NavbarAuthActionsProps & { onNavigate: () => void }) {
+  if (!isResolved) {
+    return null;
+  }
+
+  if (isAuthenticated) {
+    return (
+      <Link
+        className="cta-gradient-primary font-display rounded-full px-3 py-2.5 text-center text-sm font-medium tracking-[-0.015em] text-white"
+        href={AUTH_DASHBOARD_URL}
+        onClick={onNavigate}
+      >
+        Dashboard
+      </Link>
+    );
+  }
+
+  return (
+    <>
+      <Link
+        className="font-display rounded-md px-3 py-2 text-center text-sm tracking-[-0.015em] text-[#1E1E1E] hover:bg-[#C8B2EE26] dark:text-neutral-300 dark:hover:bg-white/6"
+        href={AUTH_SIGNIN_URL}
+        onClick={onNavigate}
+      >
+        Sign In
+      </Link>
+      <TrackedSignupLink
+        className="cta-gradient-primary font-display rounded-full px-3 py-2.5 text-center text-sm font-medium tracking-[-0.015em] text-white"
+        onClick={onNavigate}
+        source={NAVBAR_MOBILE_SIGNUP_SOURCE}
+      >
+        Sign Up
+      </TrackedSignupLink>
+    </>
   );
 }
 

--- a/apps/web/src/lib/auth/use-dashboard-session.ts
+++ b/apps/web/src/lib/auth/use-dashboard-session.ts
@@ -24,13 +24,13 @@ export function useDashboardSession(): DashboardSessionState {
   useEffect(() => {
     const controller = new AbortController();
     let cancelled = false;
+    const timeoutId = window.setTimeout(() => {
+      controller.abort();
+    }, SESSION_PROBE_TIMEOUT_MS);
 
     fetch(SESSION_ENDPOINT, {
       credentials: "include",
-      signal: AbortSignal.any([
-        controller.signal,
-        AbortSignal.timeout(SESSION_PROBE_TIMEOUT_MS),
-      ]),
+      signal: controller.signal,
     })
       .then((response) => (response.ok ? response.json() : null))
       .then((data) => {
@@ -50,10 +50,14 @@ export function useDashboardSession(): DashboardSessionState {
           isAuthenticated: false,
           isResolved: true,
         });
+      })
+      .finally(() => {
+        window.clearTimeout(timeoutId);
       });
 
     return () => {
       cancelled = true;
+      window.clearTimeout(timeoutId);
       controller.abort();
     };
   }, []);

--- a/apps/web/src/lib/auth/use-dashboard-session.ts
+++ b/apps/web/src/lib/auth/use-dashboard-session.ts
@@ -8,6 +8,7 @@ const SESSION_ENDPOINT =
   process.env.NODE_ENV === "development"
     ? "http://localhost:3000/api/session"
     : `${APP_URL}/api/session`;
+const SESSION_PROBE_TIMEOUT_MS = 4_000;
 
 export interface DashboardSessionState {
   isAuthenticated: boolean;
@@ -22,20 +23,27 @@ export function useDashboardSession(): DashboardSessionState {
 
   useEffect(() => {
     const controller = new AbortController();
+    let cancelled = false;
 
     fetch(SESSION_ENDPOINT, {
       credentials: "include",
-      signal: controller.signal,
+      signal: AbortSignal.any([
+        controller.signal,
+        AbortSignal.timeout(SESSION_PROBE_TIMEOUT_MS),
+      ]),
     })
       .then((response) => (response.ok ? response.json() : null))
       .then((data) => {
+        if (cancelled) {
+          return;
+        }
         setState({
           isAuthenticated: Boolean(data),
           isResolved: true,
         });
       })
-      .catch((error: unknown) => {
-        if (error instanceof DOMException && error.name === "AbortError") {
+      .catch(() => {
+        if (cancelled) {
           return;
         }
         setState({
@@ -44,7 +52,10 @@ export function useDashboardSession(): DashboardSessionState {
         });
       });
 
-    return () => controller.abort();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
   }, []);
 
   return state;

--- a/apps/web/src/types/navbar.ts
+++ b/apps/web/src/types/navbar.ts
@@ -6,6 +6,7 @@ export interface NavbarProps {
 
 export interface NavbarAuthActionsProps {
   isAuthenticated: boolean;
+  isResolved: boolean;
 }
 
 export interface NavbarKbdProps {


### PR DESCRIPTION
### Description
Allow `app.usenotra.com` in the marketing site `connect-src` so the navbar can read `/api/session`. CSP was blocking that request, so signed-in visitors never redirected from `/` and the header stayed on Sign In / Sign Up.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the marketing site CSP blocking the dashboard session probe, so the navbar correctly reflects sign-in state and redirects signed-in users from the home page.

- Splits desktop and mobile auth actions into branches that render only after the session check resolves, so the navbar no longer flickers between Sign In and Dashboard.
- Adds a 4s timeout so the auth links still appear if the probe stalls.

<sup>Written for commit 935dcb5d1082eebe7dc88a94962c3e8324946a4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

