### PR TITLE
fix(blog): update broken links and exclude X crawler failures

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -1,0 +1,26 @@
+name: Blog
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["apps/web/src/content/blog/**/*.mdx"]
+  pull_request:
+    paths: ["apps/web/src/content/blog/**/*.mdx"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Lint blog links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        with:
+          args: >-
+            --no-progress --max-redirects 0 --accept '200..=299'
+            --base-url https://www.usenotra.com/blog/
+            'apps/web/src/content/blog/**/*.mdx'

--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Lint blog links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
+          # X profiles load in browsers but return 403 to GitHub-hosted crawlers.
           args: >-
             --no-progress --max-redirects 0 --accept '200..=299'
+            --exclude '^https://x\.com/'
             --base-url https://www.usenotra.com/blog/
             'apps/web/src/content/blog/**/*.mdx'

--- a/apps/web/src/content/blog/best-ai-tools-for-developer-marketing-in-2026.mdx
+++ b/apps/web/src/content/blog/best-ai-tools-for-developer-marketing-in-2026.mdx
@@ -6,7 +6,7 @@ updatedAt: "2026-06-09T12:53:08.191Z"
 author: "dominik"
 ---
 
-The best AI tools for developer marketing in 2026 are **Notra** (auto-generates marketing content from GitHub activity), **Jasper** (enterprise AI content platform with brand voice controls), [**Copy.ai**](http://Copy.ai) (go-to-market workflow automation), **Buffer** (social scheduling with AI generation), **ContentBot** (AI content workflows and automation), and [**daily.dev**](http://daily.dev) **Ads** (developer audience targeting). Each serves a different part of the developer marketing stack, from content creation to distribution.
+The best AI tools for developer marketing in 2026 are **Notra** (auto-generates marketing content from GitHub activity), **Jasper** (enterprise AI content platform with brand voice controls), [**Copy.ai**](https://www.copy.ai/) (go-to-market workflow automation), **Buffer** (social scheduling with AI generation), **ContentBot** (AI content workflows and automation), and [**daily.dev**](http://daily.dev) **Ads** (developer audience targeting). Each serves a different part of the developer marketing stack, from content creation to distribution.
 
 Developer marketing is fundamentally different from traditional B2B marketing. Your audience is technical, skeptical of hype, and values substance over polish. They want to see what you've built, not just what you claim. That's why the right AI tools for developer marketing need to do more than generate generic blog posts—they need to understand technical workflows, respect developer culture, and help you turn actual product work into credible content.
 
@@ -88,22 +88,22 @@ The challenge with Jasper for developer marketing is that it's optimized for tra
 
 **Developer marketing fit:** Good for educational content and product marketing pages. Less useful for product update content or highly technical documentation.
 
-## **3.** [**Copy.ai**](http://Copy.ai) **— Go-to-Market Workflow Automation** [#3-copy-ai-go-to-market-workflow-automation]
+## **3.** [**Copy.ai**](https://www.copy.ai/) **— Go-to-Market Workflow Automation** [#3-copy-ai-go-to-market-workflow-automation]
 
-**What it does:** [Copy.ai](http://Copy.ai) focuses on automating go-to-market workflows, from sales copy to blog content. It's designed to help teams move faster across the entire customer journey, with AI-powered templates for emails, landing pages, ads, and long-form content.
+**What it does:** [Copy.ai](https://www.copy.ai/) focuses on automating go-to-market workflows, from sales copy to blog content. It's designed to help teams move faster across the entire customer journey, with AI-powered templates for emails, landing pages, ads, and long-form content.
 
 **Best for:** Growth teams and product marketers who need to test messaging quickly and produce content across multiple channels.
 
 **Pricing:** Free plan available; paid plans start around $49/month.
 
-**How it works for developer marketing:** [Copy.ai](http://Copy.ai) is particularly strong at generating variations quickly. Need to test five different ways to explain your API? [Copy.ai](http://Copy.ai) can generate them in seconds. It's useful for:
+**How it works for developer marketing:** [Copy.ai](https://www.copy.ai/) is particularly strong at generating variations quickly. Need to test five different ways to explain your API? [Copy.ai](https://www.copy.ai/) can generate them in seconds. It's useful for:
 
 - A/B testing landing page copy
 - Generating social media variations
 - Drafting email sequences for developer onboarding
 - Creating ad copy for developer-focused campaigns
 
-Like Jasper, [Copy.ai](http://Copy.ai) doesn't integrate with developer tools, so you're feeding it information manually. The output tends to be more casual and conversational than Jasper, which can be a good fit for developer audiences if you edit carefully.
+Like Jasper, [Copy.ai](https://www.copy.ai/) doesn't integrate with developer tools, so you're feeding it information manually. The output tends to be more casual and conversational than Jasper, which can be a good fit for developer audiences if you edit carefully.
 
 **Pros:**
 
@@ -182,7 +182,7 @@ The trade-off is that ContentBot's output can feel formulaic. It's optimized for
 
 - Output can feel generic and formulaic
 - No integration with developer tools
-- Less sophisticated than Jasper or [Copy.ai](http://Copy.ai) for brand voice
+- Less sophisticated than Jasper or [Copy.ai](https://www.copy.ai/) for brand voice
 - Requires heavy editing for technical accuracy
 
 **Developer marketing fit:** Good for SEO-focused educational content and documentation. Less useful for product updates or thought leadership.
@@ -225,7 +225,7 @@ This isn't a content creation tool, but it's a powerful distribution channel tha
 | --- | --- | --- | --- | --- | --- |
 | **Notra** | Product update content | $20-50/mo | GitHub, Linear (Slack coming) | Changelogs, blog posts, social, marketing assets | Only tool that generates from dev activity |
 | **Jasper** | High-volume marketing content | $49+/mo | None | All marketing content types | Brand voice control, enterprise features |
-| [**Copy.ai**](http://Copy.ai) | GTM workflow automation | Free-$49/mo | None | Sales copy, ads, social, blog | Fast iteration and testing |
+| [**Copy.ai**](https://www.copy.ai/) | GTM workflow automation | Free-$49/mo | None | Sales copy, ads, social, blog | Fast iteration and testing |
 | **Buffer** | Social media management | $6+/mo per channel | None | Social posts | Scheduling and analytics |
 | **ContentBot** | SEO content at scale | $29+/mo | None | Blog, SEO, documentation | Bulk generation, multi-language |
 | [**daily.dev**](http://daily.dev) **Ads** | Developer audience targeting | $500+ min spend | None | Sponsored content | Targeted developer reach |
@@ -238,7 +238,7 @@ The best tool depends on your team size, content needs, and where you are in you
 
 **If you need high-volume educational content:** Jasper or ContentBot will help you produce blog posts, guides, and tutorials at scale. Expect to invest time in editing for technical accuracy and voice.
 
-**If you're experimenting with messaging:** [Copy.ai](http://Copy.ai) is excellent for testing different angles quickly. Use it to generate variations, then validate with your audience.
+**If you're experimenting with messaging:** [Copy.ai](https://www.copy.ai/) is excellent for testing different angles quickly. Use it to generate variations, then validate with your audience.
 
 **If you have budget for distribution:** Combine any of the content tools above with [daily.dev](http://daily.dev) Ads to reach a targeted developer audience.
 
@@ -276,4 +276,4 @@ Yes, but choose carefully. A small team (1-2 people) benefits most from tools th
 
 ---
 
-**About Notra:** We help dev teams turn their daily work into publish-ready content. Connect your GitHub repo and automatically generate changelogs, blog posts, and social updates from your commits and releases. Learn more at [usenotra.com](http://usenotra.com).
+**About Notra:** We help dev teams turn their daily work into publish-ready content. Connect your GitHub repo and automatically generate changelogs, blog posts, and social updates from your commits and releases. Learn more at [usenotra.com](https://www.usenotra.com/).

--- a/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
+++ b/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
@@ -6,7 +6,7 @@ updatedAt: "2026-05-22T19:53:55.267Z"
 author: "dominik"
 ---
 
-Part of why [Vercel](https://vercel.com/) stays top of mind is that many employees consistently share what they are building on Twitter and engage with users and customers. We see the same pattern at [**Anomaly**](https://anoma.ly/) (behind OpenCode), which has hired engineers like [Ryan Vogel](https://x.com/ryanvogel), [Kit Langton](https://x.com/kitlangton), and [Rhys Sullivan](https://x.com/RhysSullivan) who actively talk about their work, and even at larger companies like [Cloudflare](https://cloudflare.com), where engineers such as [Dillon Mulroy](https://x.com/dillon_mulroy) stream on Twitch and regularly post updates publicly on Twitter.
+Part of why [Vercel](https://vercel.com/) stays top of mind is that many employees consistently share what they are building on Twitter and engage with users and customers. We see the same pattern at [**Anomaly**](https://anoma.ly/) (behind OpenCode), which has hired engineers like [Ryan Vogel](https://x.com/ryanvogel), [Kit Langton](https://x.com/kitlangton), and [Rhys Sullivan](https://x.com/RhysSullivan) who actively talk about their work, and even at larger companies like [Cloudflare](https://www.cloudflare.com/), where engineers such as [Dillon Mulroy](https://x.com/dillon_mulroy) stream on Twitch and regularly post updates publicly on Twitter.
 
 Helping shape a product or feature also creates a personal connection between the company and the product because people get to *see* the work happen. They learn the "why" behind decisions, follow the tradeoffs, and feel like they are part of the journey.
 

--- a/apps/web/src/content/blog/how-notra-uses-upstash-to-run-an-ai-content-pipeline.mdx
+++ b/apps/web/src/content/blog/how-notra-uses-upstash-to-run-an-ai-content-pipeline.mdx
@@ -22,7 +22,7 @@ For example, scraping a marketing site, calling an LLM with a week of GitHub dat
 
 ## Upstash Workflow: no more function timeouts [#upstash-workflow-no-more-function-timeouts]
 
-The [brand analysis workflow](https://github.com/usenotra/notra/blob/main/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts) is a good example. It runs in three steps:
+The [brand analysis workflow](https://github.com/usenotra/notra/blob/66bdd067ddac815e1425b5c239f9baa0914dd17a/apps/dashboard/src/app/api/workflows/brand-analysis/route.ts) is a good example. It runs in three steps:
 
 1. Scrape the user's website with Firecrawl
 2. Call Claude Haiku to extract brand info from the scraped content

--- a/apps/web/src/content/blog/how-to-automate-social-media-posts-from-github-commits.mdx
+++ b/apps/web/src/content/blog/how-to-automate-social-media-posts-from-github-commits.mdx
@@ -35,7 +35,7 @@ Notra is purpose-built for this workflow. It connects directly to GitHub, monito
 
 **1. Connect your GitHub account**
 
-Sign up at [app.usenotra.com](https://app.usenotra.com/) and authorize GitHub access. Notra requests read-only permissions for repository metadata and commit history.
+Sign up at [app.usenotra.com](https://app.usenotra.com/signup) and authorize GitHub access. Notra requests read-only permissions for repository metadata and commit history.
 
 **2. Select repositories to track**
 
@@ -48,7 +48,7 @@ Notra offers three output formats:
 - **Social Posts** — short-form updates for Twitter, LinkedIn, Threads
 - **Changelogs** — structured release notes with grouped changes
 - **Blog Posts** — long-form articles explaining feature launches
-- **Marketing Assets** — marketing assets you can edit directly in [figma](https://figma.com/) or [paper](https://paper.design/)
+- **Marketing Assets** — marketing assets you can edit directly in [figma](https://www.figma.com/) or [paper](https://paper.design/)
 
 Enable the formats you need. Social posts are the most common starting point.
 

--- a/apps/web/src/content/blog/how-to-create-a-grok-bot-plugin.mdx
+++ b/apps/web/src/content/blog/how-to-create-a-grok-bot-plugin.mdx
@@ -26,7 +26,7 @@ We believe that good GEO strategies are all about making your product discoverab
 
 ## Context.dev is a good example [#context-dev-is-a-good-example]
 
-Starting with a good example, let's look at [Context.dev](https://context.dev/).
+Starting with a good example, let's look at [Context.dev](https://www.context.dev/).
 
 Context.dev allows agents to search the web and scrape websites, which is super useful for research and analysis. It is [listed on Cursor's marketplace](https://cursor.com/marketplace/context.dev) and its [plugin source is public](https://github.com/context-dot-dev/cursor-plugin). It's a great example of a tool that is easy to use and discover for agents.
 

--- a/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
+++ b/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
@@ -17,5 +17,3 @@ The plan is straightforward. Basic is $20/month with $12 of included usage. Pro 
 ## Why we did this [#why-we-did-this]
 
 Free tiers feel generous when your growth metrics are the only metric. But they hide the cost of what we're actually building. Syncing with GitHub and Linear, running LLMs on every generation, storing and versioning your content. That costs money.
-
-[Temporary CI 404 test](https://www.usenotra.com/blog/codex-ci-missing-page-404-test)

--- a/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
+++ b/apps/web/src/content/blog/paid-trials-goodbye-free.mdx
@@ -17,3 +17,5 @@ The plan is straightforward. Basic is $20/month with $12 of included usage. Pro 
 ## Why we did this [#why-we-did-this]
 
 Free tiers feel generous when your growth metrics are the only metric. But they hide the cost of what we're actually building. Syncing with GitHub and Linear, running LLMs on every generation, storing and versioning your content. That costs money.
+
+[Temporary CI 404 test](https://www.usenotra.com/blog/codex-ci-missing-page-404-test)


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken links across several blog posts and stops the blog link lint from failing on X profiles, which return 403 to GitHub-hosted crawlers.

**Bug Fixes**
- Updates broken destination links to use correct domains and HTTPS, including `Copy.ai`, `Cloudflare`, `Figma`, `Context.dev`, and `usenotra.com`.
- Pins a GitHub source link in the Upstash post to a specific commit so the link stays valid.
- Excludes `x.com` URLs from the link lint workflow and adds a comment explaining why.

<sup>Written for commit 817b8a333b58b48699a19533cda4547b270d03da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

