### PR TITLE
feat(dashboard): split usage into its own settings tab

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/billing/page.tsx
@@ -1,11 +1,7 @@
 import { redirect } from "next/navigation";
 
-import { BILLING_SETTINGS_SEARCH_KEYS } from "@/constants/settings";
 import type { SettingsUrlSearchParams } from "@/types/settings/modal";
-import {
-  settingsPath,
-  settingsQueryFromSearchParams,
-} from "@/utils/settings-path";
+import { firstSearchParamValue, settingsPath } from "@/utils/settings-path";
 
 export const instant = true;
 
@@ -17,11 +13,8 @@ export default async function SettingsBillingRedirect({
   searchParams: Promise<SettingsUrlSearchParams>;
 }) {
   const [{ slug }, query] = await Promise.all([params, searchParams]);
-  redirect(
-    settingsPath(
-      slug,
-      "billing",
-      settingsQueryFromSearchParams(query, BILLING_SETTINGS_SEARCH_KEYS)
-    )
-  );
+  if (firstSearchParamValue(query.tab) === "usage") {
+    redirect(settingsPath(slug, "usage"));
+  }
+  redirect(settingsPath(slug, "billing"));
 }

--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/usage/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/usage/page.tsx
@@ -4,7 +4,7 @@ import { settingsPath } from "@/utils/settings-path";
 
 export const instant = true;
 
