### PR TITLE
fix(dashboard): unblock GEO loading and defer unused dialog requests

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/gaps/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/gaps/page-client.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { GEO_SEARCH_GAP_DISMISSED_TOAST } from "@notra/geo-core/constants/geo";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
+import { Button } from "@/components/button";
 import { GeoGapsTable } from "@/components/geo/gaps-table";
 import { GeoWriterNeedsSetup } from "@/components/geo/writer/page-gate";
-import { WriteDialog } from "@/components/geo/writer/write-dialog";
 import { PageContainer } from "@/components/layout/container";
 import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -33,6 +34,12 @@ import {
 
 import { GeoGapsSkeleton } from "./skeleton";
 
+const WriteDialog = dynamic(() =>
+  import("@/components/geo/writer/write-dialog").then(
+    (module) => module.WriteDialog
+  )
+);
+
 export default function PageClient({ organizationSlug }: GeoPageClientProps) {
   const [projectParam] = useGeoProjectQueryState();
 
@@ -53,8 +60,8 @@ function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
       : orgFromList;
   const organizationId = organization?.id ?? "";
 
-  const { data: settingsData, isPending: isSettingsPending } =
-    useGeoSettings(organizationId);
+  const settingsQuery = useGeoSettings(organizationId);
+  const { data: settingsData, isPending: isSettingsPending } = settingsQuery;
   const gapsQuery = useGeoWriterGaps(organizationId);
   const competitorsQuery = useGeoCompetitors(organizationId);
   const startScan = useGeoStartScan(organizationId);
@@ -70,6 +77,36 @@ function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
     setDialogInitial(initial ?? emptyWriteDialogState());
     setDialogOpen(true);
   }, []);
+
+  if (
+    (settingsQuery.isError && !settingsData) ||
+    (settingsData?.settings && gapsQuery.isError && !gapsQuery.data)
+  ) {
+    return (
+      <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:py-6">
+        <div className="space-y-4 px-4 lg:px-6" role="alert">
+          <h1 className="text-3xl font-bold tracking-tight">Content Gaps</h1>
+          <p className="text-muted-foreground">
+            We couldn&apos;t load content gaps. Try again.
+          </p>
+          <Button
+            disabled={settingsQuery.isFetching || gapsQuery.isFetching}
+            onClick={() => {
+              if (settingsQuery.isError) {
+                void settingsQuery.refetch();
+              }
+              if (gapsQuery.isError) {
+                void gapsQuery.refetch();
+              }
+            }}
+            variant="outline"
+          >
+            Retry
+          </Button>
+        </div>
+      </PageContainer>
+    );
+  }
 
   if (!(isSettingsPending || settingsData?.settings)) {
     return (
@@ -156,7 +193,7 @@ function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
         )}
       </div>
 
