### PR TITLE
feat(geo): add per-prompt scans with live job tracking

### DIFF
--- a/apps/dashboard/knip.json
+++ b/apps/dashboard/knip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["scripts/*.ts"],
+  "entry": [
+    "scripts/*.ts",
+    "tests/fixtures/prompt-answer-selection.fixture.ts"
+  ],
   "paths": {
     "@/*": ["./src/*"]
   },

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/prompts/page-client.tsx
@@ -16,11 +16,13 @@ import { GeoSetupButton } from "@/components/geo/geo-setup-button";
 import { PromptAddDialog } from "@/components/geo/prompt-add-dialog";
 import { PromptSuggestions } from "@/components/geo/prompt-suggestions";
 import { PromptsTable } from "@/components/geo/prompts-table";
+import { ScanActivity } from "@/components/geo/scan-activity";
 import { PageContainer } from "@/components/layout/container";
 import {
   GeoProjectProvider,
   useGeoProjectScope,
 } from "@/components/providers/geo-project-provider";
+import { GeoScanControlsProvider } from "@/components/providers/geo-scan-controls-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
   EMPTY_STATE_TABLE_COLUMNS,
@@ -106,57 +108,64 @@ function GeoPromptsPageContent({ organizationSlug }: PageClientProps) {
   }
 
   return (
-    <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <div className="w-full space-y-6 px-4 lg:px-6">
-        <header className="flex flex-wrap items-center justify-between gap-3">
-          <div className="space-y-1">
-            <h1 className="text-3xl font-bold tracking-tight">Prompts</h1>
-            <p className="text-muted-foreground">
-              The questions we ask AI engines on your behalf
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <GeoRangePicker control={geoRange} />
-            <Button
-              className="gap-1.5"
-              onClick={() => setImportOpen(true)}
-              variant="outline"
-            >
-              <HugeiconsIcon className="size-4" icon={Upload01Icon} />
-              Import CSV
-            </Button>
-            <Button className="gap-1.5" onClick={() => setAddOpen(true)}>
-              <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
-              Add Prompt
-              <Kbd className="ml-1 hidden sm:inline-flex">P</Kbd>
-            </Button>
-          </div>
-        </header>
-        <PromptsTable
-          isScanning={isScanning}
+    <GeoScanControlsProvider
+      key={`${organizationId}:${projectId ?? "default"}`}
+      organizationId={organizationId}
+      promptCount={prompts.filter((prompt) => prompt.enabled).length}
+    >
+      <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+        <div className="w-full space-y-6 px-4 lg:px-6">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-1">
+              <h1 className="text-3xl font-bold tracking-tight">Prompts</h1>
+              <p className="text-muted-foreground">
+                The questions we ask AI engines on your behalf
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <GeoRangePicker control={geoRange} />
+              <Button
+                className="gap-1.5"
+                onClick={() => setImportOpen(true)}
+                variant="outline"
+              >
+                <HugeiconsIcon className="size-4" icon={Upload01Icon} />
+                Import CSV
+              </Button>
+              <Button className="gap-1.5" onClick={() => setAddOpen(true)}>
+                <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
+                Add Prompt
+                <Kbd className="ml-1 hidden sm:inline-flex">P</Kbd>
+              </Button>
+            </div>
+          </header>
+          <ScanActivity organizationId={organizationId} />
+          <PromptsTable
+            isScanning={isScanning}
+            organizationId={organizationId}
+            prompts={prompts}
+            results={promptResults?.results ?? []}
+          />
+          <ConversationsCard organizationId={organizationId} />
+          <PromptSuggestions
+            callbackPath={withGeoProject(
+              `/${organizationSlug}/geo/prompts`,
+              projectId
+            )}
+            organizationId={organizationId}
+          />
+        </div>
+        <PromptAddDialog
+          onOpenChange={setAddOpen}
+          open={addOpen}
           organizationId={organizationId}
-          prompts={prompts}
-          results={promptResults?.results ?? []}
         />
-        <ConversationsCard organizationId={organizationId} />
-        <PromptSuggestions
-          callbackPath={withGeoProject(
-            `/${organizationSlug}/geo/prompts`,
-            projectId
-          )}
+        <PromptsCsvImportDialog
+          onOpenChange={setImportOpen}
+          open={importOpen}
           organizationId={organizationId}
         />
-      </div>
-      <PromptAddDialog
-        onOpenChange={setAddOpen}
-        open={addOpen}
-        organizationId={organizationId}
-      />
-      <PromptsCsvImportDialog
-        onOpenChange={setImportOpen}
-        open={importOpen}
-        organizationId={organizationId}
-      />
-    </PageContainer>
+      </PageContainer>
+    </GeoScanControlsProvider>
   );
 }

