### PR TITLE
fix(build): skip unrelated Vercel app deployments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,31 @@ Open an issue or start a discussion in the repo.
 
 Thanks for helping improve Notra.
 
+## Vercel build selection
+
+Keep Vercel's **Skip unaffected projects** setting enabled. Each deployed app
+also has a version-pinned `ignoreCommand` in its `vercel.json` to check its
+workspace and transitive dependencies before installing dependencies or building.
+This catches unnecessary builds triggered by root documentation changes and
+unrelated workspaces' Bun lockfile changes. Root install configuration and the
+prepare script are declared in `turbo.json#globalDependencies` so changes to
+those files still trigger builds. Declare any new shared build inputs there too.
+
+The check uses `VERCEL_GIT_PREVIOUS_SHA`, the last successful deployment for
+that project and branch. There is deliberately no `HEAD^` fallback: first
+deployments and unavailable history must build, and multiple commits since the
+last deployment must be considered together. Errors also allow the build.
+
+`turbo-ignore` is deprecated in favor of Vercel's built-in skipping, but the
+pinned version remains a secondary check because built-in skipping currently
+deploys unrelated apps for these changes. Update its version and `--turbo-version`
+across all five app configs together when upgrading, and verify both skipped
+and required builds. Ignored builds still create canceled deployment records
+and briefly occupy a build slot; they avoid the install and full build.
+
+For a deliberate redeploy after an environment or project-setting change,
+uncheck **Use project's Ignore Build Step** in Vercel's Redeploy dialog.
+
 ## Automated tests
 
 Run the complete suite from the repository root:

--- a/apps/agent/vercel.json
+++ b/apps/agent/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 @notra/agent --turbo-version=2.10.12"
+}

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 dashboard --turbo-version=2.10.12",
   "crons": [
     {
       "path": "/api/cron/monitoring",

--- a/apps/onboarding-agent/vercel.json
+++ b/apps/onboarding-agent/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 @notra/onboarding-agent --turbo-version=2.10.12"
+}

--- a/apps/ui/vercel.json
+++ b/apps/ui/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 ui --turbo-version=2.10.12"
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 web --turbo-version=2.10.12"
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://v2-10-12.turborepo.dev/schema.json",
   "ui": "tui",
+  "globalDependencies": [".npmrc", "bunfig.toml", "scripts/prepare-effect.sh"],
   "globalEnv": [
     "AI_GATEWAY_API_KEY",
     "APP_URL",


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Vercel from deploying apps when their workspace and dependencies haven't changed, so root documentation or unrelated lockfile changes no longer trigger needless builds.

**Details**
- Added a pinned `turbo-ignore` command to each app's `vercel.json` to skip builds when the workspace and its transitive dependencies are unchanged.
- Added root install and prepare script files to `turbo.json#globalDependencies` so those changes still trigger builds.
- Updated `CONTRIBUTING.md` with build-selection behavior, including that ignored builds still create canceled deployment records and briefly occupy a build slot.
- Kept `turbo-ignore` as a secondary check even though Vercel's built-in skipping is preferred, because built-in skipping currently deploys unrelated apps.

<sup>Written for commit 777ac09616a8b83f46f101014591b7319966adc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

