### PR TITLE
chore(web): regenerate shared UI stylesheet

### DIFF
--- a/apps/web/src/styles/ui-sources.css
+++ b/apps/web/src/styles/ui-sources.css
@@ -13,6 +13,8 @@
 @source "../../../../packages/ui/src/components/brainless/claude/claude-prompt.tsx";
 @source "../../../../packages/ui/src/components/brainless/claude/claude-todo-list.tsx";
 @source "../../../../packages/ui/src/components/brainless/claude/claude-tool-call.tsx";
+@source "../../../../packages/ui/src/components/brainless/codex/codex-composer.tsx";
+@source "../../../../packages/ui/src/components/brainless/codex/codex-message.tsx";
 @source "../../../../packages/ui/src/components/brainless/gemini/gemini-actions.tsx";
 @source "../../../../packages/ui/src/components/brainless/gemini/gemini-composer.tsx";
 @source "../../../../packages/ui/src/components/brainless/gemini/gemini-message.tsx";


### PR DESCRIPTION
### Description
Regenerate `apps/web` shared UI stylesheet so Tailwind sources include the newly reachable Codex composer and message components.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates the `apps/web` shared UI stylesheet so Tailwind now includes the newly reachable Codex composer and message components in its source scanning.

<sup>Written for commit 818bde24cd4c6d76caf4708d631321e2d43ce928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

