### PR TITLE
perf(build): cache workspace type checks and update turbo

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,5 +34,15 @@ jobs:
       - name: Run unit and integration tests
         run: bun run test --force
 
+      - name: Restore incremental TypeScript state
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            apps/*/.cache/typecheck.tsbuildinfo
+            packages/*/.cache/typecheck.tsbuildinfo
+          key: typecheck-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock', 'package.json', 'apps/*/package.json', 'packages/*/package.json', 'apps/*/tsconfig*.json', 'packages/*/tsconfig*.json', 'packages/typescript-config/*.json') }}-${{ github.sha }}
+          restore-keys: |
+            typecheck-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock', 'package.json', 'apps/*/package.json', 'packages/*/package.json', 'apps/*/tsconfig*.json', 'packages/*/tsconfig*.json', 'packages/typescript-config/*.json') }}-
+
       - name: Typecheck tested packages and UI docs
         run: bun run check-types --filter=@notra/ai --filter=@notra/geo-core --filter=dashboard --filter=ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,20 @@ after `Deployment completed`; it is not additional time until the app is live.
 Both projects use filtered Turbo build commands and skip unaffected projects.
 Preserve those settings when changing the Vercel configuration.
 
+Standalone `check-types` scripts that run `tsc` enable incremental checking with
+command-line flags and write to `.cache/typecheck.tsbuildinfo` within each
+package. Run them through `bun run check-types` (optionally with `--filter`) to
+reuse this state. These flags override the shared base config for type checks
+without changing Eve or tsup builds. The files are already ignored by Git's
+`*.tsbuildinfo` rule and are declared as Turbo task outputs.
+
+The code-quality workflow restores these files using a cache key scoped to the
+runner platform, dependencies, configuration, and commit. A matching prefix can
+restore state from an earlier commit; TypeScript still checks changed source and
+its affected dependents. The workflow retains its existing package selection.
+Blume's `ui` app uses its own checker and does not produce this cache file.
+Next.js production builds continue to use their separate `.next/cache` state.
+
 ## Database Workflow
 
 Common Drizzle commands from the repo root:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,25 @@ NEXT_PUBLIC_APP_URL=https://your-public-tunnel-url
 If you need a stable or custom URL, use a locally managed tunnel setup from the official docs:
 https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/create-local-tunnel/
 
+## Build performance
+
+The web and dashboard apps enable incremental TypeScript checking in their
+`tsconfig.json` files, overriding the shared base config. Keep this enabled:
+Next.js writes the build's type-check state to `.next/cache/.tsbuildinfo`, which
+Vercel restores on subsequent builds. A cold build still checks the whole project;
+warm builds reuse unchanged checks without disabling type errors.
+
+Next.js 16.3 also enables the Turbopack filesystem build cache by default. Keep
+`.next/cache` in Vercel's build cache, but exclude it and `.next/dev` from Turbo's
+task outputs. Turbo caches completed build artifacts; Vercel's build cache keeps
+the incremental compiler state used when a task needs to run again.
+
+When comparing deployments, measure compilation, TypeScript, static generation,
+and output deployment separately. Vercel's `Creating build cache` phase occurs
+after `Deployment completed`; it is not additional time until the app is live.
+Both projects use filtered Turbo build commands and skip unaffected projects.
+Preserve those settings when changing the Vercel configuration.
+
 ## Database Workflow
 
 Common Drizzle commands from the repo root:

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -8,7 +8,7 @@
     "agent:dev": "dotenv -e ../../.env -- eve dev",
     "agent:build": "eve build",
     "agent:start": "eve start",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "agent:dev:devtools": "AI_SDK_DEVTOOLS=true dotenv -e ../../.env -- eve dev",
     "devtools": "bun x @ai-sdk/devtools"
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
     "dev": "NODE_ENV=development bun --watch src/index.ts",
     "build": "tsup",
     "start": "node dist/index.mjs",
-    "check-types": "bunx tsc --noEmit",
+    "check-types": "bunx tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "test": "bun test tests",
     "knip": "knip"
   },

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "knip": "knip",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@notra/typescript-config/nextjs.json",
   "compilerOptions": {
     "incremental": true,
+    "tsBuildInfoFile": ".cache/typecheck.tsbuildinfo",
     "strict": true,
     "plugins": [
       {

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@notra/typescript-config/nextjs.json",
   "compilerOptions": {
+    "incremental": true,
     "strict": true,
     "plugins": [
       {

--- a/apps/onboarding-agent/package.json
+++ b/apps/onboarding-agent/package.json
@@ -8,7 +8,7 @@
     "agent:dev": "dotenv -e ../../.env -- eve dev",
     "agent:build": "eve build",
     "agent:start": "eve start",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "agent:dev:devtools": "AI_SDK_DEVTOOLS=true dotenv -e ../../.env -- eve dev",
     "devtools": "bun x @ai-sdk/devtools"
   },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@notra/typescript-config/nextjs.json",
   "compilerOptions": {
     "incremental": true,
+    "tsBuildInfoFile": ".cache/typecheck.tsbuildinfo",
     "strict": true,
     "plugins": [
       {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@notra/typescript-config/nextjs.json",
   "compilerOptions": {
+    "incremental": true,
     "strict": true,
     "plugins": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "openlogs": "^0.0.1",
         "oxfmt": "0.64.0",
         "oxlint": "1.79.0",
-        "turbo": "^2.10.11",
+        "turbo": "^2.10.12",
         "ultracite": "7.10.6",
       },
     },
@@ -2303,17 +2303,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-v3R+1R/Ysozyo+p7Ri8MCIbndOvYt3DgPFrGLhrhQHfvyvbxyH3WyJj+A/2JTNmNleuAlh3JUyCV0iSVHIONTA=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-R0a0CvGAeYYsBgPIgFNB3agGXh6qukjduNhFlwVVX1Ss2IdBJLXmgjytNGmo084bLKS0B6UdLRwKhXMHKKaObQ=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.10.11", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-dGlY2vg7jpsLjGS1bf9sD/cw1sGMAYbeHGQKGRFxd5Zaj+Ufbj8cNXl/vIit8ueCU97zhL/znn60ZV5iSfZAxw=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.12", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.11", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-eSP9+jjsSCBs2x0QpJZlp49dSD1EIMwXH7PsMIhdWk7w6IThhuKJ+jL95JQ2IW7tRjRmdh8gKcKQtrHLD5R5lA=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.12", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.10.11", "", { "os": "win32", "cpu": "x64" }, "sha512-4aD7edogJ8arK8DOyvjTI2KKwmchD5M/WM4BZgidrtFf7aSgn8Ce2rJnDwmriw980c2cKlHnhXtlGy38VtKB8g=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.12", "", { "os": "win32", "cpu": "x64" }, "sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-m8tJkIrTrbQ9O1uHxV0GUq623Zg1678xGna8eMsy4KbygUX/wVFgdZDYV/AxyoyaW/U7nyKoBvaDVwm22p9xqA=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
@@ -5053,7 +5053,7 @@
 
     "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
-    "turbo": ["turbo@2.10.11", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.11", "@turbo/darwin-arm64": "2.10.11", "@turbo/linux-64": "2.10.11", "@turbo/linux-arm64": "2.10.11", "@turbo/windows-64": "2.10.11", "@turbo/windows-arm64": "2.10.11" }, "bin": { "turbo": "bin/turbo" } }, "sha512-yQfwQVoRXwOuyX1LxiJFBFNg6VfuYh+/RyZLd82+isgyLkBXw3S5XRRzvcck1FAjSCG5sVyLd+O1eDMvYa3J7g=="],
+    "turbo": ["turbo@2.10.12", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.12", "@turbo/darwin-arm64": "2.10.12", "@turbo/linux-64": "2.10.12", "@turbo/linux-arm64": "2.10.12", "@turbo/windows-64": "2.10.12", "@turbo/windows-arm64": "2.10.12" }, "bin": { "turbo": "bin/turbo" } }, "sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,6 +3,14 @@ linkWorkspacePackages = false
 # Only install package versions published at least 7 days ago
 minimumReleaseAge = 604800
 minimumReleaseAgeExcludes = [
+  # Turbo requires the matching native binary on each build platform.
+  "turbo",
+  "@turbo/darwin-64",
+  "@turbo/darwin-arm64",
+  "@turbo/linux-64",
+  "@turbo/linux-arm64",
+  "@turbo/windows-64",
+  "@turbo/windows-arm64",
   "@base-ui/react",
   "@next/env",
   "@next/swc-darwin-arm64",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "openlogs": "^0.0.1",
     "oxfmt": "0.64.0",
     "oxlint": "1.79.0",
-    "turbo": "^2.10.11",
+    "turbo": "^2.10.12",
     "ultracite": "7.10.6"
   },
   "overrides": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -35,7 +35,7 @@
     "./crypto/*": "./src/crypto/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "test": "bun test src && bun test tests"
   },
   "dependencies": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -7,7 +7,7 @@
     "./*": "./src/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "tinybird:dev": "tinybird dev",
     "tinybird:build": "tinybird build",
     "tinybird:deploy": "tinybird deploy",

--- a/packages/content-generation/package.json
+++ b/packages/content-generation/package.json
@@ -9,7 +9,7 @@
     "./schemas": "./src/schemas.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo"
   },
   "dependencies": {
     "@notra/ai": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,7 @@
     "./utils/*": "./src/utils/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "seed:brand-identity": "bun run src/scripts/seed-brand-identity.ts",
     "seed:chat-attachments": "bun run src/scripts/seed-chat-attachments.ts"
   },

--- a/packages/geo-core/package.json
+++ b/packages/geo-core/package.json
@@ -13,7 +13,7 @@
     "./csv/*": "./src/csv/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "test": "bun test tests"
   },
   "dependencies": {

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -74,7 +74,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo",
     "prepublishOnly": "bun run build"
   },
   "devDependencies": {

--- a/packages/kiwi/package.json
+++ b/packages/kiwi/package.json
@@ -13,7 +13,7 @@
     "./schema": "./src/schemas/figma.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo"
   },
   "dependencies": {
     "opentype.js": "^2.0.0",

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -11,7 +11,7 @@
     "./constants/*": "./src/constants/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo"
   },
   "dependencies": {
     "posthog-node": "5.50.0"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -12,7 +12,7 @@
     "./utils/*": "./src/utils/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo"
   },
   "dependencies": {
     "@hono/zod-openapi": "^1.2.2",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -7,7 +7,7 @@
     "./*": "./src/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1009.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,7 @@
     "./hooks/use-mobile": "./src/hooks/use-mobile.tsx"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo"
   },
   "dependencies": {
     "@base-ui/react": "^1.8.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,7 @@
     "./types/*": "./src/types/*.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .cache/typecheck.tsbuildinfo"
   },
   "devDependencies": {
     "@notra/typescript-config": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://v2-10-11.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-12.turborepo.dev/schema.json",
   "ui": "tui",
   "globalEnv": [
     "AI_GATEWAY_API_KEY",
@@ -116,7 +116,13 @@
     "build": {
       "dependsOn": ["transit"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**", ".vercel/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "!.next/dev/**",
+        "dist/**",
+        ".vercel/**"
+      ]
     },
     "@notra/onboarding-agent#build": {
       "dependsOn": ["^build", "transit"],

--- a/turbo.json
+++ b/turbo.json
@@ -134,7 +134,12 @@
       ]
     },
     "check-types": {
-      "dependsOn": ["transit"]
+      "dependsOn": ["transit"],
+      "outputs": [".cache/typecheck.tsbuildinfo"]
+    },
+    "ui#check-types": {
+      "dependsOn": ["transit"],
+      "outputs": []
     },
     "knip": {
       "dependsOn": ["transit"]


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up builds by making TypeScript checks incremental across all workspaces and their CI runs, so warm runs reuse unchanged type-check state instead of rechecking everything. Type errors still surface on cold builds, so behavior is unchanged.

- Standalone `check-types` scripts write incremental state to `.cache/typecheck.tsbuildinfo` (the Next.js apps also enable it via `tsconfig.json`), which the code-quality workflow caches and restores.
- Turbo is updated to 2.10.12, `.next/dev` is excluded from Turbo outputs to align with Next.js 16.3's Turbopack build cache, and the release-age restriction is lifted for Turbo native packages.

<sup>Written for commit 7f0745e49e076b705dcc7519ccea3f4a2c4b43b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

