### PR TITLE
fix(dashboard): narrow GSC sync result before reading completed fields

### DIFF
--- a/apps/dashboard/src/workflows/steps/gsc-sync-steps.ts
+++ b/apps/dashboard/src/workflows/steps/gsc-sync-steps.ts
@@ -22,8 +22,9 @@ export async function runGscSyncStep(
     properties: {
       status: result.status,
       reason: result.reason ?? null,
-      keywords: result.keywords ?? 0,
-      suggestions_created: result.suggestionsAdded ?? 0,
+      keywords: result.status === "completed" ? result.keywords : 0,
+      suggestions_created:
+        result.status === "completed" ? result.suggestionsAdded : 0,
       duration_ms: Date.now() - startedAt,
     },
   });


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows GSC sync result before reading completion-only fields so failed or pending syncs no longer log undefined values for keywords and suggestions.

<sup>Written for commit c08b3634193bc1619968f23c4f51351ee8c0b104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

