### PR TITLE
ci: lint blog links on blog changes

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -1,0 +1,26 @@
+name: Blog
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["apps/web/src/content/blog/**/*.mdx"]
+  pull_request:
+    paths: ["apps/web/src/content/blog/**/*.mdx"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Lint blog links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        with:
+          args: >-
+            --no-progress --max-redirects 0 --accept '200..=299'
+            --base-url https://www.usenotra.com/blog/
+            'apps/web/src/content/blog/**/*.mdx'

--- a/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
+++ b/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
@@ -17,5 +17,3 @@ The plan is straightforward. Basic is $20/month with $12 of included usage. Pro 
 ## Why we did this [#why-we-did-this]
 
 Free tiers feel generous when your growth metrics are the only metric. But they hide the cost of what we're actually building. Syncing with GitHub and Linear, running LLMs on every generation, storing and versioning your content. That costs money.
-
-[Temporary CI 404 test](https://www.usenotra.com/blog/codex-ci-missing-page-404-test)

--- a/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
+++ b/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
@@ -17,3 +17,5 @@ The plan is straightforward. Basic is $20/month with $12 of included usage. Pro 
 ## Why we did this [#why-we-did-this]
 
 Free tiers feel generous when your growth metrics are the only metric. But they hide the cost of what we're actually building. Syncing with GitHub and Linear, running LLMs on every generation, storing and versioning your content. That costs money.
+
+[Temporary CI 404 test](https://www.usenotra.com/blog/codex-ci-missing-page-404-test)


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action that lints blog post links on changes to blog content, catching broken links in CI before they reach production.

- The workflow runs on push to `main` and on pull requests touching `apps/web/src/content/blog/**/*.mdx`.
- It uses lychee to verify links return HTTP 200–299 with no redirects.

<sup>Written for commit 81db8b8eb44174d2edbf20a324eb66e3715aa28f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

