### PR TITLE
fix(web): focus agent discovery copy on GEO

### DIFF
--- a/apps/web/src/app/(site)/agent/page.tsx
+++ b/apps/web/src/app/(site)/agent/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 import { MarketingHeroWash } from "@/components/marketing-hero-wash";
-import { apiUrl, buildAgentJson, siteUrl } from "@/utils/agent-metadata";
+import { buildAgentJson, siteUrl } from "@/utils/agent-metadata";
 
 export const metadata: Metadata = {
   title: "Notra Agent Interface",
@@ -22,6 +22,16 @@ export default function AgentPage() {
           </>
         }
       />
+      <section className="mx-auto w-[min(100%-3rem,56rem)]">
+        <h2 className="font-sans text-lg font-medium">
+          What you can do with Notra
+        </h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-[#1E1E1E99] dark:text-white/60">
+          {agent.capabilities.map((capability) => (
+            <li key={capability}>{capability}</li>
+          ))}
+        </ul>
+      </section>
       <section className="mx-auto grid w-[min(100%-3rem,56rem)] gap-4 text-sm md:grid-cols-2">
         <div className="rounded-3xl border border-[#1E1E1E14] bg-[linear-gradient(in_oklab_180deg,oklab(95.1%_0.011_-0.018_/_15%)_0%,oklab(93.7%_0.019_-0.031_/_75%)_100%)] p-6 dark:border-white/10 dark:bg-white/[0.02] dark:bg-none">
           <h2 className="font-sans text-lg font-medium tracking-[-0.015em] text-[#1E1E1E] dark:text-white">
@@ -34,7 +44,7 @@ export default function AgentPage() {
             <li>
               Integration Surfaces: {siteUrl("/.well-known/integrations.json")}
             </li>
-            <li>Auth guide: {siteUrl("/auth.md")}</li>
+            <li>Auth guide: {agent.api.auth}</li>
           </ul>
         </div>
         <div className="rounded-3xl border border-[#1E1E1E14] bg-[linear-gradient(in_oklab_180deg,oklab(95.1%_0.011_-0.018_/_15%)_0%,oklab(93.7%_0.019_-0.031_/_75%)_100%)] p-6 dark:border-white/10 dark:bg-white/[0.02] dark:bg-none">
@@ -42,14 +52,18 @@ export default function AgentPage() {
             Endpoints
           </h2>
           <ul className="mt-3 list-disc space-y-1.5 pl-5 text-[#1E1E1E99] dark:text-white/60">
-            <li>API: {apiUrl()}</li>
-            <li>OpenAPI: {apiUrl("/openapi.json")}</li>
-            <li>MCP: {agent.mcp.streamable_http}</li>
-            <li>NLWeb ask: {siteUrl("/ask")}</li>
+            <li>API base URL: {agent.api.base_url}</li>
+            <li>OpenAPI (GET): {agent.api.openapi}</li>
+            <li>MCP (streamable HTTP): {agent.mcp.streamable_http}</li>
+            <li>API status (GET): {agent.api.status}</li>
+            <li>Product discovery (POST): {siteUrl("/ask")}</li>
           </ul>
         </div>
       </section>
-      <pre className="bg-background overflow-auto rounded-2xl border border-[#1E1E1E14] p-5 font-mono text-xs leading-6 text-[#1E1E1E] dark:border-white/10 dark:text-white/80">
+      <pre
+        aria-label="Notra agent discovery JSON"
+        className="bg-background w-[min(100%-3rem,56rem)] overflow-auto rounded-2xl border border-[#1E1E1E14] p-5 font-mono text-xs leading-6 text-[#1E1E1E] dark:border-white/10 dark:text-white/80"
+      >
         {JSON.stringify(agent, null, 2)}
       </pre>
     </main>

--- a/apps/web/src/app/(site)/agent/page.tsx
+++ b/apps/web/src/app/(site)/agent/page.tsx
@@ -6,7 +6,7 @@ import { apiUrl, buildAgentJson, siteUrl } from "@/utils/agent-metadata";
 export const metadata: Metadata = {
   title: "Notra Agent Interface",
   description:
-    "Machine-readable Notra discovery view for agents, API clients, and MCP integrations.",
+    "Explore Notra's generative engine optimization (GEO) tools for AI visibility, competitor share of voice, and content gaps through the API and MCP.",
 };
 
 export default function AgentPage() {
@@ -15,7 +15,7 @@ export default function AgentPage() {
   return (
     <main className="flex w-full flex-col items-center gap-8 pb-28 antialiased [font-synthesis:none]">
       <MarketingHeroWash
-        subtitle="Notra turns shipped product work into changelogs, launch posts, blog drafts, marketing assets, and social updates in a saved brand voice. Agents should use this view for discovery instead of parsing the marketing homepage."
+        subtitle="Notra helps you track and improve your visibility in AI answers. Monitor brand mentions across ChatGPT, Claude, Gemini, and Perplexity, compare your share of voice with competitors, and turn content gaps into articles in your brand voice."
         title={
           <>
             Notra <span className="text-primary">Agent</span> Interface

--- a/apps/web/src/app/.well-known/mcp/route.ts
+++ b/apps/web/src/app/.well-known/mcp/route.ts
@@ -14,7 +14,7 @@ export function GET() {
       endpoint: MCP_URL,
       documentation: `${DOCS_URL}/devtools/mcp`,
       instructions:
-        "Use Notra MCP after authenticating with OAuth or a Notra API key. The server exposes tools for reading organization content, generating drafts, and applying saved brand voice guidance.",
+        "Use Notra MCP after authenticating with OAuth or a Notra API key. The server exposes tools for GEO projects, prompts, competitors, scans, visibility, content briefs, agent readiness, and AI traffic, alongside content generation and saved brand voices.",
       authentication: {
         type: "bearer",
         resource_metadata: MCP_PROTECTED_RESOURCE_METADATA_URL,

--- a/apps/web/src/app/ask/route.ts
+++ b/apps/web/src/app/ask/route.ts
@@ -18,8 +18,7 @@ export async function POST(request: Request) {
       version: "1.0",
     },
     query: body.query ?? null,
-    answer:
-      "Notra turns shipped work into changelogs, launch posts, blog posts, marketing assets, and social updates in a saved brand voice.",
+    answer: agent.description,
     resources: [agent.api.openapi, agent.api.auth, agent.mcp.docs],
   };
 

--- a/apps/web/src/app/auth.md/route.ts
+++ b/apps/web/src/app/auth.md/route.ts
@@ -14,7 +14,7 @@ OAuth-capable clients should follow the authorization server advertised by the p
 
 ## Register
 
-Call \`POST https://oauth.usenotra.com/oauth2/register\` for dynamic OAuth client registration, or identify with a Client ID Metadata Document if your client supports it. Agents should request the least privileged resource scopes, such as \`projects.read\`, \`prompts.read\`, \`scans.write\`, \`visibility.read\`, \`briefs.read\`, and \`traffic.read\`. GEO tools also require a plan that includes GEO. Include \`offline_access\` when a refresh token is needed.
+Call \`POST https://oauth.usenotra.com/oauth2/register\` for dynamic OAuth client registration, or identify with a Client ID Metadata Document if your client supports it. Agents should request the least privileged resource scopes, such as \`projects.read\`, \`prompts.read\`, \`scans.read\`, \`scans.write\`, \`visibility.read\`, \`briefs.read\`, and \`traffic.read\`. Request both \`scans.write\` to start a scan and \`scans.read\` to poll its status and read results. GEO tools also require a plan that includes GEO. Include \`offline_access\` when a refresh token is needed.
 
 ## Authorize
 

--- a/apps/web/src/app/auth.md/route.ts
+++ b/apps/web/src/app/auth.md/route.ts
@@ -2,7 +2,7 @@ import { markdownResponse } from "@/utils/http";
 
 const AUTH_MD = `# Notra Agent Authentication
 
-Notra exposes an authenticated API and MCP server for agents that generate, read, and manage product content. Use this guide to discover the supported auth metadata, request an OAuth or API-key credential, and recover from common errors.
+Notra exposes an authenticated API and MCP server for agents that track AI visibility, manage GEO projects and prompts, analyze competitors and AI traffic, and create content in a saved brand voice. Use this guide to discover the supported auth metadata, request an OAuth or API-key credential, and recover from common errors.
 
 ## Discover
 
@@ -14,7 +14,7 @@ OAuth-capable clients should follow the authorization server advertised by the p
 
 ## Register
 
-Call \`POST https://oauth.usenotra.com/oauth2/register\` for dynamic OAuth client registration, or identify with a Client ID Metadata Document if your client supports it. Agents should request the least privileged resource scopes, such as \`posts.read\`, \`posts.write\`, \`skills.read\`, \`skills.write\`, \`integrations.read\`, and \`integrations.write\`. Include \`offline_access\` when a refresh token is needed.
+Call \`POST https://oauth.usenotra.com/oauth2/register\` for dynamic OAuth client registration, or identify with a Client ID Metadata Document if your client supports it. Agents should request the least privileged resource scopes, such as \`projects.read\`, \`prompts.read\`, \`scans.write\`, \`visibility.read\`, \`briefs.read\`, and \`traffic.read\`. GEO tools also require a plan that includes GEO. Include \`offline_access\` when a refresh token is needed.
 
 ## Authorize
 

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -86,7 +86,7 @@ export function buildAgentJson() {
     description: SITE_DESCRIPTION,
     url: SITE_URL,
     icon: siteUrl("/notra-mark.svg"),
-    category: "AI content generation",
+    category: "Generative engine optimization (GEO)",
     docs: DOCS_URL,
     api: {
       base_url: API_URL,

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -2,7 +2,7 @@ import { PUBLIC_API_SCOPES } from "@notra/utils/api-scopes";
 
 import { SITE_DESCRIPTION } from "@/utils/metadata";
 import { SOCIAL_LINKS } from "@/utils/social-links";
-import { API_URL, APP_URL, DOCS_URL, MCP_URL, SITE_URL } from "@/utils/urls";
+import { API_URL, DOCS_URL, MCP_URL, SITE_URL } from "@/utils/urls";
 
 const AGENT_DISCOVERY_PATHS = {
   agentJson: "/.well-known/agent.json",
@@ -52,19 +52,14 @@ function authIssuerUrl() {
 function buildAgentAuthMetadata() {
   return {
     register_uri: `${authIssuerUrl()}/oauth2/register`,
-    claim_uri: siteUrl("/agent/auth/claim"),
+    authorization_uri: `${authIssuerUrl()}/oauth2/authorize`,
+    token_uri: `${authIssuerUrl()}/oauth2/token`,
+    device_authorization_uri: `${authIssuerUrl()}/oauth2/device_authorization`,
     revocation_uri: `${authIssuerUrl()}/oauth2/revoke`,
     skill: siteUrl(AGENT_DISCOVERY_PATHS.authMarkdown),
-    identity_types_supported: ["anonymous", "identity_assertion"],
-    anonymous: {
-      credential_types_supported: ["api_key"],
-    },
-    identity_assertion: {
-      assertion_types_supported: [
-        "verified_email",
-        "urn:ietf:params:oauth:token-type:id-jag",
-      ],
-      credential_types_supported: ["api_key", "bearer"],
+    credential_types_supported: ["api_key", "bearer"],
+    api_key: {
+      issuance: "Create a scoped API key in the Notra dashboard",
     },
   };
 }
@@ -93,7 +88,7 @@ export function buildAgentJson() {
       openapi: apiUrl("/openapi.json"),
       catalog: siteUrl(AGENT_DISCOVERY_PATHS.apiCatalog),
       auth: siteUrl(AGENT_DISCOVERY_PATHS.authMarkdown),
-      sandbox: apiUrl("/v1/status?sandbox=true"),
+      status: apiUrl("/v1/status"),
     },
     mcp: {
       streamable_http: MCP_URL,

--- a/apps/web/src/utils/agent-metadata.ts
+++ b/apps/web/src/utils/agent-metadata.ts
@@ -52,9 +52,9 @@ function authIssuerUrl() {
 function buildAgentAuthMetadata() {
   return {
     register_uri: `${authIssuerUrl()}/oauth2/register`,
-    authorization_uri: `${authIssuerUrl()}/oauth2/authorize`,
-    token_uri: `${authIssuerUrl()}/oauth2/token`,
-    device_authorization_uri: `${authIssuerUrl()}/oauth2/device_authorization`,
+    authorization_endpoint: `${authIssuerUrl()}/oauth2/authorize`,
+    token_endpoint: `${authIssuerUrl()}/oauth2/token`,
+    device_authorization_endpoint: `${authIssuerUrl()}/oauth2/device_authorization`,
     revocation_uri: `${authIssuerUrl()}/oauth2/revoke`,
     skill: siteUrl(AGENT_DISCOVERY_PATHS.authMarkdown),
     credential_types_supported: ["api_key", "bearer"],

--- a/apps/web/src/utils/integrations-manifest.ts
+++ b/apps/web/src/utils/integrations-manifest.ts
@@ -63,7 +63,7 @@ export function buildIntegrationsManifest(): IntegrationsManifest {
   return {
     version: 3,
     summary:
-      "Notra exposes an HTTP API, a hosted MCP server, and a CLI for turning shipped engineering work into changelogs, blog posts, and social updates in a saved brand voice.",
+      "Notra exposes an HTTP API, a hosted MCP server, and a CLI for tracking AI visibility, comparing competitors, analyzing AI traffic, and turning content gaps into articles in a saved brand voice.",
     credentials: {
       [API_KEY_CREDENTIAL_ID]: {
         type: "api_key",
@@ -75,7 +75,7 @@ export function buildIntegrationsManifest(): IntegrationsManifest {
       [OAUTH_CREDENTIAL_ID]: {
         type: "oauth2",
         label: "Notra OAuth 2.1",
-        setup: `Read the protected resource metadata at ${MCP_PROTECTED_RESOURCE_METADATA_URL} to find the authorization server, register a client at https://oauth.usenotra.com/oauth2/register, and run the authorization code flow with PKCE. Request least privilege scopes such as posts.read and include offline_access when you need a refresh token. Headless clients can use the device authorization grant instead, which is what notra auth login does. Send the access token as an Authorization bearer token.`,
+        setup: `Read the protected resource metadata at ${MCP_PROTECTED_RESOURCE_METADATA_URL} to find the authorization server, register a client at https://oauth.usenotra.com/oauth2/register, and run the authorization code flow with PKCE. Request least privilege scopes such as projects.read and visibility.read and include offline_access when you need a refresh token. Headless clients can use the device authorization grant instead, which is what notra auth login does. Send the access token as an Authorization bearer token.`,
       },
     },
     surfaces: [


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refocuses Notra's agent-facing discovery copy and metadata on generative engine optimization (GEO) instead of general AI content generation, so agents and API clients discover the actual positioning around AI visibility tracking.

- Refreshes copy on the agent page, MCP instructions, auth guide, and integrations manifest to describe GEO projects, competitor share of voice, and AI traffic.
- Restructures `agent.json` auth metadata: exposes standard OAuth URIs (authorization, token, device authorization) and drops the custom `claim_uri` and identity-assertion structure.
- Replaces the `sandbox` API field with `status` and updates recommended scopes from `posts.*`/`skills.*` to GEO scopes like `projects.read`, `visibility.read`, `scans.read`, and `scans.write`.

Agents that relied on the old `claim_uri` or identity-assertion fields must migrate to the new OAuth URIs.

<sup>Written for commit 6f2321689e8a25d6f118058c8449050468ed2854. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

