### PR TITLE
chore(api): sync dockerignore with the API image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,16 @@
-# Version control
+# Build context is the monorepo root:
+#   docker build -f apps/api/Dockerfile -t notra-api .
+# Keep exceptions in sync with COPY lines in apps/api/Dockerfile.
+
+# VCS
 .git
 .gitignore
 
-# Node modules (reinstalled inside Docker)
+# Dependencies & caches (reinstalled in the image)
 node_modules
 **/node_modules
+.turbo
+**/.turbo
 
 # Build outputs
 dist
@@ -12,46 +18,61 @@ dist
 **/.vercel
 **/.wrangler
 
-# Environment files
+# Secrets / env
 .env
 .env.*
 **/.env
 **/.env.*
 **/.dev.vars
 
-# Turbo cache
-.turbo
-**/.turbo
-
-# Test & coverage
+# Tests
 coverage
 **/*.test.ts
 **/*.spec.ts
 
-# Misc dev tooling
+# Local tooling (not used to build the API)
 .vscode
 .idea
 .cursor
 .claude
 .agents
-.opencode
-.stagewise
+.eve
+.deepsec
+.repos
+.output
+.workflow-data
+.openlogs
+.github
+scripts
 
-# OS
+# OS / logs
 .DS_Store
 Thumbs.db
-
-# Logs
 *.log
 logs/
 
-# Docs & non-essential apps (not needed to build the API)
-apps/dashboard
-apps/web
-apps/docs
+# Apps not copied as source — keep package.json for bun workspaces
+apps/agent/**
+!apps/agent/package.json
+apps/dashboard/**
 !apps/dashboard/package.json
-!apps/web/package.json
+apps/docs/**
 !apps/docs/package.json
+apps/onboarding-agent/**
+!apps/onboarding-agent/package.json
+apps/ui/**
+!apps/ui/package.json
+apps/web/**
+!apps/web/package.json
 
-# Openlogs
-.openlogs/
+# Packages copied as package.json only (not source)
+packages/email/**
+!packages/email/package.json
+packages/geo/**
+!packages/geo/package.json
+packages/kiwi/**
+!packages/kiwi/package.json
+packages/tools/**
+!packages/tools/package.json
+packages/ui/**
+!packages/ui/package.json

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,9 +9,12 @@ WORKDIR /app
 
 # Copy workspace manifests needed to resolve the full dependency graph
 COPY package.json bun.lock bunfig.toml ./
+COPY apps/agent/package.json ./apps/agent/package.json
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/dashboard/package.json ./apps/dashboard/package.json
 COPY apps/docs/package.json ./apps/docs/package.json
+COPY apps/onboarding-agent/package.json ./apps/onboarding-agent/package.json
+COPY apps/ui/package.json ./apps/ui/package.json
 COPY apps/web/package.json ./apps/web/package.json
 COPY packages/ai/package.json ./packages/ai/package.json
 COPY packages/analytics/package.json ./packages/analytics/package.json
@@ -23,6 +26,7 @@ COPY packages/geo-core/package.json ./packages/geo-core/package.json
 COPY packages/kiwi/package.json ./packages/kiwi/package.json
 COPY packages/posthog/package.json ./packages/posthog/package.json
 COPY packages/schemas/package.json ./packages/schemas/package.json
+COPY packages/tools/package.json ./packages/tools/package.json
 COPY packages/typescript-config/package.json ./packages/typescript-config/package.json
 COPY packages/ui/package.json ./packages/ui/package.json
 COPY packages/utils/package.json ./packages/utils/package.json


### PR DESCRIPTION
### Description
Align the root `.dockerignore` with `apps/api/Dockerfile`: keep workspace `package.json` files for `bun install`, exclude unused app/package source, drop stale OpenCode/Stagewise ignores, and copy the remaining workspace manifests the lockfile expects.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the root `.dockerignore` with `apps/api/Dockerfile` so the Docker build context no longer excludes files the API image needs, while still keeping unused app/package source out of the build.

- Retains `package.json` for every workspace package so `bun install` can resolve the full dependency graph.
- Drops stale ignores for OpenCode and Stagewise and adds the newly required workspace manifests to the Dockerfile.

<sup>Written for commit be47d957212e072750a9263607183090ed110708. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