-export default async function BillingUsagePage({
+export default async function SettingsUsageRedirect({
   params,
 }: {
   params: Promise<{ slug: string }>;

--- a/apps/dashboard/src/components/billing/usage-breakdown-chart.tsx
+++ b/apps/dashboard/src/components/billing/usage-breakdown-chart.tsx
@@ -129,6 +129,7 @@ function UsageBreakdownChartBody({
         <ChartTooltip
           content={
             <ChartTooltipContent
+              formatter={(value) => formatCount(Number(value))}
               indicator="dot"
               labelFormatter={(_, payload) => {
                 const item = payload?.[0]?.payload as

--- a/apps/dashboard/src/components/billing/usage-breakdown-chart.tsx
+++ b/apps/dashboard/src/components/billing/usage-breakdown-chart.tsx
@@ -1,22 +1,20 @@
 "use client";
 
 import {
+  Bar,
+  BarChart,
+  CartesianGrid,
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
+  Rectangle,
+  XAxis,
+  YAxis,
 } from "@notra/ui/components/ui/chart";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@notra/ui/components/ui/tabs";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { useId } from "react";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Rectangle,
-  XAxis,
-  YAxis,
-} from "recharts";
 
 import {
   USAGE_ANSWERS_CHART_CONFIG,
@@ -90,7 +88,6 @@ function UsageBreakdownChartBody({
       <BarChart
         accessibilityLayer
         data={data}
-        isAnimationActive={false}
         margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
       >
         <defs>

--- a/apps/dashboard/src/components/billing/usage-breakdown-chart.tsx
+++ b/apps/dashboard/src/components/billing/usage-breakdown-chart.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@notra/ui/components/ui/chart";
+import { Skeleton } from "@notra/ui/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@notra/ui/components/ui/tabs";
+import { TitleCard } from "@notra/ui/components/ui/title-card";
+import { useId } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Rectangle,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  USAGE_ANSWERS_CHART_CONFIG,
+  USAGE_CHART_ACCENT,
+  USAGE_RANGE_TAB_LABELS,
+  USAGE_RANGES,
+} from "@/constants/billing";
+import type { UsageBreakdownChartProps } from "@/types/hooks/billing";
+import { formatCount, formatShortDate, isCreditRange } from "@/utils/format";
+
+export function UsageBreakdownChart({
+  data,
+  loading,
+  range,
+  onRangeChange,
+}: UsageBreakdownChartProps) {
+  return (
+    <TitleCard
+      accentClassName="duration-0"
+      accentColor={USAGE_CHART_ACCENT}
+      action={
+        <Tabs
+          onValueChange={(value) => {
+            if (isCreditRange(value, USAGE_RANGES)) {
+              onRangeChange(value);
+            }
+          }}
+          value={range}
+        >
+          <TabsList aria-label="Usage range">
+            {USAGE_RANGES.map((value) => (
+              <TabsTrigger key={value} value={value}>
+                {USAGE_RANGE_TAB_LABELS[value]}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      }
+      className="min-w-0"
+      heading="Usage breakdown"
+      headingAs="h2"
+    >
+      <UsageBreakdownChartBody data={data} loading={loading} />
+    </TitleCard>
+  );
+}
+
+function UsageBreakdownChartBody({
+  data,
+  loading,
+}: Pick<UsageBreakdownChartProps, "data" | "loading">) {
+  const gradientId = `ai-answers-bar-${useId().replaceAll(":", "")}`;
+
+  if (loading) {
+    return <Skeleton className="h-[240px] w-full rounded-lg" />;
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-[240px] items-center justify-center text-sm">
+        No AI Answers usage in this period
+      </div>
+    );
+  }
+
+  return (
+    <ChartContainer
+      className="aspect-auto h-[240px] w-full"
+      config={USAGE_ANSWERS_CHART_CONFIG}
+    >
+      <BarChart
+        accessibilityLayer
+        data={data}
+        isAnimationActive={false}
+        margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+            <stop
+              offset="0%"
+              stopColor="var(--color-ai_answers)"
+              stopOpacity={1}
+            />
+            <stop
+              offset="100%"
+              stopColor="var(--color-ai_answers)"
+              stopOpacity={0.18}
+            />
+          </linearGradient>
+        </defs>
+        <CartesianGrid
+          className="stroke-border/20"
+          strokeDasharray="3 3"
+          vertical={false}
+        />
+        <XAxis
+          axisLine={false}
+          className="text-muted-foreground/60 text-xs"
+          dataKey="date"
+          minTickGap={32}
+          tickFormatter={(value: number) => formatShortDate(value)}
+          tickLine={false}
+          tickMargin={8}
+        />
+        <YAxis
+          axisLine={false}
+          className="text-muted-foreground/60 text-xs"
+          tickFormatter={(value: number) => formatCount(value)}
+          tickLine={false}
+          tickMargin={8}
+          width={56}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              indicator="dot"
+              labelFormatter={(_, payload) => {
+                const item = payload?.[0]?.payload as
+                  | UsageBreakdownChartProps["data"][number]
+                  | undefined;
+                return item?.date ? formatShortDate(item.date) : "";
+              }}
+            />
+          }
+          cursor={{ fill: "var(--foreground)", fillOpacity: 0.06 }}
+        />
+        <Bar
+          activeBar={
+            <Rectangle fill="var(--color-ai_answers)" radius={[4, 4, 0, 0]} />
+          }
+          dataKey="ai_answers"
+          fill={`url(#${gradientId})`}
+          isAnimationActive={false}
+          radius={[4, 4, 0, 0]}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/apps/dashboard/src/components/billing/usage-section.tsx
+++ b/apps/dashboard/src/components/billing/usage-section.tsx
@@ -1,77 +1,104 @@
 "use client";
 
-import { InformationCircleIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FEATURES } from "@notra/ai/billing/features";
-import {
-  Context,
-  ContextContent,
-  ContextContentBody,
-  ContextContentHeader,
-  ContextTrigger,
-} from "@notra/ui/components/ai-elements/context";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
-import { Tabs, TabsList, TabsTrigger } from "@notra/ui/components/ui/tabs";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@notra/ui/components/ui/tooltip";
+import { cn } from "@notra/ui/lib/utils";
+import { keepPreviousData } from "@tanstack/react-query";
 import { useAggregateEvents } from "autumn-js/react";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { CreditTopupModal } from "@/components/billing/credit-topup-modal";
+import { UsageBreakdownChart } from "@/components/billing/usage-breakdown-chart";
+import { Button } from "@/components/button";
 import {
   IntegrationCardDither,
   useIntegrationCardDither,
 } from "@/components/integrations/integration-card-dither";
 import {
+  USAGE_ANSWERS_ACCENT,
   USAGE_FEATURE_SKELETON_KEYS,
   USAGE_METRIC_SKELETON_KEYS,
 } from "@/constants/billing";
+import { useAutumnRefreshListener } from "@/lib/hooks/use-autumn-refresh-listener";
 import { useBillingCustomer } from "@/lib/hooks/use-billing-customer";
 import type {
   FeatureData,
+  UsageBreakdownPoint,
   UsageLimitedFeatureRowProps,
   UsageRangeOption,
   UsageSectionBodyProps,
 } from "@/types/hooks/billing";
+import {
+  aiAnswersFooter,
+  aiAnswersHint,
+  aiAnswersValue,
+  featuresFromBalances,
+  isRetentionFeature,
+  limitedUsageFeatures,
+  remainingCountLabel,
+  unlimitedUsageFeatures,
+  usageRetentionDays,
+} from "@/utils/billing-usage";
+import {
+  formatCount,
+  formatDollars,
+  formatPercent,
+  remainingBarColor,
+  remainingPercent,
+} from "@/utils/format";
 
-const ranges = ["7d", "30d", "90d", "last_cycle"] as const;
-
-const RANGE_LABELS: Record<UsageRangeOption, string> = {
-  "7d": "last 7 days",
-  "30d": "last 30 days",
-  "90d": "last 90 days",
-  last_cycle: "last cycle",
-};
-
-function formatNumber(value: number) {
-  return new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: 0,
-  }).format(value);
-}
-
-function formatDollars(cents: number) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(cents / 100);
-}
-
-function formatFeatureName(id: string): string {
-  return id.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function UsageMetricCard({
-  accentColor,
-  heading,
-  children,
+function RemainingBar({
+  label,
+  remaining,
 }: {
+  label: string;
+  remaining: number;
+}) {
+  return (
+    <div
+      aria-label={`${label}: ${formatPercent(remaining)}% remaining`}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(remaining)}
+      className="bg-muted h-2 w-full overflow-hidden rounded-full"
+      role="progressbar"
+    >
+      <div
+        className={cn(
+          "duration-slower h-full rounded-full transition-[width]",
+          remainingBarColor(remaining)
+        )}
+        style={{ width: `${remaining}%` }}
+      />
+    </div>
+  );
+}
+
+function BalanceCard({
+  title,
+  value,
+  hint,
+  footer,
+  remaining,
+  action,
+  accentColor,
+}: {
+  title: string;
+  value: string;
+  hint?: string;
+  footer?: string;
+  remaining?: number | null;
+  action?: ReactNode;
   accentColor: string;
-  heading: string;
-  children: ReactNode;
 }) {
   const dither = useIntegrationCardDither();
 
@@ -79,12 +106,32 @@ function UsageMetricCard({
     <TitleCard
       {...dither.interactionProps}
       accentColor={accentColor}
-      heading={heading}
+      action={action}
+      className="h-full min-w-0"
+      footer={
+        footer ? (
+          <p className="text-muted-foreground text-xs text-pretty">{footer}</p>
+        ) : undefined
+      }
+      footerClassName="border-t-0 pt-0"
+      heading={title}
       hoverBackground={
         <IntegrationCardDither active={dither.active} color={accentColor} />
       }
     >
-      {children}
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <p className="text-3xl font-bold tracking-tight tabular-nums">
+            {value}
+          </p>
+          {hint ? (
+            <p className="text-muted-foreground text-sm text-pretty">{hint}</p>
+          ) : null}
+        </div>
+        {remaining != null ? (
+          <RemainingBar label={title} remaining={remaining} />
+        ) : null}
+      </div>
     </TitleCard>
   );
 }
@@ -92,114 +139,73 @@ function UsageMetricCard({
 function UsageSectionSkeleton() {
   return (
     <div className="space-y-8">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+      <div className="space-y-4">
         <div className="space-y-1">
-          <h2 className="text-lg font-semibold tracking-tight">Usage</h2>
-          <p className="text-muted-foreground text-sm">
-            Track your feature usage and remaining balances
-          </p>
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-4 w-64" />
         </div>
-        <Skeleton className="h-8 w-64 rounded-lg" />
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        {USAGE_METRIC_SKELETON_KEYS.map((key) => (
-          <TitleCard heading={<Skeleton className="h-5 w-32" />} key={key}>
-            <Skeleton className="h-8 w-24" />
-          </TitleCard>
-        ))}
+        <div className="grid gap-4 sm:grid-cols-2">
+          {USAGE_METRIC_SKELETON_KEYS.map((key) => (
+            <TitleCard heading={<Skeleton className="h-5 w-32" />} key={key}>
+              <Skeleton className="h-8 w-28" />
+            </TitleCard>
+          ))}
+        </div>
       </div>
       <div className="space-y-4">
-        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-6 w-32" />
         <div className="divide-y rounded-xl border">
           {USAGE_FEATURE_SKELETON_KEYS.map((key) => (
-            <div
-              className="flex items-center justify-between gap-4 p-4"
-              key={key}
-            >
-              <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-col gap-3 p-4" key={key}>
+              <div className="space-y-2">
                 <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-3 w-48" />
+                <Skeleton className="h-4 w-48" />
               </div>
-              <Skeleton className="h-8 w-16 rounded-full" />
+              <Skeleton className="h-2 w-full rounded-full" />
             </div>
           ))}
         </div>
       </div>
+      <Skeleton className="h-[280px] rounded-xl" />
     </div>
   );
 }
 
-function UsageLimitedFeatureRow({
-  feature,
-  range,
-}: UsageLimitedFeatureRowProps) {
+function UsageLimitedFeatureRow({ feature }: UsageLimitedFeatureRowProps) {
+  const remaining = remainingPercent(feature.balance, feature.included);
   const used =
     feature.included !== null && feature.balance !== null
-      ? feature.included - feature.balance
+      ? Math.max(feature.included - feature.balance, 0)
       : 0;
-  const percent =
-    feature.included && feature.included > 0
-      ? Math.min((used / feature.included) * 100, 100)
-      : 0;
-  const descriptionText =
-    feature.balance !== null
-      ? `${formatNumber(feature.balance)} of ${formatNumber(feature.included ?? 0)} remaining`
-      : `of ${formatNumber(feature.included ?? 0)}`;
 
   return (
-    <div className="flex items-center justify-between gap-4 p-4">
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          <p className="truncate text-sm font-medium">{feature.name}</p>
-          <Tooltip>
-            <TooltipTrigger className="text-muted-foreground inline-flex cursor-help">
-              <HugeiconsIcon
-                className="size-3.5"
-                icon={InformationCircleIcon}
-              />
-            </TooltipTrigger>
-            <TooltipContent>
-              {Math.round(percent)}% of your {feature.name.toLowerCase()} limit
-              is used ({RANGE_LABELS[range]}).
-            </TooltipContent>
-          </Tooltip>
+    <div className="flex flex-col gap-3 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <p className="truncate text-sm font-medium">{feature.name}</p>
+            <Tooltip>
+              <TooltipTrigger
+                aria-label={`About ${feature.name}`}
+                className="text-muted-foreground inline-flex size-6 items-center justify-center"
+              >
+                <HugeiconsIcon
+                  className="size-3.5"
+                  icon={InformationCircleIcon}
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                {formatCount(used)} used of {formatCount(feature.included ?? 0)}{" "}
+                this cycle.
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <p className="text-muted-foreground mt-1 text-sm tabular-nums">
+            {remainingCountLabel(feature)}
+          </p>
         </div>
-        <p className="text-muted-foreground mt-1 text-xs">{descriptionText}</p>
       </div>
-
-      <div className="shrink-0">
-        <Context
-          maxTokens={Math.max(feature.included ?? 0, 1)}
-          usedTokens={used}
-        >
-          <ContextTrigger className="h-8 px-2" />
-          <ContextContent align="end" className="w-72">
-            <ContextContentHeader />
-            <ContextContentBody className="space-y-2 text-xs">
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Feature</span>
-                <span>{feature.name}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Used</span>
-                <span>{formatNumber(used)}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Remaining</span>
-                <span>
-                  {feature.balance !== null
-                    ? formatNumber(feature.balance)
-                    : "-"}
-                </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Included</span>
-                <span>{formatNumber(feature.included ?? 0)}</span>
-              </div>
-            </ContextContentBody>
-          </ContextContent>
-        </Context>
-      </div>
+      <RemainingBar label={feature.name} remaining={remaining} />
     </div>
   );
 }
@@ -208,22 +214,9 @@ function UsageRetentionRow({ retentionDays }: { retentionDays: number }) {
   return (
     <div className="flex items-center justify-between gap-4 p-4">
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          <p className="truncate text-sm font-medium">Log Retention</p>
-          <Tooltip>
-            <TooltipTrigger className="text-muted-foreground inline-flex cursor-help">
-              <HugeiconsIcon
-                className="size-3.5"
-                icon={InformationCircleIcon}
-              />
-            </TooltipTrigger>
-            <TooltipContent>
-              Determines how long logs are stored for your workspace.
-            </TooltipContent>
-          </Tooltip>
-        </div>
-        <p className="text-muted-foreground mt-1 text-xs">
-          Your current retention window is {retentionDays} days.
+        <p className="truncate text-sm font-medium">Log retention</p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Logs are kept for {retentionDays} days.
         </p>
       </div>
       <div className="border-border bg-muted shrink-0 rounded-full border px-2.5 py-1 text-xs font-medium">
@@ -238,8 +231,8 @@ function UsageUnlimitedFeatureRow({ feature }: { feature: FeatureData }) {
     <div className="flex items-center justify-between gap-4 p-4">
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium">{feature.name}</p>
-        <p className="text-muted-foreground mt-1 text-xs">
-          Included in your plan without a usage cap
+        <p className="text-muted-foreground mt-1 text-sm">
+          Included in your plan without a usage cap.
         </p>
       </div>
       <div className="border-border bg-muted shrink-0 rounded-full border px-2.5 py-1 text-xs font-medium">
@@ -249,202 +242,189 @@ function UsageUnlimitedFeatureRow({ feature }: { feature: FeatureData }) {
   );
 }
 
-function isLogRetentionFeature(feature: FeatureData) {
-  return (
-    feature.id === FEATURES.LOG_RETENTION_7_DAYS ||
-    feature.id === FEATURES.LOG_RETENTION_14_DAYS ||
-    feature.id === FEATURES.LOG_RETENTION_30_DAYS
-  );
-}
-
-function featuresFromBalances(
-  balances:
-    | Record<
-        string,
-        {
-          remaining?: number | null;
-          granted?: number | null;
-          unlimited?: boolean;
-          feature?: { name?: string | null } | null;
-        } | null
-      >
-    | null
-    | undefined
-): FeatureData[] {
-  if (!balances) {
-    return [];
-  }
-  const features: FeatureData[] = [];
-  for (const [id, feature] of Object.entries(balances)) {
-    const balance =
-      typeof feature?.remaining === "number" ? feature.remaining : null;
-    const included =
-      typeof feature?.granted === "number" ? feature.granted : null;
-    features.push({
-      id,
-      name: feature?.feature?.name ?? formatFeatureName(id),
-      balance,
-      included,
-      unlimited: feature?.unlimited === true,
-    });
-  }
-  return features;
-}
-
-function usageRetentionDays(features: readonly FeatureData[]): number {
-  const logRetention30DaysFeature = features.find(
-    (feature) => feature.id === FEATURES.LOG_RETENTION_30_DAYS
-  );
-  const logRetention14DaysFeature = features.find(
-    (feature) => feature.id === FEATURES.LOG_RETENTION_14_DAYS
-  );
-  const has30DayRetention =
-    logRetention30DaysFeature?.unlimited === true ||
-    (logRetention30DaysFeature?.included ?? 0) > 0 ||
-    (logRetention30DaysFeature?.balance ?? 0) > 0;
-  const has14DayRetention =
-    logRetention14DaysFeature?.unlimited === true ||
-    (logRetention14DaysFeature?.included ?? 0) > 0 ||
-    (logRetention14DaysFeature?.balance ?? 0) > 0;
-  if (has30DayRetention) {
-    return 30;
-  }
-  if (has14DayRetention) {
-    return 14;
-  }
-  return 7;
-}
-
 export function UsageSection() {
   const [range, setRange] = useState<UsageRangeOption>("30d");
-  const { data: customer, isLoading: customerLoading } = useBillingCustomer({
+  const [topupOpen, setTopupOpen] = useState(false);
+  const [topupSuccess, setTopupSuccess] = useState(false);
+  const {
+    data: customer,
+    isLoading: customerLoading,
+    refetch,
+  } = useBillingCustomer({
     expand: ["balances.feature"],
   });
+  useAutumnRefreshListener(refetch);
 
-  const { total } = useAggregateEvents({
-    featureId: FEATURES.AI_CREDITS,
+  const hasAiAnswers = Boolean(customer?.balances?.[FEATURES.AI_ANSWERS]);
+  const { list: aggregatedList, isLoading: usageLoading } = useAggregateEvents({
+    featureId: FEATURES.AI_ANSWERS,
     range,
     binSize: "day",
+    queryOptions: {
+      enabled: hasAiAnswers,
+      placeholderData: keepPreviousData,
+    },
   });
 
-  const totalUsage =
-    typeof total?.[FEATURES.AI_CREDITS]?.sum === "number"
-      ? (total?.[FEATURES.AI_CREDITS]?.sum ?? 0)
-      : 0;
+  const chartData = useMemo((): UsageBreakdownPoint[] => {
+    if (!aggregatedList?.length) {
+      return [];
+    }
+    return aggregatedList.map((row) => {
+      const value = row.values?.[FEATURES.AI_ANSWERS];
+      return {
+        date: row.period,
+        ai_answers: typeof value === "number" ? value : 0,
+      };
+    });
+  }, [aggregatedList]);
 
   if (customerLoading && !customer) {
     return <UsageSectionSkeleton />;
   }
 
   const features = featuresFromBalances(customer?.balances);
-  const limitedFeatures = features.filter(
-    (feature) =>
-      !feature.unlimited &&
-      feature.included !== null &&
-      !isLogRetentionFeature(feature)
-  );
-  const unlimitedFeatures = features.filter(
-    (feature) => feature.unlimited && !isLogRetentionFeature(feature)
+  const aiAnswersFeature = features.find(
+    (feature) => feature.id === FEATURES.AI_ANSWERS
   );
   const aiCreditsFeature = features.find(
     (feature) => feature.id === FEATURES.AI_CREDITS
   );
-  const hasRetentionFeature = features.some(isLogRetentionFeature);
-  const retentionDays = usageRetentionDays(features);
 
   return (
-    <UsageSectionBody
-      aiCreditsFeature={aiCreditsFeature}
-      hasRetentionFeature={hasRetentionFeature}
-      limitedFeatures={limitedFeatures}
-      onRangeChange={setRange}
-      range={range}
-      retentionDays={retentionDays}
-      totalUsage={totalUsage}
-      unlimitedFeatures={unlimitedFeatures}
-    />
+    <>
+      <UsageSectionBody
+        aiAnswersFeature={aiAnswersFeature}
+        aiAnswersRemaining={remainingPercent(
+          aiAnswersFeature?.balance ?? null,
+          aiAnswersFeature?.included ?? null
+        )}
+        aiCreditsFeature={aiCreditsFeature}
+        chartData={chartData}
+        chartLoading={usageLoading && chartData.length === 0}
+        hasAiAnswers={hasAiAnswers}
+        hasRetentionFeature={features.some(isRetentionFeature)}
+        limitedFeatures={limitedUsageFeatures(features)}
+        onOpenTopup={() => {
+          setTopupSuccess(false);
+          setTopupOpen(true);
+        }}
+        onRangeChange={setRange}
+        range={range}
+        retentionDays={usageRetentionDays(features)}
+        unlimitedFeatures={unlimitedUsageFeatures(features)}
+      />
+      <CreditTopupModal
+        onOpenChange={(open) => {
+          setTopupOpen(open);
+          if (!open) {
+            setTopupSuccess(false);
+          }
+        }}
+        onSuccess={() => {
+          setTopupSuccess(true);
+          void refetch();
+        }}
+        open={topupOpen}
+        success={topupSuccess}
+      />
+    </>
   );
 }
 
 function UsageSectionBody({
+  aiAnswersFeature,
+  aiAnswersRemaining,
   aiCreditsFeature,
+  chartData,
+  chartLoading,
+  hasAiAnswers,
   hasRetentionFeature,
   limitedFeatures,
+  onOpenTopup,
   onRangeChange,
   range,
   retentionDays,
-  totalUsage,
   unlimitedFeatures,
 }: UsageSectionBodyProps) {
-  const showFeatures =
+  const showFeatureLimits =
     limitedFeatures.length > 0 ||
     hasRetentionFeature ||
     unlimitedFeatures.length > 0;
 
   return (
     <div className="space-y-8">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold tracking-tight">Usage</h2>
-          <p className="text-muted-foreground text-sm">
-            Track your feature usage and remaining balances
-          </p>
-        </div>
-        <Tabs
-          onValueChange={(value) => onRangeChange(value as UsageRangeOption)}
-          value={range}
-        >
-          <TabsList aria-label="Usage range">
-            {ranges.map((value) => (
-              <TabsTrigger key={value} value={value}>
-                {value === "last_cycle" ? "Last cycle" : value.toUpperCase()}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-      </div>
-
-      {aiCreditsFeature ? (
-        <div className="grid gap-4 sm:grid-cols-2">
-          <UsageMetricCard accentColor="#8b5cf6" heading="Credits Used">
-            <div className="flex items-baseline gap-2">
-              <p className="text-3xl font-bold tracking-tight tabular-nums">
-                {formatDollars(totalUsage)}
-              </p>
-              <p className="text-muted-foreground text-sm">
-                in selected period
-              </p>
-            </div>
-          </UsageMetricCard>
-          <UsageMetricCard accentColor="#10b981" heading="Credits Remaining">
-            <div className="flex items-baseline gap-2">
-              <p className="text-3xl font-bold tracking-tight tabular-nums">
-                {aiCreditsFeature.balance !== null
-                  ? formatDollars(aiCreditsFeature.balance)
-                  : "-"}
-              </p>
-              <p className="text-muted-foreground text-sm">
-                {aiCreditsFeature.included
-                  ? `of ${formatDollars(aiCreditsFeature.included)}`
-                  : "available"}
-              </p>
-            </div>
-          </UsageMetricCard>
-        </div>
+      {aiAnswersFeature || aiCreditsFeature ? (
+        <section className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold tracking-tight">Balance</h2>
+            <p className="text-muted-foreground max-w-prose text-sm text-pretty">
+              How much of each plan limit you have left this cycle.
+            </p>
+          </div>
+          <div className="grid items-stretch gap-4 sm:grid-cols-2">
+            {aiAnswersFeature ? (
+              <BalanceCard
+                accentColor={USAGE_ANSWERS_ACCENT}
+                footer={aiAnswersFooter(aiAnswersFeature, aiAnswersRemaining)}
+                hint={aiAnswersHint(aiAnswersFeature)}
+                remaining={
+                  aiAnswersFeature.unlimited ? null : aiAnswersRemaining
+                }
+                title="AI Answers remaining"
+                value={aiAnswersValue(aiAnswersFeature)}
+              />
+            ) : null}
+            {aiCreditsFeature ? (
+              <BalanceCard
+                accentColor="#8b5cf6"
+                action={
+                  <Button
+                    aria-label="Top up credits"
+                    onClick={onOpenTopup}
+                    size="icon-sm"
+                    variant="outline"
+                  >
+                    <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
+                  </Button>
+                }
+                footer="Credits extend usage beyond your plan limits."
+                title="Credits remaining"
+                value={
+                  aiCreditsFeature.balance !== null
+                    ? formatDollars(aiCreditsFeature.balance)
+                    : "-"
+                }
+              />
+            ) : null}
+          </div>
+        </section>
       ) : null}
 
-      {showFeatures ? (
-        <div className="space-y-4">
-          <h2 className="text-muted-foreground text-sm font-medium tracking-wider uppercase">
-            Features
-          </h2>
+      {hasAiAnswers ? (
+        <UsageBreakdownChart
+          data={chartData}
+          loading={chartLoading}
+          onRangeChange={onRangeChange}
+          range={range}
+        />
+      ) : null}
+
+      {showFeatureLimits ? (
+        <section className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Feature limits
+            </h2>
+            <p className="text-muted-foreground max-w-prose text-sm text-pretty">
+              {aiAnswersFeature
+                ? "Other remaining quotas on your plan."
+                : "Remaining quotas on your plan."}
+            </p>
+          </div>
           <div className="divide-y rounded-xl border">
             {limitedFeatures.map((feature) => (
-              <UsageLimitedFeatureRow
-                feature={feature}
-                key={feature.id}
-                range={range}
-              />
+              <UsageLimitedFeatureRow feature={feature} key={feature.id} />
             ))}
             {hasRetentionFeature ? (
               <UsageRetentionRow retentionDays={retentionDays} />
@@ -453,7 +433,7 @@ function UsageSectionBody({
               <UsageUnlimitedFeatureRow feature={feature} key={feature.id} />
             ))}
           </div>
-        </div>
+        </section>
       ) : null}
     </div>
   );

--- a/apps/dashboard/src/components/billing/usage-section.tsx
+++ b/apps/dashboard/src/components/billing/usage-section.tsx
@@ -13,11 +13,11 @@ import {
 import { cn } from "@notra/ui/lib/utils";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useAggregateEvents } from "autumn-js/react";
+import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 import { CreditTopupModal } from "@/components/billing/credit-topup-modal";
-import { UsageBreakdownChart } from "@/components/billing/usage-breakdown-chart";
 import { Button } from "@/components/button";
 import {
   IntegrationCardDither,
@@ -32,7 +32,6 @@ import { useAutumnRefreshListener } from "@/lib/hooks/use-autumn-refresh-listene
 import { useBillingCustomer } from "@/lib/hooks/use-billing-customer";
 import type {
   FeatureData,
-  UsageBreakdownPoint,
   UsageLimitedFeatureRowProps,
   UsageRangeOption,
   UsageSectionBodyProps,
@@ -41,20 +40,31 @@ import {
   aiAnswersFooter,
   aiAnswersHint,
   aiAnswersValue,
+  creditsValue,
   featuresFromBalances,
   isRetentionFeature,
   limitedUsageFeatures,
   remainingCountLabel,
   unlimitedUsageFeatures,
+  usageBreakdownPoints,
   usageRetentionDays,
 } from "@/utils/billing-usage";
 import {
   formatCount,
-  formatDollars,
   formatPercent,
   remainingBarColor,
   remainingPercent,
 } from "@/utils/format";
+
+const UsageBreakdownChart = dynamic(
+  () =>
+    import("@/components/billing/usage-breakdown-chart").then(
+      (mod) => mod.UsageBreakdownChart
+    ),
+  {
+    loading: () => <Skeleton className="h-[280px] w-full rounded-lg" />,
+  }
+);
 
 function RemainingBar({
   label,
@@ -266,18 +276,7 @@ export function UsageSection() {
     },
   });
 
-  const chartData = useMemo((): UsageBreakdownPoint[] => {
-    if (!aggregatedList?.length) {
-      return [];
-    }
-    return aggregatedList.map((row) => {
-      const value = row.values?.[FEATURES.AI_ANSWERS];
-      return {
-        date: row.period,
-        ai_answers: typeof value === "number" ? value : 0,
-      };
-    });
-  }, [aggregatedList]);
+  const chartData = usageBreakdownPoints(aggregatedList);
 
   if (customerLoading && !customer) {
     return <UsageSectionSkeleton />;
@@ -332,6 +331,108 @@ export function UsageSection() {
   );
 }
 
+function UsageBalanceSection({
+  aiAnswersFeature,
+  aiAnswersRemaining,
+  aiCreditsFeature,
+  onOpenTopup,
+}: Pick<
+  UsageSectionBodyProps,
+  "aiAnswersFeature" | "aiAnswersRemaining" | "aiCreditsFeature" | "onOpenTopup"
+>) {
+  if (!aiAnswersFeature && !aiCreditsFeature) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold tracking-tight">Balance</h2>
+        <p className="text-muted-foreground max-w-prose text-sm text-pretty">
+          How much of each plan limit you have left this cycle.
+        </p>
+      </div>
+      <div className="grid items-stretch gap-4 sm:grid-cols-2">
+        {aiAnswersFeature ? (
+          <BalanceCard
+            accentColor={USAGE_ANSWERS_ACCENT}
+            footer={aiAnswersFooter(aiAnswersFeature, aiAnswersRemaining)}
+            hint={aiAnswersHint(aiAnswersFeature)}
+            remaining={aiAnswersFeature.unlimited ? null : aiAnswersRemaining}
+            title="AI Answers remaining"
+            value={aiAnswersValue(aiAnswersFeature)}
+          />
+        ) : null}
+        {aiCreditsFeature ? (
+          <BalanceCard
+            accentColor="#8b5cf6"
+            action={
+              <Button
+                aria-label="Top up credits"
+                onClick={onOpenTopup}
+                size="icon-sm"
+                variant="outline"
+              >
+                <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
+              </Button>
+            }
+            footer="Credits extend usage beyond your plan limits."
+            title="Credits remaining"
+            value={creditsValue(aiCreditsFeature)}
+          />
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function UsageFeatureLimitsSection({
+  aiAnswersFeature,
+  hasRetentionFeature,
+  limitedFeatures,
+  retentionDays,
+  unlimitedFeatures,
+}: Pick<
+  UsageSectionBodyProps,
+  | "aiAnswersFeature"
+  | "hasRetentionFeature"
+  | "limitedFeatures"
+  | "retentionDays"
+  | "unlimitedFeatures"
+>) {
+  if (
+    limitedFeatures.length === 0 &&
+    !hasRetentionFeature &&
+    unlimitedFeatures.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold tracking-tight">Feature limits</h2>
+        <p className="text-muted-foreground max-w-prose text-sm text-pretty">
+          {aiAnswersFeature
+            ? "Other remaining quotas on your plan."
+            : "Remaining quotas on your plan."}
+        </p>
+      </div>
+      <div className="divide-y rounded-xl border">
+        {limitedFeatures.map((feature) => (
+          <UsageLimitedFeatureRow feature={feature} key={feature.id} />
+        ))}
+        {hasRetentionFeature ? (
+          <UsageRetentionRow retentionDays={retentionDays} />
+        ) : null}
+        {unlimitedFeatures.map((feature) => (
+          <UsageUnlimitedFeatureRow feature={feature} key={feature.id} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function UsageSectionBody({
   aiAnswersFeature,
   aiAnswersRemaining,
@@ -347,60 +448,14 @@ function UsageSectionBody({
   retentionDays,
   unlimitedFeatures,
 }: UsageSectionBodyProps) {
-  const showFeatureLimits =
-    limitedFeatures.length > 0 ||
-    hasRetentionFeature ||
-    unlimitedFeatures.length > 0;
-
   return (
     <div className="space-y-8">
-      {aiAnswersFeature || aiCreditsFeature ? (
-        <section className="space-y-4">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold tracking-tight">Balance</h2>
-            <p className="text-muted-foreground max-w-prose text-sm text-pretty">
-              How much of each plan limit you have left this cycle.
-            </p>
-          </div>
-          <div className="grid items-stretch gap-4 sm:grid-cols-2">
-            {aiAnswersFeature ? (
-              <BalanceCard
-                accentColor={USAGE_ANSWERS_ACCENT}
-                footer={aiAnswersFooter(aiAnswersFeature, aiAnswersRemaining)}
-                hint={aiAnswersHint(aiAnswersFeature)}
-                remaining={
-                  aiAnswersFeature.unlimited ? null : aiAnswersRemaining
-                }
-                title="AI Answers remaining"
-                value={aiAnswersValue(aiAnswersFeature)}
-              />
-            ) : null}
-            {aiCreditsFeature ? (
-              <BalanceCard
-                accentColor="#8b5cf6"
-                action={
-                  <Button
-                    aria-label="Top up credits"
-                    onClick={onOpenTopup}
-                    size="icon-sm"
-                    variant="outline"
-                  >
-                    <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
-                  </Button>
-                }
-                footer="Credits extend usage beyond your plan limits."
-                title="Credits remaining"
-                value={
-                  aiCreditsFeature.balance !== null
-                    ? formatDollars(aiCreditsFeature.balance)
-                    : "-"
-                }
-              />
-            ) : null}
-          </div>
-        </section>
-      ) : null}
-
+      <UsageBalanceSection
+        aiAnswersFeature={aiAnswersFeature}
+        aiAnswersRemaining={aiAnswersRemaining}
+        aiCreditsFeature={aiCreditsFeature}
+        onOpenTopup={onOpenTopup}
+      />
       {hasAiAnswers ? (
         <UsageBreakdownChart
           data={chartData}
@@ -409,32 +464,13 @@ function UsageSectionBody({
           range={range}
         />
       ) : null}
-
-      {showFeatureLimits ? (
-        <section className="space-y-4">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold tracking-tight">
-              Feature limits
-            </h2>
-            <p className="text-muted-foreground max-w-prose text-sm text-pretty">
-              {aiAnswersFeature
-                ? "Other remaining quotas on your plan."
-                : "Remaining quotas on your plan."}
-            </p>
-          </div>
-          <div className="divide-y rounded-xl border">
-            {limitedFeatures.map((feature) => (
-              <UsageLimitedFeatureRow feature={feature} key={feature.id} />
-            ))}
-            {hasRetentionFeature ? (
-              <UsageRetentionRow retentionDays={retentionDays} />
-            ) : null}
-            {unlimitedFeatures.map((feature) => (
-              <UsageUnlimitedFeatureRow feature={feature} key={feature.id} />
-            ))}
-          </div>
-        </section>
-      ) : null}
+      <UsageFeatureLimitsSection
+        aiAnswersFeature={aiAnswersFeature}
+        hasRetentionFeature={hasRetentionFeature}
+        limitedFeatures={limitedFeatures}
+        retentionDays={retentionDays}
+        unlimitedFeatures={unlimitedFeatures}
+      />
     </div>
   );
 }

--- a/apps/dashboard/src/components/billing/usage-section.tsx
+++ b/apps/dashboard/src/components/billing/usage-section.tsx
@@ -186,7 +186,7 @@ function UsageLimitedFeatureRow({ feature }: UsageLimitedFeatureRowProps) {
   const used =
     feature.included !== null && feature.balance !== null
       ? Math.max(feature.included - feature.balance, 0)
-      : 0;
+      : null;
 
   return (
     <div className="flex flex-col gap-3 p-4">
@@ -205,8 +205,9 @@ function UsageLimitedFeatureRow({ feature }: UsageLimitedFeatureRowProps) {
                 />
               </TooltipTrigger>
               <TooltipContent>
-                {formatCount(used)} used of {formatCount(feature.included ?? 0)}{" "}
-                this cycle.
+                {used !== null
+                  ? `${formatCount(used)} used of ${formatCount(feature.included ?? 0)} this cycle.`
+                  : `${formatCount(feature.included ?? 0)} included this cycle.`}
               </TooltipContent>
             </Tooltip>
           </div>
@@ -215,7 +216,9 @@ function UsageLimitedFeatureRow({ feature }: UsageLimitedFeatureRowProps) {
           </p>
         </div>
       </div>
-      <RemainingBar label={feature.name} remaining={remaining} />
+      {remaining !== null ? (
+        <RemainingBar label={feature.name} remaining={remaining} />
+      ) : null}
     </div>
   );
 }

--- a/apps/dashboard/src/components/command-palette/registry.ts
+++ b/apps/dashboard/src/components/command-palette/registry.ts
@@ -283,12 +283,21 @@ export const COMMAND_ROUTES: CommandRoute[] = [
   },
   {
     id: "settings-billing",
-    label: "Billing & Usage",
+    label: "Billing",
     keywords: ["subscription", "plan", "invoice", "payment"],
     icon: CreditCardIcon,
     section: "Settings",
     path: (slug) => `/${slug}?settings=billing`,
     settingsSection: "billing",
+  },
+  {
+    id: "settings-usage",
+    label: "Usage",
+    keywords: ["usage", "remaining", "limits", "quota", "answers"],
+    icon: ChartAnalysisIcon,
+    section: "Settings",
+    path: (slug) => `/${slug}?settings=usage`,
+    settingsSection: "usage",
   },
   {
     id: "settings-credits",

--- a/apps/dashboard/src/components/dashboard/header.tsx
+++ b/apps/dashboard/src/components/dashboard/header.tsx
@@ -51,7 +51,8 @@ function triggerScheduleDemo() {
 
 const SEGMENT_CONFIG: Record<string, { label?: string; href?: null }> = {
   collection: { label: "Collections" },
-  billing: { label: "Billing & Usage" },
+  billing: { label: "Billing" },
+  usage: { label: "Usage" },
   automation: { href: null },
   brand: { href: null },
   "api-keys": { label: "API Keys" },

--- a/apps/dashboard/src/components/settings/panes/billing-pane.tsx
+++ b/apps/dashboard/src/components/settings/panes/billing-pane.tsx
@@ -11,21 +11,14 @@ import {
   TableHeader,
   TableRow,
 } from "@notra/ui/components/ui/table";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@notra/ui/components/ui/tabs";
+import { Tabs, TabsList, TabsTrigger } from "@notra/ui/components/ui/tabs";
 import { TitleCard } from "@notra/ui/components/ui/title-card";
 import { useListPlans } from "autumn-js/react";
-import { parseAsStringLiteral, useQueryState } from "nuqs";
-import { Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { InvoicesTable } from "@/components/billing/invoices-table";
 import { PlanCard } from "@/components/billing/plan-card";
-import { UsageSection } from "@/components/billing/usage-section";
 import { ZdrAddonCard } from "@/components/billing/zdr-addon-card";
 import { Button } from "@/components/button";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
@@ -35,7 +28,6 @@ import {
   BILLING_INVOICE_SKELETON_KEYS,
   BILLING_PLAN_FEATURE_SKELETON_KEYS,
   BILLING_PLAN_SKELETON_KEYS,
-  BILLING_SECTION_VALUES,
   FEATURED_PLAN_TIER,
   PLANS_ANCHOR,
 } from "@/constants/billing";
@@ -121,59 +113,7 @@ function InvoiceTableSkeleton() {
   );
 }
 
-function BillingPaneFallback() {
-  return (
-    <SettingsPane>
-      <div className="flex items-center justify-between gap-3">
-        <Skeleton className="h-8 w-44 rounded-lg" />
-        <Skeleton className="h-8 w-40 rounded-md" />
-      </div>
-      <BillingPlansLoading />
-    </SettingsPane>
-  );
-}
-
-function BillingPlansLoading() {
-  return (
-    <div className="space-y-6">
-      <div className="space-y-4">
-        <div className="flex items-center justify-between gap-3">
-          <div className="space-y-2">
-            <Skeleton className="h-5 w-16" />
-            <Skeleton className="h-4 w-64" />
-          </div>
-          <Skeleton className="h-8 w-52 rounded-lg" />
-        </div>
-        <div className="grid gap-6 lg:grid-cols-3">
-          {BILLING_PLAN_SKELETON_KEYS.map((key) => (
-            <BillingPlanCardSkeleton key={key} />
-          ))}
-        </div>
-      </div>
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-20" />
-        <TitleCard
-          action={<Skeleton className="h-5 w-14 rounded-full" />}
-          heading={<Skeleton className="h-5 w-44" />}
-        >
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="w-full max-w-xl space-y-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
-            </div>
-            <Skeleton className="h-8 w-32 shrink-0 rounded-md" />
-          </div>
-        </TitleCard>
-      </div>
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-20" />
-        <InvoiceTableSkeleton />
-      </div>
-    </div>
-  );
-}
-
-function BillingSettingsPaneContent() {
+export function BillingSettingsPane() {
   const { activeOrganization } = useOrganizationsContext();
   const { data: plans, isLoading: plansLoading } = useListPlans();
   const {
@@ -186,10 +126,6 @@ function BillingSettingsPaneContent() {
   } = useBillingCustomer({
     expand: ["invoices", "subscriptions.plan"],
   });
-  const [activeSection, setActiveSection] = useQueryState(
-    "tab",
-    parseAsStringLiteral(BILLING_SECTION_VALUES).withDefault("billing")
-  );
   const [loading, setLoading] = useState<string | null>(null);
   const [portalLoading, setPortalLoading] = useState(false);
   const [isYearly, setIsYearly] = useState(false);
@@ -307,14 +243,7 @@ function BillingSettingsPaneContent() {
     : "Upgrade or change your plan.";
   const intervalLabel = isYearly ? "year" : "month";
 
-  function handleSectionChange(value: string) {
-    setActiveSection(value === "usage" ? "usage" : "billing");
-  }
-
   function renderManageSubscription() {
-    if (activeSection !== "billing") {
-      return null;
-    }
     if (customerLoading) {
       return <Skeleton className="h-8 w-40 rounded-md" />;
     }
@@ -386,89 +315,60 @@ function BillingSettingsPaneContent() {
   }
 
   return (
-    <SettingsPane>
-      <Tabs onValueChange={handleSectionChange} value={activeSection}>
-        <div className="flex items-center justify-between gap-3">
-          <TabsList aria-label="Billing sections">
-            <TabsTrigger value="billing">Billing</TabsTrigger>
-            <TabsTrigger value="usage">Usage</TabsTrigger>
-          </TabsList>
-          {renderManageSubscription()}
+    <SettingsPane titleAccessory={renderManageSubscription()}>
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2
+              className="scroll-mt-24 text-lg font-semibold"
+              id={PLANS_ANCHOR}
+            >
+              Plans
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              {isBillingLoading
+                ? "Upgrade or change your plan."
+                : plansDescription}
+            </p>
+          </div>
+          <Tabs
+            onValueChange={handleIntervalChange}
+            value={isYearly ? "yearly" : "monthly"}
+          >
+            <TabsList aria-label="Billing interval">
+              <TabsTrigger value="monthly">Monthly</TabsTrigger>
+              <TabsTrigger className="flex items-center gap-1.5" value="yearly">
+                Yearly
+                <Badge size="sm" variant="success">
+                  Save 20%
+                </Badge>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
         </div>
 
-        <TabsContent className="mt-4" value="billing">
-          <div className="space-y-6">
-            <div className="space-y-4">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <h2
-                    className="scroll-mt-24 text-lg font-semibold"
-                    id={PLANS_ANCHOR}
-                  >
-                    Plans
-                  </h2>
-                  <p className="text-muted-foreground text-sm">
-                    {isBillingLoading
-                      ? "Upgrade or change your plan."
-                      : plansDescription}
-                  </p>
-                </div>
-                <Tabs
-                  onValueChange={handleIntervalChange}
-                  value={isYearly ? "yearly" : "monthly"}
-                >
-                  <TabsList aria-label="Billing interval">
-                    <TabsTrigger value="monthly">Monthly</TabsTrigger>
-                    <TabsTrigger
-                      className="flex items-center gap-1.5"
-                      value="yearly"
-                    >
-                      Yearly
-                      <Badge size="sm" variant="success">
-                        Save 20%
-                      </Badge>
-                    </TabsTrigger>
-                  </TabsList>
-                </Tabs>
-              </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {isBillingLoading
+            ? BILLING_PLAN_SKELETON_KEYS.map((key) => (
+                <BillingPlanCardSkeleton key={key} />
+              ))
+            : planGroups.map(renderPlanCard)}
+        </div>
+      </div>
 
-              <div className="grid gap-6 lg:grid-cols-3">
-                {isBillingLoading
-                  ? BILLING_PLAN_SKELETON_KEYS.map((key) => (
-                      <BillingPlanCardSkeleton key={key} />
-                    ))
-                  : planGroups.map(renderPlanCard)}
-              </div>
-            </div>
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Add-ons</h2>
+        <ZdrAddonCard />
+      </div>
 
-            <div className="space-y-3">
-              <h2 className="text-lg font-semibold">Add-ons</h2>
-              <ZdrAddonCard />
-            </div>
-
-            <div className="space-y-3">
-              <h2 className="text-lg font-semibold">Invoices</h2>
-              {customerLoading ? (
-                <InvoiceTableSkeleton />
-              ) : (
-                <InvoicesTable invoices={invoices ?? []} plans={plans} />
-              )}
-            </div>
-          </div>
-        </TabsContent>
-
-        <TabsContent className="mt-4" value="usage">
-          <UsageSection />
-        </TabsContent>
-      </Tabs>
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Invoices</h2>
+        {customerLoading ? (
+          <InvoiceTableSkeleton />
+        ) : (
+          <InvoicesTable invoices={invoices ?? []} plans={plans} />
+        )}
+      </div>
     </SettingsPane>
-  );
-}
-
-export function BillingSettingsPane() {
-  return (
-    <Suspense fallback={<BillingPaneFallback />}>
-      <BillingSettingsPaneContent />
-    </Suspense>
   );
 }

--- a/apps/dashboard/src/components/settings/panes/usage-pane.tsx
+++ b/apps/dashboard/src/components/settings/panes/usage-pane.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { UsageSection } from "@/components/billing/usage-section";
+import { SettingsPane } from "@/components/settings/settings-pane";
+
+export function UsageSettingsPane() {
+  return (
+    <SettingsPane>
+      <UsageSection />
+    </SettingsPane>
+  );
+}

--- a/apps/dashboard/src/components/settings/settings-modal.tsx
+++ b/apps/dashboard/src/components/settings/settings-modal.tsx
@@ -91,6 +91,13 @@ const BillingSettingsPane = dynamic(
     })),
   { loading: SettingsPaneFallback }
 );
+const UsageSettingsPane = dynamic(
+  () =>
+    import("@/components/settings/panes/usage-pane").then((mod) => ({
+      default: mod.UsageSettingsPane,
+    })),
+  { loading: SettingsPaneFallback }
+);
 const CreditsSettingsPane = dynamic(
   () =>
     import("@/components/settings/panes/credits-pane").then((mod) => ({
@@ -127,6 +134,8 @@ function SettingsSectionContent({ section }: { section: SettingsSectionId }) {
       return <AttachmentsSettingsPane />;
     case "billing":
       return <BillingSettingsPane />;
+    case "usage":
+      return <UsageSettingsPane />;
     case "credits":
       return <CreditsSettingsPane />;
     case "logs":

--- a/apps/dashboard/src/constants/billing.ts
+++ b/apps/dashboard/src/constants/billing.ts
@@ -1,8 +1,12 @@
-import { ADDONS, LEGACY_PLANS, PLANS } from "@notra/ai/billing/features";
+import {
+  ADDONS,
+  FEATURES,
+  LEGACY_PLANS,
+  PLANS,
+} from "@notra/ai/billing/features";
+import type { ChartConfig } from "@notra/ui/components/ui/chart";
 
 import type { ProductFeature } from "@/types/hooks/billing";
-
-export const BILLING_SECTION_VALUES = ["billing", "usage"] as const;
 
 export const BILLING_PRICE_REGEX = /^\d+([.,]\d+)?$/;
 
@@ -149,3 +153,50 @@ export const ZDR_CONSENT_CONFIRM = "Enable";
 export const ZDR_CONSENT_CANCEL = "Not now";
 
 export const AUTUMN_ORGANIZATION_HEADER = "x-notra-organization";
+
+export const USAGE_RANGES = ["7d", "30d", "90d"] as const;
+
+export const USAGE_RANGE_TAB_LABELS: Record<
+  (typeof USAGE_RANGES)[number],
+  string
+> = {
+  "7d": "7D",
+  "30d": "30D",
+  "90d": "90D",
+};
+
+export const USAGE_FEATURE_ORDER: readonly string[] = [
+  FEATURES.AI_ANSWERS,
+  FEATURES.IMAGE_GENERATIONS,
+  FEATURES.LONG_FORM_POSTS,
+  FEATURES.SOCIAL_POSTS,
+  FEATURES.PROJECTS,
+  FEATURES.REFERENCES,
+  FEATURES.TEAM_MEMBERS,
+  FEATURES.WORKFLOWS,
+  FEATURES.INTEGRATIONS,
+];
+
+export const USAGE_FEATURE_LABELS: Record<string, string> = {
+  [FEATURES.AI_ANSWERS]: "AI answers",
+  [FEATURES.AI_CREDITS]: "Credits",
+  [FEATURES.IMAGE_GENERATIONS]: "Image generations",
+  [FEATURES.LONG_FORM_POSTS]: "Long-form posts",
+  [FEATURES.SOCIAL_POSTS]: "Social posts",
+  [FEATURES.PROJECTS]: "Projects",
+  [FEATURES.REFERENCES]: "References",
+  [FEATURES.TEAM_MEMBERS]: "Team members",
+  [FEATURES.WORKFLOWS]: "Workflows",
+  [FEATURES.INTEGRATIONS]: "Integrations",
+  [FEATURES.ZDR]: "Zero data retention",
+};
+
+export const USAGE_ANSWERS_ACCENT = "#10b981";
+export const USAGE_CHART_ACCENT = "#8b5cf6";
+
+export const USAGE_ANSWERS_CHART_CONFIG = {
+  ai_answers: {
+    label: "AI Answers",
+    color: "var(--primary)",
+  },
+} satisfies ChartConfig;

--- a/apps/dashboard/src/constants/settings.ts
+++ b/apps/dashboard/src/constants/settings.ts
@@ -2,6 +2,7 @@ import {
   AiBrowserIcon,
   AnalyticsUpIcon,
   Attachment01Icon,
+  ChartAnalysisIcon,
   CorporateIcon,
   CreditCardIcon,
   Globe02Icon,
@@ -24,6 +25,7 @@ export const SETTINGS_SECTION_IDS = [
   "notifications",
   "attachments",
   "billing",
+  "usage",
   "credits",
   "logs",
   "geo",
@@ -122,18 +124,32 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
       },
       {
         id: "billing",
-        label: "Billing & Usage",
-        description: "Plans, invoices, and usage",
+        label: "Billing",
+        description: "Plans, invoices, and subscription",
         icon: CreditCardIcon,
         keywords: [
           "subscription",
           "plan",
           "invoice",
           "payment",
-          "usage",
           "stripe",
           "trial",
           "upgrade",
+        ],
+      },
+      {
+        id: "usage",
+        label: "Usage",
+        description: "Remaining quotas and usage",
+        icon: ChartAnalysisIcon,
+        keywords: [
+          "usage",
+          "remaining",
+          "limits",
+          "quota",
+          "answers",
+          "cycle",
+          "breakdown",
         ],
       },
       {
@@ -225,7 +241,8 @@ export const SETTINGS_SECTION_LABELS: Record<SettingsSectionId, string> = {
   members: "Members",
   notifications: "Notifications",
   attachments: "Attachments",
-  billing: "Billing & Usage",
+  billing: "Billing",
+  usage: "Usage",
   credits: "Credits",
   logs: "Logs",
   geo: "Brand",
@@ -241,7 +258,8 @@ export const SETTINGS_SECTION_DESCRIPTIONS: Record<SettingsSectionId, string> =
     members: "Manage who has access to this organization",
     notifications: "Configure email notifications for your organization",
     attachments: "Manage your uploaded files and attachments",
-    billing: "Manage your plan, invoices, and feature usage",
+    billing: "Manage your plan, invoices, and subscription",
+    usage: "See remaining quotas and usage over time",
     credits: "Monitor your AI credit balance and usage",
     logs: "View integration events and their delivery status",
     geo: "How your brand is identified in answers",
@@ -260,4 +278,4 @@ export const LOGS_SETTINGS_SEARCH_KEYS = [
   "page",
 ] as const;
 
-export const BILLING_SETTINGS_SEARCH_KEYS = ["tab"] as const;
+export const LEGACY_BILLING_TAB_VALUES = ["billing", "usage"] as const;

--- a/apps/dashboard/src/lib/hooks/use-settings-modal.ts
+++ b/apps/dashboard/src/lib/hooks/use-settings-modal.ts
@@ -1,6 +1,11 @@
 import { parseAsStringLiteral, useQueryState } from "nuqs";
+import { useEffect } from "react";
 
-import { SETTINGS_QUERY_KEY, SETTINGS_SECTION_IDS } from "@/constants/settings";
+import {
+  LEGACY_BILLING_TAB_VALUES,
+  SETTINGS_QUERY_KEY,
+  SETTINGS_SECTION_IDS,
+} from "@/constants/settings";
 import type { SettingsSectionId } from "@/types/settings/modal";
 
 const settingsSectionParser = parseAsStringLiteral(
@@ -10,11 +15,27 @@ const settingsSectionParser = parseAsStringLiteral(
   scroll: false,
 });
 
+const legacyBillingTabParser = parseAsStringLiteral(LEGACY_BILLING_TAB_VALUES);
+
 export function useSettingsModal() {
   const [section, setSection] = useQueryState(
     SETTINGS_QUERY_KEY,
     settingsSectionParser
   );
+  const [legacyTab, setLegacyTab] = useQueryState(
+    "tab",
+    legacyBillingTabParser
+  );
+
+  useEffect(() => {
+    if (legacyTab === null) {
+      return;
+    }
+    if (legacyTab === "usage" && section === "billing") {
+      void setSection("usage", { history: "replace" });
+    }
+    void setLegacyTab(null, { history: "replace" });
+  }, [legacyTab, section, setLegacyTab, setSection]);
 
   function openSettings(next: SettingsSectionId = "account") {
     setSection(next);

--- a/apps/dashboard/src/types/hooks/billing.ts
+++ b/apps/dashboard/src/types/hooks/billing.ts
@@ -10,22 +10,39 @@ export interface FeatureData {
   balance: number | null;
   included: number | null;
   unlimited: boolean;
+  nextResetAt: number | null;
 }
 
-export type UsageRangeOption = "7d" | "30d" | "90d" | "last_cycle";
+export type UsageRangeOption = "7d" | "30d" | "90d";
 
 export interface UsageLimitedFeatureRowProps {
   feature: FeatureData;
+}
+
+export interface UsageBreakdownPoint {
+  date: number;
+  ai_answers: number;
+}
+
+export interface UsageBreakdownChartProps {
+  data: UsageBreakdownPoint[];
+  loading: boolean;
   range: UsageRangeOption;
+  onRangeChange: (range: UsageRangeOption) => void;
 }
 
 export interface UsageSectionBodyProps {
+  aiAnswersFeature: FeatureData | undefined;
+  aiAnswersRemaining: number;
   aiCreditsFeature: FeatureData | undefined;
+  chartData: UsageBreakdownPoint[];
+  chartLoading: boolean;
+  hasAiAnswers: boolean;
   hasRetentionFeature: boolean;
   limitedFeatures: FeatureData[];
+  onOpenTopup: () => void;
   onRangeChange: (range: UsageRangeOption) => void;
   range: UsageRangeOption;
   retentionDays: number;
-  totalUsage: number;
   unlimitedFeatures: FeatureData[];
 }

--- a/apps/dashboard/src/types/hooks/billing.ts
+++ b/apps/dashboard/src/types/hooks/billing.ts
@@ -24,6 +24,11 @@ export interface UsageBreakdownPoint {
   ai_answers: number;
 }
 
+export interface UsageAggregateRow {
+  period: number;
+  values?: Record<string, number | undefined>;
+}
+
 export interface UsageBreakdownChartProps {
   data: UsageBreakdownPoint[];
   loading: boolean;

--- a/apps/dashboard/src/types/hooks/billing.ts
+++ b/apps/dashboard/src/types/hooks/billing.ts
@@ -38,7 +38,7 @@ export interface UsageBreakdownChartProps {
 
 export interface UsageSectionBodyProps {
   aiAnswersFeature: FeatureData | undefined;
-  aiAnswersRemaining: number;
+  aiAnswersRemaining: number | null;
   aiCreditsFeature: FeatureData | undefined;
   chartData: UsageBreakdownPoint[];
   chartLoading: boolean;

--- a/apps/dashboard/src/types/settings/modal.ts
+++ b/apps/dashboard/src/types/settings/modal.ts
@@ -8,6 +8,7 @@ export type SettingsSectionId =
   | "notifications"
   | "attachments"
   | "billing"
+  | "usage"
   | "credits"
   | "logs"
   | "geo"

--- a/apps/dashboard/src/utils/billing-usage.ts
+++ b/apps/dashboard/src/utils/billing-usage.ts
@@ -148,9 +148,17 @@ export function aiAnswersHint(feature: FeatureData) {
   return `of ${formatCount(feature.included)} this cycle`;
 }
 
-export function aiAnswersFooter(feature: FeatureData, remaining: number) {
+export function aiAnswersFooter(
+  feature: FeatureData,
+  remaining: number | null
+) {
   if (feature.unlimited) {
     return "Included in your plan without a usage cap.";
+  }
+  if (remaining === null) {
+    return feature.nextResetAt === null
+      ? undefined
+      : `Resets ${formatFullDate(feature.nextResetAt)}`;
   }
   return remainingFooter(remaining, feature.nextResetAt);
 }

--- a/apps/dashboard/src/utils/billing-usage.ts
+++ b/apps/dashboard/src/utils/billing-usage.ts
@@ -1,8 +1,17 @@
 import { FEATURES } from "@notra/ai/billing/features";
 
 import { USAGE_FEATURE_LABELS, USAGE_FEATURE_ORDER } from "@/constants/billing";
-import type { FeatureData } from "@/types/hooks/billing";
-import { formatCount, formatFullDate, formatPercent } from "@/utils/format";
+import type {
+  FeatureData,
+  UsageAggregateRow,
+  UsageBreakdownPoint,
+} from "@/types/hooks/billing";
+import {
+  formatCount,
+  formatDollars,
+  formatFullDate,
+  formatPercent,
+} from "@/utils/format";
 
 type BalanceRecord = {
   remaining?: number | null;
@@ -144,6 +153,25 @@ export function aiAnswersFooter(feature: FeatureData, remaining: number) {
     return "Included in your plan without a usage cap.";
   }
   return remainingFooter(remaining, feature.nextResetAt);
+}
+
+export function usageBreakdownPoints(
+  rows: readonly UsageAggregateRow[] | null | undefined
+): UsageBreakdownPoint[] {
+  if (!rows?.length) {
+    return [];
+  }
+  return rows.map((row) => {
+    const value = row.values?.[FEATURES.AI_ANSWERS];
+    return {
+      date: row.period,
+      ai_answers: typeof value === "number" ? value : 0,
+    };
+  });
+}
+
+export function creditsValue(feature: FeatureData) {
+  return feature.balance !== null ? formatDollars(feature.balance) : "-";
 }
 
 export function remainingCountLabel(feature: FeatureData) {

--- a/apps/dashboard/src/utils/billing-usage.ts
+++ b/apps/dashboard/src/utils/billing-usage.ts
@@ -1,0 +1,154 @@
+import { FEATURES } from "@notra/ai/billing/features";
+
+import { USAGE_FEATURE_LABELS, USAGE_FEATURE_ORDER } from "@/constants/billing";
+import type { FeatureData } from "@/types/hooks/billing";
+import { formatCount, formatFullDate, formatPercent } from "@/utils/format";
+
+type BalanceRecord = {
+  remaining?: number | null;
+  granted?: number | null;
+  unlimited?: boolean;
+  nextResetAt?: number | null;
+};
+
+function formatFeatureName(id: string): string {
+  return id.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function usageFeatureLabel(id: string): string {
+  return USAGE_FEATURE_LABELS[id] ?? formatFeatureName(id);
+}
+
+function isLogRetentionFeature(featureId: string) {
+  return (
+    featureId === FEATURES.LOG_RETENTION_7_DAYS ||
+    featureId === FEATURES.LOG_RETENTION_14_DAYS ||
+    featureId === FEATURES.LOG_RETENTION_30_DAYS
+  );
+}
+
+function isHiddenFromFeatureList(featureId: string) {
+  return (
+    featureId === FEATURES.AI_ANSWERS ||
+    featureId === FEATURES.AI_CREDITS ||
+    featureId === FEATURES.ZDR ||
+    isLogRetentionFeature(featureId)
+  );
+}
+
+function usageFeatureOrder(featureId: string) {
+  const index = USAGE_FEATURE_ORDER.indexOf(featureId);
+  return index === -1 ? USAGE_FEATURE_ORDER.length : index;
+}
+
+function hasRetentionEntitlement(feature: FeatureData | undefined) {
+  return (
+    feature?.unlimited === true ||
+    (feature?.included ?? 0) > 0 ||
+    (feature?.balance ?? 0) > 0
+  );
+}
+
+export function isRetentionFeature(feature: FeatureData) {
+  return isLogRetentionFeature(feature.id);
+}
+
+export function featuresFromBalances(
+  balances: Record<string, BalanceRecord | null> | null | undefined
+): FeatureData[] {
+  if (!balances) {
+    return [];
+  }
+  const features: FeatureData[] = [];
+  for (const [id, feature] of Object.entries(balances)) {
+    features.push({
+      id,
+      name: usageFeatureLabel(id),
+      balance:
+        typeof feature?.remaining === "number" ? feature.remaining : null,
+      included: typeof feature?.granted === "number" ? feature.granted : null,
+      unlimited: feature?.unlimited === true,
+      nextResetAt:
+        typeof feature?.nextResetAt === "number" ? feature.nextResetAt : null,
+    });
+  }
+  return features;
+}
+
+export function limitedUsageFeatures(features: readonly FeatureData[]) {
+  return features
+    .filter(
+      (feature) =>
+        !feature.unlimited &&
+        feature.included !== null &&
+        !isHiddenFromFeatureList(feature.id)
+    )
+    .toSorted(
+      (left, right) => usageFeatureOrder(left.id) - usageFeatureOrder(right.id)
+    );
+}
+
+export function unlimitedUsageFeatures(features: readonly FeatureData[]) {
+  return features
+    .filter(
+      (feature) => feature.unlimited && !isHiddenFromFeatureList(feature.id)
+    )
+    .toSorted(
+      (left, right) => usageFeatureOrder(left.id) - usageFeatureOrder(right.id)
+    );
+}
+
+export function usageRetentionDays(features: readonly FeatureData[]): number {
+  const fourteen = features.find(
+    (feature) => feature.id === FEATURES.LOG_RETENTION_14_DAYS
+  );
+  const thirty = features.find(
+    (feature) => feature.id === FEATURES.LOG_RETENTION_30_DAYS
+  );
+  if (hasRetentionEntitlement(thirty)) {
+    return 30;
+  }
+  if (hasRetentionEntitlement(fourteen)) {
+    return 14;
+  }
+  return 7;
+}
+
+function remainingFooter(remaining: number, nextResetAt: number | null) {
+  const remainingLabel = `${formatPercent(remaining)}% remaining`;
+  if (nextResetAt === null) {
+    return remainingLabel;
+  }
+  return `${remainingLabel} · Resets ${formatFullDate(nextResetAt)}`;
+}
+
+export function aiAnswersValue(feature: FeatureData) {
+  if (feature.unlimited) {
+    return "Unlimited";
+  }
+  if (feature.balance !== null) {
+    return formatCount(feature.balance);
+  }
+  return "-";
+}
+
+export function aiAnswersHint(feature: FeatureData) {
+  if (feature.unlimited || feature.included === null) {
+    return undefined;
+  }
+  return `of ${formatCount(feature.included)} this cycle`;
+}
+
+export function aiAnswersFooter(feature: FeatureData, remaining: number) {
+  if (feature.unlimited) {
+    return "Included in your plan without a usage cap.";
+  }
+  return remainingFooter(remaining, feature.nextResetAt);
+}
+
+export function remainingCountLabel(feature: FeatureData) {
+  if (feature.balance !== null) {
+    return `${formatCount(feature.balance)} of ${formatCount(feature.included ?? 0)} remaining`;
+  }
+  return `of ${formatCount(feature.included ?? 0)} remaining`;
+}

--- a/apps/dashboard/src/utils/development-autumn.ts
+++ b/apps/dashboard/src/utils/development-autumn.ts
@@ -2,6 +2,19 @@ import { FEATURES } from "@notra/ai/billing/features";
 import { shouldBypassAutumnInDevelopment } from "@notra/ai/utils/autumn-development";
 
 const DEVELOPMENT_BALANCE = Number.MAX_SAFE_INTEGER;
+const MS_PER_DAY = 86_400_000;
+
+const RANGE_DAYS: Record<string, number> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
+type DevelopmentAggregateEventsRequest = {
+  featureId?: string | string[];
+  feature_id?: string | string[];
+  range?: string;
+};
 
 function createDevelopmentAutumnCustomer() {
   return {
@@ -44,19 +57,123 @@ function createDevelopmentAutumnCustomer() {
   };
 }
 
+function startOfUtcDay(timestamp: number) {
+  const date = new Date(timestamp);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function unitFromSeed(seed: number) {
+  const value = Math.sin(seed) * 10_000;
+  return value - Math.floor(value);
+}
+
+function seedFrom(value: string) {
+  let hash = 2_166_136_261;
+  for (const char of value) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+function featureIdsFromBody(body: DevelopmentAggregateEventsRequest) {
+  const raw = body.featureId ?? body.feature_id ?? FEATURES.AI_ANSWERS;
+  if (Array.isArray(raw)) {
+    return raw.filter((id) => typeof id === "string" && id.length > 0);
+  }
+  if (typeof raw === "string" && raw.length > 0) {
+    return [raw];
+  }
+  return [FEATURES.AI_ANSWERS];
+}
+
+function demoValue(featureId: string, isWeekend: boolean, seed: number) {
+  const random = unitFromSeed(seed);
+  const extra = unitFromSeed(seed + 17);
+  if (featureId === FEATURES.AI_CREDITS) {
+    if (isWeekend) {
+      return Math.floor(random * 40);
+    }
+    return 80 + Math.floor(random * 220);
+  }
+  if (isWeekend) {
+    return Math.floor(random * 5);
+  }
+  const spike = extra > 0.9 ? 12 + Math.floor(random * 18) : 0;
+  return 8 + Math.floor(random * 24) + spike;
+}
+
+function createDevelopmentAggregateEvents(
+  body: DevelopmentAggregateEventsRequest
+) {
+  const featureIds = featureIdsFromBody(body);
+  const days = RANGE_DAYS[body.range ?? "30d"] ?? 30;
+  const end = startOfUtcDay(Date.now());
+  const list: { period: number; values: Record<string, number> }[] = [];
+  const total: Record<string, { count: number; sum: number }> = {};
+
+  for (const featureId of featureIds) {
+    total[featureId] = { count: 0, sum: 0 };
+  }
+
+  for (let offset = days - 1; offset >= 0; offset -= 1) {
+    const period = end - offset * MS_PER_DAY;
+    const weekday = new Date(period).getUTCDay();
+    const isWeekend = weekday === 0 || weekday === 6;
+    const values: Record<string, number> = {};
+
+    for (const featureId of featureIds) {
+      const value = demoValue(
+        featureId,
+        isWeekend,
+        seedFrom(`${featureId}:${offset}`)
+      );
+      values[featureId] = value;
+      const current = total[featureId];
+      if (current) {
+        current.count += value > 0 ? 1 : 0;
+        current.sum += value;
+      }
+    }
+
+    list.push({ period, values });
+  }
+
+  return { list, total };
+}
+
+async function readJsonBody(
+  request: Request
+): Promise<DevelopmentAggregateEventsRequest> {
+  try {
+    const body: unknown = await request.json();
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      return body as DevelopmentAggregateEventsRequest;
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}
+
 export function createDevelopmentAutumnHandler(
   nodeEnv: string | undefined,
   secretKey: string | undefined
-): ((request: Request) => Response) | null {
+): ((request: Request) => Promise<Response>) | null {
   if (!shouldBypassAutumnInDevelopment(nodeEnv, secretKey)) {
     return null;
   }
 
-  return (request) => {
+  return async (request) => {
     const route = new URL(request.url).pathname.split("/").at(-1);
 
     if (route === "getOrCreateCustomer") {
       return Response.json(createDevelopmentAutumnCustomer());
+    }
+
+    if (route === "aggregateEvents") {
+      const body = await readJsonBody(request);
+      return Response.json(createDevelopmentAggregateEvents(body));
     }
 
     return Response.json(

--- a/apps/dashboard/src/utils/format.ts
+++ b/apps/dashboard/src/utils/format.ts
@@ -25,6 +25,7 @@ export function formatShortDate(timestamp: number): string {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
   }).format(new Date(timestamp));
 }
 
@@ -53,9 +54,9 @@ export function usageBarColor(percent: number): string {
 export function remainingPercent(
   balance: number | null,
   included: number | null
-): number {
+): number | null {
   if (balance === null || included === null || included <= 0) {
-    return 0;
+    return null;
   }
 
   return Math.min(Math.max((balance / included) * 100, 0), 100);

--- a/apps/dashboard/src/utils/format.ts
+++ b/apps/dashboard/src/utils/format.ts
@@ -5,6 +5,22 @@ export function formatDollars(cents: number): string {
   }).format(cents / 100);
 }
 
+const COUNT_FORMATTER = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
+const PERCENT_FORMATTER = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 1,
+});
+
+export function formatCount(value: number): string {
+  return COUNT_FORMATTER.format(value);
+}
+
+export function formatPercent(value: number): string {
+  return PERCENT_FORMATTER.format(value);
+}
+
 export function formatShortDate(timestamp: number): string {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
@@ -32,6 +48,27 @@ export function formatArticleDate(date: Date): string {
 
 export function usageBarColor(percent: number): string {
   return percent > 70 ? "bg-warning" : "bg-success";
+}
+
+export function remainingPercent(
+  balance: number | null,
+  included: number | null
+): number {
+  if (balance === null || included === null || included <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max((balance / included) * 100, 0), 100);
+}
+
+export function remainingBarColor(percent: number): string {
+  if (percent < 10) {
+    return "bg-destructive";
+  }
+  if (percent < 30) {
+    return "bg-warning";
+  }
+  return "bg-success";
 }
 
 export function isCreditRange<T extends string>(

--- a/apps/dashboard/src/utils/settings-path.ts
+++ b/apps/dashboard/src/utils/settings-path.ts
@@ -47,7 +47,7 @@ export function geoSettingsPath(
   return `/${slug}/geo${settingsQuery(DEFAULT_GEO_SETTINGS_SECTION, extra)}`;
 }
 
-function firstSearchParamValue(
+export function firstSearchParamValue(
   value: string | string[] | undefined
 ): string | undefined {
   if (typeof value === "string" && value.length > 0) {

--- a/packages/ai/src/utils/axiom-pipeline.ts
+++ b/packages/ai/src/utils/axiom-pipeline.ts
@@ -64,7 +64,10 @@ export function createAxiomPipeline(
   })(async (batch) => {
     // A full batch is dispatched synchronously by evlog.push(). Yield before
     // JSON serialization and fetch so enqueueing does not do batch-sized work.
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    // setTimeout(0) instead of setImmediate: Next traces this file as Edge.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
     reportOverflow();
     // evlog 2.13's createAxiomDrain swallows send errors. The throwing batch
     // API lets the pipeline own retries and report exhausted deliveries.

--- a/packages/ui/src/components/ui/chart.tsx
+++ b/packages/ui/src/components/ui/chart.tsx
@@ -346,11 +346,26 @@ function getPayloadConfigFromPayload(
     : config[key as keyof typeof config]
 }
 
+const {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Rectangle,
+  XAxis,
+  YAxis,
+} = RechartsPrimitive
+
 export {
+  Bar,
+  BarChart,
+  CartesianGrid,
   ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
   ChartLegend,
   ChartLegendContent,
   ChartStyle,
+  ChartTooltip,
+  ChartTooltipContent,
+  Rectangle,
+  XAxis,
+  YAxis,
 }

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -61,7 +61,7 @@ function TabsList({
       >
         {children}
         {variant === "default" ? (
-          <TabsPrimitive.Indicator className="pointer-events-none absolute top-0 left-0 z-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) translate-y-(--active-tab-top) rounded-md bg-background shadow-[0_1px_2px_rgba(0,0,0,0.08)] transition-[width,translate] duration-normal ease-in-out dark:bg-foreground/10" />
+          <TabsPrimitive.Indicator className="pointer-events-none absolute top-0 left-0 z-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) translate-y-(--active-tab-top) rounded-md bg-background shadow-[0_1px_2px_rgba(0,0,0,0.08)] transition-[width,height,translate] duration-slow ease-emphasized dark:bg-foreground/10" />
         ) : null}
       </TabsPrimitive.List>
     </TabsLayoutIdContext.Provider>

--- a/packages/ui/src/components/ui/title-card.tsx
+++ b/packages/ui/src/components/ui/title-card.tsx
@@ -13,6 +13,7 @@ interface TitleCardProps extends Omit<React.ComponentProps<"div">, "title"> {
   hoverBackground?: React.ReactNode;
   contentClassName?: string;
   footerClassName?: string;
+  accentClassName?: string;
   disabled?: boolean;
 }
 
@@ -28,6 +29,7 @@ function TitleCard({
   className,
   contentClassName,
   footerClassName,
+  accentClassName,
   disabled = false,
   children,
   ...props
@@ -51,8 +53,9 @@ function TitleCard({
       {accentColor && (
         <div
           className={cn(
-            "pointer-events-none absolute inset-0 -z-10 opacity-0 transition-opacity duration-normal",
-            !disabled && "group-hover:opacity-100"
+            "pointer-events-none absolute inset-0 -z-10 opacity-0",
+            !disabled && "group-hover:opacity-100",
+            accentClassName ?? "transition-opacity duration-normal"
           )}
           style={gradientStyle}
         />
@@ -65,7 +68,7 @@ function TitleCard({
           {hoverBackground}
         </div>
       )}
-      <div className="flex items-start justify-between gap-4 px-4 py-2.5">
+      <div className="flex h-10 items-center justify-between gap-4 px-4">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {icon && (
             <div className="flex size-8 shrink-0 items-center justify-center text-muted-foreground [&_svg]:size-5">

--- a/packages/ui/src/components/ui/title-card.tsx
+++ b/packages/ui/src/components/ui/title-card.tsx
@@ -68,7 +68,7 @@ function TitleCard({
           {hoverBackground}
         </div>
       )}
-      <div className="flex h-10 items-center justify-between gap-4 px-4">
+      <div className="flex min-h-10 items-center justify-between gap-4 px-4">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {icon && (
             <div className="flex size-8 shrink-0 items-center justify-center text-muted-foreground [&_svg]:size-5">


### PR DESCRIPTION
### Description
Give settings a dedicated Usage tab (plans stay on Billing) so remaining AI Answers, credits, and feature limits are easier to scan. Includes a remaining-first usage chart and a small Axiom drain fix: yield with `setTimeout` so Next's Edge instrumentation analysis no longer flags `setImmediate`.

Authored with Cursor.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves usage out of Billing into its own Settings tab so remaining AI Answers, credits, and feature limits are easier to scan. Old `?tab=usage` links and `/settings/billing/usage` URLs redirect to the new tab.

- Usage now leads with remaining balances, progress bars, and reset dates instead of credits used; bars are hidden when a balance is missing.
- Adds a daily AI Answers usage breakdown chart with 7, 30, and 90-day ranges, lazy-loaded so the settings page doesn't block on it; daily bins use UTC and empty periods show zero in the tooltip.
- Dev-mode Autumn mock now serves demo aggregate events so the chart renders without a billing key.
- Replaces `setImmediate` with `setTimeout` in the Axiom drain so Next's Edge instrumentation analysis doesn't fail the build.

<sup>Written for commit cd75a51a4eef2f0bf125284aae6fbb012f64742f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

