### PR TITLE
chore(vercel): remove deprecated turbo-ignore commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,28 +252,25 @@ Thanks for helping improve Notra.
 
 ## Vercel build selection
 
-Keep Vercel's **Skip unaffected projects** setting enabled. Each deployed app
-also has a version-pinned `ignoreCommand` in its `vercel.json` to check its
-workspace and transitive dependencies before installing dependencies or building.
-This catches unnecessary builds triggered by root documentation changes and
-unrelated workspaces' Bun lockfile changes. Root install configuration and the
-prepare script are declared in `turbo.json#globalDependencies` so changes to
-those files still trigger builds. Declare any new shared build inputs there too.
+Keep Vercel's **Skip unaffected projects** setting enabled for all five deployed
+apps (`web`, `dashboard`, `agent`, `onboarding-agent`, and `ui`). Vercel uses the
+workspace dependency graph to skip projects whose source and dependencies have
+not changed. Each workspace must have a unique package name and explicitly
+declare its internal dependencies in `package.json`.
 
-The check uses `VERCEL_GIT_PREVIOUS_SHA`, the last successful deployment for
-that project and branch. There is deliberately no `HEAD^` fallback: first
-deployments and unavailable history must build, and multiple commits since the
-last deployment must be considered together. Errors also allow the build.
+The app configs do not set an `ignoreCommand`; build selection relies on
+[Vercel's built-in skipping](https://vercel.com/docs/monorepos#skipping-unaffected-projects)
+instead of the deprecated `turbo-ignore` secondary check. Keep the project's
+Ignored Build Step setting at its default so it does not run an old custom
+command after the repository override is removed.
 
-`turbo-ignore` is deprecated in favor of Vercel's built-in skipping, but the
-pinned version remains a secondary check because built-in skipping currently
-deploys unrelated apps for these changes. Update its version and `--turbo-version`
-across all five app configs together when upgrading, and verify both skipped
-and required builds. Ignored builds still create canceled deployment records
-and briefly occupy a build slot; they avoid the install and full build.
+Changes outside the workspace definitions, such as root documentation, can
+trigger deployments for all apps. Built-in skipping may also select builds that
+the previous secondary check skipped for unrelated Bun lockfile changes.
 
-For a deliberate redeploy after an environment or project-setting change,
-uncheck **Use project's Ignore Build Step** in Vercel's Redeploy dialog.
+Root install configuration and the prepare script remain declared in
+`turbo.json#globalDependencies` for build cache invalidation. Declare any new
+shared build inputs there too.
 
 ## Automated tests
 

--- a/apps/agent/vercel.json
+++ b/apps/agent/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 @notra/agent --turbo-version=2.10.12"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 dashboard --turbo-version=2.10.12",
   "crons": [
     {
       "path": "/api/cron/monitoring",

--- a/apps/onboarding-agent/vercel.json
+++ b/apps/onboarding-agent/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 @notra/onboarding-agent --turbo-version=2.10.12"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/ui/vercel.json
+++ b/apps/ui/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 ui --turbo-version=2.10.12"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx --yes turbo-ignore@2.10.12 web --turbo-version=2.10.12"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the deprecated `turbo-ignore` secondary build check from all five app `vercel.json` configs and updates `CONTRIBUTING.md` to rely on Vercel's built-in workspace skipping instead.

- App builds are now selected only by Vercel's built-in skipping.
- Root documentation changes can now trigger deployments for all apps.
- Vercel may build apps for unrelated Bun lockfile changes that the old check skipped.
- Keep each project's Ignored Build Step at its default so it does not run a stale custom command.

<sup>Written for commit bde0c3fc8c4d8d057722a745bca6552c8741f5c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