--- a/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
+++ b/apps/dashboard/src/components/geo/geo-prompt-answer-thread.tsx
@@ -172,6 +172,7 @@ function ThreadMessages({
 }
 
 export function GeoPromptAnswerThread({
+  scrollable = true,
   prompt,
   result,
 }: GeoPromptAnswerThreadProps) {
@@ -199,11 +200,19 @@ export function GeoPromptAnswerThread({
   return (
     <div
       className={cn(
-        "relative flex h-full min-h-0 flex-1 flex-col overflow-hidden",
+        scrollable
+          ? "relative flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+          : "relative flex flex-col",
         GEO_CHAT_SKIN_SURFACE[skin]
       )}
     >
-      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+      <div
+        className={
+          scrollable
+            ? "min-h-0 flex-1 overflow-y-auto overscroll-contain"
+            : undefined
+        }
+      >
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-10 px-6 py-8">
           <ThreadMessages
             answer={answer}

--- a/apps/dashboard/src/components/geo/geo-tag-list.tsx
+++ b/apps/dashboard/src/components/geo/geo-tag-list.tsx
@@ -25,11 +25,15 @@ export function GeoTagList({
   disabled = false,
   labeled = true,
   inputClassName,
+  inline = false,
 }: GeoTagListProps) {
   const [draft, setDraft] = useState("");
   const atLimit = values.length >= max;
 
   const commitDraft = () => {
+    if (disabled) {
+      return;
+    }
     if (atLimit) {
       setDraft("");
       return;
@@ -41,10 +45,42 @@ export function GeoTagList({
     setDraft("");
   };
 
+  const badges =
+    values.length > 0 ? (
+      <div
+        className={inline ? "contents" : "flex flex-wrap items-center gap-1.5"}
+      >
+        {values.map((value) => (
+          <Badge
+            className="h-7 max-w-full gap-1 pr-1 text-xs"
+            key={value}
+            variant="secondary"
+          >
+            <span className="truncate">{value}</span>
+            <button
+              aria-label={`Remove ${value}`}
+              className="hover:bg-background focus-visible:ring-ring flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-sm outline-none focus-visible:ring-2 disabled:cursor-not-allowed"
+              disabled={disabled}
+              onClick={() => onChange(removeValue(values, value))}
+              type="button"
+            >
+              <HugeiconsIcon aria-hidden="true" icon={Cancel01Icon} size={12} />
+            </button>
+          </Badge>
+        ))}
+      </div>
+    ) : null;
+
   return (
-    <div className="w-full min-w-0 space-y-2">
+    <div
+      className={
+        inline
+          ? "bg-background focus-within:border-ring focus-within:ring-ring/50 flex min-h-10 w-full min-w-0 flex-wrap items-center gap-1.5 rounded-lg border px-2 py-1.5 focus-within:ring-2"
+          : "w-full min-w-0 space-y-2"
+      }
+    >
       {labeled ? (
-        <div className="space-y-1">
+        <div className="w-full space-y-1">
           <Label className="flex items-center gap-2" htmlFor={id}>
             {label}
             <span className="text-muted-foreground font-normal tabular-nums">
@@ -56,14 +92,19 @@ export function GeoTagList({
           ) : null}
         </div>
       ) : null}
+      {inline ? badges : null}
       <Input
         aria-label={labeled ? undefined : label}
         className={inputClassName}
-        disabled={disabled || atLimit}
+        disabled={atLimit}
+        readOnly={disabled}
         id={id}
         onBlur={commitDraft}
         onChange={(event) => setDraft(event.target.value)}
         onKeyDown={(event) => {
+          if (disabled) {
+            return;
+          }
           if (event.key === "Enter") {
             event.preventDefault();
             commitDraft();
@@ -81,6 +122,9 @@ export function GeoTagList({
           }
         }}
         onPaste={(event) => {
+          if (disabled) {
+            return;
+          }
           const text = event.clipboardData.getData("text");
           if (!LINE_BREAK_REGEX.test(text)) {
             return;
@@ -92,24 +136,7 @@ export function GeoTagList({
         placeholder={atLimit ? undefined : placeholder}
         value={draft}
       />
-      {values.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-1.5">
-          {values.map((value) => (
-            <Badge className="gap-1 pr-1" key={value} variant="secondary">
-              {value}
-              <button
-                aria-label={`Remove ${value}`}
-                className="hover:bg-background cursor-pointer rounded-sm p-0.5 disabled:cursor-not-allowed"
-                disabled={disabled}
-                onClick={() => onChange(removeValue(values, value))}
-                type="button"
-              >
-                <HugeiconsIcon icon={Cancel01Icon} size={12} />
-              </button>
-            </Badge>
-          ))}
-        </div>
-      ) : null}
+      {!inline ? badges : null}
     </div>
   );
 }

--- a/apps/dashboard/src/components/geo/prompt-answer-content.tsx
+++ b/apps/dashboard/src/components/geo/prompt-answer-content.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { PromptDetailStatus } from "@/components/geo/prompt-detail-status";
+import { PromptReceiptAnalysis } from "@/components/geo/prompt-receipt-analysis";
+import type { PromptAnswerContentProps } from "@/types/geo";
+
+const AnswerThread = dynamic(() =>
+  import("@/components/geo/geo-prompt-answer-thread").then(
+    (module) => module.GeoPromptAnswerThread
+  )
+);
+
+export function PromptAnswerContent({
+  state,
+  view,
+  onRetry,
+  prompt,
+  scrollable,
+  showHistory,
+  history,
+  isHistoryLoading,
+  competitors,
+  onSelectCheck,
+}: PromptAnswerContentProps) {
+  if (state.status !== "ready") {
+    return <PromptDetailStatus onRetry={onRetry} status={state.status} />;
+  }
+
+  const { result } = state;
+  const promptText = prompt ?? result.prompt;
+
+  if (view === "raw") {
+    return (
+      <AnswerThread
+        scrollable={scrollable}
+        prompt={promptText}
+        result={result}
+      />
+    );
+  }
+
+  return (
+    <PromptReceiptAnalysis
+      scrollable={scrollable}
+      showHistory={showHistory}
+      competitors={competitors}
+      history={history}
+      isHistoryLoading={isHistoryLoading}
+      onSelectCheck={onSelectCheck}
+      prompt={promptText}
+      result={result}
+    />
+  );
+}

--- a/apps/dashboard/src/components/geo/prompt-copy-button.tsx
+++ b/apps/dashboard/src/components/geo/prompt-copy-button.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import type { PromptCopyButtonProps } from "@/types/geo-prompt-detail";
+import { copyTextToClipboard } from "@/utils/copy-to-clipboard";
+
+export function PromptCopyButton({ prompt }: PromptCopyButtonProps) {
+  return (
+    <button
+      aria-label={`Copy prompt: ${prompt}`}
+      className="bg-background hover:bg-muted/50 focus-visible:ring-ring inline-flex max-w-full cursor-pointer items-center rounded-md border px-2 py-1 text-left wrap-anywhere shadow-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      onClick={() => copyTextToClipboard(prompt, "Copied prompt")}
+      title="Copy prompt"
+      type="button"
+    >
+      {prompt}
+    </button>
+  );
+}

--- a/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
@@ -44,12 +44,9 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { GEO_PROMPT_DETAIL_SURFACES } from "@/constants/geo-analytics";
 import { GEO_PROMPT_TAGS_COPY } from "@/constants/geo-prompts";
 import { trackEvent } from "@/lib/analytics/posthog-client";
-import {
-  useGeoCompetitors,
-  useGeoPromptHistory,
-  useGeoPromptResultDetail,
-} from "@/lib/hooks/use-geo";
+import { useGeoCompetitors } from "@/lib/hooks/use-geo";
 import { useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
+import { usePromptAnswerSelection } from "@/lib/hooks/use-prompt-answer-selection";
 import type {
   PromptAnswerPageProps,
   PromptDetailDialogProps,
@@ -59,16 +56,11 @@ import type {
   PromptAnswerHeaderProps,
 } from "@/types/geo-prompt-detail";
 import { sharedEngineAnswerMode } from "@/utils/geo-charts";
-import { geoPromptDetailState } from "@/utils/geo-prompt-detail";
 import {
   adjacentPromptEngine,
   promptEngineArrowDelta,
 } from "@/utils/geo-prompt-engines";
-import {
-  latestPromptResults,
-  promptHistoryForEngine,
-  promptResultFromHistoryCheck,
-} from "@/utils/geo-prompt-history";
+import { promptResultFromHistoryCheck } from "@/utils/geo-prompt-history";
 
 const INSTANT = { duration: 0 } as const;
 const SLIDE_PX = 18;
@@ -262,53 +254,38 @@ function PromptAnswerPage({
   scanId,
   initialLanguage,
 }: PromptAnswerPageProps) {
-  const [language, setLanguage] = useState(initialLanguage ?? "");
+  const {
+    history,
+    scanPromptId,
+    languages,
+    selectedLanguage,
+    setLanguage,
+    results,
+    engines,
+    engine,
+    setEngine,
+    active,
+    detail,
+    detailState,
+    engineHistory,
+    promptText,
+  } = usePromptAnswerSelection({
+    row,
+    organizationId,
+    open,
+    scanId,
+    initialLanguage,
+    initialEngine,
+  });
   const tagsInputId = useId();
   const { prompts, pendingPromptIds, setPromptTags } =
     useGeoPromptsDb(organizationId);
   const tags = prompts.find((prompt) => prompt.id === row.id)?.tags ?? row.tags;
-  const scanPromptId = row.results[0]?.promptId ?? row.id;
-  const history = useGeoPromptHistory(organizationId, scanPromptId, {
-    enabled: open,
-    scanId,
-  });
-  const scanChecks = (history.data?.checks ?? []).filter(
-    (check) => !scanId || check.scanId === scanId
-  );
-  const languages = [...new Set(scanChecks.map((check) => check.language))];
-  const selectedLanguage = languages.includes(language)
-    ? language
-    : languages[0];
-  const visibleChecks = scanId
-    ? scanChecks.filter((check) => check.language === selectedLanguage)
-    : scanChecks;
-  const results = latestPromptResults(
-    scanId && history.data ? [] : row.results,
-    visibleChecks,
-    scanPromptId,
-    row.prompt
-  );
-  const engines = results.map((result) => result.engine);
-  const [engine, setEngine] = useState(
-    () =>
-      engines.find((candidate) => candidate === initialEngine) ??
-      engines[0] ??
-      ""
-  );
   const [view, setView] = useState<GeoPromptReceiptView>("analysis");
   const [selectedCheck, setSelectedCheck] =
     useState<GeoPromptHistoryCheck | null>(null);
   const [direction, setDirection] = useState(1);
   const reduceMotion = useReducedMotion();
-  const active =
-    results.find((result) => result.engine === engine) ?? results[0] ?? null;
-  const checkId = open ? (active?.checkId ?? null) : null;
-  const detail = useGeoPromptResultDetail(organizationId, checkId);
-  const detailState = geoPromptDetailState(
-    active?.checkId ?? null,
-    detail.data,
-    detail.isError
-  );
   const openedRef = useRef(false);
   const activeEngine = active?.engine ?? null;
   const resultCount = results.length;
@@ -330,9 +307,6 @@ function PromptAnswerPage({
     });
   }, [activeEngine, open, resultCount, row.id, surface]);
   const competitors = useGeoCompetitors(organizationId);
-  const engineHistory = active
-    ? promptHistoryForEngine(visibleChecks, active.engine)
-    : [];
   const threadTransition = reduceMotion ? INSTANT : tween("slow", "emphasized");
 
   function selectEngine(next: string, nextDirection: number) {
@@ -376,9 +350,7 @@ function PromptAnswerPage({
       side="right"
     >
       <PromptAnswerHeader
-        promptText={
-          scanId ? (detail.data?.result?.prompt ?? row.prompt) : row.prompt
-        }
+        promptText={promptText}
         onPrepareScan={onPrepareScan}
         organizationId={organizationId}
         active={active}
@@ -434,11 +406,7 @@ function PromptAnswerPage({
                     void detail.refetch();
                   }}
                   onSelectCheck={openHistoryAnswer}
-                  prompt={
-                    scanId
-                      ? (detail.data?.result?.prompt ?? row.prompt)
-                      : row.prompt
-                  }
+                  prompt={promptText}
                   scanPromptId={scanPromptId}
                   selectedCheck={selectedCheck}
                   view={view}

--- a/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
@@ -2,7 +2,10 @@
 
 import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { GEO_PROMPT_HISTORY_ANSWER_LABELS } from "@notra/geo-core/constants/geo";
+import {
+  GEO_PROMPT_HISTORY_ANSWER_LABELS,
+  GEO_PROMPT_MAX_TAGS,
+} from "@notra/geo-core/constants/geo";
 import type {
   GeoPromptHistoryCheck,
   GeoPromptReceiptView,
@@ -10,6 +13,7 @@ import type {
 } from "@notra/geo-core/types/geo";
 import { formatAiTrafficTimestamp } from "@notra/geo-core/utils/ai-traffic";
 import { geoPromptIntentLabel } from "@notra/geo-core/utils/geo-prompt-intent";
+import { normalizePromptTags } from "@notra/geo-core/utils/geo-prompt-tags";
 import { geoScanEmptyMessage } from "@notra/geo-core/utils/geo-scan";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import {
@@ -21,22 +25,31 @@ import {
 } from "@notra/ui/components/ui/sheet";
 import { tween } from "@notra/ui/lib/motion";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
 
 import { Button } from "@/components/button";
 import { GeoPromptAnswerThread } from "@/components/geo/geo-prompt-answer-thread";
+import { GeoTagList } from "@/components/geo/geo-tag-list";
+import { PromptCopyButton } from "@/components/geo/prompt-copy-button";
 import { PromptDetailStatus } from "@/components/geo/prompt-detail-status";
 import { PromptEngineSwitcher } from "@/components/geo/prompt-engine-switcher";
 import { PromptReceiptAnalysis } from "@/components/geo/prompt-receipt-analysis";
 import { PromptReceiptViewSwitch } from "@/components/geo/prompt-receipt-view-switch";
+import { PromptScanButton } from "@/components/geo/prompt-scan-button";
+import {
+  GeoScanControlsProvider,
+  useGeoScanControls,
+} from "@/components/providers/geo-scan-controls-provider";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { GEO_PROMPT_DETAIL_SURFACES } from "@/constants/geo-analytics";
+import { GEO_PROMPT_TAGS_COPY } from "@/constants/geo-prompts";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import {
   useGeoCompetitors,
   useGeoPromptHistory,
   useGeoPromptResultDetail,
 } from "@/lib/hooks/use-geo";
+import { useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
 import type {
   PromptAnswerPageProps,
   PromptDetailDialogProps,
@@ -45,7 +58,6 @@ import type {
   PromptAnswerBodyProps,
   PromptAnswerHeaderProps,
 } from "@/types/geo-prompt-detail";
-import { copyTextToClipboard } from "@/utils/copy-to-clipboard";
 import { sharedEngineAnswerMode } from "@/utils/geo-charts";
 import { geoPromptDetailState } from "@/utils/geo-prompt-detail";
 import {
@@ -53,6 +65,7 @@ import {
   promptEngineArrowDelta,
 } from "@/utils/geo-prompt-engines";
 import {
+  latestPromptResults,
   promptHistoryForEngine,
   promptResultFromHistoryCheck,
 } from "@/utils/geo-prompt-history";
@@ -113,6 +126,9 @@ function HistoryAnswerBanner({
 }
 
 function PromptAnswerHeader({
+  promptText,
+  onPrepareScan,
+  organizationId,
   row,
   results,
   active,
@@ -129,15 +145,7 @@ function PromptAnswerHeader({
     <SheetHeader className="shrink-0 gap-3 border-b p-4">
       <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 pr-8">
         <SheetTitle className="min-w-0 text-sm leading-5 font-medium">
-          <button
-            aria-label={`Copy prompt: ${row.prompt}`}
-            className="bg-background hover:bg-muted/50 focus-visible:ring-ring inline-flex max-w-full cursor-pointer items-center rounded-md border px-2 py-1 text-left wrap-anywhere shadow-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
-            onClick={() => copyTextToClipboard(row.prompt, "Copied prompt")}
-            title="Copy prompt"
-            type="button"
-          >
-            {row.prompt}
-          </button>
+          <PromptCopyButton prompt={promptText ?? row.prompt} />
         </SheetTitle>
         <SheetDescription className="sr-only">
           {answerMode
@@ -152,8 +160,15 @@ function PromptAnswerHeader({
             {formatAiTrafficTimestamp(latestCheck)}
           </time>
         ) : null}
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          <PromptScanButton
+            onPrepare={onPrepareScan}
+            organizationId={organizationId}
+            row={row}
+          />
+        </div>
       </div>
-      <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-3">
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
         <div>
           <dt className="text-muted-foreground text-xs">Intent</dt>
           <dd>{geoPromptIntentLabel(row.intent)}</dd>
@@ -162,12 +177,6 @@ function PromptAnswerHeader({
           <dt className="text-muted-foreground text-xs">Best position</dt>
           <dd className="tabular-nums">
             {row.bestPosition === null ? "Not ranked" : `#${row.bestPosition}`}
-          </dd>
-        </div>
-        <div className="col-span-2 sm:col-span-1">
-          <dt className="text-muted-foreground text-xs">Tags</dt>
-          <dd className="max-h-20 overflow-auto break-words">
-            {row.tags.length > 0 ? row.tags.join(", ") : "No tags"}
           </dd>
         </div>
       </dl>
@@ -203,6 +212,7 @@ function PromptAnswerBody({
       <>
         <HistoryAnswerBanner check={selectedCheck} onBack={onBackToLatest} />
         <GeoPromptAnswerThread
+          scrollable={false}
           prompt={prompt}
           result={promptResultFromHistoryCheck(
             selectedCheck,
@@ -221,6 +231,7 @@ function PromptAnswerBody({
   if (view === "analysis") {
     return (
       <PromptReceiptAnalysis
+        scrollable={false}
         competitors={competitors}
         history={history}
         isHistoryLoading={isHistoryLoading}
@@ -231,18 +242,52 @@ function PromptAnswerBody({
     );
   }
 
-  return <GeoPromptAnswerThread prompt={prompt} result={detailState.result} />;
+  return (
+    <GeoPromptAnswerThread
+      scrollable={false}
+      prompt={prompt}
+      result={detailState.result}
+    />
+  );
 }
 
 function PromptAnswerPage({
+  onPrepareScan,
   row,
   open,
   organizationId,
   isScanning = false,
   surface,
   initialEngine,
+  scanId,
+  initialLanguage,
 }: PromptAnswerPageProps) {
-  const results = row.results;
+  const [language, setLanguage] = useState(initialLanguage ?? "");
+  const tagsInputId = useId();
+  const { prompts, pendingPromptIds, setPromptTags } =
+    useGeoPromptsDb(organizationId);
+  const tags = prompts.find((prompt) => prompt.id === row.id)?.tags ?? row.tags;
+  const scanPromptId = row.results[0]?.promptId ?? row.id;
+  const history = useGeoPromptHistory(organizationId, scanPromptId, {
+    enabled: open,
+    scanId,
+  });
+  const scanChecks = (history.data?.checks ?? []).filter(
+    (check) => !scanId || check.scanId === scanId
+  );
+  const languages = [...new Set(scanChecks.map((check) => check.language))];
+  const selectedLanguage = languages.includes(language)
+    ? language
+    : languages[0];
+  const visibleChecks = scanId
+    ? scanChecks.filter((check) => check.language === selectedLanguage)
+    : scanChecks;
+  const results = latestPromptResults(
+    scanId && history.data ? [] : row.results,
+    visibleChecks,
+    scanPromptId,
+    row.prompt
+  );
   const engines = results.map((result) => result.engine);
   const [engine, setEngine] = useState(
     () =>
@@ -284,13 +329,9 @@ function PromptAnswerPage({
       prompt_id: row.id,
     });
   }, [activeEngine, open, resultCount, row.id, surface]);
-  const scanPromptId = results[0]?.promptId ?? row.id;
-  const history = useGeoPromptHistory(organizationId, scanPromptId, {
-    enabled: open && results.length > 0,
-  });
   const competitors = useGeoCompetitors(organizationId);
   const engineHistory = active
-    ? promptHistoryForEngine(history.data?.checks ?? [], active.engine)
+    ? promptHistoryForEngine(visibleChecks, active.engine)
     : [];
   const threadTransition = reduceMotion ? INSTANT : tween("slow", "emphasized");
 
@@ -335,6 +376,11 @@ function PromptAnswerPage({
       side="right"
     >
       <PromptAnswerHeader
+        promptText={
+          scanId ? (detail.data?.result?.prompt ?? row.prompt) : row.prompt
+        }
+        onPrepareScan={onPrepareScan}
+        organizationId={organizationId}
         active={active}
         onSelectEngine={selectEngine}
         onSelectView={selectView}
@@ -342,46 +388,102 @@ function PromptAnswerPage({
         results={results}
         view={view}
       />
-      <div className="relative min-h-0 flex-1 overflow-hidden">
-        <AnimatePresence custom={direction} initial={false}>
-          {active ? (
-            <motion.div
-              animate="center"
-              className="absolute inset-0 flex flex-col"
-              custom={direction}
-              exit="exit"
-              initial="enter"
-              key={`${active.engine}-${view}-${selectedCheck?.id ?? "latest"}`}
-              transition={threadTransition}
-              variants={threadVariants(Boolean(reduceMotion))}
+      {scanId && languages.length > 1 ? (
+        <div
+          className="flex shrink-0 flex-wrap gap-1 border-b px-4 py-2"
+          aria-label="Answer language"
+          role="group"
+        >
+          {languages.map((item) => (
+            <Button
+              key={item}
+              aria-pressed={item === selectedLanguage}
+              onClick={() => {
+                setLanguage(item);
+                setSelectedCheck(null);
+              }}
+              size="sm"
+              variant={item === selectedLanguage ? "secondary" : "ghost"}
             >
-              <PromptAnswerBody
-                competitors={competitors.data?.competitors}
-                detailState={detailState}
-                history={engineHistory}
-                isHistoryLoading={history.isPending}
-                onBackToLatest={() => setSelectedCheck(null)}
-                onRetry={() => {
-                  void detail.refetch();
-                }}
-                onSelectCheck={openHistoryAnswer}
-                prompt={row.prompt}
-                scanPromptId={scanPromptId}
-                selectedCheck={selectedCheck}
-                view={view}
-              />
-            </motion.div>
+              {item}
+            </Button>
+          ))}
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <div className="relative grid">
+          <AnimatePresence custom={direction} initial={false}>
+            {active ? (
+              <motion.div
+                animate="center"
+                className="col-start-1 row-start-1 flex min-w-0 flex-col"
+                custom={direction}
+                exit="exit"
+                initial="enter"
+                key={`${active.engine}-${view}-${selectedCheck?.id ?? "latest"}`}
+                transition={threadTransition}
+                variants={threadVariants(Boolean(reduceMotion))}
+              >
+                <PromptAnswerBody
+                  competitors={competitors.data?.competitors}
+                  detailState={detailState}
+                  history={engineHistory}
+                  isHistoryLoading={history.isPending}
+                  onBackToLatest={() => setSelectedCheck(null)}
+                  onRetry={() => {
+                    void detail.refetch();
+                  }}
+                  onSelectCheck={openHistoryAnswer}
+                  prompt={
+                    scanId
+                      ? (detail.data?.result?.prompt ?? row.prompt)
+                      : row.prompt
+                  }
+                  scanPromptId={scanPromptId}
+                  selectedCheck={selectedCheck}
+                  view={view}
+                />
+              </motion.div>
+            ) : (
+              <div className="flex min-h-48 items-center justify-center px-6">
+                <p className="text-muted-foreground text-center text-sm text-pretty">
+                  {geoScanEmptyMessage(
+                    isScanning,
+                    "Run a scan to see how engines answer this"
+                  )}
+                </p>
+              </div>
+            )}
+          </AnimatePresence>
+        </div>
+        <section
+          className="bg-muted/20 space-y-3 px-4 pt-0 pb-4"
+          aria-labelledby={`${tagsInputId}-heading`}
+        >
+          <h3 className="text-sm font-medium" id={`${tagsInputId}-heading`}>
+            Tags
+          </h3>
+          {row.source === "auto" ? (
+            <p className="text-sm break-words">
+              {tags.length > 0 ? tags.join(", ") : "No tags"}
+            </p>
           ) : (
-            <div className="flex h-full min-h-0 items-center justify-center px-6">
-              <p className="text-muted-foreground text-center text-sm text-pretty">
-                {geoScanEmptyMessage(
-                  isScanning,
-                  "Run a scan to see how engines answer this"
-                )}
-              </p>
-            </div>
+            <GeoTagList
+              disabled={pendingPromptIds.has(row.id)}
+              id={tagsInputId}
+              inline
+              inputClassName="h-7 min-w-24 flex-1 basis-24 rounded-none border-0 bg-transparent px-1 text-sm shadow-none focus-visible:ring-0 dark:bg-transparent"
+              label={GEO_PROMPT_TAGS_COPY.label}
+              labeled={false}
+              max={GEO_PROMPT_MAX_TAGS}
+              onChange={(nextTags) =>
+                setPromptTags(row.id, normalizePromptTags(nextTags))
+              }
+              placeholder="Add a tag…"
+              values={tags}
+            />
           )}
-        </AnimatePresence>
+        </section>
       </div>
     </SheetContent>
   );
@@ -395,24 +497,34 @@ export function PromptDetailDialog({
   surface,
   organizationId,
   initialEngine,
+  scanId,
+  initialLanguage,
 }: PromptDetailDialogProps) {
   const { activeOrganization } = useOrganizationsContext();
+  const scanControls = useGeoScanControls();
   const resolvedOrganizationId = organizationId ?? activeOrganization?.id ?? "";
-  if (!row) {
-    return null;
-  }
 
-  return (
+  const content = row ? (
     <Sheet onOpenChange={onOpenChange} open={open}>
       <PromptAnswerPage
+        onPrepareScan={() => onOpenChange(false)}
         initialEngine={initialEngine}
+        initialLanguage={initialLanguage}
+        scanId={scanId}
         isScanning={isScanning}
-        key={row.id}
+        key={`${row.id}-${scanId ?? "latest"}`}
         open={open}
         organizationId={resolvedOrganizationId}
         row={row}
         surface={surface}
       />
     </Sheet>
+  ) : null;
+  return scanControls ? (
+    content
+  ) : (
+    <GeoScanControlsProvider organizationId={resolvedOrganizationId}>
+      {content}
+    </GeoScanControlsProvider>
   );
 }

--- a/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
@@ -30,10 +30,10 @@ import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
 import { Button } from "@/components/button";
 import { GeoPromptAnswerThread } from "@/components/geo/geo-prompt-answer-thread";
 import { GeoTagList } from "@/components/geo/geo-tag-list";
+import { PromptAnswerContent } from "@/components/geo/prompt-answer-content";
 import { PromptCopyButton } from "@/components/geo/prompt-copy-button";
 import { PromptDetailStatus } from "@/components/geo/prompt-detail-status";
 import { PromptEngineSwitcher } from "@/components/geo/prompt-engine-switcher";
-import { PromptReceiptAnalysis } from "@/components/geo/prompt-receipt-analysis";
 import { PromptReceiptViewSwitch } from "@/components/geo/prompt-receipt-view-switch";
 import { PromptScanButton } from "@/components/geo/prompt-scan-button";
 import {
@@ -216,29 +216,17 @@ function PromptAnswerBody({
     );
   }
 
-  if (detailState.status !== "ready") {
-    return <PromptDetailStatus onRetry={onRetry} status={detailState.status} />;
-  }
-
-  if (view === "analysis") {
-    return (
-      <PromptReceiptAnalysis
-        scrollable={false}
-        competitors={competitors}
-        history={history}
-        isHistoryLoading={isHistoryLoading}
-        onSelectCheck={onSelectCheck}
-        prompt={prompt}
-        result={detailState.result}
-      />
-    );
-  }
-
   return (
-    <GeoPromptAnswerThread
+    <PromptAnswerContent
+      state={detailState}
+      view={view}
+      onRetry={onRetry}
       scrollable={false}
+      competitors={competitors}
+      history={history}
+      isHistoryLoading={isHistoryLoading}
+      onSelectCheck={onSelectCheck}
       prompt={prompt}
-      result={detailState.result}
     />
   );
 }
@@ -265,7 +253,7 @@ function PromptAnswerPage({
     engine,
     setEngine,
     active,
-    detail,
+    onRetry,
     detailState,
     engineHistory,
     promptText,
@@ -343,6 +331,20 @@ function PromptAnswerPage({
     );
   }
 
+  const emptyAnswer =
+    detailState.status === "loading" || detailState.status === "error" ? (
+      <PromptDetailStatus onRetry={onRetry} status={detailState.status} />
+    ) : (
+      <div className="flex min-h-48 items-center justify-center px-6">
+        <p className="text-muted-foreground text-center text-sm text-pretty">
+          {geoScanEmptyMessage(
+            isScanning,
+            "Run a scan to see how engines answer this"
+          )}
+        </p>
+      </div>
+    );
+
   return (
     <SheetContent
       className="gap-0 overflow-hidden p-0 transition-none data-[side=right]:inset-y-0 data-[side=right]:h-dvh data-[side=right]:w-full motion-reduce:animate-none sm:rounded-2xl sm:border data-[side=right]:sm:inset-y-2 data-[side=right]:sm:right-2 data-[side=right]:sm:h-[calc(100dvh-1rem)] data-[side=right]:sm:max-w-[min(calc(100vw-2rem),54rem)]"
@@ -402,9 +404,7 @@ function PromptAnswerPage({
                   history={engineHistory}
                   isHistoryLoading={history.isPending}
                   onBackToLatest={() => setSelectedCheck(null)}
-                  onRetry={() => {
-                    void detail.refetch();
-                  }}
+                  onRetry={onRetry}
                   onSelectCheck={openHistoryAnswer}
                   prompt={promptText}
                   scanPromptId={scanPromptId}
@@ -413,14 +413,7 @@ function PromptAnswerPage({
                 />
               </motion.div>
             ) : (
-              <div className="flex min-h-48 items-center justify-center px-6">
-                <p className="text-muted-foreground text-center text-sm text-pretty">
-                  {geoScanEmptyMessage(
-                    isScanning,
-                    "Run a scan to see how engines answer this"
-                  )}
-                </p>
-              </div>
+              emptyAnswer
             )}
           </AnimatePresence>
         </div>

--- a/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
+++ b/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
@@ -68,6 +68,20 @@ export function PromptEngineSwitcher({
   const showsSearchIcon = (engine: string) =>
     answerMode === null && engineAnswerMode(engine) !== null;
 
+  if (results.length === 1) {
+    return (
+      <div className="flex min-w-0 flex-1 items-center">
+        <span className="bg-background inline-flex h-7 max-w-full min-w-0 items-center gap-1.5 rounded-lg border px-2.5 text-[0.8rem] font-medium">
+          <EngineIcon className="size-3.5 shrink-0" engine={active.engine} />
+          <span className="truncate">
+            {engineLabel(active.engine, answerMode)}
+          </span>
+          {showsSearchIcon(active.engine) ? <SearchModeIcon /> : null}
+        </span>
+      </div>
+    );
+  }
+
   return (
     <LazyMotion features={domAnimation}>
       <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
+++ b/apps/dashboard/src/components/geo/prompt-engine-switcher.tsx
@@ -74,9 +74,9 @@ export function PromptEngineSwitcher({
         <span className="bg-background inline-flex h-7 max-w-full min-w-0 items-center gap-1.5 rounded-lg border px-2.5 text-[0.8rem] font-medium">
           <EngineIcon className="size-3.5 shrink-0" engine={active.engine} />
           <span className="truncate">
-            {engineLabel(active.engine, answerMode)}
+            {formatEngineWithMode(active.engine)}
           </span>
-          {showsSearchIcon(active.engine) ? <SearchModeIcon /> : null}
+          {engineAnswerMode(active.engine) !== null ? <SearchModeIcon /> : null}
         </span>
       </div>
     );

--- a/apps/dashboard/src/components/geo/prompt-receipt-analysis.tsx
+++ b/apps/dashboard/src/components/geo/prompt-receipt-analysis.tsx
@@ -219,18 +219,23 @@ export function PromptReceiptAnalysis({
   isHistoryLoading,
   competitors,
   onSelectCheck,
+  showHistory = true,
+  scrollable = true,
 }: PromptReceiptAnalysisProps) {
   const entries = promptHistoryChanges(history);
   const competitorNames = [...new Set(result.competitors)];
 
   return (
-    <div className="bg-muted/20 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+    <div
+      className={
+        scrollable
+          ? "bg-muted/20 min-h-0 flex-1 overflow-y-auto overscroll-contain"
+          : "bg-muted/20"
+      }
+    >
       <div className="flex w-full flex-col gap-4 p-4">
         <OutcomeStrip result={result} />
-        <ReceiptSection
-          count={competitorNames.length}
-          title={GEO_PROMPT_RECEIPT_LABELS.competitors}
-        >
+        <ReceiptSection title={GEO_PROMPT_RECEIPT_LABELS.competitors}>
           <CompetitorsCell competitors={competitors} names={competitorNames} />
         </ReceiptSection>
         {result.searchQueries.length > 0 ? (
@@ -243,18 +248,17 @@ export function PromptReceiptAnalysis({
             <SourcesTable sources={result.sources} />
           </ReceiptSection>
         ) : null}
-        <ReceiptSection
-          count={isHistoryLoading ? null : entries.length}
-          title={GEO_PROMPT_RECEIPT_LABELS.history}
-        >
-          <PromptReceiptHistory
-            competitors={competitors}
-            entries={entries}
-            isLoading={isHistoryLoading}
-            key={entries[0]?.check.id ?? "empty"}
-            onSelect={onSelectCheck}
-          />
-        </ReceiptSection>
+        {showHistory ? (
+          <ReceiptSection title={GEO_PROMPT_RECEIPT_LABELS.history}>
+            <PromptReceiptHistory
+              competitors={competitors}
+              entries={entries}
+              isLoading={isHistoryLoading}
+              key={entries[0]?.check.id ?? "empty"}
+              onSelect={onSelectCheck}
+            />
+          </ReceiptSection>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/geo/prompt-receipt-history.tsx
+++ b/apps/dashboard/src/components/geo/prompt-receipt-history.tsx
@@ -252,9 +252,10 @@ export function PromptReceiptHistory({
         {
           key: "outcome",
           header: GEO_PROMPT_HISTORY_COLUMN_LABELS.outcome,
-          width: "144px",
+          width: "168px",
+          minWidth: "168px",
           cell: ({ check }) => (
-            <span className={cn(HISTORY_LINE_CLASS, "gap-2")}>
+            <span className={cn(HISTORY_LINE_CLASS, "gap-2 whitespace-nowrap")}>
               <PromptOutcomeIcon mentioned={check.mentioned} />
               <span
                 className={

--- a/apps/dashboard/src/components/geo/prompt-scan-button.tsx
+++ b/apps/dashboard/src/components/geo/prompt-scan-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ScanModelMenu } from "@/components/geo/scan-model-menu";
+import {
+  GeoScanControlsProvider,
+  useGeoScanControls,
+} from "@/components/providers/geo-scan-controls-provider";
+import { useGeoSettings, useIsGeoScanning } from "@/lib/hooks/use-geo";
+import type { PromptScanButtonProps } from "@/types/geo";
+
+export function PromptScanButton(props: PromptScanButtonProps) {
+  const controls = useGeoScanControls();
+  if (!controls) {
+    return (
+      <GeoScanControlsProvider organizationId={props.organizationId}>
+        <PromptScanMenu {...props} />
+      </GeoScanControlsProvider>
+    );
+  }
+  return <PromptScanMenu {...props} />;
+}
+
+function PromptScanMenu({
+  organizationId,
+  row,
+  compact = false,
+  onPrepare,
+}: PromptScanButtonProps) {
+  const controls = useGeoScanControls();
+  const { data } = useGeoSettings(organizationId);
+  const isScanning = useIsGeoScanning(organizationId);
+  let disabledReason: string | undefined;
+  if (isScanning) {
+    disabledReason =
+      "Wait for the current scan to finish before starting another.";
+  } else if (!row.enabled) {
+    disabledReason = "Enable this prompt to run a scan.";
+  } else if (!data) {
+    disabledReason = "Scan settings are not available yet.";
+  } else if (!data.settings?.enabled) {
+    disabledReason = "Enable GEO scanning in settings to run a scan.";
+  }
+  return (
+    <ScanModelMenu
+      compact={compact}
+      disabled={!row.enabled || !data?.settings?.enabled || isScanning}
+      disabledReason={disabledReason}
+      engines={data?.settings?.engines ?? []}
+      label={compact ? `Run scan: ${row.prompt}` : "Run scan"}
+      onContinue={(engines) => {
+        onPrepare?.();
+        controls?.prepare({
+          engines,
+          prompt: { id: row.id, prompt: row.prompt },
+        });
+      }}
+    />
+  );
+}

--- a/apps/dashboard/src/components/geo/prompt-tags-action-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-tags-action-dialog.tsx
@@ -1,0 +1,34 @@
+import { PromptTagsDialog } from "@/components/geo/prompt-tags-dialog";
+import { GEO_PROMPT_TAGS_COPY } from "@/constants/geo-prompts";
+import type { PromptTagsActionDialogProps } from "@/types/geo";
+
+export function PromptTagsActionDialog({
+  target,
+  suggestions,
+  onConfirm,
+  onClose,
+}: PromptTagsActionDialogProps) {
+  const edit = target?.mode === "edit";
+  return (
+    <PromptTagsDialog
+      confirmLabel={
+        edit ? GEO_PROMPT_TAGS_COPY.confirm : GEO_PROMPT_TAGS_COPY.bulkConfirm
+      }
+      description={
+        edit
+          ? GEO_PROMPT_TAGS_COPY.editDescription
+          : GEO_PROMPT_TAGS_COPY.bulkDescription
+      }
+      initialTags={edit ? (target?.rows[0]?.tags ?? []) : []}
+      onConfirm={onConfirm}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+      open={target !== null}
+      suggestions={suggestions}
+      title={edit ? GEO_PROMPT_TAGS_COPY.edit : GEO_PROMPT_TAGS_COPY.bulkTitle}
+    />
+  );
+}

--- a/apps/dashboard/src/components/geo/prompts-table.tsx
+++ b/apps/dashboard/src/components/geo/prompts-table.tsx
@@ -11,8 +11,6 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
-  GEO_PROMPT_AUTO_MANAGED_HINT,
-  GEO_PROMPT_AUTO_MANAGED_LABEL,
   GEO_PROMPT_TAGS_CUSTOM_ONLY_TOAST,
   PROMPTS_TABLE_HEIGHT,
   PROMPTS_TABLE_ROW_HEIGHT,
@@ -26,7 +24,6 @@ import {
   GEO_PROMPT_SOURCE_FILTER_VALUES,
 } from "@notra/schemas/constants/dashboard/geo-prompts";
 import { TruncateWithTooltip } from "@notra/ui/components/shared/truncate-with-tooltip";
-import { Badge } from "@notra/ui/components/ui/badge";
 import {
   ContextMenuItem,
   ContextMenuSeparator,
@@ -40,11 +37,6 @@ import {
   SelectValue,
 } from "@notra/ui/components/ui/select";
 import { Switch } from "@notra/ui/components/ui/switch";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@notra/ui/components/ui/tooltip";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -86,19 +78,17 @@ import {
 } from "@/utils/geo-prompts";
 
 const PROMPT_NOUNS = { singular: "prompt", plural: "prompts" } as const;
-const PROMPT_ACTIONS_WIDTH = "12rem";
+const PROMPT_ACTIONS_WIDTH = "6rem";
 
 function PromptRowActions({
   row,
   isPending,
   onToggle,
-  onEditTags,
   onDelete,
 }: {
   row: GeoPromptTableRow;
   isPending: boolean;
   onToggle: (enabled: boolean) => void;
-  onEditTags: () => void;
   onDelete: () => void;
 }) {
   const stop = (event: { stopPropagation: () => void }) =>
@@ -123,38 +113,6 @@ function PromptRowActions({
 
   return (
     <div className="flex items-center justify-end gap-1">
-      {row.source === "auto" ? (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Badge
-                className="text-muted-foreground cursor-help font-normal"
-                onClick={stop}
-                onPointerDown={stop}
-                variant="secondary"
-              >
-                {GEO_PROMPT_AUTO_MANAGED_LABEL}
-              </Badge>
-            }
-          />
-          <TooltipContent className="max-w-xs">
-            {GEO_PROMPT_AUTO_MANAGED_HINT}
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        <Button
-          aria-label={`${GEO_PROMPT_TAGS_COPY.edit}: ${row.prompt}`}
-          disabled={isPending}
-          onClick={(event) => {
-            event.stopPropagation();
-            onEditTags();
-          }}
-          size="icon"
-          variant="ghost"
-        >
-          <HugeiconsIcon icon={Tag01Icon} size={14} />
-        </Button>
-      )}
       {pauseSwitch}
       <Button
         aria-label={`Remove ${row.prompt}`}
@@ -402,13 +360,17 @@ export function PromptsTable({
       minWidth: PROMPT_ACTIONS_WIDTH,
       align: "right",
       cell: (row) => (
-        <PromptRowActions
-          isPending={pendingPromptIds.has(row.id)}
-          onDelete={() => requestDelete([row])}
-          onEditTags={() => setTagsTarget({ mode: "edit", rows: [row] })}
-          onToggle={(enabled) => togglePrompt(row.id, enabled)}
-          row={row}
-        />
+        <div
+          className="flex items-center justify-end gap-1"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <PromptRowActions
+            isPending={pendingPromptIds.has(row.id)}
+            onDelete={() => requestDelete([row])}
+            onToggle={(enabled) => togglePrompt(row.id, enabled)}
+            row={row}
+          />
+        </div>
       ),
     },
   ];

--- a/apps/dashboard/src/components/geo/prompts-table.tsx
+++ b/apps/dashboard/src/components/geo/prompts-table.tsx
@@ -49,7 +49,7 @@ import {
 } from "@/components/geo/prompt-badges";
 import { PromptDetailDialog } from "@/components/geo/prompt-detail-dialog";
 import { PromptSavedViewsMenu } from "@/components/geo/prompt-saved-views-menu";
-import { PromptTagsDialog } from "@/components/geo/prompt-tags-dialog";
+import { PromptTagsActionDialog } from "@/components/geo/prompt-tags-action-dialog";
 import { Table, type TableColumn } from "@/components/motion/table";
 import { GEO_PROMPT_DETAIL_SURFACES } from "@/constants/geo-analytics";
 import {
@@ -375,9 +375,6 @@ export function PromptsTable({
     },
   ];
 
-  const tagsDialogTarget = tagsTarget?.rows[0] ?? null;
-  const tagsDialogIsEdit = tagsTarget?.mode === "edit";
-
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -579,31 +576,11 @@ export function PromptsTable({
         }}
         open={deleteOpen}
       />
-      <PromptTagsDialog
-        confirmLabel={
-          tagsDialogIsEdit
-            ? GEO_PROMPT_TAGS_COPY.confirm
-            : GEO_PROMPT_TAGS_COPY.bulkConfirm
-        }
-        description={
-          tagsDialogIsEdit
-            ? GEO_PROMPT_TAGS_COPY.editDescription
-            : GEO_PROMPT_TAGS_COPY.bulkDescription
-        }
-        initialTags={tagsDialogIsEdit ? (tagsDialogTarget?.tags ?? []) : []}
+      <PromptTagsActionDialog
+        target={tagsTarget}
         onConfirm={applyTags}
-        onOpenChange={(openDialog) => {
-          if (!openDialog) {
-            setTagsTarget(null);
-          }
-        }}
-        open={tagsTarget !== null}
+        onClose={() => setTagsTarget(null)}
         suggestions={tagsInUse}
-        title={
-          tagsDialogIsEdit
-            ? GEO_PROMPT_TAGS_COPY.edit
-            : GEO_PROMPT_TAGS_COPY.bulkTitle
-        }
       />
       <PromptDetailDialog
         isScanning={isScanning}

--- a/apps/dashboard/src/components/geo/scan-activity-status.tsx
+++ b/apps/dashboard/src/components/geo/scan-activity-status.tsx
@@ -1,0 +1,60 @@
+import {
+  Loading03Icon,
+  MinusSignIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import type { GeoScanActivityStatusProps } from "@/types/geo-scan-activity";
+import { geoRunProgress } from "@/utils/geo-scan-activity";
+
+export function ScanActivityStatus({ run }: GeoScanActivityStatusProps) {
+  const status = run?.status ?? "running";
+  const running = status === "running";
+  const progress = run ? geoRunProgress(run) : null;
+
+  return (
+    <>
+      <span
+        className={
+          status === "completed"
+            ? "bg-success/15 text-success flex size-6 shrink-0 items-center justify-center rounded-full shadow-[inset_0_1px_2px_oklch(0_0_0/0.18)]"
+            : "flex size-6 shrink-0 items-center justify-center rounded-full"
+        }
+      >
+        {running ? (
+          <HugeiconsIcon
+            aria-hidden="true"
+            className="text-primary motion-safe:animate-spin"
+            icon={Loading03Icon}
+            size={14}
+          />
+        ) : (
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={status === "completed" ? Tick02Icon : MinusSignIcon}
+            size={14}
+          />
+        )}
+      </span>
+      <span className="font-medium">
+        {running ? "Scanning" : null}
+        {status === "completed" ? "Scan complete" : null}
+        {status === "failed" ? "Scan stopped" : null}
+      </span>
+      <span className="text-muted-foreground tabular-nums">
+        {run
+          ? `${run.checks}${run.plan ? ` / ${run.plan.totalChecks}` : ""} answers saved`
+          : "Preparing scan…"}
+      </span>
+      {running && progress !== null ? (
+        <progress
+          aria-label="Saved scan answers"
+          className="bg-border [&::-moz-progress-bar]:bg-primary [&::-webkit-progress-bar]:bg-border [&::-webkit-progress-value]:bg-primary ml-1 h-1 w-20 overflow-hidden rounded-full"
+          max={100}
+          value={progress}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/geo/scan-activity.tsx
+++ b/apps/dashboard/src/components/geo/scan-activity.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  Loading03Icon,
+  Tick02Icon,
+  MinusSignIcon,
+  ArrowRight01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useId, useState } from "react";
+
+import { ScanRunDetail } from "@/components/geo/scan-run-detail";
+import { useIsGeoScanning } from "@/lib/hooks/use-geo";
+import { useGeoScanRuns } from "@/lib/hooks/use-geo-scan-history";
+import type { GeoScanActivityProps } from "@/types/geo-scan-activity";
+import { geoRunProgress } from "@/utils/geo-scan-activity";
+
+export function ScanActivity({ organizationId }: GeoScanActivityProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [hasExpanded, setHasExpanded] = useState(false);
+  const resultsId = useId();
+  const isScanning = useIsGeoScanning(organizationId);
+  const latest = useGeoScanRuns(organizationId);
+  const newest = latest.data?.runs[0];
+  const running = newest?.status === "running";
+  const progress = newest ? geoRunProgress(newest) : null;
+
+  if (!newest && !isScanning) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-label="Latest scan"
+      className="bg-muted/60 min-w-0 overflow-hidden rounded-xl p-1"
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={resultsId}
+        onClick={() => {
+          setHasExpanded(true);
+          setExpanded((value) => !value);
+        }}
+        className="focus-visible:ring-ring hover:bg-muted/60 flex min-h-12 w-full flex-wrap items-center gap-2 rounded-lg px-3 py-2 text-left text-xs outline-none focus-visible:ring-2"
+      >
+        <span
+          className={
+            newest?.status === "completed"
+              ? "bg-success/15 text-success flex size-6 shrink-0 items-center justify-center rounded-full shadow-[inset_0_1px_2px_oklch(0_0_0/0.18)]"
+              : "flex size-6 shrink-0 items-center justify-center rounded-full"
+          }
+        >
+          {running || !newest ? (
+            <HugeiconsIcon
+              aria-hidden="true"
+              className="text-primary motion-safe:animate-spin"
+              icon={Loading03Icon}
+              size={14}
+            />
+          ) : (
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={newest.status === "completed" ? Tick02Icon : MinusSignIcon}
+              size={14}
+            />
+          )}
+        </span>
+        <span className="font-medium">
+          {running || !newest ? "Scanning" : null}
+          {newest?.status === "completed" ? "Scan complete" : null}
+          {newest?.status === "failed" ? "Scan stopped" : null}
+        </span>
+        <span className="text-muted-foreground tabular-nums">
+          {newest
+            ? `${newest.checks}${newest.plan ? ` / ${newest.plan.totalChecks}` : ""} answers saved`
+            : "Preparing scan…"}
+        </span>
+        {running && progress !== null ? (
+          <progress
+            aria-label="Saved scan answers"
+            className="bg-border [&::-moz-progress-bar]:bg-primary [&::-webkit-progress-bar]:bg-border [&::-webkit-progress-value]:bg-primary ml-1 h-1 w-20 overflow-hidden rounded-full"
+            max={100}
+            value={progress}
+          />
+        ) : null}
+        <HugeiconsIcon
+          aria-hidden="true"
+          icon={ArrowRight01Icon}
+          size={14}
+          className={`duration-normal ml-auto shrink-0 transition-transform ease-out motion-reduce:transition-none ${expanded ? "rotate-90" : ""}`}
+        />
+      </button>
+      <div
+        id={resultsId}
+        inert={!expanded}
+        aria-hidden={!expanded}
+        className={`duration-normal grid transition-[grid-template-rows,opacity] ease-out motion-reduce:transition-none ${expanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"}`}
+      >
+        <div className="min-h-0 overflow-hidden">
+          {newest && hasExpanded ? (
+            <div className="bg-background rounded-lg p-3">
+              <ScanRunDetail
+                key={newest.id}
+                organizationId={organizationId}
+                run={newest}
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/geo/scan-activity.tsx
+++ b/apps/dashboard/src/components/geo/scan-activity.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import {
-  Loading03Icon,
-  Tick02Icon,
-  MinusSignIcon,
-  ArrowRight01Icon,
-} from "@hugeicons/core-free-icons";
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useId, useState } from "react";
 
+import { ScanActivityStatus } from "@/components/geo/scan-activity-status";
 import { ScanRunDetail } from "@/components/geo/scan-run-detail";
 import { useIsGeoScanning } from "@/lib/hooks/use-geo";
 import { useGeoScanRuns } from "@/lib/hooks/use-geo-scan-history";
 import type { GeoScanActivityProps } from "@/types/geo-scan-activity";
-import { geoRunProgress } from "@/utils/geo-scan-activity";
 
 export function ScanActivity({ organizationId }: GeoScanActivityProps) {
   const [expanded, setExpanded] = useState(false);
@@ -22,8 +17,6 @@ export function ScanActivity({ organizationId }: GeoScanActivityProps) {
   const isScanning = useIsGeoScanning(organizationId);
   const latest = useGeoScanRuns(organizationId);
   const newest = latest.data?.runs[0];
-  const running = newest?.status === "running";
-  const progress = newest ? geoRunProgress(newest) : null;
 
   if (!newest && !isScanning) {
     return null;
@@ -44,46 +37,7 @@ export function ScanActivity({ organizationId }: GeoScanActivityProps) {
         }}
         className="focus-visible:ring-ring hover:bg-muted/60 flex min-h-12 w-full flex-wrap items-center gap-2 rounded-lg px-3 py-2 text-left text-xs outline-none focus-visible:ring-2"
       >
-        <span
-          className={
-            newest?.status === "completed"
-              ? "bg-success/15 text-success flex size-6 shrink-0 items-center justify-center rounded-full shadow-[inset_0_1px_2px_oklch(0_0_0/0.18)]"
-              : "flex size-6 shrink-0 items-center justify-center rounded-full"
-          }
-        >
-          {running || !newest ? (
-            <HugeiconsIcon
-              aria-hidden="true"
-              className="text-primary motion-safe:animate-spin"
-              icon={Loading03Icon}
-              size={14}
-            />
-          ) : (
-            <HugeiconsIcon
-              aria-hidden="true"
-              icon={newest.status === "completed" ? Tick02Icon : MinusSignIcon}
-              size={14}
-            />
-          )}
-        </span>
-        <span className="font-medium">
-          {running || !newest ? "Scanning" : null}
-          {newest?.status === "completed" ? "Scan complete" : null}
-          {newest?.status === "failed" ? "Scan stopped" : null}
-        </span>
-        <span className="text-muted-foreground tabular-nums">
-          {newest
-            ? `${newest.checks}${newest.plan ? ` / ${newest.plan.totalChecks}` : ""} answers saved`
-            : "Preparing scan…"}
-        </span>
-        {running && progress !== null ? (
-          <progress
-            aria-label="Saved scan answers"
-            className="bg-border [&::-moz-progress-bar]:bg-primary [&::-webkit-progress-bar]:bg-border [&::-webkit-progress-value]:bg-primary ml-1 h-1 w-20 overflow-hidden rounded-full"
-            max={100}
-            value={progress}
-          />
-        ) : null}
+        <ScanActivityStatus run={newest} />
         <HugeiconsIcon
           aria-hidden="true"
           icon={ArrowRight01Icon}

--- a/apps/dashboard/src/components/geo/scan-answer-sheet.tsx
+++ b/apps/dashboard/src/components/geo/scan-answer-sheet.tsx
@@ -20,8 +20,12 @@ import { PromptReceiptViewSwitch } from "@/components/geo/prompt-receipt-view-sw
 import { GEO_PROMPT_DEFAULT_FILTERS } from "@/constants/geo-prompts";
 import { useGeoPromptResultDetail } from "@/lib/hooks/use-geo";
 import { useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
-import type { GeoScanAnswerProps } from "@/types/geo-scan-activity";
+import type {
+  GeoScanAnswerProps,
+  GeoScanAnswerContentProps,
+} from "@/types/geo-scan-activity";
 import { formatEngineWithMode } from "@/utils/geo-charts";
+import { geoPromptDetailState } from "@/utils/geo-prompt-detail";
 import { buildPromptTableRows } from "@/utils/geo-prompts";
 
 const AnswerThread = dynamic(() =>
@@ -29,6 +33,30 @@ const AnswerThread = dynamic(() =>
     (module) => module.GeoPromptAnswerThread
   )
 );
+
+function ScanAnswerContent({
+  state,
+  view,
+  onRetry,
+}: GeoScanAnswerContentProps) {
+  if (state.status !== "ready") {
+    return <PromptDetailStatus status={state.status} onRetry={onRetry} />;
+  }
+  const { result } = state;
+  if (view === "raw") {
+    return <AnswerThread prompt={result.prompt} result={result} />;
+  }
+  return (
+    <PromptReceiptAnalysis
+      history={[]}
+      isHistoryLoading={false}
+      onSelectCheck={() => {}}
+      prompt={result.prompt}
+      result={result}
+      showHistory={false}
+    />
+  );
+}
 
 export function ScanAnswerSheet({
   organizationId,
@@ -101,43 +129,13 @@ export function ScanAnswerSheet({
             </div>
           ) : null}
         </SheetHeader>
-        {detail.isPending ? (
-          <PromptDetailStatus
-            onRetry={() => {
-              void detail.refetch();
-            }}
-            status="loading"
-          />
-        ) : null}
-        {detail.isError ? (
-          <PromptDetailStatus
-            onRetry={() => {
-              void detail.refetch();
-            }}
-            status="error"
-          />
-        ) : null}
-        {!detail.isPending && !detail.isError && !result ? (
-          <PromptDetailStatus
-            onRetry={() => {
-              void detail.refetch();
-            }}
-            status="missing"
-          />
-        ) : null}
-        {result && view === "analysis" ? (
-          <PromptReceiptAnalysis
-            history={[]}
-            isHistoryLoading={false}
-            onSelectCheck={() => {}}
-            prompt={result.prompt}
-            result={result}
-            showHistory={false}
-          />
-        ) : null}
-        {result && view === "raw" ? (
-          <AnswerThread prompt={result.prompt} result={result} />
-        ) : null}
+        <ScanAnswerContent
+          state={geoPromptDetailState(checkId, detail.data, detail.isError)}
+          view={view}
+          onRetry={() => {
+            void detail.refetch();
+          }}
+        />
       </SheetContent>
     </Sheet>
   );

--- a/apps/dashboard/src/components/geo/scan-answer-sheet.tsx
+++ b/apps/dashboard/src/components/geo/scan-answer-sheet.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import type { GeoPromptReceiptView } from "@notra/geo-core/types/geo";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@notra/ui/components/ui/sheet";
+import dynamic from "next/dynamic";
+import { useState } from "react";
+
+import { EngineIcon } from "@/components/geo/engine-icon";
+import { PromptCopyButton } from "@/components/geo/prompt-copy-button";
+import { PromptDetailDialog } from "@/components/geo/prompt-detail-dialog";
+import { PromptDetailStatus } from "@/components/geo/prompt-detail-status";
+import { PromptReceiptAnalysis } from "@/components/geo/prompt-receipt-analysis";
+import { PromptReceiptViewSwitch } from "@/components/geo/prompt-receipt-view-switch";
+import { GEO_PROMPT_DEFAULT_FILTERS } from "@/constants/geo-prompts";
+import { useGeoPromptResultDetail } from "@/lib/hooks/use-geo";
+import { useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
+import type { GeoScanAnswerProps } from "@/types/geo-scan-activity";
+import { formatEngineWithMode } from "@/utils/geo-charts";
+import { buildPromptTableRows } from "@/utils/geo-prompts";
+
+const AnswerThread = dynamic(() =>
+  import("@/components/geo/geo-prompt-answer-thread").then(
+    (module) => module.GeoPromptAnswerThread
+  )
+);
+
+export function ScanAnswerSheet({
+  organizationId,
+  checkId,
+  onClose,
+  scanId,
+  initialLanguage,
+}: GeoScanAnswerProps) {
+  const [view, setView] = useState<GeoPromptReceiptView>("analysis");
+  const detail = useGeoPromptResultDetail(organizationId, checkId);
+  const result = detail.data?.result;
+  const { prompts } = useGeoPromptsDb(organizationId);
+  const row =
+    result && checkId
+      ? buildPromptTableRows(
+          prompts,
+          [{ ...result, checkId }],
+          GEO_PROMPT_DEFAULT_FILTERS
+        ).find((item) =>
+          item.results.some((answer) => answer.promptId === result.promptId)
+        )
+      : undefined;
+
+  if (row) {
+    return (
+      <PromptDetailDialog
+        initialEngine={result?.engine}
+        initialLanguage={initialLanguage}
+        scanId={scanId}
+        onOpenChange={(open) => {
+          if (!open) {
+            onClose();
+          }
+        }}
+        open={checkId !== null}
+        organizationId={organizationId}
+        row={{ ...row, prompt: result?.prompt ?? row.prompt }}
+      />
+    );
+  }
+
+  return (
+    <Sheet
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+      open={checkId !== null}
+    >
+      <SheetContent className="gap-0 overflow-hidden p-0 data-[side=right]:w-full data-[side=right]:sm:max-w-3xl">
+        <SheetHeader className="shrink-0 gap-3 border-b p-4">
+          <SheetTitle className="min-w-0 pr-8 text-sm leading-5 font-medium">
+            {result ? (
+              <PromptCopyButton prompt={result.prompt} />
+            ) : (
+              "Scan answer"
+            )}
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            Saved prompt result from this scan
+          </SheetDescription>
+          {result ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span className="flex items-center gap-2 text-sm">
+                <EngineIcon className="size-4" engine={result.engine} />
+                {formatEngineWithMode(result.engine)}
+              </span>
+              <PromptReceiptViewSwitch onChange={setView} view={view} />
+            </div>
+          ) : null}
+        </SheetHeader>
+        {detail.isPending ? (
+          <PromptDetailStatus
+            onRetry={() => {
+              void detail.refetch();
+            }}
+            status="loading"
+          />
+        ) : null}
+        {detail.isError ? (
+          <PromptDetailStatus
+            onRetry={() => {
+              void detail.refetch();
+            }}
+            status="error"
+          />
+        ) : null}
+        {!detail.isPending && !detail.isError && !result ? (
+          <PromptDetailStatus
+            onRetry={() => {
+              void detail.refetch();
+            }}
+            status="missing"
+          />
+        ) : null}
+        {result && view === "analysis" ? (
+          <PromptReceiptAnalysis
+            history={[]}
+            isHistoryLoading={false}
+            onSelectCheck={() => {}}
+            prompt={result.prompt}
+            result={result}
+            showHistory={false}
+          />
+        ) : null}
+        {result && view === "raw" ? (
+          <AnswerThread prompt={result.prompt} result={result} />
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/dashboard/src/components/geo/scan-answer-sheet.tsx
+++ b/apps/dashboard/src/components/geo/scan-answer-sheet.tsx
@@ -8,55 +8,20 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@notra/ui/components/ui/sheet";
-import dynamic from "next/dynamic";
 import { useState } from "react";
 
 import { EngineIcon } from "@/components/geo/engine-icon";
+import { PromptAnswerContent } from "@/components/geo/prompt-answer-content";
 import { PromptCopyButton } from "@/components/geo/prompt-copy-button";
 import { PromptDetailDialog } from "@/components/geo/prompt-detail-dialog";
-import { PromptDetailStatus } from "@/components/geo/prompt-detail-status";
-import { PromptReceiptAnalysis } from "@/components/geo/prompt-receipt-analysis";
 import { PromptReceiptViewSwitch } from "@/components/geo/prompt-receipt-view-switch";
 import { GEO_PROMPT_DEFAULT_FILTERS } from "@/constants/geo-prompts";
 import { useGeoPromptResultDetail } from "@/lib/hooks/use-geo";
 import { useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
-import type {
-  GeoScanAnswerProps,
-  GeoScanAnswerContentProps,
-} from "@/types/geo-scan-activity";
+import type { GeoScanAnswerProps } from "@/types/geo-scan-activity";
 import { formatEngineWithMode } from "@/utils/geo-charts";
 import { geoPromptDetailState } from "@/utils/geo-prompt-detail";
 import { buildPromptTableRows } from "@/utils/geo-prompts";
-
-const AnswerThread = dynamic(() =>
-  import("@/components/geo/geo-prompt-answer-thread").then(
-    (module) => module.GeoPromptAnswerThread
-  )
-);
-
-function ScanAnswerContent({
-  state,
-  view,
-  onRetry,
-}: GeoScanAnswerContentProps) {
-  if (state.status !== "ready") {
-    return <PromptDetailStatus status={state.status} onRetry={onRetry} />;
-  }
-  const { result } = state;
-  if (view === "raw") {
-    return <AnswerThread prompt={result.prompt} result={result} />;
-  }
-  return (
-    <PromptReceiptAnalysis
-      history={[]}
-      isHistoryLoading={false}
-      onSelectCheck={() => {}}
-      prompt={result.prompt}
-      result={result}
-      showHistory={false}
-    />
-  );
-}
 
 export function ScanAnswerSheet({
   organizationId,
@@ -129,7 +94,10 @@ export function ScanAnswerSheet({
             </div>
           ) : null}
         </SheetHeader>
-        <ScanAnswerContent
+        <PromptAnswerContent
+          history={[]}
+          isHistoryLoading={false}
+          showHistory={false}
           state={geoPromptDetailState(checkId, detail.data, detail.isError)}
           view={view}
           onRetry={() => {

--- a/apps/dashboard/src/components/geo/scan-model-menu.tsx
+++ b/apps/dashboard/src/components/geo/scan-model-menu.tsx
@@ -71,7 +71,7 @@ export function ScanModelMenu({
           <Button
             aria-label={label}
             className="active:scale-100"
-            disabled={disabled || engines.length === 0}
+            disabled={false}
             size={compact ? "icon" : "sm"}
             type="button"
             variant={compact ? "ghost" : variant}

--- a/apps/dashboard/src/components/geo/scan-model-menu.tsx
+++ b/apps/dashboard/src/components/geo/scan-model-menu.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { ArrowDown01Icon, PlayIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@notra/ui/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@notra/ui/components/ui/tooltip";
+import { useState } from "react";
+
+import { Button } from "@/components/button";
+import { EngineIcon } from "@/components/geo/engine-icon";
+import type { GeoScanModelMenuProps } from "@/types/geo-scan-activity";
+import { engineAnswerMode, formatEngineFamily } from "@/utils/geo-charts";
+
+export function ScanModelMenu({
+  engines,
+  disabled,
+  disabledReason,
+  compact,
+  primary,
+  label = "Run scan",
+  onContinue,
+}: GeoScanModelMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [excluded, setExcluded] = useState(() => new Set<string>());
+  const selected = engines.filter((engine) => !excluded.has(engine));
+  const variant = primary ? "default" : "outline";
+
+  if (disabled || engines.length === 0) {
+    return (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              aria-label={label}
+              className="cursor-not-allowed opacity-50"
+              disabled
+              focusableWhenDisabled
+              size={compact ? "icon" : "sm"}
+              variant={compact ? "ghost" : variant}
+            />
+          }
+        >
+          <HugeiconsIcon aria-hidden="true" icon={PlayIcon} size={14} />
+          {compact ? null : label}
+        </TooltipTrigger>
+        <TooltipContent>
+          {disabledReason ??
+            "Add a tracked model in GEO settings to run a scan."}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <DropdownMenu onOpenChange={setOpen} open={open}>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            aria-label={label}
+            className="active:scale-100"
+            disabled={disabled || engines.length === 0}
+            size={compact ? "icon" : "sm"}
+            type="button"
+            variant={compact ? "ghost" : variant}
+          />
+        }
+      >
+        <HugeiconsIcon aria-hidden="true" icon={PlayIcon} size={14} />
+        {compact ? null : (
+          <>
+            {label}
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={ArrowDown01Icon}
+              size={14}
+            />
+          </>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="duration-fast w-72 max-w-[calc(100vw-2rem)] scale-100 opacity-100 transition-[opacity,scale] ease-out data-closed:animate-none data-ending-style:scale-95 data-ending-style:opacity-0 data-open:animate-none data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none"
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Select models</DropdownMenuLabel>
+          {engines.map((engine) => (
+            <DropdownMenuCheckboxItem
+              checked={!excluded.has(engine)}
+              closeOnClick={false}
+              key={engine}
+              onCheckedChange={(checked) =>
+                setExcluded((current) => {
+                  const next = new Set(current);
+                  if (checked) {
+                    next.delete(engine);
+                  } else {
+                    next.add(engine);
+                  }
+                  return next;
+                })
+              }
+            >
+              <EngineIcon className="size-4" engine={engine} />
+              <span className="min-w-0 flex-1 truncate">
+                {formatEngineFamily(engine)}
+              </span>
+              <span className="text-muted-foreground text-xs">
+                {engineAnswerMode(engine)}
+              </span>
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="bg-primary text-primary-foreground focus:bg-primary/90 focus:text-primary-foreground h-7 justify-center rounded-md px-2 py-0 text-xs font-medium"
+          disabled={selected.length === 0}
+          onClick={() => {
+            setOpen(false);
+            onContinue(selected);
+          }}
+        >
+          Continue with {selected.length}{" "}
+          {selected.length === 1 ? "model" : "models"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/dashboard/src/components/geo/scan-preflight-dialog.tsx
+++ b/apps/dashboard/src/components/geo/scan-preflight-dialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { PlayIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
   GEO_SCAN_PREFLIGHT_BODY,
   GEO_SCAN_PREFLIGHT_CANCEL,
@@ -114,18 +116,25 @@ export function ScanPreflightDialog({
   engines,
   languages,
   lastScanAt,
+  prompt,
+  confirmationOnly = false,
 }: ScanPreflightDialogProps) {
-  const selectable = engines.length > 1;
+  const selectable = !confirmationOnly && engines.length > 1;
   const [deselected, setDeselected] = useState<Set<string>>(() => new Set());
   const selected = engines.filter((engine) => !deselected.has(engine));
   const selectedCount = selected.length;
   const canRun = selectedCount > 0;
+  const title = prompt ? "Run prompt scan" : GEO_SCAN_PREFLIGHT_TITLE;
+  const description = prompt
+    ? "Choose one or more tracked models to answer this prompt in your configured languages."
+    : GEO_SCAN_PREFLIGHT_BODY;
 
   const { scanSize, warningSeverity } = useGeoScanEstimate({
     organizationId,
     promptCount,
     engines: selected,
     languages,
+    includeSequences: !prompt,
   });
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -140,7 +149,9 @@ export function ScanPreflightDialog({
       return;
     }
     onConfirm(scanPreflightEnginesToSubmit(engines, new Set(selected)));
-    setDeselected(new Set());
+    if (!prompt) {
+      setDeselected(new Set());
+    }
   };
 
   return (
@@ -148,7 +159,7 @@ export function ScanPreflightDialog({
       <ResponsiveDialogContent className="sm:max-w-md">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle className="flex items-center gap-2">
-            {GEO_SCAN_PREFLIGHT_TITLE}
+            {confirmationOnly ? "Start this scan?" : title}
             {warningSeverity ? (
               <Tooltip>
                 <TooltipTrigger
@@ -173,13 +184,16 @@ export function ScanPreflightDialog({
             ) : null}
           </ResponsiveDialogTitle>
           <ResponsiveDialogDescription>
-            {GEO_SCAN_PREFLIGHT_BODY}
+            {confirmationOnly
+              ? "Review the selected models and scan size before starting."
+              : description}
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
+        {prompt ? <p className="text-sm font-medium">{prompt}</p> : null}
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="bg-muted text-muted-foreground inline-flex items-center rounded-lg px-2 py-1 text-xs tabular-nums">
             {promptCount?.toLocaleString() ?? "—"}{" "}
-            {GEO_SCAN_PREFLIGHT_PROMPTS_LABEL}
+            {promptCount === 1 ? "prompt" : GEO_SCAN_PREFLIGHT_PROMPTS_LABEL}
           </span>
           {languages.map((language) => (
             <span
@@ -258,6 +272,11 @@ export function ScanPreflightDialog({
             </p>
           ) : null}
         </div>
+        {confirmationOnly ? (
+          <p className="text-muted-foreground text-sm">
+            Follow this scan’s progress on the Prompts page.
+          </p>
+        ) : null}
         <ResponsiveDialogFooter>
           <Button
             disabled={isPending}
@@ -268,6 +287,7 @@ export function ScanPreflightDialog({
             {GEO_SCAN_PREFLIGHT_CANCEL}
           </Button>
           <Button disabled={isPending || !canRun} onClick={runScan}>
+            <HugeiconsIcon aria-hidden="true" icon={PlayIcon} size={14} />
             {isPending
               ? GEO_SCAN_PREFLIGHT_PENDING
               : GEO_SCAN_PREFLIGHT_CONFIRM}

--- a/apps/dashboard/src/components/geo/scan-preflight-dialog.tsx
+++ b/apps/dashboard/src/components/geo/scan-preflight-dialog.tsx
@@ -39,6 +39,7 @@ import { LANGUAGE_FLAGS } from "@/constants/language-flags";
 import { useGeoScanEstimate } from "@/lib/hooks/use-geo-scan-estimate";
 import { cn } from "@/lib/utils";
 import type { ScanPreflightDialogProps } from "@/types/geo";
+import type { ScanPreflightHeaderProps } from "@/types/geo-scan-size";
 import { engineAnswerMode, formatEngineFamily } from "@/utils/geo-charts";
 import {
   formatScanPreflightLastScan,
@@ -106,6 +107,51 @@ function ScanPreflightEngineRow({
   );
 }
 
+function ScanPreflightHeader({
+  prompt,
+  confirmationOnly,
+  warningSeverity,
+}: ScanPreflightHeaderProps) {
+  const title = prompt ? "Run prompt scan" : GEO_SCAN_PREFLIGHT_TITLE;
+  const description = prompt
+    ? "Choose one or more tracked models to answer this prompt in your configured languages."
+    : GEO_SCAN_PREFLIGHT_BODY;
+  return (
+    <ResponsiveDialogHeader>
+      <ResponsiveDialogTitle className="flex items-center gap-2">
+        {confirmationOnly ? "Start this scan?" : title}
+        {warningSeverity ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span
+                  aria-label={GEO_SCAN_SIZE_MESSAGES[warningSeverity]}
+                  className={cn(
+                    "inline-flex size-3.5 cursor-help items-center justify-center rounded-full text-[10px] leading-none font-bold",
+                    warningSeverity === "danger"
+                      ? "bg-destructive text-destructive-foreground"
+                      : "bg-warning text-warning-foreground"
+                  )}
+                />
+              }
+            >
+              !
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              {GEO_SCAN_SIZE_MESSAGES[warningSeverity]}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+      </ResponsiveDialogTitle>
+      <ResponsiveDialogDescription>
+        {confirmationOnly
+          ? "Review the selected models and scan size before starting."
+          : description}
+      </ResponsiveDialogDescription>
+    </ResponsiveDialogHeader>
+  );
+}
+
 export function ScanPreflightDialog({
   organizationId,
   open,
@@ -124,10 +170,6 @@ export function ScanPreflightDialog({
   const selected = engines.filter((engine) => !deselected.has(engine));
   const selectedCount = selected.length;
   const canRun = selectedCount > 0;
-  const title = prompt ? "Run prompt scan" : GEO_SCAN_PREFLIGHT_TITLE;
-  const description = prompt
-    ? "Choose one or more tracked models to answer this prompt in your configured languages."
-    : GEO_SCAN_PREFLIGHT_BODY;
 
   const { scanSize, warningSeverity } = useGeoScanEstimate({
     organizationId,
@@ -157,38 +199,11 @@ export function ScanPreflightDialog({
   return (
     <ResponsiveDialog onOpenChange={handleOpenChange} open={open}>
       <ResponsiveDialogContent className="sm:max-w-md">
-        <ResponsiveDialogHeader>
-          <ResponsiveDialogTitle className="flex items-center gap-2">
-            {confirmationOnly ? "Start this scan?" : title}
-            {warningSeverity ? (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <span
-                      aria-label={GEO_SCAN_SIZE_MESSAGES[warningSeverity]}
-                      className={cn(
-                        "inline-flex size-3.5 cursor-help items-center justify-center rounded-full text-[10px] leading-none font-bold",
-                        warningSeverity === "danger"
-                          ? "bg-destructive text-destructive-foreground"
-                          : "bg-warning text-warning-foreground"
-                      )}
-                    />
-                  }
-                >
-                  !
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs">
-                  {GEO_SCAN_SIZE_MESSAGES[warningSeverity]}
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
-          </ResponsiveDialogTitle>
-          <ResponsiveDialogDescription>
-            {confirmationOnly
-              ? "Review the selected models and scan size before starting."
-              : description}
-          </ResponsiveDialogDescription>
-        </ResponsiveDialogHeader>
+        <ScanPreflightHeader
+          prompt={prompt}
+          confirmationOnly={confirmationOnly}
+          warningSeverity={warningSeverity}
+        />
         {prompt ? <p className="text-sm font-medium">{prompt}</p> : null}
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="bg-muted text-muted-foreground inline-flex items-center rounded-lg px-2 py-1 text-xs tabular-nums">

--- a/apps/dashboard/src/components/geo/scan-results-list.tsx
+++ b/apps/dashboard/src/components/geo/scan-results-list.tsx
@@ -1,0 +1,72 @@
+import {
+  ArrowRight01Icon,
+  MinusSignIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Badge } from "@notra/ui/components/ui/badge";
+
+import { EngineIcon } from "@/components/geo/engine-icon";
+import type { GeoScanResultsListProps } from "@/types/geo-scan-activity";
+import { formatEngineWithMode } from "@/utils/geo-charts";
+
+export function ScanResultsList({
+  results,
+  onSelect,
+  footer,
+}: GeoScanResultsListProps) {
+  return (
+    <div>
+      <ul className="divide-y overflow-hidden rounded-lg">
+        {results.map((row) => (
+          <li key={row.id}>
+            <button
+              className="hover:bg-muted/40 focus-visible:ring-ring flex w-full items-center gap-3 p-4 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset"
+              onClick={() => onSelect(row.id)}
+              type="button"
+            >
+              <div className="min-w-0 flex-1 space-y-2">
+                <p className="text-sm font-medium break-words">{row.prompt}</p>
+                <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs">
+                  <span className="inline-flex items-center gap-1.5">
+                    <EngineIcon
+                      className="size-3.5 shrink-0"
+                      engine={row.engine}
+                    />
+                    {formatEngineWithMode(row.engine)}
+                  </span>
+                  <span>
+                    {row.language}
+                    {row.sequenceId ? ` · Turn ${row.turn}` : ""}
+                  </span>
+                  <Badge variant={row.mentioned ? "success" : "secondary"}>
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={row.mentioned ? Tick02Icon : MinusSignIcon}
+                    />
+                    {row.mentioned ? "Mentioned" : "Not mentioned"}
+                  </Badge>
+                  {row.position !== null ? (
+                    <span className="tabular-nums">#{row.position}</span>
+                  ) : null}
+                  {row.sources > 0 ? (
+                    <span className="tabular-nums">
+                      {row.sources} {row.sources === 1 ? "source" : "sources"}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <HugeiconsIcon
+                aria-hidden="true"
+                className="text-muted-foreground shrink-0"
+                icon={ArrowRight01Icon}
+                size={16}
+              />
+            </button>
+          </li>
+        ))}
+      </ul>
+      {footer}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/geo/scan-run-detail.tsx
+++ b/apps/dashboard/src/components/geo/scan-run-detail.tsx
@@ -282,6 +282,7 @@ export function ScanRunDetail({ organizationId, run }: GeoScanRunDetailProps) {
         />
       </div>
       <ScanAnswerSheet
+        key={checkId}
         scanId={run.id}
         initialLanguage={
           data?.results.find((result) => result.id === checkId)?.language

--- a/apps/dashboard/src/components/geo/scan-run-detail.tsx
+++ b/apps/dashboard/src/components/geo/scan-run-detail.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import {
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+  Loading03Icon,
+  Clock01Icon,
+  MinusSignIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { GEO_SCAN_RESULTS_PAGE_SIZE } from "@notra/geo-core/constants/geo-scan-history";
+import { useState } from "react";
+
+import { Button } from "@/components/button";
+import { EngineIcon } from "@/components/geo/engine-icon";
+import { ScanAnswerSheet } from "@/components/geo/scan-answer-sheet";
+import { ScanResultsList } from "@/components/geo/scan-results-list";
+import { ScanRunSummary } from "@/components/geo/scan-run-summary";
+import { useGeoScanRun } from "@/lib/hooks/use-geo-scan-history";
+import type {
+  GeoScanResultsProps,
+  GeoScanRunDetailProps,
+} from "@/types/geo-scan-activity";
+import { formatEngineWithMode } from "@/utils/geo-charts";
+
+function ScanResults({
+  onPendingPageChange,
+  query,
+  running,
+  onSelect,
+  footer,
+}: GeoScanResultsProps) {
+  if (query.isError && !query.data) {
+    return (
+      <div className="space-y-2 py-4">
+        <p className="text-sm" role="alert">
+          Could not load scan results.
+        </p>
+        <Button
+          onClick={() => {
+            void query.refetch();
+          }}
+          size="sm"
+          variant="outline"
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+  if (query.isPending) {
+    return (
+      <p
+        className="text-muted-foreground py-6 text-center text-sm"
+        role="status"
+      >
+        Loading results…
+      </p>
+    );
+  }
+  if (!query.data) {
+    return (
+      <p className="text-muted-foreground py-6 text-center text-sm">
+        This scan is no longer available.
+      </p>
+    );
+  }
+  if (query.data.results.length === 0 && query.data.pending.length === 0) {
+    return (
+      <p
+        className="text-muted-foreground py-6 text-center text-sm"
+        role="status"
+      >
+        {running
+          ? "Waiting for the first answers. Results appear as each batch finishes."
+          : "No saved answers for this selection."}
+      </p>
+    );
+  }
+  return (
+    <>
+      {query.data.pending.length > 0 ? (
+        <ul className="divide-y rounded-lg" aria-label="Pending scan answers">
+          {query.data.pending.map((task) => (
+            <li key={task.key} className="flex items-start gap-3 p-4">
+              <HugeiconsIcon
+                aria-hidden="true"
+                className={
+                  task.status === "running"
+                    ? "text-primary mt-0.5 shrink-0 motion-safe:animate-spin"
+                    : "text-muted-foreground mt-0.5 shrink-0"
+                }
+                icon={
+                  (task.status === "running" && Loading03Icon) ||
+                  (task.status === "queued" && Clock01Icon) ||
+                  MinusSignIcon
+                }
+                size={16}
+              />
+              <div className="min-w-0 space-y-2">
+                <p className="text-sm font-medium break-words">{task.prompt}</p>
+                <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs">
+                  <span className="inline-flex items-center gap-1.5">
+                    <EngineIcon className="size-3.5" engine={task.engine} />
+                    {formatEngineWithMode(task.engine)}
+                  </span>
+                  <span>{task.language}</span>
+                  <span>
+                    {task.status === "running" ? "Generating answer…" : null}
+                    {task.status === "queued" ? "Queued" : null}
+                    {task.status === "failed" ? "No answer saved" : null}
+                  </span>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {query.data.pendingTotal > GEO_SCAN_RESULTS_PAGE_SIZE ? (
+        <nav
+          aria-label="Pending answers pages"
+          className="text-muted-foreground flex items-center justify-end gap-2 px-3 py-2 text-xs"
+        >
+          <Button
+            aria-label="Previous pending answers"
+            disabled={query.data.pendingOffset === 0 || query.isPlaceholderData}
+            onClick={() =>
+              onPendingPageChange(
+                Math.max(
+                  0,
+                  (query.data?.pendingOffset ?? 0) - GEO_SCAN_RESULTS_PAGE_SIZE
+                )
+              )
+            }
+            size="icon-sm"
+            variant="outline"
+          >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={ArrowLeft01Icon}
+              size={14}
+            />
+          </Button>
+          <span className="tabular-nums" aria-live="polite">
+            Pending{" "}
+            {Math.floor(query.data.pendingOffset / GEO_SCAN_RESULTS_PAGE_SIZE) +
+              1}{" "}
+            of {Math.ceil(query.data.pendingTotal / GEO_SCAN_RESULTS_PAGE_SIZE)}
+          </span>
+          <Button
+            aria-label="Next pending answers"
+            disabled={
+              query.data.pendingOffset + GEO_SCAN_RESULTS_PAGE_SIZE >=
+                query.data.pendingTotal || query.isPlaceholderData
+            }
+            onClick={() =>
+              onPendingPageChange(
+                (query.data?.pendingOffset ?? 0) + GEO_SCAN_RESULTS_PAGE_SIZE
+              )
+            }
+            size="icon-sm"
+            variant="outline"
+          >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={ArrowRight01Icon}
+              size={14}
+            />
+          </Button>
+        </nav>
+      ) : null}
+      <ScanResultsList
+        footer={footer}
+        onSelect={onSelect}
+        results={query.data.results}
+      />
+    </>
+  );
+}
+
+export function ScanRunDetail({ organizationId, run }: GeoScanRunDetailProps) {
+  const [pendingOffset, setPendingOffset] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [engine, setEngine] = useState("");
+  const [checkId, setCheckId] = useState<string | null>(null);
+  const query = useGeoScanRun(
+    organizationId,
+    run.id,
+    offset,
+    engine || undefined,
+    pendingOffset
+  );
+  const data = query.data;
+  const running = run.status === "running";
+
+  return (
+    <div className="space-y-3">
+      <ScanRunSummary run={run} updatedAt={query.dataUpdatedAt} />
+      {run.plan && run.plan.engines.length > 1 ? (
+        <div className="flex justify-end">
+          <select
+            aria-label="Filter scan results by model"
+            className="bg-background focus-visible:ring-ring h-8 max-w-full rounded-lg border px-2 text-xs focus-visible:ring-2"
+            onChange={(event) => {
+              setEngine(event.target.value);
+              setOffset(0);
+              setPendingOffset(0);
+            }}
+            value={engine}
+          >
+            <option value="">All models</option>
+            {run.plan.engines.map((item) => (
+              <option key={item} value={item}>
+                {formatEngineWithMode(item)}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+      <div aria-busy={query.isPlaceholderData} className="min-w-0">
+        <ScanResults
+          onPendingPageChange={setPendingOffset}
+          onSelect={setCheckId}
+          query={query}
+          running={running}
+          footer={
+            data && data.total > GEO_SCAN_RESULTS_PAGE_SIZE ? (
+              <div className="text-muted-foreground flex items-center justify-end px-3 py-2 text-xs">
+                <div className="flex items-center gap-2">
+                  <Button
+                    aria-label="Previous results"
+                    disabled={offset === 0 || query.isPlaceholderData}
+                    onClick={() =>
+                      setOffset((current) =>
+                        Math.max(0, current - GEO_SCAN_RESULTS_PAGE_SIZE)
+                      )
+                    }
+                    size="icon-sm"
+                    variant="outline"
+                  >
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={ArrowLeft01Icon}
+                      size={14}
+                    />
+                  </Button>
+                  <span
+                    className="min-w-24 text-center tabular-nums"
+                    aria-live="polite"
+                  >
+                    Page {Math.floor(offset / GEO_SCAN_RESULTS_PAGE_SIZE) + 1}{" "}
+                    of{" "}
+                    {Math.max(
+                      1,
+                      Math.ceil(data.total / GEO_SCAN_RESULTS_PAGE_SIZE)
+                    )}
+                  </span>
+                  <Button
+                    aria-label="Next results"
+                    disabled={
+                      offset + GEO_SCAN_RESULTS_PAGE_SIZE >= data.total ||
+                      query.isPlaceholderData
+                    }
+                    onClick={() =>
+                      setOffset(
+                        (current) => current + GEO_SCAN_RESULTS_PAGE_SIZE
+                      )
+                    }
+                    size="icon-sm"
+                    variant="outline"
+                  >
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={ArrowRight01Icon}
+                      size={14}
+                    />
+                  </Button>
+                </div>
+              </div>
+            ) : null
+          }
+        />
+      </div>
+      <ScanAnswerSheet
+        scanId={run.id}
+        initialLanguage={
+          data?.results.find((result) => result.id === checkId)?.language
+        }
+        checkId={checkId}
+        onClose={() => setCheckId(null)}
+        organizationId={organizationId}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/geo/scan-run-summary.tsx
+++ b/apps/dashboard/src/components/geo/scan-run-summary.tsx
@@ -1,0 +1,16 @@
+import type { GeoScanRunSummaryProps } from "@/types/geo-scan-activity";
+import { geoRunMissingAnswers } from "@/utils/geo-scan-activity";
+
+export function ScanRunSummary({ run }: GeoScanRunSummaryProps) {
+  const missing = geoRunMissingAnswers(run);
+  if (run.status !== "failed" && missing === 0) {
+    return null;
+  }
+  return (
+    <p className="text-warning text-sm" role="status">
+      {run.status === "failed" ? "This scan stopped before finishing. " : ""}
+      {missing > 0 ? `${missing} planned checks have no saved answer. ` : ""}
+      Captured answers are available below.
+    </p>
+  );
+}

--- a/apps/dashboard/src/components/providers/geo-scan-controls-provider.tsx
+++ b/apps/dashboard/src/components/providers/geo-scan-controls-provider.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { createContext, useContext, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { ScanPreflightDialog } from "@/components/geo/scan-preflight-dialog";
+import {
+  useGeoRescanPrompt,
+  useGeoSettings,
+  useGeoStartScan,
+  useIsGeoScanning,
+} from "@/lib/hooks/use-geo";
+import type {
+  GeoScanControls,
+  GeoScanControlsProviderProps,
+  GeoScanRequest,
+} from "@/types/geo-scan-activity";
+
+const GeoScanControlsContext = createContext<GeoScanControls | null>(null);
+
+export function useGeoScanControls() {
+  return useContext(GeoScanControlsContext);
+}
+
+export function GeoScanControlsProvider({
+  organizationId,
+  promptCount,
+  children,
+}: GeoScanControlsProviderProps) {
+  const [request, setRequest] = useState<GeoScanRequest | null>(null);
+  const submitting = useRef(false);
+  const { data } = useGeoSettings(organizationId);
+  const all = useGeoStartScan(organizationId);
+  const single = useGeoRescanPrompt(organizationId);
+  const isScanning = useIsGeoScanning(organizationId);
+  const settings = data?.settings;
+  const controls = useMemo(() => ({ prepare: setRequest }), []);
+
+  async function confirm() {
+    if (!request || isScanning || submitting.current) {
+      return;
+    }
+    submitting.current = true;
+    try {
+      if (request.prompt) {
+        await single.mutateAsync({
+          promptId: request.prompt.id,
+          engines: request.engines,
+        });
+      } else {
+        await all.mutateAsync({ engines: request.engines });
+      }
+      setRequest(null);
+      toast.success("Scan started. Follow its progress on the Prompts page.");
+    } catch {
+      // The mutation reports the error; keep the selection available for retry.
+    } finally {
+      submitting.current = false;
+    }
+  }
+
+  return (
+    <GeoScanControlsContext value={controls}>
+      {children}
+      {request && settings ? (
+        <ScanPreflightDialog
+          confirmationOnly
+          engines={request.engines}
+          isPending={isScanning}
+          languages={settings.languages}
+          lastScanAt={settings.lastScanAt}
+          onConfirm={() => {
+            void confirm();
+          }}
+          onOpenChange={(open) => {
+            if (!open && !all.isPending && !single.isPending) {
+              setRequest(null);
+            }
+          }}
+          open
+          organizationId={organizationId}
+          prompt={request.prompt?.prompt}
+          promptCount={request.prompt ? 1 : promptCount}
+        />
+      ) : null}
+    </GeoScanControlsContext>
+  );
+}

--- a/apps/dashboard/src/components/providers/geo-scan-controls-provider.tsx
+++ b/apps/dashboard/src/components/providers/geo-scan-controls-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { ScanPreflightDialog } from "@/components/geo/scan-preflight-dialog";
@@ -16,10 +16,13 @@ import type {
   GeoScanRequest,
 } from "@/types/geo-scan-activity";
 
-const GeoScanControlsContext = createContext<GeoScanControls | null>(null);
+const GeoScanControlsContext = createContext<GeoScanControls["prepare"] | null>(
+  null
+);
 
 export function useGeoScanControls() {
-  return useContext(GeoScanControlsContext);
+  const prepare = useContext(GeoScanControlsContext);
+  return prepare ? { prepare } : null;
 }
 
 export function GeoScanControlsProvider({
@@ -34,7 +37,6 @@ export function GeoScanControlsProvider({
   const single = useGeoRescanPrompt(organizationId);
   const isScanning = useIsGeoScanning(organizationId);
   const settings = data?.settings;
-  const controls = useMemo(() => ({ prepare: setRequest }), []);
 
   async function confirm() {
     if (!request || isScanning || submitting.current) {
@@ -59,7 +61,7 @@ export function GeoScanControlsProvider({
   }
 
   return (
-    <GeoScanControlsContext value={controls}>
+    <GeoScanControlsContext value={setRequest}>
       {children}
       {request && settings ? (
         <ScanPreflightDialog

--- a/apps/dashboard/src/components/providers/geo-scan-controls-provider.tsx
+++ b/apps/dashboard/src/components/providers/geo-scan-controls-provider.tsx
@@ -54,9 +54,8 @@ export function GeoScanControlsProvider({
       toast.success("Scan started. Follow its progress on the Prompts page.");
     } catch {
       // The mutation reports the error; keep the selection available for retry.
-    } finally {
-      submitting.current = false;
     }
+    submitting.current = false;
   }
 
   return (

--- a/apps/dashboard/src/lib/hooks/use-geo-scan-estimate.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-scan-estimate.ts
@@ -14,12 +14,17 @@ export function useGeoScanEstimate({
   promptCount,
   engines,
   languages,
+  includeSequences = true,
 }: GeoScanEstimateInput) {
   const { data: catalog } = useGeoModelCatalog(organizationId);
   const { sequences, isLoading: sequencesLoading } =
     useGeoSequencesDb(organizationId);
 
-  if (!catalog || sequencesLoading || promptCount === undefined) {
+  if (
+    !catalog ||
+    (includeSequences && sequencesLoading) ||
+    promptCount === undefined
+  ) {
     return { scanSize: null, warningSeverity: null };
   }
 
@@ -28,7 +33,7 @@ export function useGeoScanEstimate({
     engines,
     languages,
     catalog,
-    sequences,
+    sequences: includeSequences ? sequences : [],
   });
   const severity = geoScanSizeSeverity(scanSize);
   const warningSeverity = severity === "ok" ? null : severity;

--- a/apps/dashboard/src/lib/hooks/use-geo-scan-history.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-scan-history.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { GEO_SCAN_POLL_INTERVAL_MS } from "@notra/geo-core/constants/geo";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { useGeoProjectScope } from "@/components/providers/geo-project-provider";
+import { dashboardOrpc } from "@/lib/orpc/query";
+
+export function useGeoScanRuns(
+  organizationId: string,
+  offset = 0,
+  enabled = true
+) {
+  const { projectId } = useGeoProjectScope();
+  return useQuery({
+    ...dashboardOrpc.geo.scanRuns.queryOptions({
+      input: { organizationId, projectId, offset },
+    }),
+    enabled: !!organizationId && enabled,
+    refetchInterval: (query) =>
+      query.state.data?.runs.some((run) => run.status === "running")
+        ? GEO_SCAN_POLL_INTERVAL_MS
+        : false,
+    meta: { errorMessage: "Failed to load recent scans" },
+  });
+}
+
+export function useGeoScanRun(
+  organizationId: string,
+  scanId: string,
+  offset: number,
+  engine?: string,
+  pendingOffset = 0
+) {
+  const { projectId } = useGeoProjectScope();
+  return useQuery({
+    ...dashboardOrpc.geo.scanRun.queryOptions({
+      input: {
+        organizationId,
+        projectId,
+        scanId,
+        offset,
+        engine,
+        pendingOffset,
+      },
+    }),
+    enabled: !!organizationId && !!scanId,
+    placeholderData: keepPreviousData,
+    staleTime: GEO_SCAN_POLL_INTERVAL_MS,
+    refetchInterval: (query) =>
+      query.state.data?.status === "running"
+        ? GEO_SCAN_POLL_INTERVAL_MS
+        : false,
+    meta: { errorMessage: "Failed to load scan results" },
+  });
+}

--- a/apps/dashboard/src/lib/hooks/use-geo-scan-history.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-scan-history.ts
@@ -4,6 +4,7 @@ import { GEO_SCAN_POLL_INTERVAL_MS } from "@notra/geo-core/constants/geo";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import { useGeoProjectScope } from "@/components/providers/geo-project-provider";
+import { useIsGeoScanning } from "@/lib/hooks/use-geo";
 import { dashboardOrpc } from "@/lib/orpc/query";
 
 export function useGeoScanRuns(
@@ -12,12 +13,14 @@ export function useGeoScanRuns(
   enabled = true
 ) {
   const { projectId } = useGeoProjectScope();
+  const isScanning = useIsGeoScanning(organizationId);
   return useQuery({
     ...dashboardOrpc.geo.scanRuns.queryOptions({
       input: { organizationId, projectId, offset },
     }),
     enabled: !!organizationId && enabled,
     refetchInterval: (query) =>
+      isScanning ||
       query.state.data?.runs.some((run) => run.status === "running")
         ? GEO_SCAN_POLL_INTERVAL_MS
         : false,

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -30,6 +30,7 @@ import type {
   GeoIngestSetupResponse,
   GeoPromptHistoryResponse,
   GeoPromptResultSummariesResponse,
+  GeoPromptRescanInput,
   GeoSequenceResultsResponse,
   GeoSettingsResponse,
   GeoSettingsUpsertInput,
@@ -142,6 +143,12 @@ async function invalidatePromptQueries(
 
 async function invalidateGeoScanResultQueries(queryClient: QueryClient) {
   await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: dashboardOrpc.geo.scanRuns.key(),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: dashboardOrpc.geo.scanRun.key(),
+    }),
     queryClient.invalidateQueries({
       queryKey: dashboardOrpc.geo.overview.key(),
     }),
@@ -339,12 +346,17 @@ export function useGeoPromptResultDetail(
 export function useGeoPromptHistory(
   organizationId: string,
   promptId: string,
-  options: { enabled: boolean }
+  options: { enabled: boolean; scanId?: string }
 ) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoPromptHistoryResponse>({
     ...dashboardOrpc.geo.promptHistory.queryOptions({
-      input: { organizationId, projectId, promptId },
+      input: {
+        organizationId,
+        projectId,
+        promptId,
+        ...(options.scanId ? { scanId: options.scanId } : {}),
+      },
     }),
     enabled: options.enabled && !!organizationId && !!promptId,
     meta: { errorMessage: "Failed to load prompt history" },
@@ -655,6 +667,11 @@ export function useGeoStartScan(organizationId: string) {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
+        queryKey: dashboardOrpc.geo.scanRuns.queryKey({
+          input: { organizationId, projectId },
+        }),
+      });
+      await queryClient.invalidateQueries({
         queryKey: dashboardOrpc.geo.settings.queryKey({
           input: { organizationId, projectId },
         }),
@@ -671,13 +688,23 @@ export function useGeoRescanPrompt(organizationId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationKey: geoStartScanMutationKey(organizationId, projectId),
-    mutationFn: (promptId: string) =>
-      dashboardOrpc.geo.rescanPrompt.call({
+    mutationFn: (
+      input: string | Pick<GeoPromptRescanInput, "promptId" | "engines">
+    ) => {
+      const payload = typeof input === "string" ? { promptId: input } : input;
+      return dashboardOrpc.geo.rescanPrompt.call({
         organizationId,
         projectId,
-        promptId,
-      }),
+        promptId: payload.promptId,
+        engines: payload.engines ? [...payload.engines] : undefined,
+      });
+    },
     onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: dashboardOrpc.geo.scanRuns.queryKey({
+          input: { organizationId, projectId },
+        }),
+      });
       await queryClient.invalidateQueries({
         queryKey: dashboardOrpc.geo.settings.queryKey({
           input: { organizationId, projectId },

--- a/apps/dashboard/src/lib/hooks/use-prompt-answer-selection.ts
+++ b/apps/dashboard/src/lib/hooks/use-prompt-answer-selection.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  useGeoPromptHistory,
+  useGeoPromptResultDetail,
+} from "@/lib/hooks/use-geo";
+import type { PromptAnswerSelectionInput } from "@/types/geo-prompt-detail";
+import { geoPromptDetailState } from "@/utils/geo-prompt-detail";
+import {
+  latestPromptResults,
+  promptHistoryForEngine,
+  promptHistoryForScanLanguage,
+} from "@/utils/geo-prompt-history";
+
+export function usePromptAnswerSelection({
+  row,
+  organizationId,
+  open,
+  scanId,
+  initialLanguage,
+  initialEngine,
+}: PromptAnswerSelectionInput) {
+  const [language, setLanguage] = useState(initialLanguage ?? "");
+  const scanPromptId = row.results[0]?.promptId ?? row.id;
+  const history = useGeoPromptHistory(organizationId, scanPromptId, {
+    enabled: open,
+    scanId,
+  });
+  const { languages, selectedLanguage, visibleChecks } =
+    promptHistoryForScanLanguage(history.data?.checks ?? [], scanId, language);
+  const results = latestPromptResults(
+    scanId && history.data ? [] : row.results,
+    visibleChecks,
+    scanPromptId,
+    row.prompt
+  );
+  const engines = results.map((result) => result.engine);
+  const [engine, setEngine] = useState(
+    () =>
+      engines.find((candidate) => candidate === initialEngine) ??
+      engines[0] ??
+      ""
+  );
+  const active =
+    results.find((result) => result.engine === engine) ?? results[0] ?? null;
+  const checkId = open ? (active?.checkId ?? null) : null;
+  const detail = useGeoPromptResultDetail(organizationId, checkId);
+  const detailState = geoPromptDetailState(
+    active?.checkId ?? null,
+    detail.data,
+    detail.isError
+  );
+  const engineHistory = active
+    ? promptHistoryForEngine(visibleChecks, active.engine)
+    : [];
+  const promptText = scanId
+    ? (detail.data?.result?.prompt ?? row.prompt)
+    : row.prompt;
+  return {
+    history,
+    scanPromptId,
+    languages,
+    selectedLanguage,
+    setLanguage,
+    results,
+    engines,
+    engine,
+    setEngine,
+    active,
+    detail,
+    detailState,
+    engineHistory,
+    promptText,
+  };
+}

--- a/apps/dashboard/src/lib/hooks/use-prompt-answer-selection.ts
+++ b/apps/dashboard/src/lib/hooks/use-prompt-answer-selection.ts
@@ -31,18 +31,13 @@ export function usePromptAnswerSelection({
   const { languages, selectedLanguage, visibleChecks } =
     promptHistoryForScanLanguage(history.data?.checks ?? [], scanId, language);
   const results = latestPromptResults(
-    scanId && history.data ? [] : row.results,
+    scanId ? [] : row.results,
     visibleChecks,
     scanPromptId,
     row.prompt
   );
   const engines = results.map((result) => result.engine);
-  const [engine, setEngine] = useState(
-    () =>
-      engines.find((candidate) => candidate === initialEngine) ??
-      engines[0] ??
-      ""
-  );
+  const [engine, setEngine] = useState(initialEngine ?? "");
   const active =
     results.find((result) => result.engine === engine) ?? results[0] ?? null;
   const checkId = open ? (active?.checkId ?? null) : null;
@@ -50,8 +45,16 @@ export function usePromptAnswerSelection({
   const detailState = geoPromptDetailState(
     active?.checkId ?? null,
     detail.data,
-    detail.isError
+    detail.isError,
+    scanId ? history.status : undefined
   );
+  const onRetry = () => {
+    if (scanId && history.isError) {
+      void history.refetch();
+    } else {
+      void detail.refetch();
+    }
+  };
   const engineHistory = active
     ? promptHistoryForEngine(visibleChecks, active.engine)
     : [];
@@ -71,6 +74,7 @@ export function usePromptAnswerSelection({
     active,
     detail,
     detailState,
+    onRetry,
     engineHistory,
     promptText,
   };

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -72,6 +72,7 @@ import {
   loadGeoTrafficLog,
   loadGeoTrafficPages,
   startGeoPromptRescan,
+  loadGeoScanStatus,
   startGeoScan,
   toggleGeoAutoPrompt,
   toggleGeoPrompt,
@@ -94,6 +95,10 @@ import {
   seedGeoSampleData,
 } from "@notra/geo-core/geo/sample-data";
 import { runGeoSequenceNow } from "@notra/geo-core/geo/scan";
+import {
+  loadGeoScanRun,
+  loadGeoScanRuns,
+} from "@notra/geo-core/geo/scan-history";
 import {
   selectGscSiteAndSyncSuggestions,
   syncGscSuggestions,
@@ -143,6 +148,7 @@ import {
   geoPromptHistoryInputSchema,
   geoPromptResultDetailInputSchema,
   geoPromptRescanInputSchema,
+  geoScanStatusInputSchema,
   geoPromptsImportInputSchema,
   geoPromptDeleteInputSchema,
   geoPromptToggleInputSchema,
@@ -165,6 +171,10 @@ import {
   geoWriterPlanInputSchema,
   geoWriterUpdateInputSchema,
 } from "@notra/geo-core/schemas/geo";
+import {
+  geoScanRunInputSchema,
+  geoScanRunsInputSchema,
+} from "@notra/geo-core/schemas/geo-scan-history";
 import { gscSelectSiteInputSchema } from "@notra/geo-core/schemas/google-search-console";
 import { GeoSearchConsoleError } from "@notra/geo-core/schemas/search-console-errors";
 import type {
@@ -1404,6 +1414,15 @@ export const geoRouter = {
   rescanPrompt: authorizedProcedure
     .input(geoPromptRescanInputSchema)
     .handler(geoHandler((input) => startGeoPromptRescan(input))),
+  scanStatus: authorizedProcedure
+    .input(geoScanStatusInputSchema)
+    .handler(geoHandler((input) => loadGeoScanStatus(input, input.scanId))),
+  scanRuns: authorizedProcedure
+    .input(geoScanRunsInputSchema)
+    .handler(geoHandler((input) => loadGeoScanRuns(input))),
+  scanRun: authorizedProcedure
+    .input(geoScanRunInputSchema)
+    .handler(geoHandler((input) => loadGeoScanRun(input))),
   writerGaps: authorizedProcedure
     .input(geoOrganizationInputSchema)
     .handler(geoHandler((input) => loadGeoContentGaps(input))),

--- a/apps/dashboard/src/types/geo-prompt-detail.ts
+++ b/apps/dashboard/src/types/geo-prompt-detail.ts
@@ -6,7 +6,17 @@ import type {
   GeoPromptResult,
 } from "@notra/geo-core/types/geo";
 
-import type { GeoPromptTableRow } from "@/types/geo";
+import type { GeoPromptTableRow, PromptAnswerPageProps } from "@/types/geo";
+
+export type PromptAnswerSelectionInput = Pick<
+  PromptAnswerPageProps,
+  | "row"
+  | "organizationId"
+  | "open"
+  | "scanId"
+  | "initialLanguage"
+  | "initialEngine"
+>;
 
 export interface PromptCopyButtonProps {
   prompt: string;

--- a/apps/dashboard/src/types/geo-prompt-detail.ts
+++ b/apps/dashboard/src/types/geo-prompt-detail.ts
@@ -8,6 +8,10 @@ import type {
 
 import type { GeoPromptTableRow } from "@/types/geo";
 
+export interface PromptCopyButtonProps {
+  prompt: string;
+}
+
 export type GeoPromptDetailState =
   | { status: "ready"; result: GeoPromptResult }
   | { status: "loading" | "error" | "missing" };
@@ -33,6 +37,9 @@ export interface PromptAnswerBodyProps {
 }
 
 export interface PromptAnswerHeaderProps {
+  promptText?: string;
+  onPrepareScan?: () => void;
+  organizationId: string;
   row: GeoPromptTableRow;
   results: readonly GeoPromptResultSummary[];
   active: GeoPromptResultSummary | null;

--- a/apps/dashboard/src/types/geo-scan-activity.ts
+++ b/apps/dashboard/src/types/geo-scan-activity.ts
@@ -1,4 +1,3 @@
-import type { GeoPromptReceiptView } from "@notra/geo-core/types/geo";
 import type {
   GeoScanResultSummary,
   GeoScanRunSummary,
@@ -6,7 +5,6 @@ import type {
 import type { ReactNode } from "react";
 
 import type { useGeoScanRun } from "@/lib/hooks/use-geo-scan-history";
-import type { GeoPromptDetailState } from "@/types/geo-prompt-detail";
 
 export interface GeoScanActivityProps {
   organizationId: string;
@@ -14,12 +12,6 @@ export interface GeoScanActivityProps {
 
 export interface GeoScanActivityStatusProps {
   run: GeoScanRunSummary | undefined;
-}
-
-export interface GeoScanAnswerContentProps {
-  state: GeoPromptDetailState;
-  view: GeoPromptReceiptView;
-  onRetry: () => void;
 }
 
 export interface GeoScanRequest {

--- a/apps/dashboard/src/types/geo-scan-activity.ts
+++ b/apps/dashboard/src/types/geo-scan-activity.ts
@@ -1,0 +1,68 @@
+import type {
+  GeoScanResultSummary,
+  GeoScanRunSummary,
+} from "@notra/geo-core/types/geo-scan-history";
+import type { ReactNode } from "react";
+
+import type { useGeoScanRun } from "@/lib/hooks/use-geo-scan-history";
+
+export interface GeoScanActivityProps {
+  organizationId: string;
+}
+
+export interface GeoScanRequest {
+  engines: string[];
+  prompt?: { id: string; prompt: string };
+}
+
+export interface GeoScanControls {
+  prepare: (request: GeoScanRequest) => void;
+}
+
+export interface GeoScanControlsProviderProps {
+  organizationId: string;
+  promptCount?: number;
+  children: ReactNode;
+}
+
+export interface GeoScanModelMenuProps {
+  disabledReason?: string;
+  engines: readonly string[];
+  disabled?: boolean;
+  compact?: boolean;
+  label?: string;
+  primary?: boolean;
+  onContinue: (engines: string[]) => void;
+}
+
+export interface GeoScanRunDetailProps {
+  organizationId: string;
+  run: GeoScanRunSummary;
+}
+
+export interface GeoScanRunSummaryProps {
+  run: GeoScanRunSummary;
+  updatedAt: number;
+}
+
+export interface GeoScanAnswerProps {
+  scanId: string;
+  initialLanguage?: string;
+  organizationId: string;
+  checkId: string | null;
+  onClose: () => void;
+}
+
+export interface GeoScanResultsListProps {
+  footer?: ReactNode;
+  results: GeoScanResultSummary[];
+  onSelect: (checkId: string) => void;
+}
+
+export interface GeoScanResultsProps {
+  onPendingPageChange: (offset: number) => void;
+  footer?: ReactNode;
+  query: ReturnType<typeof useGeoScanRun>;
+  running: boolean;
+  onSelect: (checkId: string) => void;
+}

--- a/apps/dashboard/src/types/geo-scan-activity.ts
+++ b/apps/dashboard/src/types/geo-scan-activity.ts
@@ -1,3 +1,4 @@
+import type { GeoPromptReceiptView } from "@notra/geo-core/types/geo";
 import type {
   GeoScanResultSummary,
   GeoScanRunSummary,
@@ -5,9 +6,20 @@ import type {
 import type { ReactNode } from "react";
 
 import type { useGeoScanRun } from "@/lib/hooks/use-geo-scan-history";
+import type { GeoPromptDetailState } from "@/types/geo-prompt-detail";
 
 export interface GeoScanActivityProps {
   organizationId: string;
+}
+
+export interface GeoScanActivityStatusProps {
+  run: GeoScanRunSummary | undefined;
+}
+
+export interface GeoScanAnswerContentProps {
+  state: GeoPromptDetailState;
+  view: GeoPromptReceiptView;
+  onRetry: () => void;
 }
 
 export interface GeoScanRequest {

--- a/apps/dashboard/src/types/geo-scan-size.ts
+++ b/apps/dashboard/src/types/geo-scan-size.ts
@@ -1,3 +1,11 @@
+import type { useGeoScanEstimate } from "@/lib/hooks/use-geo-scan-estimate";
+
+export interface ScanPreflightHeaderProps {
+  prompt?: string;
+  confirmationOnly: boolean;
+  warningSeverity: ReturnType<typeof useGeoScanEstimate>["warningSeverity"];
+}
+
 export interface GeoScanEstimateInput {
   organizationId: string;
   promptCount: number | undefined;

--- a/apps/dashboard/src/types/geo-scan-size.ts
+++ b/apps/dashboard/src/types/geo-scan-size.ts
@@ -3,4 +3,5 @@ export interface GeoScanEstimateInput {
   promptCount: number | undefined;
   engines: readonly string[];
   languages: readonly string[];
+  includeSequences?: boolean;
 }

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -921,6 +921,7 @@ export interface GeoTagListProps {
   /** When false, the field still has an accessible name via `label`. */
   labeled?: boolean;
   inputClassName?: string;
+  inline?: boolean;
 }
 
 export interface GeoEnginePickerProps {
@@ -1124,7 +1125,9 @@ export interface CompetitorPromptSummaryStripProps {
 }
 
 export interface ScanPreflightDialogProps {
+  confirmationOnly?: boolean;
   organizationId: string;
+  prompt?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: (engines?: string[]) => void;
@@ -1133,6 +1136,13 @@ export interface ScanPreflightDialogProps {
   engines: readonly string[];
   languages: readonly string[];
   lastScanAt: string | null;
+}
+
+export interface PromptScanButtonProps {
+  organizationId: string;
+  row: GeoPromptTableRow;
+  compact?: boolean;
+  onPrepare?: () => void;
 }
 
 export interface GeoCompetitorDetailPoint {
@@ -1201,6 +1211,8 @@ export interface GeoRemoveDialogProps {
 }
 
 export interface PromptDetailDialogProps {
+  scanId?: string;
+  initialLanguage?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   row: GeoPromptTableRow | null;
@@ -1212,6 +1224,9 @@ export interface PromptDetailDialogProps {
 }
 
 export interface PromptAnswerPageProps {
+  scanId?: string;
+  initialLanguage?: string;
+  onPrepareScan?: () => void;
   row: GeoPromptTableRow;
   open: boolean;
   organizationId: string;
@@ -1253,6 +1268,8 @@ export interface PromptReceiptViewSwitchProps {
 }
 
 export interface PromptReceiptAnalysisProps {
+  scrollable?: boolean;
+  showHistory?: boolean;
   prompt: string;
   result: GeoPromptResult;
   history: GeoPromptHistoryCheck[];
@@ -1278,6 +1295,7 @@ export interface GeoAnswerActionsProps {
 }
 
 export interface GeoPromptAnswerThreadProps {
+  scrollable?: boolean;
   prompt: string;
   result: GeoPromptResult;
 }

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -214,6 +214,13 @@ export interface UseGeoSavedViewsResult {
   removeView: (viewId: string) => void;
 }
 
+export interface PromptTagsActionDialogProps {
+  target: PromptTagsDialogTarget | null;
+  suggestions: string[];
+  onConfirm: (tags: string[]) => void;
+  onClose: () => void;
+}
+
 export interface PromptTagsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;

--- a/apps/dashboard/src/types/geo.ts
+++ b/apps/dashboard/src/types/geo.ts
@@ -65,6 +65,7 @@ import type { Button } from "@/components/button";
 import type { TableColumn } from "@/components/motion/table";
 import type { GeoPromptDetailSurface } from "@/types/analytics/geo-events";
 import type { ChartConfig, ChartSeriesColors } from "@/types/charts";
+import type { GeoPromptDetailState } from "@/types/geo-prompt-detail";
 import type { TablePaginationState } from "@/types/table";
 
 export interface GeoProjectCreateInput {
@@ -1285,6 +1286,16 @@ export interface PromptReceiptAnalysisProps {
   competitors?: readonly GeoCompetitor[];
   /** Opens the answer captured by one scan from the history. */
   onSelectCheck?: (check: GeoPromptHistoryCheck) => void;
+}
+
+export interface PromptAnswerContentProps extends Omit<
+  PromptReceiptAnalysisProps,
+  "result" | "prompt"
+> {
+  state: GeoPromptDetailState;
+  view: GeoPromptReceiptView;
+  onRetry: () => void;
+  prompt?: string;
 }
 
 export interface PromptReceiptHistoryProps {

--- a/apps/dashboard/src/utils/geo-prompt-detail.ts
+++ b/apps/dashboard/src/utils/geo-prompt-detail.ts
@@ -5,8 +5,15 @@ import type { GeoPromptDetailState } from "@/types/geo-prompt-detail";
 export function geoPromptDetailState(
   checkId: string | null,
   data: GeoPromptResultDetailResponse | undefined,
-  isError: boolean
+  isError: boolean,
+  historyStatus?: "pending" | "error" | "success"
 ): GeoPromptDetailState {
+  if (historyStatus === "pending") {
+    return { status: "loading" };
+  }
+  if (historyStatus === "error") {
+    return { status: "error" };
+  }
   if (!checkId) {
     return { status: "missing" };
   }

--- a/apps/dashboard/src/utils/geo-prompt-history.ts
+++ b/apps/dashboard/src/utils/geo-prompt-history.ts
@@ -7,6 +7,7 @@ import {
 import type {
   GeoPromptHistoryCheck,
   GeoPromptResult,
+  GeoPromptResultSummary,
 } from "@notra/geo-core/types/geo";
 
 import type { PromptHistoryChange, PromptHistoryEntry } from "@/types/geo";
@@ -146,6 +147,32 @@ export function promptResultFromHistoryCheck(
     truncated: null,
     lastCheckedAt: check.capturedAt,
   };
+}
+
+export function latestPromptResults(
+  results: readonly GeoPromptResultSummary[],
+  checks: readonly GeoPromptHistoryCheck[],
+  promptId: string,
+  prompt: string
+): GeoPromptResultSummary[] {
+  const latest = new Map(results.map((result) => [result.engine, result]));
+  for (const check of checks) {
+    const previous = latest.get(check.engine);
+    if (!previous || check.capturedAt > previous.lastCheckedAt) {
+      latest.set(check.engine, {
+        checkId: check.id,
+        promptId,
+        prompt,
+        engine: check.engine,
+        mentioned: check.mentioned,
+        position: check.position,
+        sentiment: check.sentiment,
+        competitors: check.competitors,
+        lastCheckedAt: check.capturedAt,
+      });
+    }
+  }
+  return [...latest.values()];
 }
 
 export function promptSentimentLabel(sentiment: string | null): string {

--- a/apps/dashboard/src/utils/geo-prompt-history.ts
+++ b/apps/dashboard/src/utils/geo-prompt-history.ts
@@ -21,6 +21,24 @@ export function promptHistoryForEngine(
     .sort((left, right) => right.capturedAt.localeCompare(left.capturedAt));
 }
 
+export function promptHistoryForScanLanguage(
+  checks: readonly GeoPromptHistoryCheck[],
+  scanId: string | undefined,
+  language: string
+) {
+  const scanChecks = checks.filter(
+    (check) => !scanId || check.scanId === scanId
+  );
+  const languages = [...new Set(scanChecks.map((check) => check.language))];
+  const selectedLanguage = languages.includes(language)
+    ? language
+    : languages[0];
+  const visibleChecks = scanId
+    ? scanChecks.filter((check) => check.language === selectedLanguage)
+    : scanChecks;
+  return { languages, selectedLanguage, visibleChecks };
+}
+
 export function promptPositionLabel(position: number | null): string {
   return position === null
     ? GEO_PROMPT_RECEIPT_LABELS.notRanked

--- a/apps/dashboard/src/utils/geo-scan-activity.ts
+++ b/apps/dashboard/src/utils/geo-scan-activity.ts
@@ -1,0 +1,33 @@
+import type { GeoScanRunSummary } from "@notra/geo-core/types/geo-scan-history";
+
+export function geoRunProgress(run: GeoScanRunSummary) {
+  const total = run.plan?.totalChecks;
+  return total ? Math.min(100, (run.checks / total) * 100) : null;
+}
+
+export function geoRunMissingAnswers(run: GeoScanRunSummary) {
+  return run.status === "running" || run.plan === null
+    ? 0
+    : Math.max(0, run.plan.totalChecks - run.checks);
+}
+
+export function formatGeoRunDuration(
+  startedAt: string,
+  finishedAt: string | null,
+  now: number
+) {
+  const seconds = Math.max(
+    0,
+    Math.floor(
+      ((finishedAt ? Date.parse(finishedAt) : now) - Date.parse(startedAt)) /
+        1000
+    )
+  );
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  if (seconds < 3600) {
+    return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  }
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}

--- a/apps/dashboard/tests/constants/prompt-answer-selection.ts
+++ b/apps/dashboard/tests/constants/prompt-answer-selection.ts
@@ -1,0 +1,45 @@
+import type { GeoPromptHistoryCheck } from "@notra/geo-core/types/geo";
+
+import type { GeoPromptTableRow } from "../../src/types/geo";
+
+export const promptAnswerRow: GeoPromptTableRow = {
+  id: "prompt",
+  prompt: "Which product should I choose?",
+  enabled: true,
+  source: "custom",
+  tags: [],
+  intent: "comparison",
+  mentioned: 0,
+  total: 1,
+  bestPosition: null,
+  presence: null,
+  results: [
+    {
+      promptId: "prompt",
+      prompt: "Which product should I choose?",
+      engine: "openai/gpt-4o-mini",
+      checkId: "unscoped-latest-answer",
+      mentioned: false,
+      position: null,
+      sentiment: null,
+      competitors: [],
+      lastCheckedAt: "2026-09-09T12:00:00.000Z",
+    },
+  ],
+};
+
+export const scopedAnswer: GeoPromptHistoryCheck = {
+  id: "scoped-answer",
+  scanId: "selected-scan",
+  engine: "anthropic/claude-sonnet-4",
+  language: "German",
+  mentioned: false,
+  position: null,
+  sentiment: null,
+  competitors: [],
+  answer: "Eine Antwort.",
+  excerpt: "Eine Antwort.",
+  searchQueries: [],
+  sources: [],
+  capturedAt: "2026-09-08T12:00:00.000Z",
+};

--- a/apps/dashboard/tests/fixtures/prompt-answer-selection.fixture.ts
+++ b/apps/dashboard/tests/fixtures/prompt-answer-selection.fixture.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GeoPromptHistoryCheck } from "@notra/geo-core/types/geo";
+import type { QueryStatus } from "@tanstack/react-query";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { PromptAnswerSelectionInput } from "../../src/types/geo-prompt-detail";
+import {
+  promptAnswerRow,
+  scopedAnswer,
+} from "../constants/prompt-answer-selection";
+
+let status: QueryStatus = "pending";
+let checks: GeoPromptHistoryCheck[] | undefined;
+const retryHistory = mock(async () => {});
+const retryDetail = mock(async () => {});
+const detailQuery = mock(
+  (_organizationId: string, _checkId: string | null) => ({
+    data: undefined,
+    isError: false,
+    refetch: retryDetail,
+  })
+);
+
+mock.module("../../src/lib/hooks/use-geo", () => ({
+  useGeoPromptHistory: () => ({
+    status,
+    isError: status === "error",
+    data: checks ? { checks } : undefined,
+    refetch: retryHistory,
+  }),
+  useGeoPromptResultDetail: detailQuery,
+}));
+const { usePromptAnswerSelection } =
+  await import("../../src/lib/hooks/use-prompt-answer-selection");
+
+function SelectionProbe(props: PromptAnswerSelectionInput) {
+  const selection = usePromptAnswerSelection(props);
+  return createElement(
+    "output",
+    null,
+    JSON.stringify({
+      state: selection.detailState.status,
+      checkId: selection.active?.checkId ?? null,
+      language: selection.selectedLanguage,
+    })
+  );
+}
+
+beforeEach(() => {
+  status = "pending";
+  checks = undefined;
+  detailQuery.mockClear();
+  retryHistory.mockClear();
+  retryDetail.mockClear();
+});
+
+describe("scan-scoped prompt answer selection", () => {
+  test.each(["pending", "error"] as const)(
+    "does not fetch an unscoped answer when history is %s",
+    (nextStatus) => {
+      status = nextStatus;
+      const html = renderToStaticMarkup(
+        createElement(SelectionProbe, {
+          row: promptAnswerRow,
+          organizationId: "org",
+          open: true,
+          scanId: "selected-scan",
+        })
+      );
+      expect(detailQuery).toHaveBeenLastCalledWith("org", null);
+      expect(html).toContain(nextStatus === "pending" ? "loading" : "error");
+      expect(html).not.toContain("unscoped-latest-answer");
+    }
+  );
+
+  test("uses only the selected scan, engine, and language after history loads", () => {
+    status = "success";
+    checks = [
+      { ...scopedAnswer, id: "other-scan", scanId: "other-scan" },
+      { ...scopedAnswer, id: "english", language: "English" },
+      { ...scopedAnswer, id: "other-engine", engine: "openai/gpt-4o-mini" },
+      scopedAnswer,
+    ];
+    const html = renderToStaticMarkup(
+      createElement(SelectionProbe, {
+        row: promptAnswerRow,
+        organizationId: "org",
+        open: true,
+        scanId: "selected-scan",
+        initialEngine: scopedAnswer.engine,
+        initialLanguage: "German",
+      })
+    );
+    expect(detailQuery).toHaveBeenLastCalledWith("org", "scoped-answer");
+    expect(html).toContain("German");
+  });
+
+  test("ordinary prompt history retains its latest-summary fallback", () => {
+    status = "error";
+    renderToStaticMarkup(
+      createElement(SelectionProbe, {
+        row: promptAnswerRow,
+        organizationId: "org",
+        open: true,
+      })
+    );
+    expect(detailQuery).toHaveBeenLastCalledWith(
+      "org",
+      "unscoped-latest-answer"
+    );
+  });
+
+  test("an empty scoped history stays empty instead of using the latest answer", () => {
+    status = "success";
+    checks = [];
+    const html = renderToStaticMarkup(
+      createElement(SelectionProbe, {
+        row: promptAnswerRow,
+        organizationId: "org",
+        open: true,
+        scanId: "selected-scan",
+      })
+    );
+    expect(detailQuery).toHaveBeenLastCalledWith("org", null);
+    expect(html).toContain("missing");
+  });
+});

--- a/apps/dashboard/tests/geo-scan-workflow.test.ts
+++ b/apps/dashboard/tests/geo-scan-workflow.test.ts
@@ -202,12 +202,14 @@ describe("GEO scan workflow orchestration", () => {
       scanId: "pending-scan",
       claimedAt: plan.claimedAt,
       promptIds: ["prompt-0"],
+      engines: ["openai/gpt-4.1"],
     };
     const result = await geoScanWorkflow(payload);
     expect(prepare).toHaveBeenCalledWith("org-test", "project-test", {
       scanId: "pending-scan",
       claimedAt: plan.claimedAt,
       promptIds: ["prompt-0"],
+      engines: ["openai/gpt-4.1"],
       retried: false,
     });
     expect(taskBatch.mock.calls.map(([, batch]) => batch.length)).toEqual([
@@ -436,6 +438,7 @@ describe("GEO scan workflow orchestration", () => {
         claimedAt: "2026-09-01T00:00:00.000Z",
         scanId: "old-scan",
         promptIds: ["prompt-0"],
+        engines: ["openai/gpt-4.1"],
       })
     ).toEqual({ status: "completed", checks: 2, mentions: 0 });
     expect(sleep).toHaveBeenCalledTimes(1);
@@ -456,6 +459,7 @@ describe("GEO scan workflow orchestration", () => {
     expect(prepare.mock.calls[2]?.[2]).toEqual({
       retried: true,
       promptIds: ["prompt-0"],
+      engines: ["openai/gpt-4.1"],
     });
   });
 

--- a/apps/dashboard/tests/prompt-answer-selection.test.ts
+++ b/apps/dashboard/tests/prompt-answer-selection.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GeoPromptHistoryCheck } from "@notra/geo-core/types/geo";
+import type { QueryStatus } from "@tanstack/react-query";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { PromptAnswerSelectionInput } from "../src/types/geo-prompt-detail";
+import {
+  promptAnswerRow,
+  scopedAnswer,
+} from "./constants/prompt-answer-selection";
+
+let status: QueryStatus = "pending";
+let checks: GeoPromptHistoryCheck[] | undefined;
+const retryHistory = mock(async () => {});
+const retryDetail = mock(async () => {});
+const detailQuery = mock(
+  (_organizationId: string, _checkId: string | null) => ({
+    data: undefined,
+    isError: false,
+    refetch: retryDetail,
+  })
+);
+
+mock.module("../src/lib/hooks/use-geo", () => ({
+  useGeoPromptHistory: () => ({
+    status,
+    isError: status === "error",
+    data: checks ? { checks } : undefined,
+    refetch: retryHistory,
+  }),
+  useGeoPromptResultDetail: detailQuery,
+}));
+const { usePromptAnswerSelection } =
+  await import("../src/lib/hooks/use-prompt-answer-selection");
+
+function SelectionProbe(props: PromptAnswerSelectionInput) {
+  const selection = usePromptAnswerSelection(props);
+  return createElement(
+    "output",
+    null,
+    JSON.stringify({
+      state: selection.detailState.status,
+      checkId: selection.active?.checkId ?? null,
+      language: selection.selectedLanguage,
+    })
+  );
+}
+
+beforeEach(() => {
+  status = "pending";
+  checks = undefined;
+  detailQuery.mockClear();
+  retryHistory.mockClear();
+  retryDetail.mockClear();
+});
+
+describe("scan-scoped prompt answer selection", () => {
+  test.each(["pending", "error"] as const)(
+    "does not fetch an unscoped answer when history is %s",
+    (nextStatus) => {
+      status = nextStatus;
+      const html = renderToStaticMarkup(
+        createElement(SelectionProbe, {
+          row: promptAnswerRow,
+          organizationId: "org",
+          open: true,
+          scanId: "selected-scan",
+        })
+      );
+      expect(detailQuery).toHaveBeenLastCalledWith("org", null);
+      expect(html).toContain(nextStatus === "pending" ? "loading" : "error");
+      expect(html).not.toContain("unscoped-latest-answer");
+    }
+  );
+
+  test("uses only the selected scan, engine, and language after history loads", () => {
+    status = "success";
+    checks = [
+      { ...scopedAnswer, id: "other-scan", scanId: "other-scan" },
+      { ...scopedAnswer, id: "english", language: "English" },
+      { ...scopedAnswer, id: "other-engine", engine: "openai/gpt-4o-mini" },
+      scopedAnswer,
+    ];
+    const html = renderToStaticMarkup(
+      createElement(SelectionProbe, {
+        row: promptAnswerRow,
+        organizationId: "org",
+        open: true,
+        scanId: "selected-scan",
+        initialEngine: scopedAnswer.engine,
+        initialLanguage: "German",
+      })
+    );
+    expect(detailQuery).toHaveBeenLastCalledWith("org", "scoped-answer");
+    expect(html).toContain("German");
+  });
+
+  test("ordinary prompt history retains its latest-summary fallback", () => {
+    status = "error";
+    renderToStaticMarkup(
+      createElement(SelectionProbe, {
+        row: promptAnswerRow,
+        organizationId: "org",
+        open: true,
+      })
+    );
+    expect(detailQuery).toHaveBeenLastCalledWith(
+      "org",
+      "unscoped-latest-answer"
+    );
+  });
+
+  test("an empty scoped history stays empty instead of using the latest answer", () => {
+    status = "success";
+    checks = [];
+    const html = renderToStaticMarkup(
+      createElement(SelectionProbe, {
+        row: promptAnswerRow,
+        organizationId: "org",
+        open: true,
+        scanId: "selected-scan",
+      })
+    );
+    expect(detailQuery).toHaveBeenLastCalledWith("org", null);
+    expect(html).toContain("missing");
+  });
+});

--- a/apps/dashboard/tests/prompt-answer-selection.test.ts
+++ b/apps/dashboard/tests/prompt-answer-selection.test.ts
@@ -1,15 +1,14 @@
 import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 
 test("scan-scoped answer selection in an isolated module registry", () => {
-  const result = Bun.spawnSync({
-    cmd: [
-      process.execPath,
-      "test",
-      "./tests/fixtures/prompt-answer-selection.fixture.ts",
-    ],
-    cwd: new URL("..", import.meta.url).pathname,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  expect(result.exitCode, result.stderr.toString()).toBe(0);
+  const result = spawnSync(
+    process.execPath,
+    ["test", "./tests/fixtures/prompt-answer-selection.fixture.ts"],
+    {
+      cwd: new URL("..", import.meta.url).pathname,
+      encoding: "utf8",
+    }
+  );
+  expect(result.status, result.stderr).toBe(0);
 });

--- a/apps/dashboard/tests/prompt-answer-selection.test.ts
+++ b/apps/dashboard/tests/prompt-answer-selection.test.ts
@@ -1,129 +1,15 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { expect, test } from "bun:test";
 
-import type { GeoPromptHistoryCheck } from "@notra/geo-core/types/geo";
-import type { QueryStatus } from "@tanstack/react-query";
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-
-import type { PromptAnswerSelectionInput } from "../src/types/geo-prompt-detail";
-import {
-  promptAnswerRow,
-  scopedAnswer,
-} from "./constants/prompt-answer-selection";
-
-let status: QueryStatus = "pending";
-let checks: GeoPromptHistoryCheck[] | undefined;
-const retryHistory = mock(async () => {});
-const retryDetail = mock(async () => {});
-const detailQuery = mock(
-  (_organizationId: string, _checkId: string | null) => ({
-    data: undefined,
-    isError: false,
-    refetch: retryDetail,
-  })
-);
-
-mock.module("../src/lib/hooks/use-geo", () => ({
-  useGeoPromptHistory: () => ({
-    status,
-    isError: status === "error",
-    data: checks ? { checks } : undefined,
-    refetch: retryHistory,
-  }),
-  useGeoPromptResultDetail: detailQuery,
-}));
-const { usePromptAnswerSelection } =
-  await import("../src/lib/hooks/use-prompt-answer-selection");
-
-function SelectionProbe(props: PromptAnswerSelectionInput) {
-  const selection = usePromptAnswerSelection(props);
-  return createElement(
-    "output",
-    null,
-    JSON.stringify({
-      state: selection.detailState.status,
-      checkId: selection.active?.checkId ?? null,
-      language: selection.selectedLanguage,
-    })
-  );
-}
-
-beforeEach(() => {
-  status = "pending";
-  checks = undefined;
-  detailQuery.mockClear();
-  retryHistory.mockClear();
-  retryDetail.mockClear();
-});
-
-describe("scan-scoped prompt answer selection", () => {
-  test.each(["pending", "error"] as const)(
-    "does not fetch an unscoped answer when history is %s",
-    (nextStatus) => {
-      status = nextStatus;
-      const html = renderToStaticMarkup(
-        createElement(SelectionProbe, {
-          row: promptAnswerRow,
-          organizationId: "org",
-          open: true,
-          scanId: "selected-scan",
-        })
-      );
-      expect(detailQuery).toHaveBeenLastCalledWith("org", null);
-      expect(html).toContain(nextStatus === "pending" ? "loading" : "error");
-      expect(html).not.toContain("unscoped-latest-answer");
-    }
-  );
-
-  test("uses only the selected scan, engine, and language after history loads", () => {
-    status = "success";
-    checks = [
-      { ...scopedAnswer, id: "other-scan", scanId: "other-scan" },
-      { ...scopedAnswer, id: "english", language: "English" },
-      { ...scopedAnswer, id: "other-engine", engine: "openai/gpt-4o-mini" },
-      scopedAnswer,
-    ];
-    const html = renderToStaticMarkup(
-      createElement(SelectionProbe, {
-        row: promptAnswerRow,
-        organizationId: "org",
-        open: true,
-        scanId: "selected-scan",
-        initialEngine: scopedAnswer.engine,
-        initialLanguage: "German",
-      })
-    );
-    expect(detailQuery).toHaveBeenLastCalledWith("org", "scoped-answer");
-    expect(html).toContain("German");
+test("scan-scoped answer selection in an isolated module registry", () => {
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "test",
+      "./tests/fixtures/prompt-answer-selection.fixture.ts",
+    ],
+    cwd: new URL("..", import.meta.url).pathname,
+    stdout: "pipe",
+    stderr: "pipe",
   });
-
-  test("ordinary prompt history retains its latest-summary fallback", () => {
-    status = "error";
-    renderToStaticMarkup(
-      createElement(SelectionProbe, {
-        row: promptAnswerRow,
-        organizationId: "org",
-        open: true,
-      })
-    );
-    expect(detailQuery).toHaveBeenLastCalledWith(
-      "org",
-      "unscoped-latest-answer"
-    );
-  });
-
-  test("an empty scoped history stays empty instead of using the latest answer", () => {
-    status = "success";
-    checks = [];
-    const html = renderToStaticMarkup(
-      createElement(SelectionProbe, {
-        row: promptAnswerRow,
-        organizationId: "org",
-        open: true,
-        scanId: "selected-scan",
-      })
-    );
-    expect(detailQuery).toHaveBeenLastCalledWith("org", null);
-    expect(html).toContain("missing");
-  });
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
 });

--- a/packages/db/migrations/0083_geo_scan_plan.sql
+++ b/packages/db/migrations/0083_geo_scan_plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "geo_scans" ADD COLUMN "plan" jsonb;

--- a/packages/db/migrations/meta/0083_snapshot.json
+++ b/packages/db/migrations/meta/0083_snapshot.json
@@ -1,0 +1,10888 @@
+{
+  "id": "1da2e5df-7a0b-49b7-9edd-7c7bd73f937d",
+  "prevId": "a01d75ab-137a-4696-9fcd-560c91f7a525",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_feedback": {
+      "name": "agent_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_client": {
+          "name": "agent_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_model": {
+          "name": "agent_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_version": {
+          "name": "tool_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_url": {
+          "name": "context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agentFeedback_organizationId_createdAt_idx": {
+          "name": "agentFeedback_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agentFeedback_organizationId_status_idx": {
+          "name": "agentFeedback_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agentFeedback_projectId_idx": {
+          "name": "agentFeedback_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agentFeedback_organizationId_idempotencyKey_uidx": {
+          "name": "agentFeedback_organizationId_idempotencyKey_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_feedback_organization_id_organizations_id_fk": {
+          "name": "agent_feedback_organization_id_organizations_id_fk",
+          "tableFrom": "agent_feedback",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_feedback_project_id_projects_id_fk": {
+          "name": "agent_feedback_project_id_projects_id_fk",
+          "tableFrom": "agent_feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continuation_token": {
+          "name": "continuation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream_index": {
+          "name": "stream_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agentSessions_eveSessionId_uidx": {
+          "name": "agentSessions_eveSessionId_uidx",
+          "columns": [
+            {
+              "expression": "eve_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agentSessions_organizationId_idx": {
+          "name": "agentSessions_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agentSessions_chatId_idx": {
+          "name": "agentSessions_chatId_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_organization_id_organizations_id_fk": {
+          "name": "agent_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_chat_id_chat_sessions_id_fk": {
+          "name": "agent_sessions_chat_id_chat_sessions_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "chat_sessions",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_actions": {
+      "name": "autonomy_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_name": {
+          "name": "capability_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_version": {
+          "name": "capability_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "autonomy_action_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyActions_organizationId_idx": {
+          "name": "autonomyActions_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyActions_runId_idx": {
+          "name": "autonomyActions_runId_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyActions_org_capability_idempotency_uidx": {
+          "name": "autonomyActions_org_capability_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "capability_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyActions_organizationId_status_idx": {
+          "name": "autonomyActions_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_actions_organization_id_organizations_id_fk": {
+          "name": "autonomy_actions_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_actions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_actions_run_id_autonomy_runs_id_fk": {
+          "name": "autonomy_actions_run_id_autonomy_runs_id_fk",
+          "tableFrom": "autonomy_actions",
+          "tableTo": "autonomy_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_actions_task_id_autonomy_tasks_id_fk": {
+          "name": "autonomy_actions_task_id_autonomy_tasks_id_fk",
+          "tableFrom": "autonomy_actions",
+          "tableTo": "autonomy_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_checkpoints": {
+      "name": "autonomy_checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyCheckpoints_organizationId_idx": {
+          "name": "autonomyCheckpoints_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyCheckpoints_runId_idx": {
+          "name": "autonomyCheckpoints_runId_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_checkpoints_organization_id_organizations_id_fk": {
+          "name": "autonomy_checkpoints_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_checkpoints",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_checkpoints_run_id_autonomy_runs_id_fk": {
+          "name": "autonomy_checkpoints_run_id_autonomy_runs_id_fk",
+          "tableFrom": "autonomy_checkpoints",
+          "tableTo": "autonomy_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_checkpoints_task_id_autonomy_tasks_id_fk": {
+          "name": "autonomy_checkpoints_task_id_autonomy_tasks_id_fk",
+          "tableFrom": "autonomy_checkpoints",
+          "tableTo": "autonomy_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_claims": {
+      "name": "autonomy_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_key": {
+          "name": "claim_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyClaims_scope_claimKey_uidx": {
+          "name": "autonomyClaims_scope_claimKey_uidx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyClaims_expiresAt_idx": {
+          "name": "autonomyClaims_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_claims_organization_id_organizations_id_fk": {
+          "name": "autonomy_claims_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_claims",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_controller_leases": {
+      "name": "autonomy_controller_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyControllerLeases_organizationId_idx": {
+          "name": "autonomyControllerLeases_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_controller_leases_organization_id_organizations_id_fk": {
+          "name": "autonomy_controller_leases_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_controller_leases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_goals": {
+      "name": "autonomy_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mandate_id": {
+          "name": "mandate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "autonomy_goal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "origin_signal_ids": {
+          "name": "origin_signal_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyGoals_organizationId_idx": {
+          "name": "autonomyGoals_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyGoals_mandateId_idx": {
+          "name": "autonomyGoals_mandateId_idx",
+          "columns": [
+            {
+              "expression": "mandate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyGoals_organizationId_status_idx": {
+          "name": "autonomyGoals_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_goals_organization_id_organizations_id_fk": {
+          "name": "autonomy_goals_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_goals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_goals_mandate_id_autonomy_mandates_id_fk": {
+          "name": "autonomy_goals_mandate_id_autonomy_mandates_id_fk",
+          "tableFrom": "autonomy_goals",
+          "tableTo": "autonomy_mandates",
+          "columnsFrom": [
+            "mandate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_mandates": {
+      "name": "autonomy_mandates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "autonomy_mandate_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyMandates_organizationId_idx": {
+          "name": "autonomyMandates_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyMandates_organizationId_name_uidx": {
+          "name": "autonomyMandates_organizationId_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_mandates_organization_id_organizations_id_fk": {
+          "name": "autonomy_mandates_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_mandates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_mandates_created_by_user_id_users_id_fk": {
+          "name": "autonomy_mandates_created_by_user_id_users_id_fk",
+          "tableFrom": "autonomy_mandates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_outbox": {
+      "name": "autonomy_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "autonomy_outbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyOutbox_organizationId_idx": {
+          "name": "autonomyOutbox_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyOutbox_org_destination_dedupeKey_uidx": {
+          "name": "autonomyOutbox_org_destination_dedupeKey_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyOutbox_status_nextAttemptAt_idx": {
+          "name": "autonomyOutbox_status_nextAttemptAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_outbox_organization_id_organizations_id_fk": {
+          "name": "autonomy_outbox_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_outbox",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_outbox_run_id_autonomy_runs_id_fk": {
+          "name": "autonomy_outbox_run_id_autonomy_runs_id_fk",
+          "tableFrom": "autonomy_outbox",
+          "tableTo": "autonomy_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_runs": {
+      "name": "autonomy_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mandate_id": {
+          "name": "mandate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mandate_version": {
+          "name": "mandate_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "autonomy_run_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planner_input_hash": {
+          "name": "planner_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planner_output": {
+          "name": "planner_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "autonomy_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning'"
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyRuns_organizationId_idx": {
+          "name": "autonomyRuns_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyRuns_mandateId_idx": {
+          "name": "autonomyRuns_mandateId_idx",
+          "columns": [
+            {
+              "expression": "mandate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyRuns_goalId_idx": {
+          "name": "autonomyRuns_goalId_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyRuns_organizationId_status_idx": {
+          "name": "autonomyRuns_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_runs_organization_id_organizations_id_fk": {
+          "name": "autonomy_runs_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_runs_mandate_id_autonomy_mandates_id_fk": {
+          "name": "autonomy_runs_mandate_id_autonomy_mandates_id_fk",
+          "tableFrom": "autonomy_runs",
+          "tableTo": "autonomy_mandates",
+          "columnsFrom": [
+            "mandate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_runs_goal_id_autonomy_goals_id_fk": {
+          "name": "autonomy_runs_goal_id_autonomy_goals_id_fk",
+          "tableFrom": "autonomy_runs",
+          "tableTo": "autonomy_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_signals": {
+      "name": "autonomy_signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_hash": {
+          "name": "dedupe_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "autonomy_signal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "coalesced_into_signal_id": {
+          "name": "coalesced_into_signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomySignals_organizationId_idx": {
+          "name": "autonomySignals_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomySignals_organizationId_dedupeHash_uidx": {
+          "name": "autonomySignals_organizationId_dedupeHash_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomySignals_organizationId_status_occurredAt_idx": {
+          "name": "autonomySignals_organizationId_status_occurredAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_signals_organization_id_organizations_id_fk": {
+          "name": "autonomy_signals_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_signals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomySignals_coalescedIntoSignalId_fk": {
+          "name": "autonomySignals_coalescedIntoSignalId_fk",
+          "tableFrom": "autonomy_signals",
+          "tableTo": "autonomy_signals",
+          "columnsFrom": [
+            "coalesced_into_signal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.autonomy_tasks": {
+      "name": "autonomy_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_name": {
+          "name": "capability_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_version": {
+          "name": "capability_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depends_on_task_ids": {
+          "name": "depends_on_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "autonomy_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wait_until": {
+          "name": "wait_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "autonomyTasks_organizationId_idx": {
+          "name": "autonomyTasks_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyTasks_goalId_idx": {
+          "name": "autonomyTasks_goalId_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyTasks_runId_idx": {
+          "name": "autonomyTasks_runId_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "autonomyTasks_organizationId_status_waitUntil_idx": {
+          "name": "autonomyTasks_organizationId_status_waitUntil_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wait_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "autonomy_tasks_organization_id_organizations_id_fk": {
+          "name": "autonomy_tasks_organization_id_organizations_id_fk",
+          "tableFrom": "autonomy_tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_tasks_goal_id_autonomy_goals_id_fk": {
+          "name": "autonomy_tasks_goal_id_autonomy_goals_id_fk",
+          "tableFrom": "autonomy_tasks",
+          "tableTo": "autonomy_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "autonomy_tasks_run_id_autonomy_runs_id_fk": {
+          "name": "autonomy_tasks_run_id_autonomy_runs_id_fk",
+          "tableFrom": "autonomy_tasks",
+          "tableTo": "autonomy_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_assets": {
+      "name": "brand_guideline_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "brand_guideline_asset_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "brand_guideline_asset_variant",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineAssets_guidelineId_idx": {
+          "name": "brandGuidelineAssets_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineAssets_guideline_kind_idx": {
+          "name": "brandGuidelineAssets_guideline_kind_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineAssets_guideline_kind_variant_uidx": {
+          "name": "brandGuidelineAssets_guideline_kind_variant_uidx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_assets_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_assets_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_assets",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_colors": {
+      "name": "brand_guideline_colors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "brand_guideline_color_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "light_value": {
+          "name": "light_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dark_value": {
+          "name": "dark_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineColors_guidelineId_idx": {
+          "name": "brandGuidelineColors_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineColors_guideline_role_idx": {
+          "name": "brandGuidelineColors_guideline_role_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_colors_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_colors_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_colors",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_fonts": {
+      "name": "brand_guideline_fonts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "brand_guideline_font_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_height": {
+          "name": "line_height",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineFonts_guidelineId_idx": {
+          "name": "brandGuidelineFonts_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineFonts_guideline_role_idx": {
+          "name": "brandGuidelineFonts_guideline_role_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_fonts_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_fonts_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_fonts",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_screenshots": {
+      "name": "brand_guideline_screenshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "brand_guideline_screenshot_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_page": {
+          "name": "full_page",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineScreenshots_guidelineId_idx": {
+          "name": "brandGuidelineScreenshots_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineScreenshots_guideline_kind_uidx": {
+          "name": "brandGuidelineScreenshots_guideline_kind_uidx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_screenshots_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_screenshots_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_screenshots",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guideline_tokens": {
+      "name": "brand_guideline_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guideline_id": {
+          "name": "guideline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "brand_guideline_token_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelineTokens_guidelineId_idx": {
+          "name": "brandGuidelineTokens_guidelineId_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelineTokens_guideline_type_idx": {
+          "name": "brandGuidelineTokens_guideline_type_idx",
+          "columns": [
+            {
+              "expression": "guideline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guideline_tokens_guideline_id_brand_guidelines_id_fk": {
+          "name": "brand_guideline_tokens_guideline_id_brand_guidelines_id_fk",
+          "tableFrom": "brand_guideline_tokens",
+          "tableTo": "brand_guidelines",
+          "columnsFrom": [
+            "guideline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_guidelines": {
+      "name": "brand_guidelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "brand_guideline_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "context_dev_meta": {
+          "name": "context_dev_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generation_error": {
+          "name": "last_generation_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandGuidelines_brandSettingsId_uidx": {
+          "name": "brandGuidelines_brandSettingsId_uidx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandGuidelines_status_idx": {
+          "name": "brandGuidelines_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_guidelines_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_guidelines_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_guidelines",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_references": {
+      "name": "brand_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot_key": {
+          "name": "source_snapshot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_captured_at": {
+          "name": "source_captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_document_id": {
+          "name": "supermemory_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_memory_id": {
+          "name": "supermemory_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_synced_at": {
+          "name": "supermemory_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supermemory_last_sync_error": {
+          "name": "supermemory_last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to": {
+          "name": "applicable_to",
+          "type": "applicable_platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['all']::applicable_platform[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandReferences_brandSettingsId_idx": {
+          "name": "brandReferences_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandReferences_brandSettingsId_sourceUrl_idx": {
+          "name": "brandReferences_brandSettingsId_sourceUrl_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_references_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_references_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_references",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_settings": {
+      "name": "brand_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_description": {
+          "name": "company_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone_profile": {
+          "name": "tone_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_tone": {
+          "name": "custom_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'English'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSettings_org_name_uidx": {
+          "name": "brandSettings_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_org_default_uidx": {
+          "name": "brandSettings_org_default_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brand_settings\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSettings_organizationId_idx": {
+          "name": "brandSettings_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_settings_organization_id_organizations_id_fk": {
+          "name": "brand_settings_organization_id_organizations_id_fk",
+          "tableFrom": "brand_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "brandSettings_toneProfile_check": {
+          "name": "brandSettings_toneProfile_check",
+          "value": "\"brand_settings\".\"tone_profile\" IS NULL OR \"brand_settings\".\"tone_profile\" IN ('Conversational', 'Professional', 'Casual', 'Formal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemap_pages": {
+      "name": "brand_sitemap_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sitemap_id": {
+          "name": "sitemap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "brand_sitemap_page_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_ratio": {
+          "name": "text_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_links": {
+          "name": "internal_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_links": {
+          "name": "external_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawled_at": {
+          "name": "crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemapPages_sitemapId_idx": {
+          "name": "brandSitemapPages_sitemapId_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemapPages_sitemap_category_idx": {
+          "name": "brandSitemapPages_sitemap_category_idx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemapPages_sitemap_url_uidx": {
+          "name": "brandSitemapPages_sitemap_url_uidx",
+          "columns": [
+            {
+              "expression": "sitemap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk": {
+          "name": "brand_sitemap_pages_sitemap_id_brand_sitemaps_id_fk",
+          "tableFrom": "brand_sitemap_pages",
+          "tableTo": "brand_sitemaps",
+          "columnsFrom": [
+            "sitemap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_sitemaps": {
+      "name": "brand_sitemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "brand_sitemap_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indexed_pages": {
+          "name": "indexed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_pages": {
+          "name": "failed_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context_dev_meta": {
+          "name": "context_dev_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_started_at": {
+          "name": "last_crawl_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawled_at": {
+          "name": "last_crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_crawl_error": {
+          "name": "last_crawl_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brandSitemaps_brandSettingsId_idx": {
+          "name": "brandSitemaps_brandSettingsId_idx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brandSitemaps_brandSettings_url_uidx": {
+          "name": "brandSitemaps_brandSettings_url_uidx",
+          "columns": [
+            {
+              "expression": "brand_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_sitemaps_brand_settings_id_brand_settings_id_fk": {
+          "name": "brand_sitemaps_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "brand_sitemaps",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_attachments": {
+      "name": "chat_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatAttachments_organizationId_createdAt_idx": {
+          "name": "chatAttachments_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatAttachments_userId_idx": {
+          "name": "chatAttachments_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_attachments_organization_id_organizations_id_fk": {
+          "name": "chat_attachments_organization_id_organizations_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_attachments_user_id_users_id_fk": {
+          "name": "chat_attachments_user_id_users_id_fk",
+          "tableFrom": "chat_attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_attachments_key_unique": {
+          "name": "chat_attachments_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_source": {
+          "name": "external_channel_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_channel_id": {
+          "name": "external_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatSessions_organizationId_idx": {
+          "name": "chatSessions_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_organizationId_deletedAt_idx": {
+          "name": "chatSessions_organizationId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_org_project_idx": {
+          "name": "chatSessions_org_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_org_content_deleted_updated_idx": {
+          "name": "chatSessions_org_content_deleted_updated_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatSessions_org_externalChannel_uidx": {
+          "name": "chatSessions_org_externalChannel_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_sessions\".\"external_channel_source\" IN ('discord', 'slack') AND \"chat_sessions\".\"external_channel_id\" IS NOT NULL AND \"chat_sessions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_sessions_organization_id_organizations_id_fk": {
+          "name": "chat_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_sessions_content_id_posts_id_fk": {
+          "name": "chat_sessions_content_id_posts_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_sessions_project_id_projects_id_fk": {
+          "name": "chat_sessions_project_id_projects_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_social_accounts": {
+      "name": "connected_social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_type": {
+          "name": "verified_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectedSocialAccounts_organizationId_idx": {
+          "name": "connectedSocialAccounts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connectedSocialAccounts_org_provider_account_uidx": {
+          "name": "connectedSocialAccounts_org_provider_account_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connected_social_accounts_organization_id_organizations_id_fk": {
+          "name": "connected_social_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "connected_social_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_trigger_lookback_windows": {
+      "name": "content_trigger_lookback_windows",
+      "schema": "",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "lookback_window",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk": {
+          "name": "content_trigger_lookback_windows_trigger_id_content_triggers_id_fk",
+          "tableFrom": "content_trigger_lookback_windows",
+          "tableTo": "content_triggers",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_triggers": {
+      "name": "content_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Schedule'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_config": {
+          "name": "output_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_hash": {
+          "name": "dedupe_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_publish": {
+          "name": "auto_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentTriggers_organizationId_idx": {
+          "name": "contentTriggers_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contentTriggers_organization_dedupe_uidx": {
+          "name": "contentTriggers_organization_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_triggers_organization_id_organizations_id_fk": {
+          "name": "content_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "content_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_agent_readiness_reports": {
+      "name": "geo_agent_readiness_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_label": {
+          "name": "score_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_breakdown": {
+          "name": "score_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "issues": {
+          "name": "issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "eligible_checks": {
+          "name": "eligible_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoAgentReadinessReports_organizationId_idx": {
+          "name": "geoAgentReadinessReports_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoAgentReadinessReports_projectId_createdAt_idx": {
+          "name": "geoAgentReadinessReports_projectId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoAgentReadinessReports_projectId_running_uidx": {
+          "name": "geoAgentReadinessReports_projectId_running_uidx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"geo_agent_readiness_reports\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_agent_readiness_reports_organization_id_organizations_id_fk": {
+          "name": "geo_agent_readiness_reports_organization_id_organizations_id_fk",
+          "tableFrom": "geo_agent_readiness_reports",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_agent_readiness_reports_project_id_projects_id_fk": {
+          "name": "geo_agent_readiness_reports_project_id_projects_id_fk",
+          "tableFrom": "geo_agent_readiness_reports",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_competitors": {
+      "name": "geo_competitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synonyms": {
+          "name": "synonyms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoCompetitors_organizationId_idx": {
+          "name": "geoCompetitors_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoCompetitors_projectId_idx": {
+          "name": "geoCompetitors_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoCompetitors_projectId_name_uidx": {
+          "name": "geoCompetitors_projectId_name_uidx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_competitors_organization_id_organizations_id_fk": {
+          "name": "geo_competitors_organization_id_organizations_id_fk",
+          "tableFrom": "geo_competitors",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_competitors_project_id_projects_id_fk": {
+          "name": "geo_competitors_project_id_projects_id_fk",
+          "tableFrom": "geo_competitors",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_content_briefs": {
+      "name": "geo_content_briefs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "auto_approved": {
+          "name": "auto_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "humanized": {
+          "name": "humanized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescan_scan_id": {
+          "name": "rescan_scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescan_requested_at": {
+          "name": "rescan_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoContentBriefs_organizationId_createdAt_idx": {
+          "name": "geoContentBriefs_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoContentBriefs_projectId_status_idx": {
+          "name": "geoContentBriefs_projectId_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoContentBriefs_open_source_uidx": {
+          "name": "geoContentBriefs_open_source_uidx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"geo_content_briefs\".\"source_kind\" <> 'manual' AND \"geo_content_briefs\".\"source_id\" IS NOT NULL AND \"geo_content_briefs\".\"status\" IN ('draft', 'approved', 'writing', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_content_briefs_organization_id_organizations_id_fk": {
+          "name": "geo_content_briefs_organization_id_organizations_id_fk",
+          "tableFrom": "geo_content_briefs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_content_briefs_project_id_projects_id_fk": {
+          "name": "geo_content_briefs_project_id_projects_id_fk",
+          "tableFrom": "geo_content_briefs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_content_briefs_brand_settings_id_brand_settings_id_fk": {
+          "name": "geo_content_briefs_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "geo_content_briefs",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "geo_content_briefs_created_by_user_id_users_id_fk": {
+          "name": "geo_content_briefs_created_by_user_id_users_id_fk",
+          "tableFrom": "geo_content_briefs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "geo_content_briefs_collection_id_post_collections_id_fk": {
+          "name": "geo_content_briefs_collection_id_post_collections_id_fk",
+          "tableFrom": "geo_content_briefs",
+          "tableTo": "post_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "geo_content_briefs_post_id_posts_id_fk": {
+          "name": "geo_content_briefs_post_id_posts_id_fk",
+          "tableFrom": "geo_content_briefs",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_mention_checks": {
+      "name": "geo_mention_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn": {
+          "name": "turn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned": {
+          "name": "mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competitors": {
+          "name": "competitors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "grounding": {
+          "name": "grounding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"queries\":[],\"sources\":[]}'::jsonb"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'English'"
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zdr_enforced": {
+          "name": "zdr_enforced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoMentionChecks_organizationId_capturedAt_idx": {
+          "name": "geoMentionChecks_organizationId_capturedAt_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoMentionChecks_projectId_capturedAt_idx": {
+          "name": "geoMentionChecks_projectId_capturedAt_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoMentionChecks_projectEnginePrompt_idx": {
+          "name": "geoMentionChecks_projectEnginePrompt_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "engine",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoMentionChecks_scanId_idx": {
+          "name": "geoMentionChecks_scanId_idx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoMentionChecks_scanEnginePromptTurnLanguage_uidx": {
+          "name": "geoMentionChecks_scanEnginePromptTurnLanguage_uidx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "engine",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_mention_checks_organization_id_organizations_id_fk": {
+          "name": "geo_mention_checks_organization_id_organizations_id_fk",
+          "tableFrom": "geo_mention_checks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_mention_checks_project_id_projects_id_fk": {
+          "name": "geo_mention_checks_project_id_projects_id_fk",
+          "tableFrom": "geo_mention_checks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_mention_checks_scan_id_geo_scans_id_fk": {
+          "name": "geo_mention_checks_scan_id_geo_scans_id_fk",
+          "tableFrom": "geo_mention_checks",
+          "tableTo": "geo_scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_prompt_sequences": {
+      "name": "geo_prompt_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoPromptSequences_organizationId_idx": {
+          "name": "geoPromptSequences_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoPromptSequences_projectId_idx": {
+          "name": "geoPromptSequences_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_prompt_sequences_organization_id_organizations_id_fk": {
+          "name": "geo_prompt_sequences_organization_id_organizations_id_fk",
+          "tableFrom": "geo_prompt_sequences",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_prompt_sequences_project_id_projects_id_fk": {
+          "name": "geo_prompt_sequences_project_id_projects_id_fk",
+          "tableFrom": "geo_prompt_sequences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_prompt_suggestions": {
+      "name": "geo_prompt_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'search_console'"
+        },
+        "source_keywords": {
+          "name": "source_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_prompt_id": {
+          "name": "accepted_prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoPromptSuggestions_organizationId_status_idx": {
+          "name": "geoPromptSuggestions_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoPromptSuggestions_organizationId_prompt_uidx": {
+          "name": "geoPromptSuggestions_organizationId_prompt_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_prompt_suggestions_organization_id_organizations_id_fk": {
+          "name": "geo_prompt_suggestions_organization_id_organizations_id_fk",
+          "tableFrom": "geo_prompt_suggestions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_prompt_suggestions_accepted_prompt_id_geo_prompts_id_fk": {
+          "name": "geo_prompt_suggestions_accepted_prompt_id_geo_prompts_id_fk",
+          "tableFrom": "geo_prompt_suggestions",
+          "tableTo": "geo_prompts",
+          "columnsFrom": [
+            "accepted_prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_prompts": {
+      "name": "geo_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoPrompts_organizationId_idx": {
+          "name": "geoPrompts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoPrompts_projectId_idx": {
+          "name": "geoPrompts_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_prompts_organization_id_organizations_id_fk": {
+          "name": "geo_prompts_organization_id_organizations_id_fk",
+          "tableFrom": "geo_prompts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_prompts_project_id_projects_id_fk": {
+          "name": "geo_prompts_project_id_projects_id_fk",
+          "tableFrom": "geo_prompts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_prospect_reports": {
+      "name": "geo_prospect_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "company_domain": {
+          "name": "company_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility_score": {
+          "name": "visibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prompt_count": {
+          "name": "prompt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoProspectReports_organizationId_idx": {
+          "name": "geoProspectReports_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoProspectReports_shareToken_uidx": {
+          "name": "geoProspectReports_shareToken_uidx",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_prospect_reports_organization_id_organizations_id_fk": {
+          "name": "geo_prospect_reports_organization_id_organizations_id_fk",
+          "tableFrom": "geo_prospect_reports",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_prospect_reports_created_by_user_id_users_id_fk": {
+          "name": "geo_prospect_reports_created_by_user_id_users_id_fk",
+          "tableFrom": "geo_prospect_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_scans": {
+      "name": "geo_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoScans_organizationId_idx": {
+          "name": "geoScans_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoScans_projectId_startedAt_idx": {
+          "name": "geoScans_projectId_startedAt_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_scans_organization_id_organizations_id_fk": {
+          "name": "geo_scans_organization_id_organizations_id_fk",
+          "tableFrom": "geo_scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_scans_project_id_projects_id_fk": {
+          "name": "geo_scans_project_id_projects_id_fk",
+          "tableFrom": "geo_scans",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_settings": {
+      "name": "geo_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "competitors": {
+          "name": "competitors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "conversion_paths": {
+          "name": "conversion_paths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engines": {
+          "name": "engines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_zdr": {
+          "name": "enforce_zdr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "non_zdr_approved_engines": {
+          "name": "non_zdr_approved_engines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "paused_auto_prompt_ids": {
+          "name": "paused_auto_prompt_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "removed_auto_prompt_ids": {
+          "name": "removed_auto_prompt_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scan_interval_hours": {
+          "name": "scan_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "next_scan_at": {
+          "name": "next_scan_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_started_at": {
+          "name": "scan_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_scan_at": {
+          "name": "last_scan_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoSettings_organizationId_idx": {
+          "name": "geoSettings_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoSettings_projectId_uidx": {
+          "name": "geoSettings_projectId_uidx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_settings_organization_id_organizations_id_fk": {
+          "name": "geo_settings_organization_id_organizations_id_fk",
+          "tableFrom": "geo_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_settings_project_id_projects_id_fk": {
+          "name": "geo_settings_project_id_projects_id_fk",
+          "tableFrom": "geo_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.geo_shelf_sources": {
+      "name": "geo_shelf_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placements": {
+          "name": "placements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity": {
+          "name": "opportunity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "geoShelfSources_organizationId_idx": {
+          "name": "geoShelfSources_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoShelfSources_projectId_updatedAt_idx": {
+          "name": "geoShelfSources_projectId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geoShelfSources_projectId_url_uidx": {
+          "name": "geoShelfSources_projectId_url_uidx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geo_shelf_sources_organization_id_organizations_id_fk": {
+          "name": "geo_shelf_sources_organization_id_organizations_id_fk",
+          "tableFrom": "geo_shelf_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_shelf_sources_project_id_projects_id_fk": {
+          "name": "geo_shelf_sources_project_id_projects_id_fk",
+          "tableFrom": "geo_shelf_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "geo_shelf_sources_created_by_user_id_users_id_fk": {
+          "name": "geo_shelf_sources_created_by_user_id_users_id_fk",
+          "tableFrom": "geo_shelf_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_avatar_url": {
+          "name": "account_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubAppInstallations_organizationId_idx": {
+          "name": "githubAppInstallations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubAppInstallations_createdByUserId_idx": {
+          "name": "githubAppInstallations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubAppInstallations_organization_installation_uidx": {
+          "name": "githubAppInstallations_organization_installation_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_users_id_fk": {
+          "name": "github_app_installations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_app_installation_id": {
+          "name": "github_app_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_private": {
+          "name": "github_repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_enabled": {
+          "name": "repository_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "githubIntegrations_organizationId_idx": {
+          "name": "githubIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_createdByUserId_idx": {
+          "name": "githubIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "githubIntegrations_organization_owner_repo_uidx": {
+          "name": "githubIntegrations_organization_owner_repo_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_organization_id_organizations_id_fk": {
+          "name": "github_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_created_by_user_id_users_id_fk": {
+          "name": "github_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_github_app_installation_id_github_app_installations_id_fk": {
+          "name": "github_integrations_github_app_installation_id_github_app_installations_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "github_app_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_search_console_integrations": {
+      "name": "google_search_console_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_account_email": {
+          "name": "google_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disconnecting_at": {
+          "name": "disconnecting_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_queries": {
+          "name": "top_queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "googleSearchConsoleIntegrations_organizationId_uidx": {
+          "name": "googleSearchConsoleIntegrations_organizationId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "googleSearchConsoleIntegrations_createdByUserId_idx": {
+          "name": "googleSearchConsoleIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_search_console_integrations_organization_id_organizations_id_fk": {
+          "name": "google_search_console_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "google_search_console_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_search_console_integrations_created_by_user_id_users_id_fk": {
+          "name": "google_search_console_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "google_search_console_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.granola_integrations": {
+      "name": "granola_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "granolaIntegrations_organizationId_idx": {
+          "name": "granolaIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "granolaIntegrations_createdByUserId_idx": {
+          "name": "granolaIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "granola_integrations_organization_id_organizations_id_fk": {
+          "name": "granola_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "granola_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "granola_integrations_created_by_user_id_users_id_fk": {
+          "name": "granola_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "granola_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_integrations": {
+      "name": "linear_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_id": {
+          "name": "linear_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_team_name": {
+          "name": "linear_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_webhook_secret": {
+          "name": "encrypted_webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linearIntegrations_organizationId_idx": {
+          "name": "linearIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_createdByUserId_idx": {
+          "name": "linearIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linearIntegrations_org_linearOrg_no_team_uidx": {
+          "name": "linearIntegrations_org_linearOrg_no_team_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"linear_integrations\".\"linear_team_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_integrations_organization_id_organizations_id_fk": {
+          "name": "linear_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_integrations_created_by_user_id_users_id_fk": {
+          "name": "linear_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "linear_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_credentials": {
+      "name": "mcp_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_tokens": {
+          "name": "encrypted_tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_client_information": {
+          "name": "encrypted_client_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_authorization_server_information": {
+          "name": "encrypted_authorization_server_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_refresh_at": {
+          "name": "access_token_refresh_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_lease_id": {
+          "name": "refresh_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_lease_expires_at": {
+          "name": "refresh_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpOAuthCredentials_organizationId_idx": {
+          "name": "mcpOAuthCredentials_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthCredentials_connectedByUserId_idx": {
+          "name": "mcpOAuthCredentials_connectedByUserId_idx",
+          "columns": [
+            {
+              "expression": "connected_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_credentials_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_oauth_credentials_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_credentials_organization_id_organizations_id_fk": {
+          "name": "mcp_oauth_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_credentials_connected_by_user_id_users_id_fk": {
+          "name": "mcp_oauth_credentials_connected_by_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpOAuthCredentials_org_server_fk": {
+          "name": "mcpOAuthCredentials_org_server_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcpOAuthCredentials_status_check": {
+          "name": "mcpOAuthCredentials_status_check",
+          "value": "\"mcp_oauth_credentials\".\"status\" IN ('connected', 'refreshing', 'reauth_required')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_pending_authorizations": {
+      "name": "mcp_oauth_pending_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_source_integration_id": {
+          "name": "store_source_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callback_path": {
+          "name": "callback_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_state": {
+          "name": "encrypted_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_code_verifier": {
+          "name": "encrypted_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_client_information": {
+          "name": "encrypted_client_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_authorization_server_information": {
+          "name": "encrypted_authorization_server_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpOAuthPendingAuthorizations_organizationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_userId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_serverIntegrationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_serverIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_idx": {
+          "name": "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpOAuthPendingAuthorizations_expiresAt_idx": {
+          "name": "mcpOAuthPendingAuthorizations_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_pending_authorizations_organization_id_organizations_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_pending_authorizations_user_id_users_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_pending_authorizations_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_oauth_pending_authorizations_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpOAuthPendingAuthorizations_org_server_fk": {
+          "name": "mcpOAuthPendingAuthorizations_org_server_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_fk": {
+          "name": "mcpOAuthPendingAuthorizations_storeSourceIntegrationId_fk",
+          "tableFrom": "mcp_oauth_pending_authorizations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "store_source_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_pending_authorizations_state_hash_unique": {
+          "name": "mcp_oauth_pending_authorizations_state_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_integrations": {
+      "name": "mcp_server_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection'"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_light_url": {
+          "name": "logo_light_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_dark_url": {
+          "name": "logo_dark_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_featured_at": {
+          "name": "store_featured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_source_integration_id": {
+          "name": "store_source_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_status": {
+          "name": "store_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_tool_sync_at": {
+          "name": "last_tool_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_sync_status": {
+          "name": "tool_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "tool_sync_error": {
+          "name": "tool_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_tool_count": {
+          "name": "indexed_tool_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpServerIntegrations_resourceType_idx": {
+          "name": "mcpServerIntegrations_resourceType_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_storeStatus_idx": {
+          "name": "mcpServerIntegrations_storeStatus_idx",
+          "columns": [
+            {
+              "expression": "store_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_organizationId_idx": {
+          "name": "mcpServerIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_createdByUserId_idx": {
+          "name": "mcpServerIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_storeSourceIntegrationId_idx": {
+          "name": "mcpServerIntegrations_storeSourceIntegrationId_idx",
+          "columns": [
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_id_uidx": {
+          "name": "mcpServerIntegrations_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_resourceType_name_uidx": {
+          "name": "mcpServerIntegrations_org_resourceType_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_org_storeSource_uidx": {
+          "name": "mcpServerIntegrations_org_storeSource_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_source_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mcp_server_integrations\".\"store_source_integration_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpServerIntegrations_storeListing_slug_uidx": {
+          "name": "mcpServerIntegrations_storeListing_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mcp_server_integrations\".\"resource_type\" = 'store_listing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_integrations_organization_id_organizations_id_fk": {
+          "name": "mcp_server_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_integrations_created_by_user_id_users_id_fk": {
+          "name": "mcp_server_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpServerIntegrations_storeSourceIntegrationId_fk": {
+          "name": "mcpServerIntegrations_storeSourceIntegrationId_fk",
+          "tableFrom": "mcp_server_integrations",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "store_source_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcpServerIntegrations_authType_check": {
+          "name": "mcpServerIntegrations_authType_check",
+          "value": "\"mcp_server_integrations\".\"auth_type\" IN ('none', 'headers', 'oauth')"
+        },
+        "mcpServerIntegrations_storeStatus_check": {
+          "name": "mcpServerIntegrations_storeStatus_check",
+          "value": "\"mcp_server_integrations\".\"store_status\" IN ('draft', 'pending_review', 'live', 'rejected')"
+        },
+        "mcpServerIntegrations_resourceType_check": {
+          "name": "mcpServerIntegrations_resourceType_check",
+          "value": "\"mcp_server_integrations\".\"resource_type\" IN ('connection', 'store_listing')"
+        },
+        "mcpServerIntegrations_category_check": {
+          "name": "mcpServerIntegrations_category_check",
+          "value": "\"mcp_server_integrations\".\"category\" IS NULL OR \"mcp_server_integrations\".\"category\" IN ('AI', 'Source control', 'Project management', 'Communication', 'Design', 'Notes', 'Deploys', 'Productivity', 'Marketing', 'Publishing')"
+        },
+        "mcpServerIntegrations_resourceState_check": {
+          "name": "mcpServerIntegrations_resourceState_check",
+          "value": "(\n        (\"mcp_server_integrations\".\"resource_type\" = 'store_listing' AND \"mcp_server_integrations\".\"store_source_integration_id\" IS NULL)\n        OR\n        (\"mcp_server_integrations\".\"resource_type\" = 'connection' AND \"mcp_server_integrations\".\"store_status\" = 'draft' AND \"mcp_server_integrations\".\"review_note\" IS NULL AND \"mcp_server_integrations\".\"submitted_at\" IS NULL AND \"mcp_server_integrations\".\"reviewed_at\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_session_tool_activations": {
+      "name": "mcp_session_tool_activations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_tool_index_id": {
+          "name": "mcp_tool_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_query": {
+          "name": "source_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcpSessionToolActivations_session_tool_uidx": {
+          "name": "mcpSessionToolActivations_session_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mcp_tool_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpSessionToolActivations_session_idx": {
+          "name": "mcpSessionToolActivations_session_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpSessionToolActivations_expiresAt_idx": {
+          "name": "mcpSessionToolActivations_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_session_tool_activations_organization_id_organizations_id_fk": {
+          "name": "mcp_session_tool_activations_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk": {
+          "name": "mcp_session_tool_activations_mcp_tool_index_id_mcp_tool_index_id_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "mcp_tool_index",
+          "columnsFrom": [
+            "mcp_tool_index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpSessionToolActivations_org_tool_fk": {
+          "name": "mcpSessionToolActivations_org_tool_fk",
+          "tableFrom": "mcp_session_tool_activations",
+          "tableTo": "mcp_tool_index",
+          "columnsFrom": [
+            "organization_id",
+            "mcp_tool_index_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tool_index": {
+      "name": "mcp_tool_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_integration_id": {
+          "name": "server_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_tool_name": {
+          "name": "server_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_tool_name": {
+          "name": "runtime_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_phrase_present": {
+          "name": "action_phrase_present",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_phrase_past": {
+          "name": "action_phrase_past",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_indexed_at": {
+          "name": "last_indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcpToolIndex_server_tool_uidx": {
+          "name": "mcpToolIndex_server_tool_uidx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_org_id_uidx": {
+          "name": "mcpToolIndex_org_id_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_org_runtime_tool_uidx": {
+          "name": "mcpToolIndex_org_runtime_tool_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_organizationId_status_idx": {
+          "name": "mcpToolIndex_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_serverIntegrationId_status_idx": {
+          "name": "mcpToolIndex_serverIntegrationId_status_idx",
+          "columns": [
+            {
+              "expression": "server_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcpToolIndex_searchText_gin_idx": {
+          "name": "mcpToolIndex_searchText_gin_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"search_text\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_index_organization_id_organizations_id_fk": {
+          "name": "mcp_tool_index_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk": {
+          "name": "mcp_tool_index_server_integration_id_mcp_server_integrations_id_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcpToolIndex_org_server_fk": {
+          "name": "mcpToolIndex_org_server_fk",
+          "tableFrom": "mcp_tool_index",
+          "tableTo": "mcp_server_integrations",
+          "columnsFrom": [
+            "organization_id",
+            "server_integration_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_organizationId_idx": {
+          "name": "members_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_userId_idx": {
+          "name": "members_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_suggestions": {
+      "name": "onboarding_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "onboarding_suggestion_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboardingSuggestions_org_type_idx": {
+          "name": "onboardingSuggestions_org_type_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_suggestions_organization_id_organizations_id_fk": {
+          "name": "onboarding_suggestions_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_suggestions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_notification_settings": {
+      "name": "organization_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_content_creation": {
+          "name": "scheduled_content_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_content_failed": {
+          "name": "scheduled_content_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scheduled_content_skipped": {
+          "name": "scheduled_content_skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary": {
+          "name": "daily_summary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orgNotificationSettings_organizationId_uidx": {
+          "name": "orgNotificationSettings_organizationId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_settings_organization_id_organizations_id_fk": {
+          "name": "organization_notification_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heard_about_notra_source": {
+          "name": "heard_about_notra_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heard_about_notra_other": {
+          "name": "heard_about_notra_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_ingest_token_generation": {
+          "name": "geo_ingest_token_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_ingest_token_generation": {
+          "name": "feedback_ingest_token_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_dismissed": {
+          "name": "onboarding_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_agent_ran": {
+          "name": "onboarding_agent_ran",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_agent_started_at": {
+          "name": "onboarding_agent_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workos_org_id": {
+          "name": "workos_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organizations_slug_uidx": {
+          "name": "organizations_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_workos_org_id_unique": {
+          "name": "organizations_workos_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workos_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_collections": {
+      "name": "post_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "post_collection_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_source": {
+          "name": "name_source",
+          "type": "post_collection_name_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generated'"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_post_count": {
+          "name": "expected_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_post_count": {
+          "name": "completed_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_collections_org_created_at_idx": {
+          "name": "post_collections_org_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_collections_source_idx": {
+          "name": "post_collections_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_collections_org_project_idx": {
+          "name": "post_collections_org_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_collections_chat_source_uidx": {
+          "name": "post_collections_chat_source_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"post_collections\".\"source\" = 'chat' AND \"post_collections\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_collections_organization_id_organizations_id_fk": {
+          "name": "post_collections_organization_id_organizations_id_fk",
+          "tableFrom": "post_collections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_collections_project_id_projects_id_fk": {
+          "name": "post_collections_project_id_projects_id_fk",
+          "tableFrom": "post_collections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_subtype": {
+          "name": "content_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_org_slug_uidx": {
+          "name": "posts_org_slug_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_org_createdAt_id_idx": {
+          "name": "posts_org_createdAt_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_collection_id_idx": {
+          "name": "posts_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_organization_id_organizations_id_fk": {
+          "name": "posts_organization_id_organizations_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_collection_id_post_collections_id_fk": {
+          "name": "posts_collection_id_post_collections_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "post_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_settings_id": {
+          "name": "brand_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_organizationId_idx": {
+          "name": "projects_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organizationId_sample_uidx": {
+          "name": "projects_organizationId_sample_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"is_sample\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_brand_settings_id_brand_settings_id_fk": {
+          "name": "projects_brand_settings_id_brand_settings_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "brand_settings",
+          "columnsFrom": [
+            "brand_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_outputs": {
+      "name": "repository_outputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_type": {
+          "name": "output_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositoryOutputs_repositoryId_idx": {
+          "name": "repositoryOutputs_repositoryId_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositoryOutputs_repository_outputType_uidx": {
+          "name": "repositoryOutputs_repository_outputType_uidx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "output_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_outputs_repository_id_github_integrations_id_fk": {
+          "name": "repository_outputs_repository_id_github_integrations_id_fk",
+          "tableFrom": "repository_outputs",
+          "tableTo": "github_integrations",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skills_organizationId_idx": {
+          "name": "skills_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skills_org_name_uidx": {
+          "name": "skills_org_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_organization_id_organizations_id_fk": {
+          "name": "skills_organization_id_organizations_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_integrations": {
+      "name": "slack_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_bot_user_id": {
+          "name": "slack_bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_channel_ids": {
+          "name": "allowed_channel_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_id": {
+          "name": "notification_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slackIntegrations_organizationId_idx": {
+          "name": "slackIntegrations_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slackIntegrations_createdByUserId_idx": {
+          "name": "slackIntegrations_createdByUserId_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slackIntegrations_teamId_uidx": {
+          "name": "slackIntegrations_teamId_uidx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_integrations_organization_id_organizations_id_fk": {
+          "name": "slack_integrations_organization_id_organizations_id_fk",
+          "tableFrom": "slack_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_integrations_created_by_user_id_users_id_fk": {
+          "name": "slack_integrations_created_by_user_id_users_id_fk",
+          "tableFrom": "slack_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_connections": {
+      "name": "social_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socialConnections_userId_provider_uidx": {
+          "name": "socialConnections_userId_provider_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socialConnections_userId_idx": {
+          "name": "socialConnections_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_connections_user_id_users_id_fk": {
+          "name": "social_connections_user_id_users_id_fk",
+          "tableFrom": "social_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_experiments": {
+      "name": "social_experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hypothesis": {
+          "name": "hypothesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_a_post_id": {
+          "name": "variant_a_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_b_post_id": {
+          "name": "variant_b_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socialExperiments_organizationId_idx": {
+          "name": "socialExperiments_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_experiments_organization_id_organizations_id_fk": {
+          "name": "social_experiments_organization_id_organizations_id_fk",
+          "tableFrom": "social_experiments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_social_accounts": {
+      "name": "tracked_social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_type": {
+          "name": "verified_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trackedSocialAccounts_organizationId_idx": {
+          "name": "trackedSocialAccounts_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trackedSocialAccounts_org_provider_account_uidx": {
+          "name": "trackedSocialAccounts_org_provider_account_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracked_social_accounts_organization_id_organizations_id_fk": {
+          "name": "tracked_social_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "tracked_social_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_personal_data": {
+          "name": "hide_personal_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_agent_stats": {
+          "name": "show_agent_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workos_user_id": {
+          "name": "workos_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_workos_user_id_unique": {
+          "name": "users_workos_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workos_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.applicable_platform": {
+      "name": "applicable_platform",
+      "schema": "public",
+      "values": [
+        "all",
+        "twitter",
+        "linkedin",
+        "blog"
+      ]
+    },
+    "public.autonomy_action_status": {
+      "name": "autonomy_action_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "executing",
+        "succeeded",
+        "failed",
+        "unknown",
+        "compensated",
+        "canceled"
+      ]
+    },
+    "public.autonomy_goal_status": {
+      "name": "autonomy_goal_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "in_progress",
+        "blocked",
+        "completed",
+        "abandoned"
+      ]
+    },
+    "public.autonomy_mandate_status": {
+      "name": "autonomy_mandate_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "revoked"
+      ]
+    },
+    "public.autonomy_outbox_status": {
+      "name": "autonomy_outbox_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attempting",
+        "delivered",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.autonomy_run_status": {
+      "name": "autonomy_run_status",
+      "schema": "public",
+      "values": [
+        "planning",
+        "executing",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.autonomy_run_trigger": {
+      "name": "autonomy_run_trigger",
+      "schema": "public",
+      "values": [
+        "signal",
+        "wake",
+        "manual",
+        "repair"
+      ]
+    },
+    "public.autonomy_signal_status": {
+      "name": "autonomy_signal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "coalesced",
+        "processed",
+        "discarded"
+      ]
+    },
+    "public.autonomy_task_status": {
+      "name": "autonomy_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "running",
+        "waiting",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.brand_guideline_asset_kind": {
+      "name": "brand_guideline_asset_kind",
+      "schema": "public",
+      "values": [
+        "logo",
+        "wordmark"
+      ]
+    },
+    "public.brand_guideline_asset_variant": {
+      "name": "brand_guideline_asset_variant",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark"
+      ]
+    },
+    "public.brand_guideline_color_role": {
+      "name": "brand_guideline_color_role",
+      "schema": "public",
+      "values": [
+        "primary",
+        "secondary",
+        "accent",
+        "background",
+        "foreground",
+        "neutral",
+        "custom"
+      ]
+    },
+    "public.brand_guideline_font_role": {
+      "name": "brand_guideline_font_role",
+      "schema": "public",
+      "values": [
+        "heading",
+        "body",
+        "button",
+        "unknown"
+      ]
+    },
+    "public.brand_guideline_screenshot_kind": {
+      "name": "brand_guideline_screenshot_kind",
+      "schema": "public",
+      "values": [
+        "desktop_hero",
+        "desktop_full_page",
+        "mobile_hero"
+      ]
+    },
+    "public.brand_guideline_status": {
+      "name": "brand_guideline_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "generating",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.brand_guideline_token_type": {
+      "name": "brand_guideline_token_type",
+      "schema": "public",
+      "values": [
+        "spacing",
+        "radius",
+        "shadow",
+        "component",
+        "unknown"
+      ]
+    },
+    "public.brand_sitemap_page_category": {
+      "name": "brand_sitemap_page_category",
+      "schema": "public",
+      "values": [
+        "crawled",
+        "redirect",
+        "queued",
+        "failed"
+      ]
+    },
+    "public.brand_sitemap_status": {
+      "name": "brand_sitemap_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "crawling",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.lookback_window": {
+      "name": "lookback_window",
+      "schema": "public",
+      "values": [
+        "current_day",
+        "yesterday",
+        "last_7_days",
+        "last_14_days",
+        "last_30_days"
+      ]
+    },
+    "public.onboarding_suggestion_type": {
+      "name": "onboarding_suggestion_type",
+      "schema": "public",
+      "values": [
+        "schedule_automation",
+        "event_automation"
+      ]
+    },
+    "public.post_collection_name_source": {
+      "name": "post_collection_name_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user",
+        "backfill"
+      ]
+    },
+    "public.post_collection_source": {
+      "name": "post_collection_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "chat",
+        "schedule",
+        "automation",
+        "api",
+        "backfill"
+      ]
+    },
+    "public.post_status": {
+      "name": "post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.reference_type": {
+      "name": "reference_type",
+      "schema": "public",
+      "values": [
+        "twitter_post",
+        "linkedin_post",
+        "blog_post",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -582,6 +582,13 @@
       "when": 1788693797745,
       "tag": "0082_removed_auto_prompt_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 83,
+      "version": "7",
+      "when": 1788952459860,
+      "tag": "0083_geo_scan_plan",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -33,6 +33,7 @@ import type {
 } from "./types/agent-readiness";
 import type { GeoCheckGrounding } from "./types/geo-checks";
 import type { GeoProspectReportJson } from "./types/geo-prospect-report";
+import type { GeoScanPlanSnapshot } from "./types/geo-scan";
 import type { GeoContentBriefJson } from "./types/geo-writer";
 import type { GoogleSearchConsoleQuery } from "./types/google-search-console";
 
@@ -1621,6 +1622,7 @@ export const geoScans = pgTable(
     status: text("status", { enum: ["running", "completed", "failed"] })
       .notNull()
       .default("running"),
+    plan: jsonb("plan").$type<GeoScanPlanSnapshot>(),
     startedAt: timestamp("started_at").defaultNow().notNull(),
     finishedAt: timestamp("finished_at"),
     createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/packages/db/src/types/geo-checks.ts
+++ b/packages/db/src/types/geo-checks.ts
@@ -89,6 +89,7 @@ export interface GeoCheckPromptResultRow {
 }
 
 export interface GeoCheckPromptHistoryQuery {
+  scanId?: string;
   promptIds: string[];
   limit: number;
 }

--- a/packages/db/src/types/geo-scan.ts
+++ b/packages/db/src/types/geo-scan.ts
@@ -1,0 +1,17 @@
+export interface GeoScanPlanSnapshot {
+  tasks?: GeoScanPlannedAnswer[];
+  taskStates?: Record<string, "running" | "failed">;
+  totalChecks: number;
+  promptCount: number;
+  sequenceCount: number;
+  engines: string[];
+  languages: string[];
+}
+
+export interface GeoScanPlannedAnswer {
+  key: string;
+  promptId: string;
+  prompt: string;
+  engine: string;
+  language: string;
+}

--- a/packages/db/src/types/geo-scan.ts
+++ b/packages/db/src/types/geo-scan.ts
@@ -9,6 +9,8 @@ export interface GeoScanPlanSnapshot {
 }
 
 export interface GeoScanPlannedAnswer {
+  sequenceId?: string;
+  turn?: number;
   key: string;
   promptId: string;
   prompt: string;

--- a/packages/db/src/utils/geo-checks.ts
+++ b/packages/db/src/utils/geo-checks.ts
@@ -403,7 +403,7 @@ export async function queryGeoCheckPromptHistory(
     return [];
   }
 
-  const rows = await db
+  const rowsQuery = db
     .select({
       id: geoMentionChecks.id,
       scanId: geoMentionChecks.scanId,
@@ -424,14 +424,15 @@ export async function queryGeoCheckPromptHistory(
       and(
         mentionFilters(scope, undefined, {
           sequences: "single",
-          englishOnly: true,
+          englishOnly: !query.scanId,
         }),
         inArray(geoMentionChecks.promptId, query.promptIds),
+        query.scanId ? eq(geoMentionChecks.scanId, query.scanId) : undefined,
         eq(geoMentionChecks.turn, 0)
       )
     )
-    .orderBy(desc(geoMentionChecks.capturedAt))
-    .limit(query.limit);
+    .orderBy(desc(geoMentionChecks.capturedAt));
+  const rows = await (query.scanId ? rowsQuery : rowsQuery.limit(query.limit));
 
   return rows.map((row) => ({
     id: row.id,

--- a/packages/geo-core/src/constants/geo-scan-history.ts
+++ b/packages/geo-core/src/constants/geo-scan-history.ts
@@ -1,0 +1,2 @@
+export const GEO_SCAN_RUNS_PAGE_SIZE = 10;
+export const GEO_SCAN_RESULTS_PAGE_SIZE = 5;

--- a/packages/geo-core/src/geo/programs.ts
+++ b/packages/geo-core/src/geo/programs.ts
@@ -12,6 +12,7 @@ import {
   brandSettings,
   geoCompetitors,
   geoPrompts,
+  geoScans,
   geoSettings,
 } from "@notra/db/schema";
 import {
@@ -155,7 +156,7 @@ import {
 } from "./prompts";
 import { startClaimedGeoScanRun } from "./scan-handoff";
 import { nextGeoScanAt } from "./scan-schedule";
-import { claimGeoScanRun } from "./scan-status";
+import { claimGeoScanRun, sweepStaleGeoScanRows } from "./scan-status";
 import { geoTrafficWindowParams } from "./window";
 
 function mergeLegacyCompetitors(
@@ -871,6 +872,7 @@ export const loadGeoPromptHistory = Effect.fn("geo.promptHistory")(function* (
   const rows = yield* geoDb("prompt history query failed", () =>
     queryGeoCheckPromptHistory(geoCheckScope(scope), {
       promptIds: promptHistoryScanIds(input.promptId),
+      scanId: input.scanId,
       limit: GEO_PROMPT_HISTORY_LIMIT,
     })
   );
@@ -1800,5 +1802,42 @@ export const startGeoScan = Effect.fn("geo.startScan")(function* (
 export const startGeoPromptRescan = Effect.fn("geo.rescanPrompt")(function* (
   input: GeoPromptRescanInput
 ) {
-  return yield* startGeoScanScoped(input, [input.promptId]);
+  const { prompts } = yield* listGeoPrompts(input);
+  const prompt = prompts.find(
+    (candidate) =>
+      candidate.enabled &&
+      (candidate.id === input.promptId ||
+        customPromptScanId(candidate.id) === input.promptId)
+  );
+  if (!prompt) {
+    return yield* Effect.fail(
+      new GeoPromptNotFoundError({ promptId: input.promptId })
+    );
+  }
+  return yield* startGeoScanScoped(input, [prompt.id], input.engines);
+});
+
+export const loadGeoScanStatus = Effect.fn("geo.scanStatus")(function* (
+  input: GeoScopeInput,
+  scanId: string
+) {
+  const scope = yield* requireGeoProject(input);
+  yield* sweepStaleGeoScanRows(scope);
+  const scan = yield* geoDb("scan status lookup failed", () =>
+    db.query.geoScans.findFirst({
+      columns: { id: true, status: true, startedAt: true, finishedAt: true },
+      where: and(
+        eq(geoScans.id, scanId),
+        eq(geoScans.projectId, scope.projectId),
+        eq(geoScans.organizationId, scope.organizationId)
+      ),
+    })
+  );
+  return scan
+    ? {
+        ...scan,
+        startedAt: scan.startedAt.toISOString(),
+        finishedAt: scan.finishedAt?.toISOString() ?? null,
+      }
+    : null;
 });

--- a/packages/geo-core/src/geo/scan-history.ts
+++ b/packages/geo-core/src/geo/scan-history.ts
@@ -1,0 +1,199 @@
+import { db } from "@notra/db/drizzle";
+import { geoMentionChecks, geoScans } from "@notra/db/schema";
+import { and, asc, count, desc, eq, inArray, sql } from "drizzle-orm";
+import { Effect } from "effect";
+
+import {
+  GEO_SCAN_RESULTS_PAGE_SIZE,
+  GEO_SCAN_RUNS_PAGE_SIZE,
+} from "../constants/geo-scan-history";
+import type {
+  GeoScanRunInput,
+  GeoScanRunsInput,
+  GeoScanRunSummary,
+} from "../types/geo-scan-history";
+import { geoScanAnswerKey } from "../utils/geo-scan-plan";
+import { geoDb } from "./effect";
+import { requireGeoProject } from "./projects";
+import { sweepStaleGeoScanRows } from "./scan-status";
+
+export const loadGeoScanRuns = Effect.fn("geo.scanRuns")(function* (
+  input: GeoScanRunsInput
+) {
+  const scope = yield* requireGeoProject(input);
+  yield* sweepStaleGeoScanRows(scope);
+  const rows = yield* geoDb("scan history lookup failed", () =>
+    db.query.geoScans.findMany({
+      columns: {
+        id: true,
+        status: true,
+        startedAt: true,
+        finishedAt: true,
+        plan: true,
+      },
+      where: and(
+        eq(geoScans.organizationId, scope.organizationId),
+        eq(geoScans.projectId, scope.projectId)
+      ),
+      orderBy: [desc(geoScans.startedAt), desc(geoScans.id)],
+      limit: GEO_SCAN_RUNS_PAGE_SIZE + 1,
+      offset: input.offset,
+    })
+  );
+  const page = rows.slice(0, GEO_SCAN_RUNS_PAGE_SIZE);
+  const counts =
+    page.length === 0
+      ? []
+      : yield* geoDb("scan counts lookup failed", () =>
+          db
+            .select({
+              scanId: geoMentionChecks.scanId,
+              checks: count(),
+              mentions:
+                sql<number>`count(*) filter (where ${geoMentionChecks.mentioned})`.mapWith(
+                  Number
+                ),
+            })
+            .from(geoMentionChecks)
+            .where(
+              and(
+                eq(geoMentionChecks.organizationId, scope.organizationId),
+                eq(geoMentionChecks.projectId, scope.projectId),
+                inArray(
+                  geoMentionChecks.scanId,
+                  page.map((row) => row.id)
+                )
+              )
+            )
+            .groupBy(geoMentionChecks.scanId)
+        );
+  const countsByScan = new Map(counts.map((row) => [row.scanId, row]));
+  const runs: GeoScanRunSummary[] = page.map((row) => ({
+    ...row,
+    startedAt: row.startedAt.toISOString(),
+    finishedAt: row.finishedAt?.toISOString() ?? null,
+    checks: countsByScan.get(row.id)?.checks ?? 0,
+    mentions: countsByScan.get(row.id)?.mentions ?? 0,
+  }));
+  return { runs, hasMore: rows.length > GEO_SCAN_RUNS_PAGE_SIZE };
+});
+
+export const loadGeoScanRun = Effect.fn("geo.scanRun")(function* (
+  input: GeoScanRunInput
+) {
+  const scope = yield* requireGeoProject(input);
+  yield* sweepStaleGeoScanRows(scope);
+  const scan = yield* geoDb("scan lookup failed", () =>
+    db.query.geoScans.findFirst({
+      columns: { id: true, status: true, plan: true },
+      where: and(
+        eq(geoScans.id, input.scanId),
+        eq(geoScans.organizationId, scope.organizationId),
+        eq(geoScans.projectId, scope.projectId)
+      ),
+    })
+  );
+  if (!scan) {
+    return null;
+  }
+
+  const scopeFilter = and(
+    eq(geoMentionChecks.scanId, scan.id),
+    eq(geoMentionChecks.organizationId, scope.organizationId),
+    eq(geoMentionChecks.projectId, scope.projectId)
+  );
+  const resultFilter = and(
+    scopeFilter,
+    input.engine ? eq(geoMentionChecks.engine, input.engine) : undefined
+  );
+  const [results, totals, sources] = yield* geoDb(
+    "scan results lookup failed",
+    () =>
+      Promise.all([
+        db
+          .select({
+            id: geoMentionChecks.id,
+            prompt: geoMentionChecks.prompt,
+            engine: geoMentionChecks.engine,
+            mentioned: geoMentionChecks.mentioned,
+            position: geoMentionChecks.position,
+            language: geoMentionChecks.language,
+            turn: geoMentionChecks.turn,
+            sequenceId: geoMentionChecks.sequenceId,
+            sources:
+              sql<number>`jsonb_array_length(${geoMentionChecks.sources})`.mapWith(
+                Number
+              ),
+            capturedAt: geoMentionChecks.capturedAt,
+          })
+          .from(geoMentionChecks)
+          .where(resultFilter)
+          .orderBy(asc(geoMentionChecks.createdAt), asc(geoMentionChecks.id))
+          .limit(GEO_SCAN_RESULTS_PAGE_SIZE)
+          .offset(input.offset),
+        db
+          .select({ count: count() })
+          .from(geoMentionChecks)
+          .where(resultFilter),
+        db
+          .select({
+            count: sql<number>`count(distinct source.value->>'url')`.mapWith(
+              Number
+            ),
+          })
+          .from(geoMentionChecks)
+          .crossJoin(
+            sql`jsonb_array_elements(${geoMentionChecks.sources}) as source(value)`
+          )
+          .where(scopeFilter),
+      ])
+  );
+  const saved = scan.plan?.tasks?.length
+    ? yield* geoDb("saved scan tasks lookup failed", () =>
+        db
+          .select({
+            promptId: geoMentionChecks.promptId,
+            engine: geoMentionChecks.engine,
+            language: geoMentionChecks.language,
+          })
+          .from(geoMentionChecks)
+          .where(scopeFilter)
+      )
+    : [];
+  const savedKeys = new Set(
+    saved.map((row) => geoScanAnswerKey(row.promptId, row.engine, row.language))
+  );
+  const pending = (scan.plan?.tasks ?? [])
+    .filter(
+      (task) =>
+        !savedKeys.has(task.key) &&
+        (!input.engine || task.engine === input.engine)
+    )
+    .map((task) => ({
+      ...task,
+      status:
+        scan.status === "running"
+          ? (scan.plan?.taskStates?.[task.key] ?? "queued")
+          : "failed",
+    }));
+  const pendingOffset = Math.min(
+    input.pendingOffset ?? 0,
+    Math.max(0, Math.ceil(pending.length / GEO_SCAN_RESULTS_PAGE_SIZE) - 1) *
+      GEO_SCAN_RESULTS_PAGE_SIZE
+  );
+  return {
+    status: scan.status,
+    pendingOffset,
+    pending: pending.slice(
+      pendingOffset,
+      pendingOffset + GEO_SCAN_RESULTS_PAGE_SIZE
+    ),
+    pendingTotal: pending.length,
+    results: results.map((row) => ({
+      ...row,
+      capturedAt: row.capturedAt.toISOString(),
+    })),
+    total: totals[0]?.count ?? 0,
+    uniqueSources: sources[0]?.count ?? 0,
+  };
+});

--- a/packages/geo-core/src/geo/scan-history.ts
+++ b/packages/geo-core/src/geo/scan-history.ts
@@ -155,13 +155,16 @@ export const loadGeoScanRun = Effect.fn("geo.scanRun")(function* (
             promptId: geoMentionChecks.promptId,
             engine: geoMentionChecks.engine,
             language: geoMentionChecks.language,
+            turn: geoMentionChecks.turn,
           })
           .from(geoMentionChecks)
           .where(scopeFilter)
       )
     : [];
   const savedKeys = new Set(
-    saved.map((row) => geoScanAnswerKey(row.promptId, row.engine, row.language))
+    saved.map((row) =>
+      geoScanAnswerKey(row.promptId, row.engine, row.language, row.turn)
+    )
   );
   const pending = (scan.plan?.tasks ?? [])
     .filter(

--- a/packages/geo-core/src/geo/scan-status.ts
+++ b/packages/geo-core/src/geo/scan-status.ts
@@ -366,7 +366,7 @@ export const createGeoScanRow = Effect.fn("geo.createScanRow")(function* (
  * gets swept one stale window later.
  */
 export const sweepStaleGeoScanRows = Effect.fn("geo.sweepStaleScanRows")(
-  function* () {
+  function* (scope?: GeoScanRunScope) {
     const staleBefore = new Date(Date.now() - GEO_SCAN_STALE_MS);
     const failed = yield* geoDb("stale scan sweep failed", () =>
       db
@@ -376,6 +376,10 @@ export const sweepStaleGeoScanRows = Effect.fn("geo.sweepStaleScanRows")(
           and(
             eq(geoScans.status, "running"),
             lt(geoScans.startedAt, staleBefore),
+            scope
+              ? eq(geoScans.organizationId, scope.organizationId)
+              : undefined,
+            scope ? eq(geoScans.projectId, scope.projectId) : undefined,
             notExists(
               db
                 .select({ id: geoSettings.id })

--- a/packages/geo-core/src/geo/scan-task-status.ts
+++ b/packages/geo-core/src/geo/scan-task-status.ts
@@ -14,9 +14,15 @@ export const updateGeoScanTaskStatus = Effect.fn("geo.updateScanTaskStatus")(
       "organizationId" | "projectId" | "scanId"
     >,
     task: Pick<GeoScanPlannedTask, "prompt" | "engine" | "language">,
-    status: "running" | "failed"
+    status: "running" | "failed",
+    turn = 0
   ) {
-    const key = geoScanAnswerKey(task.prompt.id, task.engine, task.language);
+    const key = geoScanAnswerKey(
+      task.prompt.id,
+      task.engine,
+      task.language,
+      turn
+    );
     yield* geoDb("scan task status update failed", () =>
       db
         .update(geoScans)

--- a/packages/geo-core/src/geo/scan-task-status.ts
+++ b/packages/geo-core/src/geo/scan-task-status.ts
@@ -1,0 +1,45 @@
+import { db } from "@notra/db/drizzle";
+import { geoScans } from "@notra/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { Effect } from "effect";
+
+import type { GeoScanProjectContext, GeoScanPlannedTask } from "../types/geo";
+import { geoScanAnswerKey } from "../utils/geo-scan-plan";
+import { geoDb, geoSkip } from "./effect";
+
+export const updateGeoScanTaskStatus = Effect.fn("geo.updateScanTaskStatus")(
+  function* (
+    context: Pick<
+      GeoScanProjectContext,
+      "organizationId" | "projectId" | "scanId"
+    >,
+    task: Pick<GeoScanPlannedTask, "prompt" | "engine" | "language">,
+    status: "running" | "failed"
+  ) {
+    const key = geoScanAnswerKey(task.prompt.id, task.engine, task.language);
+    yield* geoDb("scan task status update failed", () =>
+      db
+        .update(geoScans)
+        .set({
+          plan: sql`jsonb_set(${geoScans.plan}, '{taskStates}', coalesce(${geoScans.plan}->'taskStates', '{}'::jsonb) || jsonb_build_object(${key}::text, ${status}::text))`,
+        })
+        .where(
+          and(
+            eq(geoScans.id, context.scanId),
+            eq(geoScans.organizationId, context.organizationId),
+            eq(geoScans.projectId, context.projectId),
+            eq(geoScans.status, "running")
+          )
+        )
+    ).pipe(
+      geoSkip("scan task status update failed", {
+        organizationId: context.organizationId,
+        projectId: context.projectId,
+        scanId: context.scanId,
+        promptId: task.prompt.id,
+        engine: task.engine,
+        language: task.language,
+      })
+    );
+  }
+);

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -13,7 +13,12 @@ import {
   GEO_CHECK_GROUNDING_MAX_SOURCES,
 } from "@notra/db/constants/geo-checks";
 import { db } from "@notra/db/drizzle";
-import { geoPromptSequences, geoPrompts, geoSettings } from "@notra/db/schema";
+import {
+  geoPromptSequences,
+  geoPrompts,
+  geoScans,
+  geoSettings,
+} from "@notra/db/schema";
 import type { GeoCheckWrite } from "@notra/db/types/geo-checks";
 import { insertGeoMentionChecks } from "@notra/db/utils/geo-checks";
 import type { ModelMessage } from "ai";
@@ -93,6 +98,7 @@ import {
   isGeoScanRunning,
   summarizeGeoEngineAttempts,
 } from "../utils/geo-scan";
+import { geoScanPlanSnapshot } from "../utils/geo-scan-plan";
 import { withGeoTiming } from "../utils/geo-timing";
 import { addAgentTokenUsage as addTokenUsage } from "../utils/token-usage";
 import { fetchGoogleAiOverview } from "./ai-overview";
@@ -130,6 +136,7 @@ import {
   renewGeoScanRun,
   withGeoScanRun,
 } from "./scan-status";
+import { updateGeoScanTaskStatus } from "./scan-task-status";
 import { resolveScanZdrPolicy } from "./zdr-policy";
 
 const MAX_JUDGE_COMPETITORS = 10;
@@ -1044,20 +1051,25 @@ const buildGeoScanProjectPlan = Effect.fn("geo.buildScanProjectPlan")(
       }
     }
 
-    const sequenceRows = yield* Effect.tryPromise({
-      try: () =>
-        db.query.geoPromptSequences.findMany({
-          columns: { id: true, steps: true },
-          where: and(
-            eq(geoPromptSequences.projectId, settingsRow.projectId),
-            eq(geoPromptSequences.enabled, true)
-          ),
-          orderBy: [asc(geoPromptSequences.createdAt)],
-          limit: GEO_MAX_SEQUENCES,
-        }),
-      catch: (cause) =>
-        new GeoScanError({ message: "Failed to load GEO sequences", cause }),
-    });
+    const sequenceRows = promptIds
+      ? []
+      : yield* Effect.tryPromise({
+          try: () =>
+            db.query.geoPromptSequences.findMany({
+              columns: { id: true, steps: true },
+              where: and(
+                eq(geoPromptSequences.projectId, settingsRow.projectId),
+                eq(geoPromptSequences.enabled, true)
+              ),
+              orderBy: [asc(geoPromptSequences.createdAt)],
+              limit: GEO_MAX_SEQUENCES,
+            }),
+          catch: (cause) =>
+            new GeoScanError({
+              message: "Failed to load GEO sequences",
+              cause,
+            }),
+        });
     const trackedCodingAgents = trackedEngines.filter(
       ({ engine }) =>
         engine === GEO_OPENCODE_ENGINE_ID || isGeoBoxCodingAgent(engine)
@@ -1121,6 +1133,22 @@ const buildGeoScanProjectPlan = Effect.fn("geo.buildScanProjectPlan")(
       engines,
     };
     const planned: GeoScanProjectPlanResult = { status: "planned", plan };
+    yield* Effect.tryPromise({
+      try: () =>
+        db
+          .update(geoScans)
+          .set({ plan: geoScanPlanSnapshot(plan) })
+          .where(
+            and(
+              eq(geoScans.id, scanId),
+              eq(geoScans.organizationId, organizationId),
+              eq(geoScans.projectId, settingsRow.projectId),
+              eq(geoScans.status, "running")
+            )
+          ),
+      catch: (cause) =>
+        new GeoScanError({ message: "Failed to store scan plan", cause }),
+    });
     return planned;
   }
 );
@@ -1166,6 +1194,7 @@ export const runGeoScanTaskBatch = Effect.fn("geo.runScanTaskBatch")(function* (
     const grounded = resolveGroundedEngineByKey(planned.groundedKey);
     if (!grounded) {
       unavailableGrounded += 1;
+      yield* updateGeoScanTaskStatus(context, planned, "failed");
       yield* geoLogWarn({
         event: "geo.check.failed",
         organizationId: context.organizationId,
@@ -1187,30 +1216,41 @@ export const runGeoScanTaskBatch = Effect.fn("geo.runScanTaskBatch")(function* (
     tasks,
     (task) => {
       const fields = checkFailureFields(checkContext, task);
-      return withGeoTiming(runGeoCheck(checkContext, task), {
-        ...fields,
-        event: "geo.check.attempt.completed",
-      }).pipe(
-        Effect.tapError((error) =>
-          (error._tag === "GeoScanError" || error._tag === "GeoJudgeError") &&
-          error.timedOut === true
-            ? geoLogWarn({
-                ...fields,
-                event: "geo.check.timeout",
-                detail: error.message,
-              })
-            : Effect.void
-        ),
-        Effect.retry({
-          times: 1,
-          while: (error) =>
-            (error._tag === "GeoScanError" || error._tag === "GeoJudgeError") &&
-            error.timedOut === true,
-        }),
-        Effect.catchTag("GeoEmptyAnswerError", (error) =>
-          Effect.sync(() => droppedCheckOutcome(fields, error))
-        ),
-        geoSkip("check failed", fields)
+      return updateGeoScanTaskStatus(context, task, "running").pipe(
+        Effect.andThen(
+          withGeoTiming(runGeoCheck(checkContext, task), {
+            ...fields,
+            event: "geo.check.attempt.completed",
+          }).pipe(
+            Effect.tapError((error) =>
+              (error._tag === "GeoScanError" ||
+                error._tag === "GeoJudgeError") &&
+              error.timedOut === true
+                ? geoLogWarn({
+                    ...fields,
+                    event: "geo.check.timeout",
+                    detail: error.message,
+                  })
+                : Effect.void
+            ),
+            Effect.retry({
+              times: 1,
+              while: (error) =>
+                (error._tag === "GeoScanError" ||
+                  error._tag === "GeoJudgeError") &&
+                error.timedOut === true,
+            }),
+            Effect.catchTag("GeoEmptyAnswerError", (error) =>
+              Effect.sync(() => droppedCheckOutcome(fields, error))
+            ),
+            geoSkip("check failed", fields),
+            Effect.tap((result) =>
+              result?.row
+                ? Effect.void
+                : updateGeoScanTaskStatus(context, task, "failed")
+            )
+          )
+        )
       );
     },
     { concurrency: GEO_SCAN_CONCURRENCY }

--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -98,7 +98,10 @@ import {
   isGeoScanRunning,
   summarizeGeoEngineAttempts,
 } from "../utils/geo-scan";
-import { geoScanPlanSnapshot } from "../utils/geo-scan-plan";
+import {
+  geoScanPlanSnapshot,
+  geoScanSequenceTasks,
+} from "../utils/geo-scan-plan";
 import { withGeoTiming } from "../utils/geo-timing";
 import { addAgentTokenUsage as addTokenUsage } from "../utils/token-usage";
 import { fetchGoogleAiOverview } from "./ai-overview";
@@ -1316,56 +1319,87 @@ export const runGeoScanSequenceBatch = Effect.fn("geo.runScanSequenceBatch")(
 
     const outcomes = yield* Effect.forEach(
       plannedSequences,
-      (planned) => {
-        const sequence: GeoSequenceDefinition = {
-          id: planned.sequenceId,
-          steps: planned.steps,
-        };
-        if (!planned.groundedKey) {
-          return runGeoOpenCodeSequenceCheck(
+      (planned) =>
+        Effect.gen(function* () {
+          const sequence: GeoSequenceDefinition = {
+            id: planned.sequenceId,
+            steps: planned.steps,
+          };
+          for (const task of geoScanSequenceTasks(planned)) {
+            yield* updateGeoScanTaskStatus(
+              context,
+              {
+                ...task,
+                prompt: { id: task.promptId, text: task.prompt },
+              },
+              "running",
+              task.turn
+            );
+          }
+          if (!planned.groundedKey) {
+            return yield* runGeoOpenCodeSequenceCheck(
+              checkContext,
+              sequence,
+              planned.engine,
+              planned.zdr
+            ).pipe(
+              geoSkip(
+                "sequence failed",
+                sequenceFailureFields(
+                  checkContext,
+                  sequence,
+                  planned.engine,
+                  false
+                )
+              ),
+              Effect.map((result) => ({ sequence, result }))
+            );
+          }
+          const grounded = resolveGroundedEngineByKey(planned.groundedKey);
+          if (!grounded) {
+            return { sequence, result: null };
+          }
+          return yield* runGeoSequenceCheck(
             checkContext,
             sequence,
-            planned.engine,
+            grounded,
             planned.zdr
           ).pipe(
+            Effect.timeoutOrElse({
+              duration: GEO_SEQUENCE_PAIR_TIMEOUT_MS,
+              orElse: () =>
+                Effect.fail(
+                  new GeoScanError({
+                    message: `Sequence ${sequence.id} on ${grounded.key} timed out after ${GEO_SEQUENCE_PAIR_TIMEOUT_MS}ms`,
+                  })
+                ),
+            }),
             geoSkip(
               "sequence failed",
-              sequenceFailureFields(
-                checkContext,
-                sequence,
-                planned.engine,
-                false
-              )
+              sequenceFailureFields(checkContext, sequence, grounded.key, true)
             ),
             Effect.map((result) => ({ sequence, result }))
           );
-        }
-        const grounded = resolveGroundedEngineByKey(planned.groundedKey);
-        if (!grounded) {
-          return Effect.succeed({ sequence, result: null });
-        }
-        return runGeoSequenceCheck(
-          checkContext,
-          sequence,
-          grounded,
-          planned.zdr
-        ).pipe(
-          Effect.timeoutOrElse({
-            duration: GEO_SEQUENCE_PAIR_TIMEOUT_MS,
-            orElse: () =>
-              Effect.fail(
-                new GeoScanError({
-                  message: `Sequence ${sequence.id} on ${grounded.key} timed out after ${GEO_SEQUENCE_PAIR_TIMEOUT_MS}ms`,
-                })
+        }).pipe(
+          Effect.tap(({ result }) =>
+            Effect.forEach(
+              geoScanSequenceTasks(planned).filter(
+                (task) => !result?.rows.some((row) => row.turn === task.turn)
               ),
-          }),
-          geoSkip(
-            "sequence failed",
-            sequenceFailureFields(checkContext, sequence, grounded.key, true)
-          ),
-          Effect.map((result) => ({ sequence, result }))
-        );
-      },
+              (task) =>
+                updateGeoScanTaskStatus(
+                  context,
+                  {
+                    ...task,
+                    prompt: { id: task.promptId, text: task.prompt },
+                  },
+                  "failed",
+                  task.turn
+                ),
+              { discard: true }
+            )
+          )
+        ),
       { concurrency: GEO_SCAN_CONCURRENCY }
     );
 

--- a/packages/geo-core/src/schemas/geo-scan-history.ts
+++ b/packages/geo-core/src/schemas/geo-scan-history.ts
@@ -1,0 +1,14 @@
+import { number, string } from "zod";
+
+import { geoOrganizationInputSchema } from "./geo";
+
+export const geoScanRunsInputSchema = geoOrganizationInputSchema.extend({
+  offset: number().int().min(0).max(100_000).default(0),
+});
+
+export const geoScanRunInputSchema = geoOrganizationInputSchema.extend({
+  pendingOffset: number().int().min(0).max(100_000).optional(),
+  scanId: string().min(1),
+  offset: number().int().min(0).max(100_000).default(0),
+  engine: string().min(1).optional(),
+});

--- a/packages/geo-core/src/schemas/geo.ts
+++ b/packages/geo-core/src/schemas/geo.ts
@@ -261,11 +261,20 @@ export const geoPromptResultDetailInputSchema =
   });
 
 export const geoPromptHistoryInputSchema = geoOrganizationInputSchema.extend({
+  scanId: string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH).optional(),
   promptId: string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
+});
+
+export const geoScanStatusInputSchema = geoOrganizationInputSchema.extend({
+  scanId: string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
 });
 
 export const geoPromptRescanInputSchema = geoOrganizationInputSchema.extend({
   promptId: string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH),
+  engines: array(string().min(1).max(GEO_SHORT_FIELD_MAX_LENGTH))
+    .min(1)
+    .max(GEO_MAX_ENGINES)
+    .optional(),
 });
 
 export const geoTimeseriesInputSchema = geoOrganizationInputSchema.extend({

--- a/packages/geo-core/src/types/geo-scan-history.ts
+++ b/packages/geo-core/src/types/geo-scan-history.ts
@@ -1,0 +1,33 @@
+import type { GeoScanPlanSnapshot } from "@notra/db/types/geo-scan";
+import type { z } from "zod";
+
+import type {
+  geoScanRunInputSchema,
+  geoScanRunsInputSchema,
+} from "../schemas/geo-scan-history";
+
+export type GeoScanRunsInput = z.infer<typeof geoScanRunsInputSchema>;
+export type GeoScanRunInput = z.infer<typeof geoScanRunInputSchema>;
+
+export interface GeoScanRunSummary {
+  id: string;
+  status: "running" | "completed" | "failed";
+  startedAt: string;
+  finishedAt: string | null;
+  plan: GeoScanPlanSnapshot | null;
+  checks: number;
+  mentions: number;
+}
+
+export interface GeoScanResultSummary {
+  id: string;
+  prompt: string;
+  engine: string;
+  mentioned: boolean;
+  position: number | null;
+  language: string;
+  turn: number;
+  sequenceId: string | null;
+  sources: number;
+  capturedAt: string;
+}

--- a/packages/geo-core/src/types/geo.ts
+++ b/packages/geo-core/src/types/geo.ts
@@ -307,11 +307,13 @@ export interface GeoPromptResultDetailResponse {
 }
 
 export interface GeoPromptHistoryInput extends GeoScopeInput {
+  scanId?: string;
   promptId: string;
 }
 
 export interface GeoPromptRescanInput extends GeoScopeInput {
   promptId: string;
+  engines?: readonly string[];
 }
 
 export interface GeoRescanForPostInput {

--- a/packages/geo-core/src/utils/geo-scan-plan.ts
+++ b/packages/geo-core/src/utils/geo-scan-plan.ts
@@ -1,0 +1,40 @@
+import type { GeoScanPlanSnapshot } from "@notra/db/types/geo-scan";
+
+import { GEO_SEQUENCE_MAX_TURNS } from "../constants/geo";
+import type { GeoScanProjectPlan } from "../types/geo";
+
+export function geoScanAnswerKey(
+  promptId: string,
+  engine: string,
+  language: string
+): string {
+  return JSON.stringify([promptId, engine, language]);
+}
+
+export function geoScanPlanSnapshot(
+  plan: GeoScanProjectPlan
+): GeoScanPlanSnapshot {
+  return {
+    tasks: plan.tasks.map((task) => ({
+      key: geoScanAnswerKey(task.prompt.id, task.engine, task.language),
+      promptId: task.prompt.id,
+      prompt: task.prompt.text,
+      engine: task.engine,
+      language: task.language,
+    })),
+    taskStates: {},
+    totalChecks:
+      plan.tasks.length +
+      plan.sequences.reduce(
+        (total, sequence) =>
+          total + Math.min(sequence.steps.length, GEO_SEQUENCE_MAX_TURNS),
+        0
+      ),
+    promptCount: plan.promptCount,
+    sequenceCount: new Set(
+      plan.sequences.map((sequence) => sequence.sequenceId)
+    ).size,
+    engines: [...plan.engines],
+    languages: [...plan.languages],
+  };
+}

--- a/packages/geo-core/src/utils/geo-scan-plan.ts
+++ b/packages/geo-core/src/utils/geo-scan-plan.ts
@@ -1,35 +1,62 @@
-import type { GeoScanPlanSnapshot } from "@notra/db/types/geo-scan";
+import { DEFAULT_LANGUAGE } from "@notra/ai/constants/languages";
+import type {
+  GeoScanPlannedAnswer,
+  GeoScanPlanSnapshot,
+} from "@notra/db/types/geo-scan";
 
 import { GEO_SEQUENCE_MAX_TURNS } from "../constants/geo";
-import type { GeoScanProjectPlan } from "../types/geo";
+import type { GeoScanPlannedSequence, GeoScanProjectPlan } from "../types/geo";
 
 export function geoScanAnswerKey(
   promptId: string,
   engine: string,
-  language: string
+  language: string,
+  turn = 0
 ): string {
-  return JSON.stringify([promptId, engine, language]);
+  return JSON.stringify(
+    turn > 0 ? [promptId, engine, language, turn] : [promptId, engine, language]
+  );
+}
+
+export function geoScanSequenceTasks(
+  sequence: GeoScanPlannedSequence
+): GeoScanPlannedAnswer[] {
+  const promptId = `sequence-${sequence.sequenceId}`;
+  return sequence.steps
+    .slice(0, GEO_SEQUENCE_MAX_TURNS)
+    .map((prompt, index) => ({
+      key: geoScanAnswerKey(
+        promptId,
+        sequence.engine,
+        DEFAULT_LANGUAGE,
+        index + 1
+      ),
+      promptId,
+      prompt,
+      engine: sequence.engine,
+      language: DEFAULT_LANGUAGE,
+      sequenceId: sequence.sequenceId,
+      turn: index + 1,
+    }));
 }
 
 export function geoScanPlanSnapshot(
   plan: GeoScanProjectPlan
 ): GeoScanPlanSnapshot {
-  return {
-    tasks: plan.tasks.map((task) => ({
+  const tasks = [
+    ...plan.tasks.map((task) => ({
       key: geoScanAnswerKey(task.prompt.id, task.engine, task.language),
       promptId: task.prompt.id,
       prompt: task.prompt.text,
       engine: task.engine,
       language: task.language,
     })),
+    ...plan.sequences.flatMap(geoScanSequenceTasks),
+  ];
+  return {
+    tasks,
     taskStates: {},
-    totalChecks:
-      plan.tasks.length +
-      plan.sequences.reduce(
-        (total, sequence) =>
-          total + Math.min(sequence.steps.length, GEO_SEQUENCE_MAX_TURNS),
-        0
-      ),
+    totalChecks: tasks.length,
     promptCount: plan.promptCount,
     sequenceCount: new Set(
       plan.sequences.map((sequence) => sequence.sequenceId)

--- a/packages/geo-core/tests/model-scan.test.ts
+++ b/packages/geo-core/tests/model-scan.test.ts
@@ -5,14 +5,19 @@ import {
   beforeEach,
   describe,
   expect,
+  spyOn,
   test,
 } from "bun:test";
 
+import { geoLog } from "@notra/ai/evlog";
 import { geoMentionChecks, geoScans } from "@notra/db/schema";
 import { Effect } from "effect";
 
+import { GEO_SEQUENCE_MAX_TURNS } from "../src/constants/geo";
 import { GeoModelService, GeoFeatureFlagService } from "../src/deps";
 import { GeoScanError } from "../src/geo/errors";
+import type { GeoScanPlannedSequence } from "../src/types/geo";
+import { geoScanPlanSnapshot } from "../src/utils/geo-scan-plan";
 import {
   fakeModels,
   testBillingGate,
@@ -25,13 +30,132 @@ import {
   seedProject,
   testDb,
 } from "./utils/database";
-const { runGeoScanTaskBatch } = await import("../src/geo/scan");
+const { runGeoScanTaskBatch, runGeoScanSequenceBatch } =
+  await import("../src/geo/scan");
+const { loadGeoScanRun } = await import("../src/geo/scan-history");
 
 beforeAll(initializeDatabase, 30_000);
 afterAll(() => database.postgres.close());
 beforeEach(resetDatabase);
 
 describe("model service in real scan batches", () => {
+  test("sequence turns move from queued to running to saved or failed independently", async () => {
+    const scope = await seedProject("sequence-progress");
+    const context = {
+      ...scope,
+      scanId: "sequence-scan",
+      runId: "test",
+      companyName: "Selected",
+      aliases: [],
+      gate: testBillingGate,
+      startedAtMs: Date.now(),
+    };
+    const sequences: GeoScanPlannedSequence[] = [
+      {
+        sequenceId: "conversation",
+        engine: "openai/gpt-4o-mini-grounded",
+        groundedKey: "openai/gpt-4o-mini-grounded",
+        zdr: "none",
+        steps: Array.from(
+          { length: GEO_SEQUENCE_MAX_TURNS + 1 },
+          (_, index) => `Question ${index}`
+        ),
+      },
+      {
+        sequenceId: "unavailable",
+        engine: "unavailable",
+        groundedKey: "unavailable",
+        zdr: "none",
+        steps: ["Unavailable question"],
+      },
+    ];
+    const plan = geoScanPlanSnapshot({
+      context,
+      claimedAt: new Date().toISOString(),
+      tasks: [],
+      sequences,
+      promptCount: 0,
+      engines: sequences.map((sequence) => sequence.engine),
+      languages: ["English"],
+    });
+    expect(plan.tasks).toHaveLength(GEO_SEQUENCE_MAX_TURNS + 1);
+    expect(new Set(plan.tasks?.map((task) => task.key)).size).toBe(
+      plan.totalChecks
+    );
+    await testDb
+      .insert(geoScans)
+      .values({ ...scope, id: context.scanId, plan });
+    const queued = await Effect.runPromise(
+      loadGeoScanRun({ ...context, offset: 0 })
+    );
+    expect(queued?.pendingTotal).toBe(plan.totalChecks);
+    expect(queued?.pending.every((task) => task.status === "queued")).toBe(
+      true
+    );
+    let calls = 0;
+    const result = await Effect.runPromise(
+      runGeoScanSequenceBatch(context, sequences).pipe(
+        Effect.provideService(GeoFeatureFlagService, testFeatureFlags),
+        Effect.provideService(GeoModelService, {
+          ...fakeModels,
+          groundedAnswer: () =>
+            Effect.gen(function* () {
+              calls += 1;
+              const active = yield* loadGeoScanRun({
+                ...context,
+                offset: 0,
+              }).pipe(Effect.orDie);
+              expect(
+                active?.pending
+                  .filter((task) => task.sequenceId === "conversation")
+                  .every((task) => task.status === "running")
+              ).toBe(true);
+              return {
+                text: calls === 1 ? "Selected is a good choice." : "",
+                grounding: { queries: [], sources: [] },
+                sources: [],
+                finishReason: "stop",
+                zdrEnforced: false,
+                usage: {
+                  inputTokens: 1,
+                  outputTokens: 1,
+                  totalTokens: 2,
+                  inputTokenDetails: {
+                    noCacheTokens: 1,
+                    cacheReadTokens: 0,
+                    cacheWriteTokens: 0,
+                  },
+                  outputTokenDetails: { textTokens: 1, reasoningTokens: 0 },
+                },
+              };
+            }),
+        })
+      )
+    );
+    expect(calls).toBe(2);
+    expect(result.checks).toBe(1);
+    expect(result.dropped).toBe(plan.totalChecks - 1);
+    const finished = await Effect.runPromise(
+      loadGeoScanRun({ ...context, offset: 0 })
+    );
+    expect(finished?.total).toBe(1);
+    expect(finished?.results[0]?.turn).toBe(1);
+    expect(finished?.pendingTotal).toBe(plan.totalChecks - 1);
+    expect(finished?.pending.every((task) => task.status === "failed")).toBe(
+      true
+    );
+    expect(
+      finished?.pending
+        .filter((task) => task.sequenceId === "conversation")
+        .map((task) => task.turn)
+    ).toEqual(
+      Array.from(
+        { length: GEO_SEQUENCE_MAX_TURNS - 1 },
+        (_, index) => index + 2
+      )
+    );
+  });
+
   test("a failed progress write cannot discard a successful sibling answer", async () => {
     const scope = await seedProject("progress-failure");
     await testDb.insert(geoScans).values({
@@ -49,6 +173,8 @@ describe("model service in real scan batches", () => {
     await database.postgres.exec(
       "ALTER TABLE geo_scans ADD CONSTRAINT simulate_status_write_failure CHECK (position($$failed$$ in plan::text) = 0)"
     );
+    const errors = spyOn(geoLog, "error");
+    errors.mockClear();
     try {
       const result = await Effect.runPromise(
         runGeoScanTaskBatch(
@@ -84,7 +210,22 @@ describe("model service in real scan batches", () => {
       const rows = await testDb.select().from(geoMentionChecks);
       expect(rows).toHaveLength(1);
       expect(rows[0]?.promptId).toBe("good");
+      expect(errors).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "scan task status update failed",
+          scanId: "progress-scan",
+          promptId: "bad",
+          causeMessage: expect.stringContaining("failed"),
+        })
+      );
+      const scan = await testDb.query.geoScans.findFirst();
+      expect(
+        scan?.plan?.taskStates?.[
+          JSON.stringify(["bad", "openai/gpt-4o-mini", "English"])
+        ]
+      ).toBe("running");
     } finally {
+      errors.mockRestore();
       await database.postgres.exec(
         "ALTER TABLE geo_scans DROP CONSTRAINT simulate_status_write_failure"
       );

--- a/packages/geo-core/tests/model-scan.test.ts
+++ b/packages/geo-core/tests/model-scan.test.ts
@@ -215,7 +215,6 @@ describe("model service in real scan batches", () => {
           message: "scan task status update failed",
           scanId: "progress-scan",
           promptId: "bad",
-          causeMessage: expect.stringContaining("failed"),
         })
       );
       const scan = await testDb.query.geoScans.findFirst();

--- a/packages/geo-core/tests/model-scan.test.ts
+++ b/packages/geo-core/tests/model-scan.test.ts
@@ -32,6 +32,65 @@ afterAll(() => database.postgres.close());
 beforeEach(resetDatabase);
 
 describe("model service in real scan batches", () => {
+  test("a failed progress write cannot discard a successful sibling answer", async () => {
+    const scope = await seedProject("progress-failure");
+    await testDb.insert(geoScans).values({
+      id: "progress-scan",
+      ...scope,
+      plan: {
+        totalChecks: 2,
+        promptCount: 2,
+        sequenceCount: 0,
+        engines: ["openai/gpt-4o-mini"],
+        languages: ["English"],
+        taskStates: {},
+      },
+    });
+    await database.postgres.exec(
+      "ALTER TABLE geo_scans ADD CONSTRAINT simulate_status_write_failure CHECK (position($$failed$$ in plan::text) = 0)"
+    );
+    try {
+      const result = await Effect.runPromise(
+        runGeoScanTaskBatch(
+          {
+            ...scope,
+            scanId: "progress-scan",
+            runId: "review",
+            companyName: "Selected",
+            aliases: [],
+            gate: testBillingGate,
+            startedAtMs: Date.now(),
+          },
+          ["good", "bad"].map((id) => ({
+            engine: "openai/gpt-4o-mini",
+            groundedKey: null,
+            prompt: { id, text: id },
+            language: "English",
+            zdr: "none" as const,
+          }))
+        ).pipe(
+          Effect.provideService(GeoModelService, {
+            ...fakeModels,
+            answer: (input) =>
+              input.prompt === "bad"
+                ? Effect.fail(new GeoScanError({ message: "provider refused" }))
+                : fakeModels.answer(input),
+          }),
+          Effect.provideService(GeoFeatureFlagService, testFeatureFlags)
+        )
+      );
+      expect(result.checks).toBe(1);
+      expect(result.dropped).toBe(1);
+      const rows = await testDb.select().from(geoMentionChecks);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.promptId).toBe("good");
+    } finally {
+      await database.postgres.exec(
+        "ALTER TABLE geo_scans DROP CONSTRAINT simulate_status_write_failure"
+      );
+    }
+  });
+
   test("fake answer and judge persist the selected project and prompt", async () => {
     const scope = await seedProject("selected");
     await testDb.insert(geoScans).values({ id: "scan-test", ...scope });

--- a/packages/geo-core/tests/scan-history.test.ts
+++ b/packages/geo-core/tests/scan-history.test.ts
@@ -1,0 +1,406 @@
+import "./utils/infrastructure";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { geoMentionChecks, geoScans, geoSettings } from "@notra/db/schema";
+import { eq } from "drizzle-orm";
+import { Effect } from "effect";
+
+import { GEO_SCAN_STALE_MS } from "../src/constants/geo";
+import {
+  GEO_SCAN_RESULTS_PAGE_SIZE,
+  GEO_SCAN_RUNS_PAGE_SIZE,
+} from "../src/constants/geo-scan-history";
+import {
+  database,
+  initializeDatabase,
+  resetDatabase,
+  seedProject,
+  testDb,
+} from "./utils/database";
+
+const { loadGeoScanRun, loadGeoScanRuns } =
+  await import("../src/geo/scan-history");
+const { updateGeoScanTaskStatus } = await import("../src/geo/scan-task-status");
+const { geoScanAnswerKey } = await import("../src/utils/geo-scan-plan");
+const { loadGeoPromptHistory } = await import("../src/geo/programs");
+
+beforeAll(initializeDatabase, 30_000);
+afterAll(() => database.postgres.close());
+beforeEach(resetDatabase);
+
+describe("scan history", () => {
+  test("scan-specific prompt history includes both languages and excludes other runs and projects", async () => {
+    const scope = await seedProject("languages");
+    const other = await seedProject("other");
+    await testDb.insert(geoScans).values([
+      { id: "selected", ...scope },
+      { id: "older", ...scope },
+      { id: "foreign", ...other },
+    ]);
+    await testDb.insert(geoMentionChecks).values(
+      [
+        { id: "german", ...scope, scanId: "selected", language: "German" },
+        { id: "english", ...scope, scanId: "selected", language: "English" },
+        { id: "old", ...scope, scanId: "older", language: "English" },
+        {
+          id: "other-project",
+          ...other,
+          scanId: "foreign",
+          language: "English",
+        },
+      ].map((row) => ({
+        ...row,
+        promptId: "custom-prompt",
+        prompt: row.language,
+        engine: "engine",
+        answer: row.language,
+        mentioned: false,
+        capturedAt: new Date(),
+      }))
+    );
+    const history = await Effect.runPromise(
+      loadGeoPromptHistory({
+        ...scope,
+        promptId: "custom-prompt",
+        scanId: "selected",
+      })
+    );
+    expect(history.checks.map((check) => check.language).sort()).toEqual([
+      "English",
+      "German",
+    ]);
+    expect(history.checks.every((check) => check.scanId === "selected")).toBe(
+      true
+    );
+    const foreign = await Effect.runPromise(
+      loadGeoPromptHistory({
+        ...scope,
+        promptId: "custom-prompt",
+        scanId: "foreign",
+      })
+    );
+    expect(foreign.checks).toEqual([]);
+    const legacy = await Effect.runPromise(
+      loadGeoPromptHistory({ ...scope, promptId: "custom-prompt" })
+    );
+    expect(legacy.checks.every((check) => check.language === "English")).toBe(
+      true
+    );
+    expect(legacy.checks).toHaveLength(2);
+  });
+
+  test("pending pages are independent of saved pages and clamp as the queue shrinks", async () => {
+    const scope = await seedProject("pending-pages");
+    const tasks = Array.from(
+      { length: GEO_SCAN_RESULTS_PAGE_SIZE + 1 },
+      (_, index) => ({
+        key: geoScanAnswerKey(String(index), "engine", "English"),
+        promptId: String(index),
+        prompt: `Question ${index}`,
+        engine: "engine",
+        language: "English",
+      })
+    );
+    await testDb.insert(geoScans).values({
+      id: "pending-scan",
+      ...scope,
+      plan: {
+        totalChecks: tasks.length,
+        promptCount: tasks.length,
+        sequenceCount: 0,
+        engines: ["engine"],
+        languages: ["English"],
+        tasks,
+        taskStates: {},
+      },
+    });
+    const first = await Effect.runPromise(
+      loadGeoScanRun({ ...scope, scanId: "pending-scan", offset: 0 })
+    );
+    const second = await Effect.runPromise(
+      loadGeoScanRun({
+        ...scope,
+        scanId: "pending-scan",
+        offset: 0,
+        pendingOffset: GEO_SCAN_RESULTS_PAGE_SIZE,
+      })
+    );
+    expect(first?.pending).toHaveLength(GEO_SCAN_RESULTS_PAGE_SIZE);
+    expect(second?.pending.map((task) => task.promptId)).toEqual([
+      String(GEO_SCAN_RESULTS_PAGE_SIZE),
+    ]);
+    expect(second?.total).toBe(0);
+    await testDb.insert(geoMentionChecks).values({
+      id: "now-saved",
+      ...scope,
+      scanId: "pending-scan",
+      promptId: "0",
+      engine: "engine",
+      language: "English",
+      prompt: "Question 0",
+      answer: "Answer",
+      mentioned: false,
+      capturedAt: new Date(),
+    });
+    const shrunk = await Effect.runPromise(
+      loadGeoScanRun({
+        ...scope,
+        scanId: "pending-scan",
+        offset: 0,
+        pendingOffset: GEO_SCAN_RESULTS_PAGE_SIZE,
+      })
+    );
+    expect(shrunk?.pendingOffset).toBe(0);
+    expect(shrunk?.pending).toHaveLength(GEO_SCAN_RESULTS_PAGE_SIZE);
+    expect(shrunk?.total).toBe(1);
+  });
+
+  test("tracks queued and concurrent active answers and replaces persisted tasks", async () => {
+    const scope = await seedProject("progress");
+    const context = { ...scope, scanId: "progress-scan" };
+    const tasks = ["German", "English"].map((language) => ({
+      prompt: { id: "prompt", text: `Question in ${language}` },
+      engine: "engine-a",
+      language,
+    }));
+    const plan = {
+      totalChecks: 2,
+      promptCount: 1,
+      sequenceCount: 0,
+      engines: ["engine-a"],
+      languages: ["German", "English"],
+      tasks: tasks.map((task) => ({
+        key: geoScanAnswerKey(task.prompt.id, task.engine, task.language),
+        promptId: task.prompt.id,
+        prompt: task.prompt.text,
+        engine: task.engine,
+        language: task.language,
+      })),
+      taskStates: {},
+    };
+    await testDb
+      .insert(geoScans)
+      .values({ id: context.scanId, ...scope, plan });
+    const queued = await Effect.runPromise(
+      loadGeoScanRun({ ...context, offset: 0 })
+    );
+    expect(queued?.pending.map((task) => task.status)).toEqual([
+      "queued",
+      "queued",
+    ]);
+    await Promise.all(
+      tasks.map((task) =>
+        Effect.runPromise(updateGeoScanTaskStatus(context, task, "running"))
+      )
+    );
+    const active = await Effect.runPromise(
+      loadGeoScanRun({ ...context, offset: 0 })
+    );
+    expect(active?.pending.map((task) => task.status)).toEqual([
+      "running",
+      "running",
+    ]);
+    await testDb.insert(geoMentionChecks).values({
+      ...scope,
+      id: "saved-german",
+      mentioned: false,
+      scanId: context.scanId,
+      promptId: "prompt",
+      prompt: "Question in German",
+      language: "German",
+      engine: "engine-a",
+      answer: "Answer",
+      capturedAt: new Date(),
+    });
+    const saved = await Effect.runPromise(
+      loadGeoScanRun({ ...context, offset: 0 })
+    );
+    expect(saved?.results).toHaveLength(1);
+    expect(saved?.pending).toHaveLength(1);
+    expect(saved?.pending[0]?.language).toBe("English");
+    await testDb
+      .update(geoScans)
+      .set({ status: "failed" })
+      .where(eq(geoScans.id, context.scanId));
+    const failed = await Effect.runPromise(
+      loadGeoScanRun({ ...context, offset: 0 })
+    );
+    expect(failed?.pending[0]?.status).toBe("failed");
+  });
+
+  test("polling finalizes expired runs only in the requested project", async () => {
+    const scope = await seedProject("expired");
+    const other = await seedProject("other");
+    const startedAt = new Date(Date.now() - GEO_SCAN_STALE_MS - 60_000);
+    await testDb.insert(geoScans).values([
+      { id: "expired-scan", ...scope, startedAt },
+      { id: "other-scan", ...other, startedAt },
+    ]);
+    const response = await Effect.runPromise(
+      loadGeoScanRuns({ ...scope, offset: 0 })
+    );
+    expect(response.runs[0]?.status).toBe("failed");
+    expect(response.runs[0]?.finishedAt).not.toBeNull();
+    const detail = await Effect.runPromise(
+      loadGeoScanRun({ ...scope, scanId: "expired-scan", offset: 0 })
+    );
+    expect(detail?.status).toBe("failed");
+    const untouched = await testDb.query.geoScans.findFirst({
+      where: eq(geoScans.id, "other-scan"),
+    });
+    expect(untouched?.status).toBe("running");
+  });
+
+  test("keeps a long run alive while its project claim is fresh", async () => {
+    const scope = await seedProject("alive");
+    await testDb
+      .update(geoSettings)
+      .set({ scanStartedAt: new Date() })
+      .where(eq(geoSettings.projectId, scope.projectId));
+    await testDb.insert(geoScans).values({
+      id: "alive-scan",
+      ...scope,
+      startedAt: new Date(Date.now() - GEO_SCAN_STALE_MS - 60_000),
+    });
+    const detail = await Effect.runPromise(
+      loadGeoScanRun({ ...scope, scanId: "alive-scan", offset: 0 })
+    );
+    expect(detail?.status).toBe("running");
+    const response = await Effect.runPromise(
+      loadGeoScanRuns({ ...scope, offset: 0 })
+    );
+    expect(response.runs[0]?.status).toBe("running");
+    expect(response.runs[0]?.finishedAt).toBeNull();
+  });
+
+  test("scopes history and detail to the selected project and organization", async () => {
+    const selected = await seedProject("selected");
+    const other = await seedProject("other");
+    const foreign = await seedProject("foreign", {
+      organizationId: "other-org",
+    });
+    await testDb.insert(geoScans).values([
+      { id: "selected-scan", ...selected },
+      { id: "other-scan", ...other },
+      { id: "foreign-scan", ...foreign },
+    ]);
+    const history = await Effect.runPromise(
+      loadGeoScanRuns({ ...selected, offset: 0 })
+    );
+    expect(history.runs.map((run) => run.id)).toEqual(["selected-scan"]);
+    expect(
+      await Effect.runPromise(
+        loadGeoScanRun({ ...selected, scanId: "other-scan", offset: 0 })
+      )
+    ).toBeNull();
+    expect(
+      await Effect.runPromise(
+        loadGeoScanRun({ ...selected, scanId: "foreign-scan", offset: 0 })
+      )
+    ).toBeNull();
+  });
+
+  test("counts saved answers, deduplicates sources and pages lightweight results", async () => {
+    const scope = await seedProject("selected");
+    const plan = {
+      totalChecks: 12,
+      promptCount: 6,
+      sequenceCount: 0,
+      engines: ["engine-a", "engine-b"],
+      languages: ["English"],
+    };
+    await testDb.insert(geoScans).values({ id: "scan", ...scope, plan });
+    await testDb.insert(geoMentionChecks).values(
+      Array.from({ length: 7 }, (_, index) => ({
+        id: `check-${index}`,
+        ...scope,
+        scanId: "scan",
+        promptId: `prompt-${index}`,
+        prompt: `Question ${index}`,
+        engine: index === 6 ? "engine-b" : "engine-a",
+        answer: "Saved answer",
+        mentioned: index < 3,
+        capturedAt: new Date(),
+        sources: [
+          { url: "https://example.com/shared", title: null },
+          { url: `https://example.com/${index}`, title: null },
+        ],
+      }))
+    );
+    const history = await Effect.runPromise(
+      loadGeoScanRuns({ ...scope, offset: 0 })
+    );
+    expect(history.runs[0]).toMatchObject({
+      plan,
+      checks: 7,
+      mentions: 3,
+      status: "running",
+    });
+    const detail = await Effect.runPromise(
+      loadGeoScanRun({ ...scope, scanId: "scan", offset: 0 })
+    );
+    expect(detail?.uniqueSources).toBe(8);
+    expect(detail?.total).toBe(7);
+    expect(detail?.results).toHaveLength(GEO_SCAN_RESULTS_PAGE_SIZE);
+    expect(detail?.results[0]).not.toHaveProperty("answer");
+    const second = await Effect.runPromise(
+      loadGeoScanRun({
+        ...scope,
+        scanId: "scan",
+        offset: GEO_SCAN_RESULTS_PAGE_SIZE,
+      })
+    );
+    expect(second?.results).toHaveLength(2);
+    expect(
+      second?.results.some((row) =>
+        detail?.results.some((first) => first.id === row.id)
+      )
+    ).toBe(false);
+    const filtered = await Effect.runPromise(
+      loadGeoScanRun({
+        ...scope,
+        scanId: "scan",
+        offset: 0,
+        engine: "engine-b",
+      })
+    );
+    expect(filtered?.total).toBe(1);
+    expect(filtered?.results[0]?.engine).toBe("engine-b");
+    expect(filtered?.uniqueSources).toBe(8);
+  });
+
+  test("paginates tied timestamps deterministically and supports legacy runs", async () => {
+    const scope = await seedProject("selected");
+    const startedAt = new Date("2026-09-09T12:00:00Z");
+    await testDb.insert(geoScans).values(
+      Array.from({ length: 12 }, (_, index) => ({
+        id: `scan-${index.toString().padStart(2, "0")}`,
+        ...scope,
+        startedAt,
+        status: "completed" as const,
+      }))
+    );
+    const first = await Effect.runPromise(
+      loadGeoScanRuns({ ...scope, offset: 0 })
+    );
+    const second = await Effect.runPromise(
+      loadGeoScanRuns({ ...scope, offset: GEO_SCAN_RUNS_PAGE_SIZE })
+    );
+    expect(first.hasMore).toBe(true);
+    expect(second.hasMore).toBe(false);
+    expect(first.runs).toHaveLength(10);
+    expect(second.runs).toHaveLength(2);
+    expect(
+      new Set([...first.runs, ...second.runs].map((run) => run.id)).size
+    ).toBe(12);
+    expect(first.runs[0]?.plan).toBeNull();
+    expect(first.runs[0]?.checks).toBe(0);
+  });
+});


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GEO scans now support running one prompt instead of only project-wide scans, while the dashboard tracks each run live and keeps its results for review.

**New Features**
- Prompt rows can start scans with selected engines and languages.
- Scan activity shows recent runs, progress, per-task status, and incomplete or failed work, including multi-step sequences.
- Run details show saved answers by language in the existing answer view with scan-scoped answer selection.
- Adds prompt copy and tag actions alongside the inline scan controls.

**Migration**
- Adds a `plan` JSONB column to `geo_scans` (migration `0083_geo_scan_plan`) to persist planned checks and task status.

<sup>Written for commit 06841e50f8cd3daeaac968de76c48deed38744ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

