### PR TITLE
feat(logs): extend activity logs beyond content automations

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/settings/logs/columns.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/settings/logs/columns.tsx
@@ -16,7 +16,7 @@ import { IntegrationIcon } from "@/components/logs/integration-icon";
 import { LogStatusBadge } from "@/components/logs/log-status-badge";
 import type { TableColumn } from "@/components/motion/table";
 import type { Log, StatusWithCode } from "@/types/webhooks/webhooks";
-import { formatLogTimestamp } from "@/utils/logs";
+import { formatLogTimestamp, getSourceLabel } from "@/utils/logs";
 
 export const columns: TableColumn<Log>[] = [
   {
@@ -48,7 +48,7 @@ export const columns: TableColumn<Log>[] = [
     cell: (log) => (
       <span className="flex items-center gap-2">
         <IntegrationIcon type={log.integrationType} />
-        <span className="truncate capitalize">{log.integrationType}</span>
+        <span className="truncate">{getSourceLabel(log.integrationType)}</span>
       </span>
     ),
   },

--- a/apps/dashboard/src/components/logs/integration-icon.tsx
+++ b/apps/dashboard/src/components/logs/integration-icon.tsx
@@ -1,11 +1,15 @@
 import {
+  AiScanIcon,
   Calendar03Icon,
+  Globe02Icon,
   Link04Icon,
   Notification03Icon,
+  PaintBoardIcon,
   PlayCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Github } from "@notra/ui/components/ui/svgs/github";
+import { Google } from "@notra/ui/components/ui/svgs/google";
 import { Linear } from "@notra/ui/components/ui/svgs/linear";
 import { Slack } from "@notra/ui/components/ui/svgs/slack";
 
@@ -45,6 +49,29 @@ export function IntegrationIcon({ type }: { type: IntegrationType }) {
         <HugeiconsIcon
           className="text-muted-foreground size-4"
           icon={Notification03Icon}
+        />
+      );
+    case "geo":
+      return (
+        <HugeiconsIcon
+          className="text-muted-foreground size-4"
+          icon={Globe02Icon}
+        />
+      );
+    case "agent-readiness":
+      return (
+        <HugeiconsIcon
+          className="text-muted-foreground size-4"
+          icon={AiScanIcon}
+        />
+      );
+    case "search-console":
+      return <Google className="size-4" />;
+    case "brand":
+      return (
+        <HugeiconsIcon
+          className="text-muted-foreground size-4"
+          icon={PaintBoardIcon}
         />
       );
     default: {

--- a/apps/dashboard/src/components/settings/panes/logs-pane.tsx
+++ b/apps/dashboard/src/components/settings/panes/logs-pane.tsx
@@ -133,7 +133,7 @@ export function LogsSettingsPane() {
               : {
                   title: "No logs yet",
                   description:
-                    "Activity from your integrations and automations will show up here.",
+                    "Activity from your integrations, automations, GEO scans, and syncs will show up here.",
                 }
           }
           onPageChange={setPage}

--- a/apps/dashboard/src/constants/logs.ts
+++ b/apps/dashboard/src/constants/logs.ts
@@ -22,6 +22,15 @@ export const LOG_CONTEXT_FIELDS = {
   outputType: "Content type",
   lookbackWindow: "Lookback window",
   repositoryCount: "Repositories checked",
+  companyName: "Project",
+  checks: "Checks run",
+  mentions: "Mentions found",
+  prompts: "Prompts scanned",
+  engines: "AI engines",
+  keywords: "Keywords synced",
+  suggestionsAdded: "Suggestions created",
+  url: "URL",
+  stage: "Stage",
   runId: "Run ID",
 } as const;
 
@@ -38,6 +47,10 @@ export const SOURCE_VALUES = [
   "manual",
   "schedule",
   "events",
+  "geo",
+  "agent-readiness",
+  "search-console",
+  "brand",
 ] as const satisfies readonly LogSourceFilter[];
 
 export const STATUS_VALUES = [
@@ -56,6 +69,10 @@ export const SOURCE_LABELS: Record<LogSourceFilter, string> = {
   manual: "Manual",
   schedule: "Schedule",
   events: "Events",
+  geo: "GEO",
+  "agent-readiness": "Agent Readiness",
+  "search-console": "Search Console",
+  brand: "Brand",
 };
 
 export const STATUS_LABELS: Record<LogStatusFilter, string> = {

--- a/apps/dashboard/src/types/webhooks/webhooks.ts
+++ b/apps/dashboard/src/types/webhooks/webhooks.ts
@@ -32,7 +32,11 @@ export type IntegrationType =
   | "webhook"
   | "manual"
   | "schedule"
-  | "events";
+  | "events"
+  | "geo"
+  | "agent-readiness"
+  | "search-console"
+  | "brand";
 
 export type LogSourceFilter = "all" | Exclude<IntegrationType, "slack">;
 

--- a/apps/dashboard/src/utils/log-details.ts
+++ b/apps/dashboard/src/utils/log-details.ts
@@ -11,6 +11,21 @@ export function getLogDestination(source: IntegrationType, slug: string) {
   if (source === "events") {
     return { href: `${base}/automation/events`, label: "Open event triggers" };
   }
+  if (source === "geo") {
+    return { href: `${base}/geo`, label: "Open GEO" };
+  }
+  if (source === "agent-readiness") {
+    return {
+      href: `${base}/geo/agent-readiness`,
+      label: "Open agent readiness",
+    };
+  }
+  if (source === "search-console") {
+    return { href: `${base}/geo/traffic`, label: "Open traffic analytics" };
+  }
+  if (source === "brand") {
+    return { href: `${base}/brand/identity`, label: "Open brand identity" };
+  }
   if (source === "github" || source === "linear" || source === "slack") {
     return {
       href: `${base}/integrations/${source}`,

--- a/apps/dashboard/src/workflows/agent-readiness.ts
+++ b/apps/dashboard/src/workflows/agent-readiness.ts
@@ -6,6 +6,10 @@ import type {
 import { flattenError } from "zod";
 
 import { runAgentReadinessScanStep } from "./steps/agent-readiness-steps";
+import {
+  appendAutomationLogBestEffort,
+  fetchLogRetention,
+} from "./steps/content-generation-steps";
 
 export async function agentReadinessWorkflow(
   payload: AgentReadinessWorkflowPayload
@@ -21,5 +25,47 @@ export async function agentReadinessWorkflow(
     return { status: "invalid_payload" };
   }
 
-  return await runAgentReadinessScanStep(parseResult.data);
+  const { organizationId, projectId, reportId, targetUrl } = parseResult.data;
+  const retentionDays = await fetchLogRetention(organizationId);
+
+  let result: AgentReadinessWorkflowResult;
+  try {
+    result = await runAgentReadinessScanStep(parseResult.data);
+  } catch (error) {
+    await appendAutomationLogBestEffort({
+      organizationId,
+      integrationId: projectId,
+      integrationType: "agent-readiness",
+      title: "Agent readiness scan failed",
+      status: "failed",
+      referenceId: reportId,
+      errorMessage: "Workflow failed unexpectedly",
+      payload: { reportId, url: targetUrl },
+      retentionDays,
+    });
+    throw error;
+  }
+  if (result.status === "invalid_payload") {
+    return result;
+  }
+
+  await appendAutomationLogBestEffort({
+    organizationId,
+    integrationId: projectId,
+    integrationType: "agent-readiness",
+    title:
+      result.status === "completed"
+        ? "Agent readiness report generated"
+        : "Agent readiness scan failed",
+    status: result.status === "completed" ? "success" : "failed",
+    referenceId: reportId,
+    payload: {
+      reportId,
+      url: targetUrl,
+    },
+    ...(result.status === "failed" ? { errorMessage: result.reason } : {}),
+    retentionDays,
+  });
+
+  return result;
 }

--- a/apps/dashboard/src/workflows/brand-analysis.ts
+++ b/apps/dashboard/src/workflows/brand-analysis.ts
@@ -2,6 +2,7 @@ import { publicWebsiteUrlSchema } from "@notra/geo-core/schemas/url";
 import { flattenError, object, string } from "zod";
 
 import type { BrandAnalysisPayload } from "@/types/brand-analysis";
+import type { LogRetentionDays } from "@/types/webhooks/webhooks";
 import type { BrandAnalysisWorkflowResult } from "@/types/workflows/brand-analysis";
 
 import {
@@ -10,6 +11,10 @@ import {
   scrapeBrandWebsite,
   setBrandAnalysisProgress,
 } from "./steps/brand-analysis-steps";
+import {
+  appendAutomationLogBestEffort,
+  fetchLogRetention,
+} from "./steps/content-generation-steps";
 
 const STEP_COUNT = 3;
 
@@ -19,6 +24,46 @@ export const brandAnalysisPayloadSchema = object({
   voiceId: string().optional(),
   jobId: string().optional(),
 });
+
+interface BrandAnalysisLogContext {
+  organizationId: string;
+  url: string;
+  voiceId?: string;
+  jobId?: string;
+  retentionDays: LogRetentionDays;
+}
+
+/**
+ * Records the analysis outcome in the organization activity log. The progress
+ * state above powers the live UI only; without a log entry there is no
+ * durable record of what ran or why it failed.
+ */
+async function logBrandAnalysisRun(
+  context: BrandAnalysisLogContext,
+  outcome:
+    | { status: "success"; companyName?: string }
+    | { status: "failed"; stage: string; errorMessage: string }
+): Promise<void> {
+  await appendAutomationLogBestEffort({
+    organizationId: context.organizationId,
+    integrationId: context.voiceId ?? context.organizationId,
+    integrationType: "brand",
+    title:
+      outcome.status === "success"
+        ? `Brand analysis completed${outcome.companyName ? ` for ${outcome.companyName}` : ""}`
+        : "Brand analysis failed",
+    status: outcome.status,
+    payload: {
+      url: context.url,
+      ...(outcome.status === "failed" ? { stage: outcome.stage } : {}),
+    },
+    ...(outcome.status === "failed"
+      ? { errorMessage: outcome.errorMessage }
+      : {}),
+    ...(context.jobId ? { referenceId: context.jobId } : {}),
+    retentionDays: context.retentionDays,
+  });
+}
 
 export async function brandAnalysisWorkflow(
   payload: BrandAnalysisPayload
@@ -35,6 +80,14 @@ export async function brandAnalysisWorkflow(
   }
   const { organizationId, url, voiceId, jobId } = parseResult.data;
   const workflowStartedAt = Date.now();
+  const retentionDays = await fetchLogRetention(organizationId);
+  const logContext: BrandAnalysisLogContext = {
+    organizationId,
+    url,
+    retentionDays,
+    ...(voiceId ? { voiceId } : {}),
+    ...(jobId ? { jobId } : {}),
+  };
 
   try {
     await setBrandAnalysisProgress({
@@ -56,6 +109,11 @@ export async function brandAnalysisWorkflow(
           totalSteps: STEP_COUNT,
           error: scrapingResult.error,
         },
+      });
+      await logBrandAnalysisRun(logContext, {
+        status: "failed",
+        stage: "scraping",
+        errorMessage: scrapingResult.error,
       });
       return { status: "scraping_failed" };
     }
@@ -89,6 +147,11 @@ export async function brandAnalysisWorkflow(
           error: extractionResult.error,
         },
       });
+      await logBrandAnalysisRun(logContext, {
+        status: "failed",
+        stage: "extraction",
+        errorMessage: extractionResult.error,
+      });
       return { status: "extraction_failed" };
     }
 
@@ -117,6 +180,13 @@ export async function brandAnalysisWorkflow(
       },
     });
 
+    await logBrandAnalysisRun(logContext, {
+      status: "success",
+      ...(extractionResult.brandInfo.companyName
+        ? { companyName: extractionResult.brandInfo.companyName }
+        : {}),
+    });
+
     return { status: "completed", brandInfo: extractionResult.brandInfo };
   } catch (error) {
     await setBrandAnalysisProgress({
@@ -129,6 +199,11 @@ export async function brandAnalysisWorkflow(
         totalSteps: STEP_COUNT,
         error: "Workflow failed unexpectedly",
       },
+    });
+    await logBrandAnalysisRun(logContext, {
+      status: "failed",
+      stage: "unexpected",
+      errorMessage: "Workflow failed unexpectedly",
     });
     console.error(
       `[Brand Analysis] Workflow failed for organization ${organizationId}`

--- a/apps/dashboard/src/workflows/brand-guidelines.ts
+++ b/apps/dashboard/src/workflows/brand-guidelines.ts
@@ -18,6 +18,10 @@ import {
   markBrandGuidelinesUnexpectedFailure,
   runBrandGuidelineStage,
 } from "./steps/brand-guidelines-steps";
+import {
+  appendAutomationLogBestEffort,
+  fetchLogRetention,
+} from "./steps/content-generation-steps";
 import { trackWorkflowOutcome } from "./steps/workflow-lifecycle-steps";
 
 export async function brandGuidelinesWorkflow(
@@ -35,6 +39,7 @@ export async function brandGuidelinesWorkflow(
   }
   const { brandSettingsId, organizationId, sourceUrl } = parseResult.data;
   const workflowStartedAt = Date.now();
+  const retentionDays = await fetchLogRetention(organizationId);
 
   try {
     await markBrandGuidelinesGenerating(brandSettingsId);
@@ -59,6 +64,16 @@ export async function brandGuidelinesWorkflow(
           stepFailed: stage,
           reason: result.error,
         });
+        await appendAutomationLogBestEffort({
+          organizationId,
+          integrationId: brandSettingsId,
+          integrationType: "brand",
+          title: "Brand guidelines generation failed",
+          status: "failed",
+          errorMessage: result.error,
+          payload: { url: sourceUrl, stage },
+          retentionDays,
+        });
         return { status: "stage_failed", stage };
       }
     }
@@ -68,6 +83,15 @@ export async function brandGuidelinesWorkflow(
       outcome: WORKFLOW_OUTCOMES.COMPLETED,
       organizationId,
       startedAt: workflowStartedAt,
+    });
+    await appendAutomationLogBestEffort({
+      organizationId,
+      integrationId: brandSettingsId,
+      integrationType: "brand",
+      title: "Brand guidelines generated",
+      status: "success",
+      payload: { url: sourceUrl },
+      retentionDays,
     });
     return { status: "completed" };
   } catch (error) {
@@ -81,6 +105,16 @@ export async function brandGuidelinesWorkflow(
       organizationId,
       startedAt: workflowStartedAt,
       reason: WORKFLOW_UNEXPECTED_FAILURE_REASON,
+    });
+    await appendAutomationLogBestEffort({
+      organizationId,
+      integrationId: brandSettingsId,
+      integrationType: "brand",
+      title: "Brand guidelines generation failed",
+      status: "failed",
+      errorMessage: WORKFLOW_UNEXPECTED_FAILURE_REASON,
+      payload: { url: sourceUrl, stage: "unexpected" },
+      retentionDays,
     });
     throw error;
   }

--- a/apps/dashboard/src/workflows/geo-scan.ts
+++ b/apps/dashboard/src/workflows/geo-scan.ts
@@ -9,6 +9,7 @@ import { geoScanWorkflowPayloadSchema } from "@notra/geo-core/schemas/geo";
 import type {
   GeoScanBatchOutcome,
   GeoScanProjectContext,
+  GeoScanProjectPlan,
   GeoScanProjectTotals,
   GeoScanResult,
 } from "@notra/geo-core/types/geo";
@@ -24,7 +25,12 @@ import { FatalError, sleep } from "workflow";
 import { flattenError } from "zod";
 
 import type { GeoScanPayload } from "@/types/geo";
+import type { LogRetentionDays } from "@/types/webhooks/webhooks";
 
+import {
+  appendAutomationLogBestEffort,
+  fetchLogRetention,
+} from "./steps/content-generation-steps";
 import {
   finalizeGeoScanProjectStep,
   listGeoScanProjectsStep,
@@ -138,6 +144,57 @@ async function runGeoScanBatchWindow<T>(
 }
 
 /**
+ * Persists the project outcome and records it in the organization activity
+ * log, so a finished scan stays visible (with checks, mentions, and the
+ * failure reason) after the live job tracking has disappeared.
+ */
+async function finalizeProjectRun(
+  plan: GeoScanProjectPlan,
+  totals: GeoScanProjectTotals,
+  status: "completed" | "failed",
+  claimedAt: string,
+  options: {
+    retried: boolean;
+    failureReason?: string;
+    retentionDays?: LogRetentionDays;
+  }
+): Promise<void> {
+  await finalizeGeoScanProjectStep(plan.context, totals, status, claimedAt, {
+    retried: options.retried,
+    ...(options.failureReason ? { failureReason: options.failureReason } : {}),
+  });
+  const { context } = plan;
+  const errorMessage =
+    status === "failed"
+      ? (options.failureReason ?? "No successful checks")
+      : undefined;
+  await appendAutomationLogBestEffort({
+    organizationId: context.organizationId,
+    integrationId: context.projectId,
+    integrationType: "geo",
+    title:
+      status === "completed"
+        ? `GEO scan completed for ${context.companyName}`
+        : `GEO scan failed for ${context.companyName}`,
+    status: status === "completed" ? "success" : "failed",
+    referenceId: context.runId,
+    payload: {
+      companyName: context.companyName,
+      scanId: context.scanId,
+      runId: context.runId,
+      checks: totals.checks,
+      mentions: totals.mentions,
+      dropped: totals.dropped,
+      prompts: plan.promptCount,
+      engines: plan.engines.join(", "),
+      retried: options.retried,
+    },
+    ...(errorMessage ? { errorMessage } : {}),
+    ...(options.retentionDays ? { retentionDays: options.retentionDays } : {}),
+  });
+}
+
+/**
  * One project scan as a chain of small steps: plan → task batches →
  * sequence batches → finalize. Each batch persists its own results, so a
  * killed invocation costs one batch, not the scan — the previous single-step
@@ -157,12 +214,14 @@ async function runGeoScanProjectRun(
     retried: boolean;
     promptIds?: string[];
     engines?: string[];
+    retentionDays?: LogRetentionDays;
   }
 ): Promise<GeoScanProjectOutcome | null> {
+  const { retentionDays, ...prepareOptions } = options;
   const planResult = await prepareGeoScanProjectStep(
     organizationId,
     projectId,
-    options
+    prepareOptions
   );
   if (planResult.status === "skipped") {
     return null;
@@ -197,41 +256,26 @@ async function runGeoScanProjectRun(
       state
     );
   } catch (error) {
-    await finalizeGeoScanProjectStep(
-      plan.context,
-      totals,
-      "failed",
-      state.claimedAt,
-      {
-        retried: options.retried,
-        failureReason: describeGeoScanFailure(error),
-      }
-    );
+    await finalizeProjectRun(plan, totals, "failed", state.claimedAt, {
+      retried: options.retried,
+      failureReason: describeGeoScanFailure(error),
+      ...(retentionDays ? { retentionDays } : {}),
+    });
     return { totals, attempted, noSuccessfulChecks: totals.checks === 0 };
   }
 
   if (totals.checks === 0 && attempted > 0) {
-    await finalizeGeoScanProjectStep(
-      plan.context,
-      totals,
-      "failed",
-      state.claimedAt,
-      {
-        retried: options.retried,
-      }
-    );
+    await finalizeProjectRun(plan, totals, "failed", state.claimedAt, {
+      retried: options.retried,
+      ...(retentionDays ? { retentionDays } : {}),
+    });
     return { totals, attempted, noSuccessfulChecks: true };
   }
 
-  await finalizeGeoScanProjectStep(
-    plan.context,
-    totals,
-    "completed",
-    state.claimedAt,
-    {
-      retried: options.retried,
-    }
-  );
+  await finalizeProjectRun(plan, totals, "completed", state.claimedAt, {
+    retried: options.retried,
+    ...(retentionDays ? { retentionDays } : {}),
+  });
   return { totals, attempted, noSuccessfulChecks: false };
 }
 
@@ -256,6 +300,7 @@ export async function geoScanWorkflow(
   if (projectIds.length === 0) {
     return { status: "skipped" };
   }
+  const retentionDays = await fetchLogRetention(organizationId);
   const orderedProjectIds =
     projectId && projectIds.includes(projectId)
       ? [projectId, ...projectIds.filter((id) => id !== projectId)]
@@ -278,6 +323,7 @@ export async function geoScanWorkflow(
       retried: false,
       promptIds,
       engines,
+      retentionDays,
     });
     if (!outcome) {
       continue;
@@ -311,6 +357,7 @@ export async function geoScanWorkflow(
       retried: true,
       promptIds,
       engines,
+      retentionDays,
     });
     if (!outcome) {
       continue;

--- a/apps/dashboard/src/workflows/geo-writer.ts
+++ b/apps/dashboard/src/workflows/geo-writer.ts
@@ -142,7 +142,7 @@ export async function geoWriterWorkflow(
       await appendAutomationLog({
         organizationId,
         integrationId: GEO_WRITER_TRIGGER_ID,
-        integrationType: "manual",
+        integrationType: "geo",
         title: `GEO writer created "${result.title}"`,
         status: "success",
         referenceId: result.postId,
@@ -181,7 +181,7 @@ export async function geoWriterWorkflow(
       appendAutomationLog({
         organizationId,
         integrationId: GEO_WRITER_TRIGGER_ID,
-        integrationType: "manual",
+        integrationType: "geo",
         title: "GEO writer failed",
         status: "failed",
         errorMessage: reason,

--- a/apps/dashboard/src/workflows/gsc-sync.ts
+++ b/apps/dashboard/src/workflows/gsc-sync.ts
@@ -5,6 +5,10 @@ import type {
 } from "@notra/geo-core/types/google-search-console";
 import { flattenError } from "zod";
 
+import {
+  appendAutomationLogBestEffort,
+  fetchLogRetention,
+} from "./steps/content-generation-steps";
 import { runGscSyncStep } from "./steps/gsc-sync-steps";
 
 export async function gscSyncWorkflow(
@@ -18,5 +22,44 @@ export async function gscSyncWorkflow(
     return { status: "invalid_payload" };
   }
 
-  return await runGscSyncStep(parseResult.data.organizationId);
+  const { organizationId } = parseResult.data;
+  const retentionDays = await fetchLogRetention(organizationId);
+
+  let result: GscSyncResult;
+  try {
+    result = await runGscSyncStep(organizationId);
+  } catch (error) {
+    await appendAutomationLogBestEffort({
+      organizationId,
+      integrationId: organizationId,
+      integrationType: "search-console",
+      title: "Search Console sync failed",
+      status: "failed",
+      errorMessage: "Workflow failed unexpectedly",
+      retentionDays,
+    });
+    throw error;
+  }
+  if (result.status === "invalid_payload") {
+    return result;
+  }
+
+  await appendAutomationLogBestEffort({
+    organizationId,
+    integrationId: organizationId,
+    integrationType: "search-console",
+    title:
+      result.status === "completed"
+        ? "Search Console sync completed"
+        : "Search Console sync skipped",
+    status: result.status === "completed" ? "success" : "skipped",
+    payload: {
+      keywords: result.keywords ?? 0,
+      suggestionsAdded: result.suggestionsAdded ?? 0,
+    },
+    ...(result.reason ? { errorMessage: result.reason } : {}),
+    retentionDays,
+  });
+
+  return result;
 }

--- a/apps/dashboard/src/workflows/steps/content-generation-steps.ts
+++ b/apps/dashboard/src/workflows/steps/content-generation-steps.ts
@@ -479,6 +479,26 @@ export async function appendAutomationLog(
   });
 }
 
+/**
+ * Best-effort variant of appendAutomationLog for workflow outcome logging.
+ * Recording activity must never change the outcome of the underlying
+ * workflow: a Redis hiccup goes to stderr, not into a failed
+ * scan/sync/generation (or a broad catch that would mark a successful run as
+ * failed). Intentionally not a step itself so the rejection is swallowed at
+ * the workflow level after the step's own retries are exhausted.
+ */
+export async function appendAutomationLogBestEffort(
+  input: AppendAutomationLogInput
+): Promise<void> {
+  const [result] = await Promise.allSettled([appendAutomationLog(input)]);
+  if (result?.status === "rejected") {
+    console.error(
+      "[ActivityLog] Failed to record activity log:",
+      result.reason
+    );
+  }
+}
+
 export async function trackContentOutcome(
   input: TrackContentOutcomeInput
 ): Promise<void> {

--- a/apps/dashboard/tests/geo-scan-workflow.test.ts
+++ b/apps/dashboard/tests/geo-scan-workflow.test.ts
@@ -10,6 +10,7 @@ import {
 import { EMPTY_AGENT_TOKEN_USAGE } from "@notra/geo-core/utils/token-usage";
 import { FatalError } from "workflow";
 
+import type { AppendAutomationLogInput } from "../src/types/workflows/content-generation-steps";
 import type * as Steps from "../src/workflows/steps/geo-scan-steps";
 import { scanPlan } from "./utils/geo-scan-plan";
 
@@ -21,9 +22,26 @@ const renewClaim = mock<typeof Steps.renewGeoScanClaimStep>();
 const finalize = mock<typeof Steps.finalizeGeoScanProjectStep>();
 const trackRetry = mock<typeof Steps.trackGeoScanRetryScheduledStep>();
 const sleep = mock(async (_delay: string) => undefined);
+const appendLog = mock(async (_input: AppendAutomationLogInput) => undefined);
+const fetchRetention = mock(async () => 30 as const);
 // These tests exercise orchestration decisions as ordinary functions. The
-// durable runtime and model/billing steps have separate integration boundaries.
+// durable runtime and model/billing steps have separate integration
+// boundaries — the activity-log steps are mocked too, otherwise they would
+// perform real Redis/billing network I/O during orchestration tests.
 mock.module("workflow", () => ({ FatalError, sleep }));
+mock.module("../src/workflows/steps/content-generation-steps", () => ({
+  appendAutomationLog: appendLog,
+  fetchLogRetention: fetchRetention,
+  // Mirrors the production best-effort wrapper so orchestration tests can
+  // exercise logging failures without real Redis access.
+  appendAutomationLogBestEffort: async (input: AppendAutomationLogInput) => {
+    try {
+      await appendLog(input);
+    } catch {
+      // swallowed, like the production implementation
+    }
+  },
+}));
 mock.module("../src/workflows/steps/geo-scan-steps", () => ({
   listGeoScanProjectsStep: listProjects,
   prepareGeoScanProjectStep: prepare,
@@ -56,9 +74,13 @@ beforeEach(() => {
     finalize,
     trackRetry,
     sleep,
+    appendLog,
+    fetchRetention,
   ]) {
     fn.mockReset();
   }
+  appendLog.mockResolvedValue(undefined);
+  fetchRetention.mockResolvedValue(30);
   renewClaim.mockImplementation(async (_projectId, claimedAt) => claimedAt);
   listProjects.mockResolvedValue(["project-test"]);
   prepare.mockImplementation(async (_org, projectId) => ({
@@ -113,6 +135,7 @@ describe("GEO scan workflow orchestration", () => {
     });
     expect(taskBatch).not.toHaveBeenCalled();
     expect(finalize).not.toHaveBeenCalled();
+    expect(appendLog).not.toHaveBeenCalled();
     expect(sleep).not.toHaveBeenCalled();
   });
 
@@ -243,6 +266,22 @@ describe("GEO scan workflow orchestration", () => {
       plan.claimedAt,
       { retried: false }
     );
+    expect(appendLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org-test",
+        integrationId: "project-test",
+        integrationType: "geo",
+        title: "GEO scan completed for Notra",
+        status: "success",
+        referenceId: "run-test",
+        retentionDays: 30,
+        payload: expect.objectContaining({
+          checks: plan.tasks.length + plan.sequences.length,
+          mentions: 2,
+          scanId: "scan-project-test",
+        }),
+      })
+    );
     expect(sleep).not.toHaveBeenCalled();
   });
 
@@ -348,6 +387,16 @@ describe("GEO scan workflow orchestration", () => {
       "failed",
       plan.claimedAt,
       { retried: false, failureReason: "Error" }
+    );
+    expect(appendLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org-test",
+        integrationId: "project-test",
+        integrationType: "geo",
+        title: "GEO scan failed for Notra",
+        status: "failed",
+        errorMessage: "Error",
+      })
     );
   });
 
@@ -461,6 +510,19 @@ describe("GEO scan workflow orchestration", () => {
       promptIds: ["prompt-0"],
       engines: ["openai/gpt-4.1"],
     });
+    // Each attempt leaves an activity-log entry: the failed first pass, the
+    // healthy project, and the successful retry.
+    expect(
+      appendLog.mock.calls.map(([input]) => [
+        input.integrationId,
+        input.status,
+        input.payload?.retried,
+      ])
+    ).toEqual([
+      ["empty", "failed", false],
+      ["healthy", "success", false],
+      ["empty", "success", true],
+    ]);
   });
 
   test("a second empty scan fails permanently instead of retrying indefinitely", async () => {
@@ -479,5 +541,52 @@ describe("GEO scan workflow orchestration", () => {
       "failed",
       "failed",
     ]);
+  });
+
+  test("a logging failure on the success path does not change the scan outcome", async () => {
+    appendLog.mockRejectedValue(new Error("Redis unavailable"));
+    const result = await geoScanWorkflow({ organizationId: "org-test" });
+    expect(result).toMatchObject({ status: "completed" });
+    expect(finalize.mock.calls.map(([, , status]) => status)).toEqual([
+      "completed",
+    ]);
+    expect(appendLog).toHaveBeenCalledTimes(1);
+  });
+
+  test("a logging failure after a failed wave does not escalate the failure", async () => {
+    const plan = scanPlan("project-test", GEO_SCAN_TASK_BATCH_SIZE + 1);
+    prepare.mockResolvedValue({ status: "planned", plan });
+    taskBatch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                checks: 2,
+                mentions: 1,
+                dropped: 1,
+                usage: EMPTY_AGENT_TOKEN_USAGE,
+              }),
+            5
+          );
+        })
+    );
+    taskBatch.mockRejectedValueOnce(new Error("Engine unavailable"));
+    appendLog.mockRejectedValue(new Error("Redis unavailable"));
+    // The batch failure is already finalized as "failed"; the rejected log
+    // append must not throw on top of it or alter the returned result.
+    expect(await geoScanWorkflow({ organizationId: "org-test" })).toEqual({
+      status: "completed",
+      checks: 2,
+      mentions: 1,
+    });
+    expect(finalize).toHaveBeenCalledWith(
+      plan.context,
+      expect.objectContaining({ checks: 2 }),
+      "failed",
+      plan.claimedAt,
+      { retried: false, failureReason: "Error" }
+    );
+    expect(appendLog).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/schemas/src/schemas/dashboard/api-params.ts
+++ b/packages/schemas/src/schemas/dashboard/api-params.ts
@@ -14,6 +14,10 @@ export const webhookLogSourceFilterSchema = z.enum([
   "manual",
   "schedule",
   "events",
+  "geo",
+  "agent-readiness",
+  "search-console",
+  "brand",
 ]);
 
 export const webhookLogStatusFilterSchema = z.enum([
@@ -36,6 +40,10 @@ export const webhookLogsQuerySchema = z.object({
       "manual",
       "schedule",
       "events",
+      "geo",
+      "agent-readiness",
+      "search-console",
+      "brand",
     ])
     .default("github"),
   integrationId: z.string().nullish(),


### PR DESCRIPTION
### Description
The Logs page previously only showed content-generation events, even though the product now runs many more automations. This PR turns it into an org-wide activity log so users can see what actually happened across the platform.

**What changed**
- Added new log sources: `geo` (GEO scans), `agent-readiness`, `search-console` (GSC syncs), and `brand` (brand analysis + guidelines)
- Extended `IntegrationType`, zod schemas, source labels/icons, deeplinks, and the logs table/empty-state accordingly
- Added log writers to the `geo-scan`, `agent-readiness`, `gsc-sync`, `brand-analysis`, and `brand-guidelines` workflows
- Reclassified manual GEO scans from `manual` → `geo` source for consistent filtering
- Hardened all new logging as **best-effort** (`Promise.allSettled`): a Redis/logging failure can no longer fail an otherwise successful workflow run (found in review)

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Logs page now shows org-wide activity instead of only content-generation events, so GEO scans, agent-readiness audits, Search Console syncs, and brand analysis/guideline runs appear with outcome counts and failure reasons.

- Adds `geo`, `agent-readiness`, `search-console`, and `brand` log sources across schemas, filters, icons, labels, deeplinks, and the empty-state text.
- Records logs from the geo-scan, geo-writer, agent-readiness, gsc-sync, brand-analysis, and brand-guidelines workflows.
- Reclassifies manual GEO writer entries from `manual` to `geo` for consistent filtering.
- Wraps all new logging in a best-effort helper so a Redis failure cannot fail or alter a workflow result.

<sup>Written for commit dbe3c5c1a8c60d3b580f30e281a45806b320b099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

