### PR TITLE
fix(web): prevent mobile traffic table header overlap

### DIFF
--- a/apps/web/src/components/landing/citation-rows.tsx
+++ b/apps/web/src/components/landing/citation-rows.tsx
@@ -78,7 +78,7 @@ export function CitationRows({
   headers,
 }: CitationRowsProps) {
   return (
-    <Table className="table-fixed">
+    <Table className="min-w-[52rem] table-fixed">
       <TableHeader className="bg-muted sticky top-0 z-10">
         <TableRow>
           <TableHead className={cn(HEADER_CLASS, "w-[11.5rem]")}>

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -76,7 +76,7 @@ export function HeroSection() {
           </div>
 
           <div className="mt-9 flex w-full flex-1 flex-col items-center overflow-clip py-3.75 sm:mt-16.25">
-            <div className="flex w-full flex-col items-center">
+            <div className="flex w-full flex-col items-center px-3">
               <HeroCollage engine={word.engine} />
             </div>
           </div>

--- a/apps/web/src/components/landing/live-traffic-log.tsx
+++ b/apps/web/src/components/landing/live-traffic-log.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ScrollArea } from "@notra/ui/components/ui/scroll-area";
+import { ScrollArea, ScrollBar } from "@notra/ui/components/ui/scroll-area";
 import { useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 
@@ -40,6 +40,7 @@ export function LiveTrafficLog({ engine }: HeroCollageProps) {
         headers={HERO_COLLAGE_CITATION_HEADERS}
         rows={rows}
       />
+      <ScrollBar orientation="horizontal" />
     </ScrollArea>
   );
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile traffic table header overlap on the landing page so headers no longer misalign with their columns on narrow screens.

- Adds a minimum width to the citation table so it keeps its layout and scrolls horizontally on mobile.
- Adds horizontal padding to the hero collage and a visible horizontal scrollbar for the traffic log.

<sup>Written for commit bfb90fa5d44fa8b52b72c282d83f5b664435213c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