-      {organizationId ? (
+      {organizationId && dialogInitial ? (
         <WriteDialog
           entry={GEO_WRITE_DIALOG_ENTRIES.GAP}
           initial={dialogInitial}

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/layout.tsx
@@ -18,7 +18,7 @@ export default async function GeoLayout({
       <GeoCatalogWarmer organizationSlug={slug} />
       <Suspense fallback={<GeoPageSkeleton />}>
         <GeoProjectQueryProvider key={slug}>
-          <GeoUpgradeGate slug={slug}>
+          <GeoUpgradeGate fallback={<GeoPageSkeleton />} slug={slug}>
             {children}
             {modal}
           </GeoUpgradeGate>

--- a/apps/dashboard/src/components/content/create-content-dialog.tsx
+++ b/apps/dashboard/src/components/content/create-content-dialog.tsx
@@ -204,7 +204,7 @@ export function CreateContentDialog({
   const { data: brandResponse, isLoading: isLoadingVoices } = useQuery(
     dashboardOrpc.brand.voices.list.queryOptions({
       input: { organizationId },
-      enabled: !!organizationId,
+      enabled: open && !!organizationId,
     })
   );
   const brandVoices = brandResponse?.voices ?? [];
@@ -212,7 +212,7 @@ export function CreateContentDialog({
   const { data: integrationsResponse, isLoading: isLoadingRepos } = useQuery(
     dashboardOrpc.integrations.list.queryOptions({
       input: { organizationId },
-      enabled: !!organizationId,
+      enabled: open && !!organizationId,
     })
   );
 

--- a/apps/dashboard/src/components/geo/geo-upgrade-gate.tsx
+++ b/apps/dashboard/src/components/geo/geo-upgrade-gate.tsx
@@ -21,10 +21,14 @@ import { pickSidebarMode } from "@/lib/hooks/use-sidebar-mode";
 import type { GeoUpgradeGateProps } from "@/types/components/geo";
 import { sidebarRouteFromPathname } from "@/utils/nav";
 
-export function GeoUpgradeGate({ slug, children }: GeoUpgradeGateProps) {
+export function GeoUpgradeGate({
+  slug,
+  children,
+  fallback,
+}: GeoUpgradeGateProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const { isLocked } = useHasGeoFeature();
+  const { isLocked, isLoading } = useHasGeoFeature();
   const route = toAnalyticsRoute(pathname, slug);
   const shownRef = useRef(false);
 
@@ -39,7 +43,10 @@ export function GeoUpgradeGate({ slug, children }: GeoUpgradeGateProps) {
     });
   }, [isLocked, route]);
 
-  // GEO procedures enforce entitlement; billing must not block page loading.
+  if (isLoading) {
+    return fallback;
+  }
+
   if (!isLocked) {
     return children;
   }

--- a/apps/dashboard/src/components/geo/geo-upgrade-gate.tsx
+++ b/apps/dashboard/src/components/geo/geo-upgrade-gate.tsx
@@ -24,7 +24,7 @@ import { sidebarRouteFromPathname } from "@/utils/nav";
 export function GeoUpgradeGate({ slug, children }: GeoUpgradeGateProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const { isLocked, isLoading } = useHasGeoFeature();
+  const { isLocked } = useHasGeoFeature();
   const route = toAnalyticsRoute(pathname, slug);
   const shownRef = useRef(false);
 
@@ -39,10 +39,7 @@ export function GeoUpgradeGate({ slug, children }: GeoUpgradeGateProps) {
     });
   }, [isLocked, route]);
 
-  if (isLoading) {
-    return null;
-  }
-
+  // GEO procedures enforce entitlement; billing must not block page loading.
   if (!isLocked) {
     return children;
   }

--- a/apps/dashboard/src/constants/content-preview.ts
+++ b/apps/dashboard/src/constants/content-preview.ts
@@ -11,6 +11,8 @@ export const GITHUB_API_MAX_RESULTS = 500;
 
 export const DEFAULT_CONTENT_TYPE: OnDemandContentType = "changelog";
 
+export const DASHBOARD_HOME_POST_LIMIT = 3;
+
 export const DEFAULT_DATA_POINTS: ContentDataPointSettings = {
   includePullRequests: true,
   includeCommits: true,

--- a/apps/dashboard/src/lib/db/geo-collections.ts
+++ b/apps/dashboard/src/lib/db/geo-collections.ts
@@ -5,6 +5,7 @@ import type {
   GeoScopeInput,
   GeoTrackedPrompt,
 } from "@notra/geo-core/types/geo";
+import { ORPCError } from "@orpc/client";
 import { queryCollectionOptions } from "@tanstack/query-db-collection";
 import { collectionOptions } from "@tanstack/react-db";
 import type { QueryClient } from "@tanstack/react-query";
@@ -56,7 +57,12 @@ function buildScopedCollection<T extends object>(
         try {
           return await spec.fetch(scope);
         } catch (error) {
-          toast.error(spec.errorMessage, { id });
+          // The upgrade gate handles entitlement denials, not load-error toasts.
+          if (
+            !(error instanceof ORPCError && error.code === "PAYMENT_REQUIRED")
+          ) {
+            toast.error(spec.errorMessage, { id });
+          }
           throw error;
         }
       },

--- a/apps/dashboard/src/lib/hooks/use-posts.ts
+++ b/apps/dashboard/src/lib/hooks/use-posts.ts
@@ -3,6 +3,8 @@
 import type { PostsResponse } from "@notra/schemas/dashboard/content";
 import { useQuery } from "@tanstack/react-query";
 
+import { DASHBOARD_HOME_POST_LIMIT } from "@/constants/content-preview";
+
 import { dashboardOrpc } from "../orpc/query";
 import { useActiveProject } from "./use-active-project";
 
@@ -32,7 +34,7 @@ export function useTodayPosts(organizationId: string) {
         organizationId,
         projectId: projectId ?? undefined,
         page: 1,
-        pageSize: DEFAULT_PAGE_SIZE,
+        pageSize: DASHBOARD_HOME_POST_LIMIT,
         date: "today",
       },
     }),

--- a/apps/dashboard/src/types/components/geo.ts
+++ b/apps/dashboard/src/types/components/geo.ts
@@ -74,6 +74,7 @@ export interface SearchConsoleConnectedStateProps {
 export interface GeoUpgradeGateProps {
   slug: string;
   children: ReactNode;
+  fallback: ReactNode;
 }
 
 export interface GeoUpgradeDialogProps {

--- a/apps/dashboard/tests/geo-gaps-page.test.tsx
+++ b/apps/dashboard/tests/geo-gaps-page.test.tsx
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+let settingsFails = false;
+let gapsFails = false;
+let cachedGaps = false;
+let configured = true;
+const retrySettings = mock(async () => undefined);
+const retryGaps = mock(async () => undefined);
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({ push: mock() }),
+  usePathname: () => "/fixture/geo/gaps",
+}));
+mock.module("@/components/providers/organization-provider", () => ({
+  useOrganizationsContext: () => ({
+    activeOrganization: { id: "org-fixture", slug: "fixture" },
+    getOrganization: () => undefined,
+  }),
+}));
+mock.module("@/lib/hooks/use-geo-project-query", () => ({
+  useGeoProjectQueryState: () => ["project-fixture"],
+}));
+mock.module("@/lib/hooks/use-geo", () => ({
+  useGeoSettings: () => ({
+    data: settingsFails
+      ? undefined
+      : { settings: configured ? { id: "settings-fixture" } : null },
+    isPending: false,
+    isError: settingsFails,
+    isFetching: false,
+    refetch: retrySettings,
+  }),
+  useGeoCompetitors: () => ({ data: { competitors: [] } }),
+  useGeoStartScan: () => ({ mutate: mock() }),
+  useGeoRescanPrompt: () => ({ mutate: mock() }),
+  useIsGeoScanning: () => false,
+  useGeoSuggestionDismiss: () => ({ isPending: false, mutate: mock() }),
+}));
+mock.module("@/lib/hooks/use-geo-writer", () => ({
+  useGeoWriterGaps: () => ({
+    data:
+      !gapsFails || cachedGaps
+        ? { hasScanData: true, promptGaps: [], searchGaps: [] }
+        : undefined,
+    isPending: false,
+    isError: gapsFails,
+    isFetching: false,
+    refetch: retryGaps,
+  }),
+}));
+mock.module("@/components/geo/gaps-table", () => ({
+  GeoGapsTable: () => <div>Loaded gaps table</div>,
+}));
+mock.module("@/components/geo/writer/page-gate", () => ({
+  GeoWriterNeedsSetup: () => <h1>Set up your brand</h1>,
+}));
+mock.module("@/components/geo/writer/write-dialog", () => ({
+  WriteDialog: () => <div>Writer dialog mounted</div>,
+}));
+
+const { default: GeoGapsPage } =
+  await import("../src/app/(dashboard)/[slug]/geo/gaps/page-client");
+
+beforeEach(() => {
+  settingsFails = false;
+  gapsFails = false;
+  cachedGaps = false;
+  configured = true;
+});
+
+describe("Content Gaps load failures", () => {
+  test("does not mount the writer before a write action", () => {
+    const html = renderToStaticMarkup(
+      <GeoGapsPage organizationSlug="fixture" />
+    );
+
+    expect(html).toContain("Loaded gaps table");
+    expect(html).not.toContain("Writer dialog mounted");
+  });
+
+  test("preserves setup when settings confirm that no brand is configured", () => {
+    configured = false;
+    gapsFails = true;
+    const html = renderToStaticMarkup(
+      <GeoGapsPage organizationSlug="fixture" />
+    );
+
+    expect(html).toContain("Set up your brand");
+    expect(html).not.toContain('role="alert"');
+  });
+
+  test("shows a retryable error rather than setup when settings fail", () => {
+    settingsFails = true;
+    const html = renderToStaticMarkup(
+      <GeoGapsPage organizationSlug="fixture" />
+    );
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Retry");
+    expect(html).not.toContain("Set up your brand");
+  });
+
+  test("shows a retryable error rather than an empty table when gaps fail", () => {
+    gapsFails = true;
+    const html = renderToStaticMarkup(
+      <GeoGapsPage organizationSlug="fixture" />
+    );
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Retry");
+    expect(html).not.toContain("Loaded gaps table");
+  });
+
+  test("keeps previously loaded gaps visible after a background refresh fails", () => {
+    gapsFails = true;
+    cachedGaps = true;
+    const html = renderToStaticMarkup(
+      <GeoGapsPage organizationSlug="fixture" />
+    );
+
+    expect(html).toContain("Loaded gaps table");
+    expect(html).not.toContain('role="alert"');
+  });
+});

--- a/apps/dashboard/tests/geo-upgrade-gate.test.tsx
+++ b/apps/dashboard/tests/geo-upgrade-gate.test.tsx
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { GeoPageSkeleton } from "../src/app/(dashboard)/[slug]/geo/skeleton";
+
 const geoFeature = mock(() => ({ isLocked: false, isLoading: true }));
+const GeoPage = mock(() => <h1>Protected page content</h1>);
 
 mock.module("@/lib/hooks/use-plan", () => ({
   useHasGeoFeature: geoFeature,
@@ -27,41 +30,47 @@ const { GeoUpgradeGate } =
 
 beforeEach(() => {
   geoFeature.mockReturnValue({ isLocked: false, isLoading: true });
+  GeoPage.mockClear();
 });
 
 describe("GEO billing gate", () => {
-  test("renders the page while billing loads instead of a blank content area", () => {
+  test("shows the GEO skeleton without rendering page children while billing loads", () => {
     const html = renderToStaticMarkup(
-      <GeoUpgradeGate slug="fixture">
-        <h1>Content Gaps</h1>
+      <GeoUpgradeGate fallback={<GeoPageSkeleton />} slug="fixture">
+        <GeoPage />
       </GeoUpgradeGate>
     );
 
-    expect(html).toContain("Content Gaps");
+    expect(html).toContain('data-slot="skeleton"');
+    expect(html).not.toContain("Checking GEO access");
+    expect(html).not.toContain("Protected page content");
     expect(html).not.toContain("Upgrade required");
+    expect(GeoPage).not.toHaveBeenCalled();
   });
 
   test("renders the page for a confirmed entitled customer", () => {
     geoFeature.mockReturnValue({ isLocked: false, isLoading: false });
     const html = renderToStaticMarkup(
-      <GeoUpgradeGate slug="fixture">
-        <h1>Content Gaps</h1>
+      <GeoUpgradeGate fallback={<GeoPageSkeleton />} slug="fixture">
+        <GeoPage />
       </GeoUpgradeGate>
     );
 
-    expect(html).toContain("Content Gaps");
+    expect(html).toContain("Protected page content");
     expect(html).not.toContain("Upgrade required");
+    expect(GeoPage).toHaveBeenCalledTimes(1);
   });
 
   test("keeps the paywall and excludes page children for a confirmed locked customer", () => {
     geoFeature.mockReturnValue({ isLocked: true, isLoading: false });
     const html = renderToStaticMarkup(
-      <GeoUpgradeGate slug="fixture">
-        <h1>Protected page content</h1>
+      <GeoUpgradeGate fallback={<GeoPageSkeleton />} slug="fixture">
+        <GeoPage />
       </GeoUpgradeGate>
     );
 
     expect(html).toContain("Upgrade required");
     expect(html).not.toContain("Protected page content");
+    expect(GeoPage).not.toHaveBeenCalled();
   });
 });

--- a/apps/dashboard/tests/geo-upgrade-gate.test.tsx
+++ b/apps/dashboard/tests/geo-upgrade-gate.test.tsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+const geoFeature = mock(() => ({ isLocked: false, isLoading: true }));
+
+mock.module("@/lib/hooks/use-plan", () => ({
+  useHasGeoFeature: geoFeature,
+}));
+mock.module("next/navigation", () => ({
+  usePathname: () => "/fixture/geo/gaps",
+  useRouter: () => ({ push: mock() }),
+}));
+mock.module("@/components/billing/geo-upgrade-dialog", () => ({
+  GeoUpgradeDialog: () => <div>Upgrade required</div>,
+}));
+mock.module("@/components/empty-state-preview", () => ({
+  EmptyStateAnalyticsPreview: () => null,
+}));
+mock.module("@/lib/analytics/posthog-client", () => ({ trackEvent: mock() }));
+mock.module("@/lib/hooks/use-sidebar-mode", () => ({
+  pickSidebarMode: mock(),
+}));
+
+const { GeoUpgradeGate } =
+  await import("../src/components/geo/geo-upgrade-gate");
+
+beforeEach(() => {
+  geoFeature.mockReturnValue({ isLocked: false, isLoading: true });
+});
+
+describe("GEO billing gate", () => {
+  test("renders the page while billing loads instead of a blank content area", () => {
+    const html = renderToStaticMarkup(
+      <GeoUpgradeGate slug="fixture">
+        <h1>Content Gaps</h1>
+      </GeoUpgradeGate>
+    );
+
+    expect(html).toContain("Content Gaps");
+    expect(html).not.toContain("Upgrade required");
+  });
+
+  test("renders the page for a confirmed entitled customer", () => {
+    geoFeature.mockReturnValue({ isLocked: false, isLoading: false });
+    const html = renderToStaticMarkup(
+      <GeoUpgradeGate slug="fixture">
+        <h1>Content Gaps</h1>
+      </GeoUpgradeGate>
+    );
+
+    expect(html).toContain("Content Gaps");
+    expect(html).not.toContain("Upgrade required");
+  });
+
+  test("keeps the paywall and excludes page children for a confirmed locked customer", () => {
+    geoFeature.mockReturnValue({ isLocked: true, isLoading: false });
+    const html = renderToStaticMarkup(
+      <GeoUpgradeGate slug="fixture">
+        <h1>Protected page content</h1>
+      </GeoUpgradeGate>
+    );
+
+    expect(html).toContain("Upgrade required");
+    expect(html).not.toContain("Protected page content");
+  });
+});

--- a/apps/dashboard/tests/home-posts.test.tsx
+++ b/apps/dashboard/tests/home-posts.test.tsx
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const activeProject = mock(() => ({
+  projectId: "project-1",
+  isResolved: true,
+}));
+
+mock.module("@/lib/hooks/use-active-project", () => ({
+  useActiveProject: activeProject,
+}));
+mock.module("@/lib/orpc/query", () => ({
+  dashboardOrpc: {
+    content: {
+      list: {
+        queryOptions: ({ input }: { input: unknown }) => ({
+          queryKey: ["content", "list", input],
+          queryFn: async () => ({ posts: [] }),
+        }),
+      },
+    },
+  },
+}));
+
+const { usePosts, useTodayPosts } = await import("../src/lib/hooks/use-posts");
+let organizationId = "org-1";
+
+function TodayPostsProbe() {
+  useTodayPosts(organizationId);
+  return null;
+}
+
+function ContentListProbe() {
+  usePosts(organizationId, 2);
+  return null;
+}
+
+beforeEach(() => {
+  organizationId = "org-1";
+  activeProject.mockReturnValue({ projectId: "project-1", isResolved: true });
+});
+
+describe("dashboard home post query", () => {
+  test("requests only three scoped posts for today's preview", () => {
+    const client = new QueryClient();
+    renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TodayPostsProbe />
+      </QueryClientProvider>
+    );
+
+    expect(client.getQueryCache().getAll()[0]?.queryKey).toEqual([
+      "content",
+      "list",
+      {
+        organizationId: "org-1",
+        projectId: "project-1",
+        page: 1,
+        pageSize: 3,
+        date: "today",
+      },
+    ]);
+  });
+
+  test("keeps content-list pagination at twelve posts", () => {
+    const client = new QueryClient();
+    renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <ContentListProbe />
+      </QueryClientProvider>
+    );
+
+    expect(client.getQueryCache().getAll()[0]?.queryKey).toEqual([
+      "content",
+      "list",
+      {
+        organizationId: "org-1",
+        projectId: "project-1",
+        page: 2,
+        pageSize: 12,
+      },
+    ]);
+  });
+
+  test("waits for the active project before requesting today's posts", () => {
+    activeProject.mockReturnValue({
+      projectId: "project-1",
+      isResolved: false,
+    });
+    const client = new QueryClient();
+    renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TodayPostsProbe />
+      </QueryClientProvider>
+    );
+
+    expect(client.getQueryCache().getAll()[0]?.options).toMatchObject({
+      enabled: false,
+    });
+  });
+
+  test("does not request today's posts without an organization", () => {
+    organizationId = "";
+    const client = new QueryClient();
+    renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TodayPostsProbe />
+      </QueryClientProvider>
+    );
+
+    expect(client.getQueryCache().getAll()[0]?.options).toMatchObject({
+      enabled: false,
+    });
+  });
+});


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks GEO dashboard pages that sat on a blank screen while the billing entitlement check ran, and defers data requests that only matter once a user acts.

**Bug Fixes**
- GEO pages show a skeleton instead of a blank screen while the entitlement check runs, then render the page or paywall once access is confirmed; entitlement denials no longer fire load-error toasts since the server enforces access.
- Content Gaps shows a retryable error when settings or gaps queries fail, and keeps already-loaded gaps visible if a background refresh fails.

**Refactors**
- `CreateContentDialog` fetches brand voices and integrations only when the dialog is open.
- The write dialog is lazy-loaded and mounts only when a user starts a write action.
- Today's posts preview requests 3 posts instead of the default page size of 12.

<sup>Written for commit 5517b09aabc322e566ba5911f2030d04166cdaff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

