### PR TITLE
fix(ai): honor non-enforced ZDR and approved privacy exceptions

### DIFF
--- a/packages/ai/src/constants/router.ts
+++ b/packages/ai/src/constants/router.ts
@@ -119,3 +119,6 @@ export const ROUTER_POLICY = {
   allowNonZdr: process.env.NODE_ENV === "development",
   crossGatewayFallback: true,
 } satisfies RouterPolicyConfig;
+
+export const NO_TRAINING_PROVIDER_ERROR_PATTERN =
+  /No providers that disallow prompt training available for model:/i;

--- a/packages/ai/src/router/README.md
+++ b/packages/ai/src/router/README.md
@@ -34,32 +34,25 @@ one explicitly; other environments enforce ZDR.
 
 ## Privacy
 
-Outside development, every request forces zero data retention and no training:
+Strict requests (`zdr: "required"`) enforce zero data retention and no training:
 
-- OpenRouter: `provider: { zdr: true, data_collection: "deny" }` — set on the
-  provider, on the model and on every call (`providerOptions.openrouter`).
+- OpenRouter: `provider: { zdr: true, data_collection: "deny" }`.
 - Vercel: `gateway: { zeroDataRetention: true, disallowPromptTraining: true }`.
 
-If the preferred gateway cannot serve a compliant request (not configured,
-model unsupported, credits exhausted, upstream outage, or the gateway rejects
-the ZDR requirement — Vercel ZDR is Pro/Enterprise only) the router retries on
-the other gateway **with the same privacy flags**. When no compliant route is
-left it throws `NoCompliantRouteError` instead of downgrading.
+If no compliant route is available, strict requests fail closed.
 
-Callers that may run without ZDR (e.g. GEO scans of a project that disabled
-"Enforce ZDR", or a model the user explicitly approved without a ZDR host)
-pass `zdr: "preferred"`:
+Callers that accept best-effort privacy pass `zdr: "preferred"`. The router
+tries a compliant route first. If providers reject the privacy requirements
+and no compliant fallback exists, it retries with ZDR and no-training defaults
+relaxed. This includes Muse Spark's "No providers that disallow prompt training"
+error. The result is logged as `ai.router.zdr_bypassed` with `zdrEnforced: false`.
 
-```ts
-gateway("meta/muse-spark-1.2", { organizationId, zdr: "preferred" });
-```
+Requests with `zdr: "none"` relax both defaults immediately. These modes work
+outside development and do not depend on the development-only `allowNonZdr`
+policy. Explicit caller no-training restrictions remain in effect.
 
