### PR TITLE
fix(ui): remove opaque background from opencode engine icons

### DIFF
--- a/packages/ui/src/components/ui/svgs/opencode.tsx
+++ b/packages/ui/src/components/ui/svgs/opencode.tsx
@@ -2,7 +2,7 @@ import type { SVGProps } from "react";
 
 const Opencode = (props: SVGProps<SVGSVGElement>) => (
   <svg {...props} viewBox="0 0 512 512" fill="none">
-    <title>OpenCode</title><rect width="512" height="512" fill="#FDFCFC"/><path d="M320 224V352H192V224H320Z" fill="#E6E5E6"/><path fillRule="evenodd" clipRule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="#17181C"/></svg>
+    <title>OpenCode</title><path d="M320 224V352H192V224H320Z" fill="#E6E5E6"/><path fillRule="evenodd" clipRule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="#17181C"/></svg>
 );
 
 export { Opencode };

--- a/packages/ui/src/components/ui/svgs/opencodeDark.tsx
+++ b/packages/ui/src/components/ui/svgs/opencodeDark.tsx
@@ -1,8 +1,8 @@
 import type { SVGProps } from "react";
 
 const OpencodeDark = (props: SVGProps<SVGSVGElement>) => (
-  <svg {...props} xmlnsXlink="http://www.w3.org/1999/xlink" viewBox="0 0 512 512">
-    <title>OpenCode</title><svg viewBox="0 0 512 512" fill="none"><rect width="512" height="512" fill="#131010"/><path d="M320 224V352H192V224H320Z" fill="#5A5858"/><path fillRule="evenodd" clipRule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="white"/></svg></svg>
+  <svg {...props} viewBox="0 0 512 512" fill="none">
+    <title>OpenCode</title><path d="M320 224V352H192V224H320Z" fill="#5A5858"/><path fillRule="evenodd" clipRule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="white"/></svg>
 );
 
 export { OpencodeDark };


### PR DESCRIPTION
### Description
Fixes the OpenCode icon in the "All Models" stack of the mention activity graph in dark mode. `Opencode` / `OpencodeDark` were the only engine icons with an opaque full-bleed `<rect>` background (`#FDFCFC` / `#131010`), which rendered as a black square sticking out of the circular badge instead of a clean glyph like the other engines. Removed the background rect so both variants are transparent glyphs (fills unchanged), and flattened the needlessly nested `<svg>` in the dark variant.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the opaque background rects from the `Opencode` and `OpencodeDark` engine icons so they render as clean glyphs inside circular badges in dark mode. The icons previously showed as black squares due to the full-bleed `<rect>`; now they're transparent with fills unchanged, and the dark variant's nested `<svg>` is removed.

<sup>Written for commit 82c626432f2908f40b3e5a6fb9bbd7eecb530bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

