### PR TITLE
fix(web): redirect signed-out landing aliases to homepage

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -28,7 +28,7 @@ import {
   useScroll,
 } from "motion/react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -299,6 +299,7 @@ function getNavbarPresentation(
 
 export function Navbar({ variant }: NavbarProps = {}) {
   const pathname = usePathname();
+  const router = useRouter();
   const resolvedVariant = variant ?? getNavbarVariantForPath(pathname);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -335,14 +336,26 @@ export function Navbar({ variant }: NavbarProps = {}) {
   useNavbarAuthHotkeys({ isAuthenticated, isResolved });
 
   useEffect(() => {
-    if (pathname === "/" && isResolved && isAuthenticated) {
+    if (!isResolved) {
+      return;
+    }
+
+    if (!isAuthenticated) {
+      if (pathname === "/home" || pathname === "/landing") {
+        // Keep the resolved session in this shared layout to avoid redirect loops.
+        router.replace(`/${window.location.search}${window.location.hash}`);
+      }
+      return;
+    }
+
+    if (pathname === "/") {
       window.location.replace(
         process.env.NODE_ENV === "development"
           ? "http://localhost:3000/callback"
           : AUTH_DASHBOARD_URL
       );
     }
-  }, [pathname, isResolved, isAuthenticated]);
+  }, [pathname, router, isResolved, isAuthenticated]);
 
   const reduceMotion = useReducedMotion();
   const { scrollY } = useScroll();

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -28,7 +28,7 @@ import {
   useScroll,
 } from "motion/react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -61,6 +61,7 @@ import {
 } from "@/utils/navigation";
 
 import { NotraMark, notraMarkSvgString } from "./notra-mark";
+import { SignedOutLandingRedirect } from "./signed-out-landing-redirect";
 import { ThemeToggle } from "./theme-toggle";
 import { TrackedSignupLink } from "./tracked-signup-link";
 
@@ -299,7 +300,6 @@ function getNavbarPresentation(
 
 export function Navbar({ variant }: NavbarProps = {}) {
   const pathname = usePathname();
-  const router = useRouter();
   const resolvedVariant = variant ?? getNavbarVariantForPath(pathname);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -336,26 +336,14 @@ export function Navbar({ variant }: NavbarProps = {}) {
   useNavbarAuthHotkeys({ isAuthenticated, isResolved });
 
   useEffect(() => {
-    if (!isResolved) {
-      return;
-    }
-
-    if (!isAuthenticated) {
-      if (pathname === "/home" || pathname === "/landing") {
-        // Keep the resolved session in this shared layout to avoid redirect loops.
-        router.replace(`/${window.location.search}${window.location.hash}`);
-      }
-      return;
-    }
-
-    if (pathname === "/") {
+    if (pathname === "/" && isResolved && isAuthenticated) {
       window.location.replace(
         process.env.NODE_ENV === "development"
           ? "http://localhost:3000/callback"
           : AUTH_DASHBOARD_URL
       );
     }
-  }, [pathname, router, isResolved, isAuthenticated]);
+  }, [pathname, isResolved, isAuthenticated]);
 
   const reduceMotion = useReducedMotion();
   const { scrollY } = useScroll();
@@ -476,6 +464,10 @@ export function Navbar({ variant }: NavbarProps = {}) {
 
   return (
     <LazyMotion features={domAnimation} strict>
+      <SignedOutLandingRedirect
+        isAuthenticated={isAuthenticated}
+        isResolved={isResolved}
+      />
       <m.div
         animate={shellAnimate}
         className={`z-50 mx-auto ${positionClass}`}

--- a/apps/web/src/components/signed-out-landing-redirect.tsx
+++ b/apps/web/src/components/signed-out-landing-redirect.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { redirect, usePathname } from "next/navigation";
+
+import type { DashboardSessionState } from "@/lib/auth/use-dashboard-session";
+
+export function SignedOutLandingRedirect({
+  isAuthenticated,
+  isResolved,
+}: DashboardSessionState) {
+  const pathname = usePathname();
+
+  if (
+    typeof window !== "undefined" &&
+    isResolved &&
+    !isAuthenticated &&
+    (pathname === "/home" || pathname === "/landing")
+  ) {
+    const destination = new URL(window.location.href);
+    destination.searchParams.delete("mode");
+    redirect(`/${destination.search}${destination.hash}`);
+  }
+
+  return null;
+}


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects signed-out users on `/home` or `/landing` to the homepage. The redirect strips the `mode` query parameter and preserves the remaining query string and hash. Authenticated users are unaffected.

<sup>Written for commit 8af8f193691f38f41c19f9c0362a2a553cb2cef2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