-The first attempt still carries the ZDR flags. Only when the gateway rejects
-ZDR for that model (Vercel 403, OpenRouter 404 "no endpoints matching your
-data policy") the same route is retried without the ZDR flag — no-training
-stays on, the gateway is not marked unavailable for strict requests, and the
-result is logged as `ai.router.zdr_bypassed` (`bypassReason: caller-preferred`)
-with `zdrEnforced: false` in the route metadata.
+OpenRouter receives `zdr: false` on relaxed calls to override the strict
+provider and model defaults.
 
 ## Gateway coverage
 

--- a/packages/ai/src/router/lazy-model.ts
+++ b/packages/ai/src/router/lazy-model.ts
@@ -12,6 +12,7 @@ import {
   HTTP_PAYMENT_REQUIRED,
   HTTP_SERVER_ERROR_MIN,
   OPENROUTER_NO_ZDR_ENDPOINT_PATTERN,
+  NO_TRAINING_PROVIDER_ERROR_PATTERN,
   RETRYABLE_STATUS_CODES,
   ROUTED_MODEL_PROVIDER,
   ROUTER_METADATA_KEY,
@@ -102,6 +103,9 @@ export function classifyUpstreamFailure(
   const status = readStatusCode(error);
   if (status === HTTP_PAYMENT_REQUIRED) {
     return "no-credits";
+  }
+  if (NO_TRAINING_PROVIDER_ERROR_PATTERN.test(readMessage(error))) {
+    return "non-compliant";
   }
   if (
     status !== undefined &&

--- a/packages/ai/src/router/provider-options.ts
+++ b/packages/ai/src/router/provider-options.ts
@@ -182,7 +182,7 @@ export function buildOpenRouterProviderOptions(
   const { zdr: _ignoredZdr, ...existingProviderWithoutZdr } = existingProvider;
   const provider: Record<string, unknown> = {
     ...existingProviderWithoutZdr,
-    zdr,
+    ...(relaxZdr || zdr ? { zdr } : {}),
     data_collection: dataCollection,
   };
 

--- a/packages/ai/src/router/provider-options.ts
+++ b/packages/ai/src/router/provider-options.ts
@@ -99,18 +99,16 @@ export function buildVercelProviderOptions(
     toVercelModelId
   );
 
-  // Production: ZDR + no-training are always forced. Development bypass
-  // (allowNonZdr): ZDR is only sent when the caller asks for it explicitly,
-  // no-training stays on unless the caller opts out. relaxZdr (caller asked
-  // for zdr: "preferred" and the gateway rejected ZDR) drops only the ZDR flag.
+  // Relaxed routes accept providers without ZDR or no-training guarantees.
+  // Explicit caller no-training restrictions still apply.
   const zeroDataRetention = resolveZdrFlag(
     relaxZdr,
     allowNonZdr,
     existing.zeroDataRetention
   );
-  const disallowPromptTraining = !(
-    allowNonZdr && existing.disallowPromptTraining === false
-  );
+  const disallowPromptTraining = relaxZdr
+    ? existing.disallowPromptTraining === true
+    : !(allowNonZdr && existing.disallowPromptTraining === false);
 
   const { zeroDataRetention: _ignoredZdr, ...existingWithoutZdr } = existing;
   const gatewayOptions: Record<string, unknown> = {
@@ -176,14 +174,15 @@ export function buildOpenRouterProviderOptions(
 
   const zdr = resolveZdrFlag(relaxZdr, allowNonZdr, existingProvider.zdr);
   const dataCollection =
-    allowNonZdr && existingProvider.data_collection === "allow"
+    (relaxZdr && existingProvider.data_collection !== "deny") ||
+    (allowNonZdr && existingProvider.data_collection === "allow")
       ? "allow"
       : "deny";
 
   const { zdr: _ignoredZdr, ...existingProviderWithoutZdr } = existingProvider;
   const provider: Record<string, unknown> = {
     ...existingProviderWithoutZdr,
-    ...(zdr ? { zdr: true } : {}),
+    zdr,
     data_collection: dataCollection,
   };
 

--- a/packages/ai/src/router/router.test.ts
+++ b/packages/ai/src/router/router.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@notra/ai/constants/router";
 import type { ZdrMode } from "@notra/ai/types/router";
 
+import { createOpenRouterAdapter } from "./adapters/openrouter";
 import { createVercelAdapter } from "./adapters/vercel";
 import {
   GatewayCreditBalanceError,
@@ -907,7 +908,7 @@ describe("zdr: preferred", () => {
     );
     assert.equal(
       vercel.calls[0]?.options.providerOptions?.gateway?.disallowPromptTraining,
-      true
+      false
     );
     assert.equal(vercel.calls.length, 1);
     assert.equal(openrouter.calls.length, 0);
@@ -941,11 +942,11 @@ describe("zdr: preferred", () => {
       ),
       [true, undefined, undefined]
     );
-    assert.ok(
-      vercel.calls.every(
-        (call) =>
-          call.options.providerOptions?.gateway?.disallowPromptTraining === true
-      )
+    assert.deepEqual(
+      vercel.calls.map(
+        (call) => call.options.providerOptions?.gateway?.disallowPromptTraining
+      ),
+      [true, false, false]
     );
     await assert.rejects(
       async () =>
@@ -1119,4 +1120,122 @@ describe("classifyUpstreamFailure", () => {
     abort.name = "AbortError";
     assert.equal(classifyUpstreamFailure(abort), undefined);
   });
+});
+
+describe("non-enforced workspace privacy", () => {
+  test("none relaxes both gateways with the production policy", async () => {
+    const { router, vercel, openrouter } = createTestRouter({ plans });
+    for (const gateway of ["vercel", "openrouter"] as const) {
+      await router
+        .model(MODEL, { organizationId: PAID_ORG, gateway, zdr: "none" })
+        .doGenerate(callOptions());
+    }
+    assert.equal(
+      vercel?.calls[0]?.options.providerOptions?.gateway?.zeroDataRetention,
+      undefined
+    );
+    assert.equal(
+      vercel?.calls[0]?.options.providerOptions?.gateway
+        ?.disallowPromptTraining,
+      false
+    );
+    assert.deepEqual(
+      openrouter?.calls[0]?.options.providerOptions?.openrouter?.provider,
+      {
+        zdr: false,
+        data_collection: "allow",
+      }
+    );
+  });
+
+  test("preferred recovers from the Muse Spark rejection but required stays strict", async () => {
+    const vercel = createFakeAdapter({
+      id: "vercel",
+      onCall: (call) => {
+        if (call.options.providerOptions?.gateway?.disallowPromptTraining) {
+          throw httpError(
+            500,
+            "No providers that disallow prompt training available for model: meta/muse-spark-1.2. Providers considered: meta"
+          );
+        }
+      },
+    });
+    const { router } = createTestRouter({ plans, vercel, openrouter: null });
+    await router
+      .model(MODEL, {
+        organizationId: PAID_ORG,
+        gateway: "vercel",
+        zdr: "preferred",
+      })
+      .doGenerate(callOptions());
+    assert.deepEqual(
+      vercel.calls.map(
+        (call) => call.options.providerOptions?.gateway?.disallowPromptTraining
+      ),
+      [true, false]
+    );
+    await assert.rejects(
+      async () =>
+        await router
+          .model(MODEL, {
+            organizationId: PAID_ORG,
+            gateway: "vercel",
+            zdr: "required",
+          })
+          .doGenerate(callOptions()),
+      NoCompliantRouteError
+    );
+  });
+});
+
+test("relaxed OpenRouter calls override provider and model privacy defaults on the wire", async () => {
+  const adapter = createOpenRouterAdapter({
+    apiKey: "test-key",
+    fetch: async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      assert.deepEqual(body.provider, { zdr: false, data_collection: "allow" });
+      return Response.json({
+        id: "test",
+        created: 0,
+        model: MODEL,
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "OK" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      });
+    },
+  });
+  await adapter.createModel(MODEL).doGenerate({
+    ...callOptions(),
+    providerOptions: adapter.buildProviderOptions({
+      providerOptions: {},
+      router: {},
+      allowNonZdr: false,
+      relaxZdr: true,
+    }),
+  });
+});
+
+test("relaxed routes preserve explicit no-training restrictions", async () => {
+  const { router, vercel, openrouter } = createTestRouter({ plans });
+  await router
+    .model(MODEL, { gateway: "vercel", zdr: "none" })
+    .doGenerate(callOptions({ gateway: { disallowPromptTraining: true } }));
+  await router
+    .model(MODEL, { gateway: "openrouter", zdr: "none" })
+    .doGenerate(
+      callOptions({ openrouter: { provider: { data_collection: "deny" } } })
+    );
+  assert.equal(
+    vercel?.calls[0]?.options.providerOptions?.gateway?.disallowPromptTraining,
+    true
+  );
+  assert.deepEqual(
+    openrouter?.calls[0]?.options.providerOptions?.openrouter?.provider,
+    { zdr: false, data_collection: "deny" }
+  );
 });

--- a/packages/ai/src/router/router.test.ts
+++ b/packages/ai/src/router/router.test.ts
@@ -793,6 +793,32 @@ describe("RoutedLanguageModel", () => {
 });
 
 describe("development ZDR bypass", () => {
+  test("OpenRouter omits ZDR in development unless requested or explicitly relaxed", async () => {
+    const { router, openrouter } = createTestRouter({
+      plans,
+      policy: { allowNonZdr: true },
+    });
+    await router
+      .model(MODEL, { gateway: "openrouter", zdr: "required" })
+      .doGenerate(callOptions());
+    await router
+      .model(MODEL, { gateway: "openrouter", zdr: "required" })
+      .doGenerate(callOptions({ openrouter: { provider: { zdr: true } } }));
+    await router
+      .model(MODEL, { gateway: "openrouter", zdr: "none" })
+      .doGenerate(callOptions());
+    assert.deepEqual(
+      openrouter?.calls.map(
+        (call) => call.options.providerOptions?.openrouter?.provider
+      ),
+      [
+        { data_collection: "deny" },
+        { zdr: true, data_collection: "deny" },
+        { zdr: false, data_collection: "allow" },
+      ]
+    );
+  });
+
   test("omits ZDR flags unless the caller sets them, keeps no-training on", async () => {
     const { router, vercel, openrouter } = createTestRouter({
       plans,

--- a/packages/ai/src/router/router.test.ts
+++ b/packages/ai/src/router/router.test.ts
@@ -793,32 +793,6 @@ describe("RoutedLanguageModel", () => {
 });
 
 describe("development ZDR bypass", () => {
-  test("OpenRouter omits ZDR in development unless requested or explicitly relaxed", async () => {
-    const { router, openrouter } = createTestRouter({
-      plans,
-      policy: { allowNonZdr: true },
-    });
-    await router
-      .model(MODEL, { gateway: "openrouter", zdr: "required" })
-      .doGenerate(callOptions());
-    await router
-      .model(MODEL, { gateway: "openrouter", zdr: "required" })
-      .doGenerate(callOptions({ openrouter: { provider: { zdr: true } } }));
-    await router
-      .model(MODEL, { gateway: "openrouter", zdr: "none" })
-      .doGenerate(callOptions());
-    assert.deepEqual(
-      openrouter?.calls.map(
-        (call) => call.options.providerOptions?.openrouter?.provider
-      ),
-      [
-        { data_collection: "deny" },
-        { zdr: true, data_collection: "deny" },
-        { zdr: false, data_collection: "allow" },
-      ]
-    );
-  });
-
   test("omits ZDR flags unless the caller sets them, keeps no-training on", async () => {
     const { router, vercel, openrouter } = createTestRouter({
       plans,
@@ -834,13 +808,23 @@ describe("development ZDR bypass", () => {
 
     await router
       .model(MODEL, { organizationId: FREE_ORG })
+      .doGenerate(callOptions());
+    await router
+      .model(MODEL, { organizationId: FREE_ORG })
       .doGenerate(callOptions({ openrouter: { provider: { zdr: true } } }));
-    const openrouterSent = openrouter?.calls[0]?.options.providerOptions
-      ?.openrouter as Record<string, unknown>;
-    assert.deepEqual(openrouterSent.provider, {
-      zdr: true,
-      data_collection: "deny",
-    });
+    await router
+      .model(MODEL, { organizationId: FREE_ORG, zdr: "none" })
+      .doGenerate(callOptions());
+    assert.deepEqual(
+      openrouter?.calls.map(
+        (call) => call.options.providerOptions?.openrouter?.provider
+      ),
+      [
+        { data_collection: "deny" },
+        { zdr: true, data_collection: "deny" },
+        { zdr: false, data_collection: "allow" },
+      ]
+    );
   });
 });
 

--- a/packages/ai/src/types/router.ts
+++ b/packages/ai/src/types/router.ts
@@ -38,8 +38,8 @@ export type RouterErrorCode =
  * How strictly zero data retention is required for a request.
  * - `required` (default): fail closed, never send a non-ZDR request.
  * - `preferred`: try with ZDR; when no gateway has a ZDR host for the model,
- *   run without it (no-training stays on).
- * - `none`: never send the ZDR flag (no-training stays on).
+ *   relax ZDR and no-training defaults.
+ * - `none`: relax ZDR and no-training defaults immediately.
  */
 export type ZdrMode = "required" | "preferred" | "none";
 
@@ -145,9 +145,8 @@ export interface BuildProviderOptionsInput {
   /** When true privacy flags may be relaxed by the caller (dev only). */
   allowNonZdr: boolean;
   /**
-   * When true the ZDR flag is dropped for this call because the caller
-   * requested `zdr: "preferred"` and the gateway rejected ZDR for the model.
-   * No-training stays enforced.
+   * Relax privacy defaults for `zdr: "none"` or an accepted best-effort
+   * fallback from `zdr: "preferred"`. Explicit no-training options remain.
    */
   relaxZdr?: boolean;
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes privacy-mode routing so `zdr: "preferred"` can use an approved non-compliant fallback when no compliant route exists, while `zdr: "required"` still fails closed. Previously, preferred fallbacks and `zdr: "none"` kept no-training enforced; they now relax both defaults, while explicit caller restrictions remain in effect.

- Treats Muse Spark's "No providers that disallow prompt training" response as a non-compliant route and retries preferred requests.
- Sends `zdr: false` and `data_collection: "allow"` to OpenRouter on relaxed calls, overriding stricter provider and model defaults.
- Adds coverage for relaxed Vercel and OpenRouter requests, required-mode failures, and OpenRouter dev-mode ZDR defaults.

<sup>Written for commit 0847670191f2bce66ab82675444930eebcd654ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

