### PR TITLE
feat(web): add GEO upsell to blog posts and markdown

### DIFF
--- a/apps/web/src/app/(site)/(blog)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(site)/(blog)/blog/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { BlogCopyArticle } from "@/components/blog-copy-article";
 import { getBlogMDXComponents } from "@/components/blog-mdx-components";
 import { BlogPostPagination } from "@/components/blog-post-pagination";
 import { BlogPostSidebar } from "@/components/blog-post-sidebar";
+import { CtaBanner } from "@/components/landing/cta-banner";
 import {
   formatBlogDate,
   getNotraBlogPostBySlug,
@@ -23,6 +24,7 @@ import {
   buildBlogFaqJsonLd,
 } from "@/utils/blog-jsonld";
 import { blogPostTitleTransitionName } from "@/utils/blog-view-transitions";
+import { buildCtaBannerMarkdown } from "@/utils/cta-banner-markdown";
 import { buildBreadcrumbJsonLd, serializeJsonLd } from "@/utils/jsonld";
 import { DEFAULT_SOCIAL_IMAGE, TWITTER_HANDLE } from "@/utils/metadata";
 import { getReadingTimeMinutes } from "@/utils/reading-time";
@@ -150,7 +152,7 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 
         <div className="col-start-2 row-start-2 self-end justify-self-end lg:col-start-1">
           <BlogCopyArticle
-            markdown={post.markdown}
+            markdown={`${post.markdown.trim()}\n\n${buildCtaBannerMarkdown()}`}
             markdownUrl={markdownUrl}
             title={post.title}
           />
@@ -164,6 +166,9 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
           <BlogPostPagination next={next} previous={previous} />
         </div>
       </article>
+      <div className="mt-16">
+        <CtaBanner />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/constants/landing/cta-banner.ts
+++ b/apps/web/src/constants/landing/cta-banner.ts
@@ -1,4 +1,5 @@
-export const CTA_BANNER_HEADING = "Find out what agents say about you";
+export const CTA_BANNER_HEADING =
+  "Find out what agents say about you. Then change it.";
 
 export const CTA_BANNER_SUBCOPY =
   "Add a few prompts, run a scan, read the answers. Free to start.";

--- a/apps/web/src/utils/cta-banner-markdown.ts
+++ b/apps/web/src/utils/cta-banner-markdown.ts
@@ -1,0 +1,20 @@
+import { AUTH_SIGNUP_URL } from "@/constants/auth";
+import {
+  CTA_BANNER_CONTACT_HREF,
+  CTA_BANNER_HEADING,
+  CTA_BANNER_PRIMARY_LABEL,
+  CTA_BANNER_SECONDARY_LABEL,
+  CTA_BANNER_SUBCOPY,
+} from "@/constants/landing/cta-banner";
+import { markdownSection } from "@/utils/markdown";
+import { SITE_URL } from "@/utils/urls";
+
+export function buildCtaBannerMarkdown() {
+  return markdownSection(CTA_BANNER_HEADING, [
+    CTA_BANNER_SUBCOPY,
+    "",
+    `[${CTA_BANNER_PRIMARY_LABEL}](${AUTH_SIGNUP_URL})`,
+    "",
+    `[${CTA_BANNER_SECONDARY_LABEL}](${new URL(CTA_BANNER_CONTACT_HREF, SITE_URL).href})`,
+  ]);
+}

--- a/apps/web/src/utils/markdown-twins.ts
+++ b/apps/web/src/utils/markdown-twins.ts
@@ -11,6 +11,7 @@ import {
   getChangelogPostHref,
   listNotraChangelogPosts,
 } from "@/utils/changelog";
+import { buildCtaBannerMarkdown } from "@/utils/cta-banner-markdown";
 import { stripFrontmatter } from "@/utils/markdown";
 import {
   getShowcaseCompany,
@@ -126,7 +127,7 @@ async function getBlogEntries(): Promise<MarkdownTwinEntry[]> {
       dateLabel: post.createdAt,
       publishedDate: new Date(post.createdAt),
     },
-    body: post.markdown,
+    body: `${post.markdown.trim()}\n\n${buildCtaBannerMarkdown()}`,
   }));
 }
 

--- a/apps/web/src/utils/site-markdown.ts
+++ b/apps/web/src/utils/site-markdown.ts
@@ -2,10 +2,6 @@ import {
   ANSWER_EXAMPLE_HEADING,
   ANSWER_EXAMPLE_SUBCOPY,
 } from "@/constants/landing/answer-example";
-import {
-  CTA_BANNER_HEADING,
-  CTA_BANNER_SUBCOPY,
-} from "@/constants/landing/cta-banner";
 import { FAQ_CONTENT } from "@/constants/landing/faq";
 import {
   FEATURES_ENGINES_COPY,
@@ -35,6 +31,7 @@ import {
   PRICING_PLANS,
   SOCIAL_PROOF_LOGOS,
 } from "@/utils/constants";
+import { buildCtaBannerMarkdown } from "@/utils/cta-banner-markdown";
 import { markdownSection } from "@/utils/markdown";
 import { SITE_DESCRIPTION, SITE_TAGLINE } from "@/utils/metadata";
 import { SITE_URL } from "@/utils/urls";
@@ -261,12 +258,7 @@ export function buildLandingMarkdown() {
         "",
       ])
     ),
-    markdownSection("Call to Action", [
-      CTA_BANNER_HEADING,
-      CTA_BANNER_SUBCOPY,
-      "",
-      "[Start for free](https://app.usenotra.com/signup)",
-    ]),
+    buildCtaBannerMarkdown(),
   ].join("\n");
 }
 


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GEO upsell call-to-action to blog posts and generated markdown, and unifies the CTA banner copy across landing pages, blog posts, and markdown exports.

The CTA banner heading is updated to "Find out what agents say about you. Then change it.", and the banner markdown is now built from a shared utility so blog post pages and markdown twins render the same upsell block as the landing page.

<sup>Written for commit ea1c7f4c70a50879c50af11215d20f1e9cce6127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

