### PR TITLE
feat(web): polish marketing nav, 404, and landing hero

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -22,7 +22,13 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname, "../.."),
   },
-  transpilePackages: ["@notra/ui", "@notra/email", "@notra/kiwi"],
+  transpilePackages: [
+    "@notra/ui",
+    "@notra/email",
+    "@notra/kiwi",
+    "@scritto/react",
+    "@scritto/core",
+  ],
   serverExternalPackages: ["@remotion/bundler", "@remotion/renderer"],
   outputFileTracingIncludes: {
     "/blog/**/opengraph-image*": [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "@remotion/fonts": "4.0.487",
     "@remotion/player": "4.0.487",
     "@remotion/renderer": "4.0.487",
+    "@scritto/react": "^0.1.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-form": "^1.33.5",
     "@tanstack/react-hotkeys": "^0.3.0",

--- a/apps/web/src/app/(landing)/layout.tsx
+++ b/apps/web/src/app/(landing)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import FooterSection from "@/components/footer-section";
+import { MobileNavInert } from "@/components/mobile-nav-inert";
 import { Navbar } from "@/components/navbar";
 
 export default function LandingLayout({ children }: { children: ReactNode }) {
@@ -8,8 +9,10 @@ export default function LandingLayout({ children }: { children: ReactNode }) {
     <div className="bg-background relative flex min-h-svh w-full flex-col items-center justify-start">
       <div className="relative isolate flex w-full flex-col items-stretch justify-start">
         <Navbar />
-        {children}
-        <FooterSection />
+        <MobileNavInert>
+          {children}
+          <FooterSection />
+        </MobileNavInert>
       </div>
     </div>
   );

--- a/apps/web/src/app/(site)/layout.tsx
+++ b/apps/web/src/app/(site)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import FooterSection from "@/components/footer-section";
+import { MobileNavInert } from "@/components/mobile-nav-inert";
 import { Navbar } from "@/components/navbar";
 
 export default function SiteLayout({ children }: { children: ReactNode }) {
@@ -8,10 +9,12 @@ export default function SiteLayout({ children }: { children: ReactNode }) {
     <div className="bg-background relative flex min-h-svh w-full flex-col items-stretch justify-start">
       <div className="relative isolate flex w-full flex-col items-stretch justify-start">
         <Navbar />
-        <main className="flex w-full flex-col items-center pb-8 md:pb-12">
-          {children}
-        </main>
-        <FooterSection />
+        <MobileNavInert>
+          <main className="flex w-full flex-col items-center pb-8 md:pb-12">
+            {children}
+          </main>
+          <FooterSection />
+        </MobileNavInert>
       </div>
     </div>
   );

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,46 +1,44 @@
+import { CtaButton } from "@notra/ui/components/shared/cta-button";
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import FooterSection from "@/components/footer-section";
+import { MobileNavInert } from "@/components/mobile-nav-inert";
 import { Navbar } from "@/components/navbar";
-import { NOT_FOUND_AGENT_LINKS } from "@/constants/not-found";
+import { NotFoundNumeral } from "@/components/not-found-numeral";
+import { NOT_FOUND_HOME_LABEL, NOT_FOUND_MESSAGE } from "@/constants/not-found";
+
+const HOME_CTA_CLASSNAME =
+  "h-auto rounded-[2.5625rem] px-6 py-3 font-display font-medium text-[1.125rem] leading-[1.14] tracking-[-0.015em]";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+  robots: { index: false, follow: false },
+};
 
 export default function NotFound() {
   return (
-    <div className="bg-background relative flex min-h-svh w-full flex-col items-center justify-start">
+    <div className="bg-background relative flex min-h-svh w-full flex-col items-center justify-start overflow-x-clip">
       <div className="relative isolate flex w-full flex-col items-stretch justify-start">
-        <Navbar />
-        <div className="flex min-h-[80svh] w-full flex-col items-center justify-center gap-8 px-6">
-          <div className="flex flex-col items-center gap-2">
-            <span className="text-foreground font-serif text-[8rem] leading-none tracking-tight sm:text-[12rem] md:text-[16rem]">
-              404
-            </span>
-            <p className="text-foreground font-serif text-xl sm:text-2xl">
-              This page doesn&apos;t exist yet.
-            </p>
-          </div>
-          <Link
-            className="text-primary hover:text-primary/80 font-sans text-sm underline underline-offset-4 transition-colors"
-            href="/"
-          >
-            Back to home
-          </Link>
-          <nav
-            aria-label="Site indexes"
-            className="text-muted-foreground flex flex-wrap items-center justify-center gap-x-4 gap-y-2 font-sans text-xs"
-          >
-            <span>Looking for an index?</span>
-            {NOT_FOUND_AGENT_LINKS.map((link) => (
-              <a
-                className="hover:text-foreground underline underline-offset-4 transition-colors"
-                href={link.href}
-                key={link.href}
-              >
-                {link.label}
-              </a>
-            ))}
-          </nav>
-        </div>
-        <FooterSection />
+        <Navbar variant="page" />
+        <MobileNavInert>
+          <main className="flex min-h-[80svh] w-full flex-col items-center justify-center gap-8 px-6 py-16">
+            <div className="flex flex-col items-center gap-5">
+              <NotFoundNumeral />
+              <p className="max-w-[28rem] text-center font-sans text-lg font-medium tracking-[-0.01em] text-pretty text-[#1E1E1EBF] sm:text-xl dark:text-white/70">
+                {NOT_FOUND_MESSAGE}
+              </p>
+            </div>
+            <CtaButton
+              className={HOME_CTA_CLASSNAME}
+              nativeButton={false}
+              render={<Link href="/" />}
+            >
+              {NOT_FOUND_HOME_LABEL}
+            </CtaButton>
+          </main>
+          <FooterSection />
+        </MobileNavInert>
       </div>
     </div>
   );

--- a/apps/web/src/components/deferred-dithering.tsx
+++ b/apps/web/src/components/deferred-dithering.tsx
@@ -1,23 +1,11 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
-import dynamic from "next/dynamic";
-import { useSyncExternalStore } from "react";
 
-import { DITHER_MOBILE_MAX_PIXELS } from "@/constants/dithering";
 import { useDitherVisibility } from "@/lib/dithering/use-dither-visibility";
 import type { DeferredDitheringProps } from "@/types/dithering";
-import {
-  getDitherEnvironmentServerSnapshot,
-  getDitherMobileSnapshot,
-  subscribeToDitherViewport,
-} from "@/utils/dither-environment";
 
-const Dithering = dynamic(
-  () =>
-    import("@paper-design/shaders-react").then((module_) => module_.Dithering),
-  { ssr: false }
-);
+import { DitheringCanvas } from "./dithering-canvas";
 
 export function DeferredDithering({
   className,
@@ -28,11 +16,6 @@ export function DeferredDithering({
 }: DeferredDitheringProps) {
   const { containerRef, shouldRender, isAnimating } =
     useDitherVisibility(unmountOffscreen);
-  const isMobile = useSyncExternalStore(
-    subscribeToDitherViewport,
-    getDitherMobileSnapshot,
-    getDitherEnvironmentServerSnapshot
-  );
 
   return (
     <div
@@ -40,17 +23,15 @@ export function DeferredDithering({
       className={cn("pointer-events-none", className)}
       ref={containerRef}
     >
-      {shouldRender && (
-        <Dithering
+      {shouldRender ? (
+        <DitheringCanvas
           {...shaderProps}
+          animate={isAnimating}
           className="h-full w-full"
-          maxPixelCount={
-            maxPixelCount ?? (isMobile ? DITHER_MOBILE_MAX_PIXELS : undefined)
-          }
-          minPixelRatio={isMobile ? 1 : undefined}
-          speed={isAnimating ? speed : 0}
+          maxPixelCount={maxPixelCount}
+          speed={speed}
         />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/deferred-dithering.tsx
+++ b/apps/web/src/components/deferred-dithering.tsx
@@ -1,12 +1,40 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useDitherVisibility } from "@/lib/dithering/use-dither-visibility";
-import type { DeferredDitheringProps } from "@/types/dithering";
+import type {
+  DeferredDitheringProps,
+  DitheringCanvasProps,
+} from "@/types/dithering";
 
 import { DitheringCanvas } from "./dithering-canvas";
+
+function DeferredDitherLayer({
+  speed,
+  maxPixelCount,
+  onPainted,
+  ...shaderProps
+}: DitheringCanvasProps) {
+  const [painted, setPainted] = useState(false);
+
+  return (
+    <DitheringCanvas
+      {...shaderProps}
+      className={cn(
+        "h-full w-full transition-opacity duration-300",
+        painted ? "opacity-100" : "opacity-0"
+      )}
+      maxPixelCount={maxPixelCount}
+      onPainted={() => {
+        setPainted(true);
+        onPainted?.();
+      }}
+      speed={speed}
+    />
+  );
+}
 
 export function DeferredDithering({
   className,
@@ -14,22 +42,13 @@ export function DeferredDithering({
   maxPixelCount,
   unmountOffscreen = false,
   eager = false,
+  onPainted,
   ...shaderProps
 }: DeferredDitheringProps) {
   const { containerRef, shouldRender, isAnimating } = useDitherVisibility(
     unmountOffscreen,
     eager
   );
-  const [painted, setPainted] = useState(false);
-  const handlePainted = useCallback(() => {
-    setPainted(true);
-  }, []);
-
-  useEffect(() => {
-    if (!shouldRender) {
-      setPainted(false);
-    }
-  }, [shouldRender]);
 
   return (
     <div
@@ -38,15 +57,11 @@ export function DeferredDithering({
       ref={containerRef}
     >
       {shouldRender ? (
-        <DitheringCanvas
+        <DeferredDitherLayer
           {...shaderProps}
           animate={isAnimating}
-          className={cn(
-            "h-full w-full transition-opacity duration-300",
-            painted ? "opacity-100" : "opacity-0"
-          )}
           maxPixelCount={maxPixelCount}
-          onPainted={handlePainted}
+          onPainted={onPainted}
           speed={speed}
         />
       ) : null}

--- a/apps/web/src/components/deferred-dithering.tsx
+++ b/apps/web/src/components/deferred-dithering.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { useDitherVisibility } from "@/lib/dithering/use-dither-visibility";
 import type {
@@ -18,6 +18,9 @@ function DeferredDitherLayer({
   ...shaderProps
 }: DitheringCanvasProps) {
   const [painted, setPainted] = useState(false);
+  const onPaintedRef = useRef(onPainted);
+  const didNotify = useRef(false);
+  onPaintedRef.current = onPainted;
 
   return (
     <DitheringCanvas
@@ -28,8 +31,12 @@ function DeferredDitherLayer({
       )}
       maxPixelCount={maxPixelCount}
       onPainted={() => {
+        if (didNotify.current) {
+          return;
+        }
+        didNotify.current = true;
         setPainted(true);
-        onPainted?.();
+        onPaintedRef.current?.();
       }}
       speed={speed}
     />

--- a/apps/web/src/components/deferred-dithering.tsx
+++ b/apps/web/src/components/deferred-dithering.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
+import { useCallback, useEffect, useState } from "react";
 
 import { useDitherVisibility } from "@/lib/dithering/use-dither-visibility";
 import type { DeferredDitheringProps } from "@/types/dithering";
@@ -12,10 +13,23 @@ export function DeferredDithering({
   speed,
   maxPixelCount,
   unmountOffscreen = false,
+  eager = false,
   ...shaderProps
 }: DeferredDitheringProps) {
-  const { containerRef, shouldRender, isAnimating } =
-    useDitherVisibility(unmountOffscreen);
+  const { containerRef, shouldRender, isAnimating } = useDitherVisibility(
+    unmountOffscreen,
+    eager
+  );
+  const [painted, setPainted] = useState(false);
+  const handlePainted = useCallback(() => {
+    setPainted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!shouldRender) {
+      setPainted(false);
+    }
+  }, [shouldRender]);
 
   return (
     <div
@@ -27,8 +41,12 @@ export function DeferredDithering({
         <DitheringCanvas
           {...shaderProps}
           animate={isAnimating}
-          className="h-full w-full"
+          className={cn(
+            "h-full w-full transition-opacity duration-300",
+            painted ? "opacity-100" : "opacity-0"
+          )}
           maxPixelCount={maxPixelCount}
+          onPainted={handlePainted}
           speed={speed}
         />
       ) : null}

--- a/apps/web/src/components/deferred-dithering.tsx
+++ b/apps/web/src/components/deferred-dithering.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useDitherVisibility } from "@/lib/dithering/use-dither-visibility";
 import type {
@@ -20,13 +20,16 @@ function DeferredDitherLayer({
   const [painted, setPainted] = useState(false);
   const onPaintedRef = useRef(onPainted);
   const didNotify = useRef(false);
-  onPaintedRef.current = onPainted;
+
+  useEffect(() => {
+    onPaintedRef.current = onPainted;
+  }, [onPainted]);
 
   return (
     <DitheringCanvas
       {...shaderProps}
       className={cn(
-        "h-full w-full transition-opacity duration-300",
+        "h-full w-full transition-opacity duration-300 motion-reduce:transition-none",
         painted ? "opacity-100" : "opacity-0"
       )}
       maxPixelCount={maxPixelCount}

--- a/apps/web/src/components/dithering-canvas.tsx
+++ b/apps/web/src/components/dithering-canvas.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const DitheringCanvas = dynamic(
+  () => import("./dithering-shader").then((module_) => module_.DitheringShader),
+  { ssr: false }
+);

--- a/apps/web/src/components/dithering-shader.tsx
+++ b/apps/web/src/components/dithering-shader.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+import { Dithering } from "@paper-design/shaders-react";
+import { useSyncExternalStore } from "react";
+
+import { DITHER_MOBILE_MAX_PIXELS } from "@/constants/dithering";
+import { useDitherPainted } from "@/lib/dithering/use-dither-painted";
+import type { DitheringCanvasProps } from "@/types/dithering";
+import {
+  getDitherEnvironmentServerSnapshot,
+  getDitherMobileSnapshot,
+  subscribeToDitherViewport,
+} from "@/utils/dither-environment";
+
+export function DitheringShader({
+  className,
+  speed,
+  maxPixelCount,
+  animate = true,
+  onPainted,
+  ...shaderProps
+}: DitheringCanvasProps) {
+  const isMobile = useSyncExternalStore(
+    subscribeToDitherViewport,
+    getDitherMobileSnapshot,
+    getDitherEnvironmentServerSnapshot
+  );
+  const paintRef = useDitherPainted(onPainted);
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("pointer-events-none", className)}
+      ref={paintRef}
+    >
+      <Dithering
+        {...shaderProps}
+        className="h-full w-full"
+        maxPixelCount={
+          maxPixelCount ?? (isMobile ? DITHER_MOBILE_MAX_PIXELS : undefined)
+        }
+        minPixelRatio={isMobile ? 1 : undefined}
+        speed={animate ? speed : 0}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/citation-rows.tsx
+++ b/apps/web/src/components/landing/citation-rows.tsx
@@ -3,7 +3,6 @@
 import { EngineIcon } from "@notra/ui/components/geo/engine-icon";
 import { PurposeBadge } from "@notra/ui/components/geo/purpose-badge";
 import { ScrollArea, ScrollBar } from "@notra/ui/components/ui/scroll-area";
-import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import {
   TableBody,
   TableCell,
@@ -12,7 +11,6 @@ import {
   TableRow,
 } from "@notra/ui/components/ui/table";
 import { cn } from "@notra/ui/lib/utils";
-import { AnimatePresence, domAnimation, LazyMotion, m } from "motion/react";
 
 import { formatCapturedAt } from "@/lib/landing/live-traffic";
 import type { CitationRowsProps, LiveCitationRow } from "@/types/landing/geo";
@@ -24,11 +22,8 @@ const DUAL_TONE_HEADER =
   "border-border bg-muted overflow-hidden rounded-t-2xl border border-b-0 pb-5";
 const DUAL_TONE_BODY =
   "border-border bg-background relative z-10 -mt-5 min-h-0 flex-1 overflow-hidden rounded-2xl border";
-
-const ROW_ENTER = { opacity: 0, y: -12 } as const;
-const ROW_VISIBLE = { opacity: 1, y: 0 } as const;
-const ROW_EXIT = { opacity: 0 } as const;
-const ROW_TRANSITION = { duration: 0.45, ease: [0.22, 1, 0.36, 1] } as const;
+const ROW_ENTER_CLASS =
+  "animate-in fade-in slide-in-from-top-2 fill-mode-both duration-normal ease-emphasized motion-reduce:animate-none";
 
 function MarkdownFlag() {
   return (
@@ -71,15 +66,9 @@ function CitationCells({
     <>
       <TableCell className="text-muted-foreground hidden py-3.5 text-sm whitespace-nowrap tabular-nums lg:table-cell">
         {base === null ? (
-          <Skeleton aria-hidden className="h-4 w-32" />
+          <span aria-hidden>{"\u00a0"}</span>
         ) : (
-          <m.span
-            animate={{ opacity: 1 }}
-            initial={{ opacity: 0 }}
-            transition={{ duration: 0.3 }}
-          >
-            {formatCapturedAt(row, base)}
-          </m.span>
+          formatCapturedAt(row, base)
         )}
       </TableCell>
       <TableCell className="min-w-0 py-3.5">
@@ -102,73 +91,60 @@ export function CitationRows({
   rows,
   base,
   animated,
+  enteringId,
   headers,
 }: CitationRowsProps) {
   return (
-    <LazyMotion features={domAnimation}>
-      <div
-        className="flex h-full min-h-0 flex-col"
-        role="region"
-        aria-label="Recent AI crawlers"
-      >
-        <div className={DUAL_TONE_HEADER}>
+    <div
+      className="flex h-full min-h-0 flex-col"
+      role="region"
+      aria-label="Recent AI crawlers"
+    >
+      <div className={DUAL_TONE_HEADER}>
+        <table className={TABLE_CLASS}>
+          <CitationColGroup />
+          <TableHeader className="bg-muted">
+            <TableRow className="hover:bg-transparent">
+              <TableHead
+                className={cn(
+                  HEADER_CLASS,
+                  "hidden lg:table-cell lg:w-[11.5rem]"
+                )}
+              >
+                {headers.when}
+              </TableHead>
+              <TableHead className={HEADER_CLASS}>{headers.provider}</TableHead>
+              <TableHead className={cn(HEADER_CLASS, "hidden lg:table-cell")}>
+                {headers.path}
+              </TableHead>
+              <TableHead className={cn(HEADER_CLASS, "lg:w-[11.5rem]")}>
+                {headers.purpose}
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+        </table>
+      </div>
+      <div className={DUAL_TONE_BODY}>
+        <ScrollArea className="h-full">
           <table className={TABLE_CLASS}>
             <CitationColGroup />
-            <TableHeader className="bg-muted">
-              <TableRow className="hover:bg-transparent">
-                <TableHead
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow
                   className={cn(
-                    HEADER_CLASS,
-                    "hidden lg:table-cell lg:w-[11.5rem]"
+                    "[&>td]:border-border [&>td]:border-b",
+                    animated && row.id === enteringId ? ROW_ENTER_CLASS : null
                   )}
+                  key={row.id}
                 >
-                  {headers.when}
-                </TableHead>
-                <TableHead className={HEADER_CLASS}>
-                  {headers.provider}
-                </TableHead>
-                <TableHead className={cn(HEADER_CLASS, "hidden lg:table-cell")}>
-                  {headers.path}
-                </TableHead>
-                <TableHead className={cn(HEADER_CLASS, "lg:w-[11.5rem]")}>
-                  {headers.purpose}
-                </TableHead>
-              </TableRow>
-            </TableHeader>
+                  <CitationCells base={base} row={row} />
+                </TableRow>
+              ))}
+            </TableBody>
           </table>
-        </div>
-        <div className={DUAL_TONE_BODY}>
-          <ScrollArea className="h-full">
-            <table className={TABLE_CLASS}>
-              <CitationColGroup />
-              <TableBody>
-                <AnimatePresence initial={false}>
-                  {rows.map((row) =>
-                    animated ? (
-                      <m.tr
-                        animate={ROW_VISIBLE}
-                        className="[&>td]:border-border [&>td]:border-b"
-                        exit={ROW_EXIT}
-                        initial={ROW_ENTER}
-                        key={row.id}
-                        layout="position"
-                        transition={ROW_TRANSITION}
-                      >
-                        <CitationCells base={base} row={row} />
-                      </m.tr>
-                    ) : (
-                      <TableRow key={row.id}>
-                        <CitationCells base={base} row={row} />
-                      </TableRow>
-                    )
-                  )}
-                </AnimatePresence>
-              </TableBody>
-            </table>
-            <ScrollBar className="max-lg:hidden" orientation="horizontal" />
-          </ScrollArea>
-        </div>
+          <ScrollBar className="max-lg:hidden" orientation="horizontal" />
+        </ScrollArea>
       </div>
-    </LazyMotion>
+    </div>
   );
 }

--- a/apps/web/src/components/landing/citation-rows.tsx
+++ b/apps/web/src/components/landing/citation-rows.tsx
@@ -2,9 +2,9 @@
 
 import { EngineIcon } from "@notra/ui/components/geo/engine-icon";
 import { PurposeBadge } from "@notra/ui/components/geo/purpose-badge";
+import { ScrollArea, ScrollBar } from "@notra/ui/components/ui/scroll-area";
 import { Skeleton } from "@notra/ui/components/ui/skeleton";
 import {
-  Table,
   TableBody,
   TableCell,
   TableHead,
@@ -18,11 +18,47 @@ import { formatCapturedAt } from "@/lib/landing/live-traffic";
 import type { CitationRowsProps, LiveCitationRow } from "@/types/landing/geo";
 
 const HEADER_CLASS = "h-11 text-muted-foreground text-sm";
+const TABLE_CLASS =
+  "w-full table-fixed caption-bottom border-separate border-spacing-0 text-sm";
+const DUAL_TONE_HEADER =
+  "border-border bg-muted overflow-hidden rounded-t-2xl border border-b-0 pb-5";
+const DUAL_TONE_BODY =
+  "border-border bg-background relative z-10 -mt-5 min-h-0 flex-1 overflow-hidden rounded-2xl border";
 
 const ROW_ENTER = { opacity: 0, y: -12 } as const;
 const ROW_VISIBLE = { opacity: 1, y: 0 } as const;
 const ROW_EXIT = { opacity: 0 } as const;
 const ROW_TRANSITION = { duration: 0.45, ease: [0.22, 1, 0.36, 1] } as const;
+
+function MarkdownFlag() {
+  return (
+    <span className="border-border text-muted-foreground inline-flex h-4.5 shrink-0 items-center rounded border px-1 font-mono text-[0.6875rem] leading-none">
+      MD
+    </span>
+  );
+}
+
+function CitationPath({ row }: { row: LiveCitationRow }) {
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="text-muted-foreground min-w-0 truncate font-mono text-[0.8125rem]">
+        {row.path}
+      </span>
+      {row.markdown ? <MarkdownFlag /> : null}
+    </span>
+  );
+}
+
+function CitationColGroup() {
+  return (
+    <colgroup>
+      <col className="hidden lg:table-column lg:w-[11.5rem]" />
+      <col />
+      <col className="hidden lg:table-column" />
+      <col className="w-[9.75rem] lg:w-[11.5rem]" />
+    </colgroup>
+  );
+}
 
 function CitationCells({
   row,
@@ -33,7 +69,7 @@ function CitationCells({
 }) {
   return (
     <>
-      <TableCell className="text-muted-foreground py-3.5 text-sm whitespace-nowrap tabular-nums">
+      <TableCell className="text-muted-foreground hidden py-3.5 text-sm whitespace-nowrap tabular-nums lg:table-cell">
         {base === null ? (
           <Skeleton aria-hidden className="h-4 w-32" />
         ) : (
@@ -46,25 +82,16 @@ function CitationCells({
           </m.span>
         )}
       </TableCell>
-      <TableCell className="py-3.5">
+      <TableCell className="min-w-0 py-3.5">
         <span className="flex items-center gap-2.5 text-[0.9375rem] font-medium whitespace-nowrap">
-          <EngineIcon className="size-4.5" engine={row.engine} />
-          {row.provider}
+          <EngineIcon className="size-4.5 shrink-0" engine={row.engine} />
+          <span className="truncate">{row.provider}</span>
         </span>
       </TableCell>
-      <TableCell className="py-3.5">
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="text-muted-foreground min-w-0 truncate font-mono text-[0.8125rem]">
-            {row.path}
-          </span>
-          {row.markdown ? (
-            <span className="border-border text-muted-foreground inline-flex h-4.5 shrink-0 items-center rounded border px-1 font-mono text-[0.6875rem] leading-none">
-              MD
-            </span>
-          ) : null}
-        </span>
+      <TableCell className="hidden py-3.5 lg:table-cell">
+        <CitationPath row={row} />
       </TableCell>
-      <TableCell className="py-3.5">
+      <TableCell className="w-[1%] py-3.5 whitespace-nowrap">
         <PurposeBadge category={row.purpose} />
       </TableCell>
     </>
@@ -78,46 +105,70 @@ export function CitationRows({
   headers,
 }: CitationRowsProps) {
   return (
-    <Table className="min-w-[52rem] table-fixed">
-      <TableHeader className="bg-muted sticky top-0 z-10">
-        <TableRow>
-          <TableHead className={cn(HEADER_CLASS, "w-[11.5rem]")}>
-            {headers.when}
-          </TableHead>
-          <TableHead className={cn(HEADER_CLASS, "w-[14rem]")}>
-            {headers.provider}
-          </TableHead>
-          <TableHead className={HEADER_CLASS}>{headers.path}</TableHead>
-          <TableHead className={cn(HEADER_CLASS, "w-[11.5rem]")}>
-            {headers.purpose}
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <LazyMotion features={domAnimation}>
-        <TableBody>
-          <AnimatePresence initial={false}>
-            {rows.map((row) =>
-              animated ? (
-                <m.tr
-                  animate={ROW_VISIBLE}
-                  className="[&>td]:border-border [&>td]:border-b"
-                  exit={ROW_EXIT}
-                  initial={ROW_ENTER}
-                  key={row.id}
-                  layout="position"
-                  transition={ROW_TRANSITION}
+    <LazyMotion features={domAnimation}>
+      <div
+        className="flex h-full min-h-0 flex-col"
+        role="region"
+        aria-label="Recent AI crawlers"
+      >
+        <div className={DUAL_TONE_HEADER}>
+          <table className={TABLE_CLASS}>
+            <CitationColGroup />
+            <TableHeader className="bg-muted">
+              <TableRow className="hover:bg-transparent">
+                <TableHead
+                  className={cn(
+                    HEADER_CLASS,
+                    "hidden lg:table-cell lg:w-[11.5rem]"
+                  )}
                 >
-                  <CitationCells base={base} row={row} />
-                </m.tr>
-              ) : (
-                <TableRow key={row.id}>
-                  <CitationCells base={base} row={row} />
-                </TableRow>
-              )
-            )}
-          </AnimatePresence>
-        </TableBody>
-      </LazyMotion>
-    </Table>
+                  {headers.when}
+                </TableHead>
+                <TableHead className={HEADER_CLASS}>
+                  {headers.provider}
+                </TableHead>
+                <TableHead className={cn(HEADER_CLASS, "hidden lg:table-cell")}>
+                  {headers.path}
+                </TableHead>
+                <TableHead className={cn(HEADER_CLASS, "lg:w-[11.5rem]")}>
+                  {headers.purpose}
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+          </table>
+        </div>
+        <div className={DUAL_TONE_BODY}>
+          <ScrollArea className="h-full">
+            <table className={TABLE_CLASS}>
+              <CitationColGroup />
+              <TableBody>
+                <AnimatePresence initial={false}>
+                  {rows.map((row) =>
+                    animated ? (
+                      <m.tr
+                        animate={ROW_VISIBLE}
+                        className="[&>td]:border-border [&>td]:border-b"
+                        exit={ROW_EXIT}
+                        initial={ROW_ENTER}
+                        key={row.id}
+                        layout="position"
+                        transition={ROW_TRANSITION}
+                      >
+                        <CitationCells base={base} row={row} />
+                      </m.tr>
+                    ) : (
+                      <TableRow key={row.id}>
+                        <CitationCells base={base} row={row} />
+                      </TableRow>
+                    )
+                  )}
+                </AnimatePresence>
+              </TableBody>
+            </table>
+            <ScrollBar className="max-lg:hidden" orientation="horizontal" />
+          </ScrollArea>
+        </div>
+      </div>
+    </LazyMotion>
   );
 }

--- a/apps/web/src/components/landing/citation-rows.tsx
+++ b/apps/web/src/components/landing/citation-rows.tsx
@@ -92,6 +92,7 @@ export function CitationRows({
   base,
   animated,
   enteringId,
+  onEntered,
   headers,
 }: CitationRowsProps) {
   return (
@@ -136,6 +137,15 @@ export function CitationRows({
                     animated && row.id === enteringId ? ROW_ENTER_CLASS : null
                   )}
                   key={row.id}
+                  onAnimationEnd={
+                    animated && row.id === enteringId
+                      ? (event) => {
+                          if (event.target === event.currentTarget) {
+                            onEntered?.(row.id);
+                          }
+                        }
+                      : undefined
+                  }
                 >
                   <CitationCells base={base} row={row} />
                 </TableRow>

--- a/apps/web/src/components/landing/features-card-engines.tsx
+++ b/apps/web/src/components/landing/features-card-engines.tsx
@@ -72,7 +72,7 @@ export function FeaturesCardEngines() {
               <TableCell className={cn("py-3", RATE_COL)}>
                 <span className="flex items-center gap-2">
                   <GeoBar
-                    className="h-1.5 w-10 @2xl:w-16"
+                    className="h-1.5 w-10 @lg:w-16"
                     max={RATE_MAX}
                     value={row.mentionRate}
                   />

--- a/apps/web/src/components/landing/features-card-engines.tsx
+++ b/apps/web/src/components/landing/features-card-engines.tsx
@@ -21,6 +21,9 @@ import { GEO_ENGINE_NAMES } from "@/constants/landing/geo-engines";
 
 const HEADER_CLASS = "text-muted-foreground text-xs";
 const RATE_MAX = 100;
+const RATE_COL = "w-[8.25rem]";
+const POSITION_COL = "w-[6.75rem]";
+const CHECKED_COL = "w-[6.5rem]";
 
 export function FeaturesCardEngines() {
   return (
@@ -28,22 +31,30 @@ export function FeaturesCardEngines() {
       heading={FEATURES_ENGINES_FRAME.heading}
       subhead={FEATURES_ENGINES_FRAME.subhead}
     >
-      <Table className="sm:table-fixed">
+      <Table className="table-fixed">
         <TableHeader className="bg-muted/60">
           <TableRow>
             <TableHead className={HEADER_CLASS}>
               {FEATURES_ENGINE_HEADERS.engine}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead className={cn(HEADER_CLASS, RATE_COL)}>
               {FEATURES_ENGINE_HEADERS.mentionRate}
             </TableHead>
             <TableHead
-              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+              className={cn(
+                HEADER_CLASS,
+                FEATURES_TABLE_OPTIONAL_COL,
+                POSITION_COL
+              )}
             >
               {FEATURES_ENGINE_HEADERS.avgPosition}
             </TableHead>
             <TableHead
-              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+              className={cn(
+                HEADER_CLASS,
+                FEATURES_TABLE_OPTIONAL_COL,
+                CHECKED_COL
+              )}
             >
               {FEATURES_ENGINE_HEADERS.lastChecked}
             </TableHead>
@@ -52,18 +63,16 @@ export function FeaturesCardEngines() {
         <TableBody>
           {FEATURES_ENGINE_ROWS.map((row) => (
             <TableRow key={row.id}>
-              <TableCell className="min-w-0 py-3">
-                <span className="flex items-center gap-2 text-sm font-medium">
+              <TableCell className="min-w-0 overflow-hidden py-3">
+                <span className="flex min-w-0 items-center gap-2 text-sm font-medium">
                   <EngineIcon className="shrink-0" engine={row.id} />
-                  <span className="sm:truncate">
-                    {GEO_ENGINE_NAMES[row.id]}
-                  </span>
+                  <span className="truncate">{GEO_ENGINE_NAMES[row.id]}</span>
                 </span>
               </TableCell>
-              <TableCell className="w-[1%] py-3 whitespace-nowrap">
-                <span className="flex items-center gap-2 sm:gap-2.5">
+              <TableCell className={cn("py-3", RATE_COL)}>
+                <span className="flex items-center gap-2">
                   <GeoBar
-                    className="h-1.5 w-10 sm:w-16"
+                    className="h-1.5 w-10 @2xl:w-16"
                     max={RATE_MAX}
                     value={row.mentionRate}
                   />
@@ -74,16 +83,18 @@ export function FeaturesCardEngines() {
               </TableCell>
               <TableCell
                 className={cn(
-                  "text-muted-foreground w-[4.5rem] py-3 text-sm tabular-nums",
-                  FEATURES_TABLE_OPTIONAL_COL
+                  "text-muted-foreground py-3 text-sm tabular-nums",
+                  FEATURES_TABLE_OPTIONAL_COL,
+                  POSITION_COL
                 )}
               >
                 #{row.avgPosition}
               </TableCell>
               <TableCell
                 className={cn(
-                  "text-muted-foreground py-3 text-sm whitespace-nowrap",
-                  FEATURES_TABLE_OPTIONAL_COL
+                  "text-muted-foreground py-3 text-sm",
+                  FEATURES_TABLE_OPTIONAL_COL,
+                  CHECKED_COL
                 )}
               >
                 {row.lastChecked}

--- a/apps/web/src/components/landing/features-card-engines.tsx
+++ b/apps/web/src/components/landing/features-card-engines.tsx
@@ -8,12 +8,14 @@ import {
   TableHeader,
   TableRow,
 } from "@notra/ui/components/ui/table";
+import { cn } from "@notra/ui/lib/utils";
 
 import { MockFrame } from "@/components/landing/mock-frame";
 import {
   FEATURES_ENGINE_HEADERS,
   FEATURES_ENGINE_ROWS,
   FEATURES_ENGINES_FRAME,
+  FEATURES_TABLE_OPTIONAL_COL,
 } from "@/constants/landing/features";
 import { GEO_ENGINE_NAMES } from "@/constants/landing/geo-engines";
 
@@ -23,11 +25,10 @@ const RATE_MAX = 100;
 export function FeaturesCardEngines() {
   return (
     <MockFrame
-      className="w-full min-w-[27rem]"
       heading={FEATURES_ENGINES_FRAME.heading}
       subhead={FEATURES_ENGINES_FRAME.subhead}
     >
-      <Table>
+      <Table className="sm:table-fixed">
         <TableHeader className="bg-muted/60">
           <TableRow>
             <TableHead className={HEADER_CLASS}>
@@ -36,10 +37,14 @@ export function FeaturesCardEngines() {
             <TableHead className={HEADER_CLASS}>
               {FEATURES_ENGINE_HEADERS.mentionRate}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead
+              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+            >
               {FEATURES_ENGINE_HEADERS.avgPosition}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead
+              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+            >
               {FEATURES_ENGINE_HEADERS.lastChecked}
             </TableHead>
           </TableRow>
@@ -47,16 +52,18 @@ export function FeaturesCardEngines() {
         <TableBody>
           {FEATURES_ENGINE_ROWS.map((row) => (
             <TableRow key={row.id}>
-              <TableCell className="py-3">
-                <span className="flex items-center gap-2 text-sm font-medium whitespace-nowrap">
-                  <EngineIcon engine={row.id} />
-                  {GEO_ENGINE_NAMES[row.id]}
+              <TableCell className="min-w-0 py-3">
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <EngineIcon className="shrink-0" engine={row.id} />
+                  <span className="sm:truncate">
+                    {GEO_ENGINE_NAMES[row.id]}
+                  </span>
                 </span>
               </TableCell>
-              <TableCell className="py-3">
-                <span className="flex items-center gap-2.5">
+              <TableCell className="w-[1%] py-3 whitespace-nowrap">
+                <span className="flex items-center gap-2 sm:gap-2.5">
                   <GeoBar
-                    className="w-16"
+                    className="h-1.5 w-10 sm:w-16"
                     max={RATE_MAX}
                     value={row.mentionRate}
                   />
@@ -65,10 +72,20 @@ export function FeaturesCardEngines() {
                   </span>
                 </span>
               </TableCell>
-              <TableCell className="text-muted-foreground py-3 text-sm tabular-nums">
+              <TableCell
+                className={cn(
+                  "text-muted-foreground w-[4.5rem] py-3 text-sm tabular-nums",
+                  FEATURES_TABLE_OPTIONAL_COL
+                )}
+              >
                 #{row.avgPosition}
               </TableCell>
-              <TableCell className="text-muted-foreground py-3 text-sm whitespace-nowrap">
+              <TableCell
+                className={cn(
+                  "text-muted-foreground py-3 text-sm whitespace-nowrap",
+                  FEATURES_TABLE_OPTIONAL_COL
+                )}
+              >
                 {row.lastChecked}
               </TableCell>
             </TableRow>

--- a/apps/web/src/components/landing/features-card-gaps.tsx
+++ b/apps/web/src/components/landing/features-card-gaps.tsx
@@ -13,12 +13,14 @@ import {
   TableRow,
 } from "@notra/ui/components/ui/table";
 import { GEO_GAPS_METER_STEPS } from "@notra/ui/constants/geo";
+import { cn } from "@notra/ui/lib/utils";
 
 import { MockFrame } from "@/components/landing/mock-frame";
 import {
   FEATURES_GAP_HEADERS,
   FEATURES_GAP_ROWS,
   FEATURES_GAPS_FRAME,
+  FEATURES_TABLE_OPTIONAL_COL,
 } from "@/constants/landing/features";
 import { GEO_ENGINE_NAMES } from "@/constants/landing/geo-engines";
 
@@ -27,7 +29,6 @@ const HEADER_CLASS = "text-muted-foreground text-xs";
 export function FeaturesCardGaps() {
   return (
     <MockFrame
-      className="w-full min-w-[27rem]"
       heading={FEATURES_GAPS_FRAME.heading}
       subhead={FEATURES_GAPS_FRAME.subhead}
     >
@@ -40,10 +41,14 @@ export function FeaturesCardGaps() {
             <TableHead className={HEADER_CLASS}>
               {FEATURES_GAP_HEADERS.opportunity}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead
+              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+            >
               {FEATURES_GAP_HEADERS.missing}
             </TableHead>
-            <TableHead className={HEADER_CLASS} />
+            <TableHead
+              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+            />
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -60,7 +65,7 @@ export function FeaturesCardGaps() {
                   level={row.opportunity}
                 />
               </TableCell>
-              <TableCell className="py-3">
+              <TableCell className={cn("py-3", FEATURES_TABLE_OPTIONAL_COL)}>
                 <LogoStack
                   items={row.missing.map((engine) => ({
                     key: engine,
@@ -71,7 +76,7 @@ export function FeaturesCardGaps() {
                   }))}
                 />
               </TableCell>
-              <TableCell className="py-3">
+              <TableCell className={cn("py-3", FEATURES_TABLE_OPTIONAL_COL)}>
                 <Button size="sm" variant="outline">
                   {FEATURES_GAP_HEADERS.action}
                 </Button>

--- a/apps/web/src/components/landing/features-card-gaps.tsx
+++ b/apps/web/src/components/landing/features-card-gaps.tsx
@@ -25,6 +25,9 @@ import {
 import { GEO_ENGINE_NAMES } from "@/constants/landing/geo-engines";
 
 const HEADER_CLASS = "text-muted-foreground text-xs";
+const OPPORTUNITY_COL = "w-[7.5rem]";
+const MISSING_COL = "w-[7.5rem]";
+const ACTION_COL = "w-[4.75rem]";
 
 export function FeaturesCardGaps() {
   return (
@@ -32,40 +35,50 @@ export function FeaturesCardGaps() {
       heading={FEATURES_GAPS_FRAME.heading}
       subhead={FEATURES_GAPS_FRAME.subhead}
     >
-      <Table>
+      <Table className="table-fixed">
         <TableHeader className="bg-muted/60">
           <TableRow>
             <TableHead className={HEADER_CLASS}>
               {FEATURES_GAP_HEADERS.content}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead className={cn(HEADER_CLASS, OPPORTUNITY_COL)}>
               {FEATURES_GAP_HEADERS.opportunity}
             </TableHead>
             <TableHead
-              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+              className={cn(
+                HEADER_CLASS,
+                FEATURES_TABLE_OPTIONAL_COL,
+                MISSING_COL
+              )}
             >
               {FEATURES_GAP_HEADERS.missing}
             </TableHead>
             <TableHead
-              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+              className={cn(
+                HEADER_CLASS,
+                FEATURES_TABLE_OPTIONAL_COL,
+                ACTION_COL
+              )}
             />
           </TableRow>
         </TableHeader>
         <TableBody>
           {FEATURES_GAP_ROWS.map((row) => (
             <TableRow key={row.id}>
-              <TableCell className="max-w-[9rem] py-3">
+              <TableCell className="min-w-0 overflow-hidden py-3">
                 <span className="block truncate text-sm font-medium">
                   {row.content}
                 </span>
               </TableCell>
-              <TableCell className="py-3">
+              <TableCell className={cn("py-3", OPPORTUNITY_COL)}>
                 <GapMeter
                   label={`${row.mentionRate}% mention rate, ${row.opportunity}/${GEO_GAPS_METER_STEPS} opportunity`}
                   level={row.opportunity}
                 />
               </TableCell>
-              <TableCell className={cn("py-3", FEATURES_TABLE_OPTIONAL_COL)}>
+              <TableCell
+                className={cn("py-3", FEATURES_TABLE_OPTIONAL_COL, MISSING_COL)}
+              >
                 <LogoStack
                   items={row.missing.map((engine) => ({
                     key: engine,
@@ -76,7 +89,9 @@ export function FeaturesCardGaps() {
                   }))}
                 />
               </TableCell>
-              <TableCell className={cn("py-3", FEATURES_TABLE_OPTIONAL_COL)}>
+              <TableCell
+                className={cn("py-3", FEATURES_TABLE_OPTIONAL_COL, ACTION_COL)}
+              >
                 <Button size="sm" variant="outline">
                   {FEATURES_GAP_HEADERS.action}
                 </Button>

--- a/apps/web/src/components/landing/features-card-share.tsx
+++ b/apps/web/src/components/landing/features-card-share.tsx
@@ -9,7 +9,6 @@ import {
 export function FeaturesCardShare() {
   return (
     <MockFrame
-      className="w-full min-w-[27rem]"
       heading={FEATURES_SHARE_FRAME.heading}
       subhead={FEATURES_SHARE_FRAME.subhead}
     >

--- a/apps/web/src/components/landing/features-card-traffic.tsx
+++ b/apps/web/src/components/landing/features-card-traffic.tsx
@@ -42,16 +42,20 @@ export function FeaturesCardTraffic() {
             <TableHead className={HEADER_CLASS}>
               {FEATURES_TRAFFIC_HEADERS.source}
             </TableHead>
-            <TableHead className={cn(HEADER_CLASS, "w-[9.75rem] sm:w-auto")}>
+            <TableHead className={cn(HEADER_CLASS, "w-[11.5rem]")}>
               {FEATURES_TRAFFIC_HEADERS.purpose}
             </TableHead>
             <TableHead
-              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL, "w-14")}
             >
               {FEATURES_TRAFFIC_HEADERS.visits}
             </TableHead>
             <TableHead
-              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+              className={cn(
+                HEADER_CLASS,
+                FEATURES_TABLE_OPTIONAL_COL,
+                "w-[4.75rem]"
+              )}
             >
               {FEATURES_TRAFFIC_HEADERS.lastSeen}
             </TableHead>
@@ -60,13 +64,13 @@ export function FeaturesCardTraffic() {
         <TableBody>
           {FEATURES_TRAFFIC_ROWS.map((row) => (
             <TableRow key={row.id}>
-              <TableCell className="min-w-0 py-3">
-                <span className="flex items-center gap-2 text-sm font-medium">
+              <TableCell className="min-w-0 overflow-hidden py-3">
+                <span className="flex min-w-0 items-center gap-2 text-sm font-medium">
                   <EngineIcon className="shrink-0" engine={row.engine} />
                   <span className="truncate">{row.source}</span>
                 </span>
               </TableCell>
-              <TableCell className="w-[9.75rem] py-3 whitespace-nowrap sm:w-auto">
+              <TableCell className="w-[11.5rem] overflow-hidden py-3">
                 <PurposeBadge category={row.purpose} />
               </TableCell>
               <TableCell
@@ -79,7 +83,7 @@ export function FeaturesCardTraffic() {
               </TableCell>
               <TableCell
                 className={cn(
-                  "text-muted-foreground py-3 text-sm whitespace-nowrap",
+                  "text-muted-foreground py-3 text-sm",
                   FEATURES_TABLE_OPTIONAL_COL
                 )}
               >

--- a/apps/web/src/components/landing/features-card-traffic.tsx
+++ b/apps/web/src/components/landing/features-card-traffic.tsx
@@ -9,9 +9,11 @@ import {
   TableHeader,
   TableRow,
 } from "@notra/ui/components/ui/table";
+import { cn } from "@notra/ui/lib/utils";
 
 import { MockFrame } from "@/components/landing/mock-frame";
 import {
+  FEATURES_TABLE_OPTIONAL_COL,
   FEATURES_TRAFFIC_FRAME,
   FEATURES_TRAFFIC_HEADERS,
   FEATURES_TRAFFIC_KPIS,
@@ -23,7 +25,6 @@ const HEADER_CLASS = "text-muted-foreground text-xs";
 export function FeaturesCardTraffic() {
   return (
     <MockFrame
-      className="w-full min-w-[27rem]"
       heading={FEATURES_TRAFFIC_FRAME.heading}
       subhead={FEATURES_TRAFFIC_FRAME.subhead}
     >
@@ -35,19 +36,23 @@ export function FeaturesCardTraffic() {
           value: kpi.value,
         }))}
       />
-      <Table>
+      <Table className="table-fixed">
         <TableHeader className="bg-muted/60">
           <TableRow>
             <TableHead className={HEADER_CLASS}>
               {FEATURES_TRAFFIC_HEADERS.source}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead className={cn(HEADER_CLASS, "w-[9.75rem] sm:w-auto")}>
               {FEATURES_TRAFFIC_HEADERS.purpose}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead
+              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+            >
               {FEATURES_TRAFFIC_HEADERS.visits}
             </TableHead>
-            <TableHead className={HEADER_CLASS}>
+            <TableHead
+              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}
+            >
               {FEATURES_TRAFFIC_HEADERS.lastSeen}
             </TableHead>
           </TableRow>
@@ -55,19 +60,29 @@ export function FeaturesCardTraffic() {
         <TableBody>
           {FEATURES_TRAFFIC_ROWS.map((row) => (
             <TableRow key={row.id}>
-              <TableCell className="py-3">
-                <span className="flex items-center gap-2 text-sm font-medium whitespace-nowrap">
-                  <EngineIcon engine={row.engine} />
-                  {row.source}
+              <TableCell className="min-w-0 py-3">
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <EngineIcon className="shrink-0" engine={row.engine} />
+                  <span className="truncate">{row.source}</span>
                 </span>
               </TableCell>
-              <TableCell className="py-3">
+              <TableCell className="w-[9.75rem] py-3 whitespace-nowrap sm:w-auto">
                 <PurposeBadge category={row.purpose} />
               </TableCell>
-              <TableCell className="py-3 text-sm tabular-nums">
+              <TableCell
+                className={cn(
+                  "py-3 text-sm tabular-nums",
+                  FEATURES_TABLE_OPTIONAL_COL
+                )}
+              >
                 {row.visits.toLocaleString()}
               </TableCell>
-              <TableCell className="text-muted-foreground py-3 text-sm whitespace-nowrap">
+              <TableCell
+                className={cn(
+                  "text-muted-foreground py-3 text-sm whitespace-nowrap",
+                  FEATURES_TABLE_OPTIONAL_COL
+                )}
+              >
                 {row.lastSeen}
               </TableCell>
             </TableRow>

--- a/apps/web/src/components/landing/features-card-traffic.tsx
+++ b/apps/web/src/components/landing/features-card-traffic.tsx
@@ -21,6 +21,8 @@ import {
 } from "@/constants/landing/features";
 
 const HEADER_CLASS = "text-muted-foreground text-xs";
+const VISITS_COL = "w-16";
+const LAST_SEEN_COL = "w-[5.5rem]";
 
 export function FeaturesCardTraffic() {
   return (
@@ -46,7 +48,11 @@ export function FeaturesCardTraffic() {
               {FEATURES_TRAFFIC_HEADERS.purpose}
             </TableHead>
             <TableHead
-              className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL, "w-14")}
+              className={cn(
+                HEADER_CLASS,
+                FEATURES_TABLE_OPTIONAL_COL,
+                VISITS_COL
+              )}
             >
               {FEATURES_TRAFFIC_HEADERS.visits}
             </TableHead>
@@ -54,7 +60,7 @@ export function FeaturesCardTraffic() {
               className={cn(
                 HEADER_CLASS,
                 FEATURES_TABLE_OPTIONAL_COL,
-                "w-[4.75rem]"
+                LAST_SEEN_COL
               )}
             >
               {FEATURES_TRAFFIC_HEADERS.lastSeen}
@@ -76,7 +82,8 @@ export function FeaturesCardTraffic() {
               <TableCell
                 className={cn(
                   "py-3 text-sm tabular-nums",
-                  FEATURES_TABLE_OPTIONAL_COL
+                  FEATURES_TABLE_OPTIONAL_COL,
+                  VISITS_COL
                 )}
               >
                 {row.visits.toLocaleString()}
@@ -84,7 +91,8 @@ export function FeaturesCardTraffic() {
               <TableCell
                 className={cn(
                   "text-muted-foreground py-3 text-sm",
-                  FEATURES_TABLE_OPTIONAL_COL
+                  FEATURES_TABLE_OPTIONAL_COL,
+                  LAST_SEEN_COL
                 )}
               >
                 {row.lastSeen}

--- a/apps/web/src/components/landing/features-section.tsx
+++ b/apps/web/src/components/landing/features-section.tsx
@@ -38,7 +38,7 @@ function FeaturesCard({
           {copy.description}
         </p>
       </div>
-      <div className="relative z-10 -mx-6 mt-2 h-[24.5rem] min-w-0 self-stretch overflow-hidden [mask-image:linear-gradient(to_bottom,black_78%,transparent)] px-6 pt-6">
+      <div className="relative z-10 -mx-6 mt-2 flex h-[24.5rem] min-w-0 flex-col self-stretch overflow-hidden [mask-image:linear-gradient(to_bottom,black_78%,transparent)] px-6 pt-6">
         {children}
       </div>
       {footnote ? (

--- a/apps/web/src/components/landing/hero-collage.tsx
+++ b/apps/web/src/components/landing/hero-collage.tsx
@@ -3,7 +3,7 @@ import type { HeroCollageProps } from "@/types/landing/hero";
 
 export function HeroCollage({ engine }: HeroCollageProps) {
   return (
-    <div className="border-border bg-card h-[36rem] w-full max-w-[64rem] overflow-hidden rounded-2xl border">
+    <div className="h-[36rem] w-full max-w-[64rem]">
       <LiveTrafficLog engine={engine} />
     </div>
   );

--- a/apps/web/src/components/landing/hero-dither.tsx
+++ b/apps/web/src/components/landing/hero-dither.tsx
@@ -1,12 +1,13 @@
 import { DeferredDithering } from "@/components/deferred-dithering";
+import type { HeroDitherProps } from "@/types/dithering";
 
-export function HeroDither() {
+export function HeroDither({ eager = false }: HeroDitherProps) {
   return (
     <DeferredDithering
       className="absolute inset-0 h-full w-full"
       colorBack="#00000000"
       colorFront="#8B5CF633"
-      eager
+      eager={eager}
       fit="cover"
       scale={0.53}
       shape="wave"

--- a/apps/web/src/components/landing/hero-dither.tsx
+++ b/apps/web/src/components/landing/hero-dither.tsx
@@ -6,6 +6,7 @@ export function HeroDither() {
       className="absolute inset-0 h-full w-full"
       colorBack="#00000000"
       colorFront="#8B5CF633"
+      eager
       fit="cover"
       scale={0.53}
       shape="wave"

--- a/apps/web/src/components/landing/hero-headline.tsx
+++ b/apps/web/src/components/landing/hero-headline.tsx
@@ -31,22 +31,18 @@ function EngineMark({
 }: Pick<HeroCycleWord, "engine"> & { animated: boolean }) {
   return (
     <span className={ICON_SLOT_CLASS}>
-      {animated ? (
-        <AnimatePresence initial={false}>
-          <m.span
-            animate={{ opacity: 1 }}
-            className="absolute inset-0"
-            exit={{ opacity: 0 }}
-            initial={{ opacity: 0 }}
-            key={engine}
-            transition={ICON_SWAP}
-          >
-            <EngineIcon className="size-full" engine={engine} />
-          </m.span>
-        </AnimatePresence>
-      ) : (
-        <EngineIcon className="size-full" engine={engine} />
-      )}
+      <AnimatePresence initial={false}>
+        <m.span
+          animate={{ opacity: 1 }}
+          className="absolute inset-0"
+          exit={animated ? { opacity: 0 } : undefined}
+          initial={animated ? { opacity: 0 } : false}
+          key={engine}
+          transition={animated ? ICON_SWAP : { duration: 0 }}
+        >
+          <EngineIcon className="size-full" engine={engine} />
+        </m.span>
+      </AnimatePresence>
     </span>
   );
 }

--- a/apps/web/src/components/landing/hero-headline.tsx
+++ b/apps/web/src/components/landing/hero-headline.tsx
@@ -52,9 +52,9 @@ function WordContent({ word }: { word: HeroCycleWord }) {
 
 export function HeroHeadline({ word }: HeroHeadlineProps) {
   return (
-    <h1 className="font-display max-w-[20.5rem] text-center text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:max-w-[56.875rem] sm:text-[3.25rem] sm:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
-      <span className="block whitespace-nowrap">{HERO_HEADLINE_LINE_ONE} </span>
-      <span className="block whitespace-nowrap">
+    <h1 className="font-display mx-auto w-fit max-w-[20.5rem] text-left text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:max-w-[56.875rem] sm:text-[3.25rem] sm:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
+      <span className="block whitespace-nowrap">{HERO_HEADLINE_LINE_ONE}</span>
+      <span className="flex items-center gap-[0.22em] whitespace-nowrap">
         <LazyMotion features={domMax}>
           <m.span
             className="inline-block"
@@ -62,57 +62,59 @@ export function HeroHeadline({ word }: HeroHeadlineProps) {
             transition={WORD_TRANSITION}
           >
             {HERO_HEADLINE_LINE_TWO_PREFIX}
-          </m.span>{" "}
+          </m.span>
           <span className="sr-only">{listEngineNames()}</span>
-          <m.span
-            aria-hidden
-            className={cn(
-              "relative inline-grid h-[1em] items-center overflow-hidden align-middle",
-              "bg-white text-[#1E1E1E] shadow-[0_0.05em_0.22em_rgba(0,0,0,0.1),0_0_0_0.0625rem_rgba(0,0,0,0.04)] dark:bg-white/[0.08] dark:text-white dark:shadow-[0_0_0_0.0625rem_rgba(255,255,255,0.12)]"
-            )}
-            layout
-            style={{ borderRadius: "0.24em" }}
-            transition={WORD_TRANSITION}
-          >
-            <span
+          <span className="inline-flex items-center">
+            <m.span
               aria-hidden
               className={cn(
-                WORD_CONTENT_CLASS,
-                "invisible col-start-1 row-start-1"
+                "relative inline-grid h-[1em] items-center overflow-hidden",
+                "bg-white text-[#1E1E1E] shadow-[0_0.05em_0.22em_rgba(0,0,0,0.1),0_0_0_0.0625rem_rgba(0,0,0,0.04)] dark:bg-white/[0.08] dark:text-white dark:shadow-[0_0_0_0.0625rem_rgba(255,255,255,0.12)]"
               )}
-              style={{ fontSize: `${wordSizeEm(word)}em` }}
+              layout
+              style={{ borderRadius: "0.24em" }}
+              transition={WORD_TRANSITION}
             >
-              <WordContent word={word} />
-            </span>
-            <span
-              className="absolute inset-0"
-              style={{ fontSize: `${wordSizeEm(word)}em` }}
+              <span
+                aria-hidden
+                className={cn(
+                  WORD_CONTENT_CLASS,
+                  "invisible col-start-1 row-start-1"
+                )}
+                style={{ fontSize: `${wordSizeEm(word)}em` }}
+              >
+                <WordContent word={word} />
+              </span>
+              <span
+                className="absolute inset-0"
+                style={{ fontSize: `${wordSizeEm(word)}em` }}
+              >
+                <AnimatePresence initial={false}>
+                  <m.span
+                    animate={{ opacity: 1, y: 0 }}
+                    className={cn(
+                      WORD_CONTENT_CLASS,
+                      "absolute inset-0 justify-center"
+                    )}
+                    exit={{ opacity: 0, y: "-0.3em" }}
+                    initial={{ opacity: 0, y: "0.3em" }}
+                    key={word.text}
+                    layout="position"
+                    transition={WORD_TRANSITION}
+                  >
+                    <WordContent word={word} />
+                  </m.span>
+                </AnimatePresence>
+              </span>
+            </m.span>
+            <m.span
+              className="inline-block"
+              layout="position"
+              transition={WORD_TRANSITION}
             >
-              <AnimatePresence initial={false}>
-                <m.span
-                  animate={{ opacity: 1, y: 0 }}
-                  className={cn(
-                    WORD_CONTENT_CLASS,
-                    "absolute inset-0 justify-center"
-                  )}
-                  exit={{ opacity: 0, y: "-0.3em" }}
-                  initial={{ opacity: 0, y: "0.3em" }}
-                  key={word.text}
-                  layout="position"
-                  transition={WORD_TRANSITION}
-                >
-                  <WordContent word={word} />
-                </m.span>
-              </AnimatePresence>
-            </span>
-          </m.span>
-          <m.span
-            className="inline-block"
-            layout="position"
-            transition={WORD_TRANSITION}
-          >
-            {HERO_HEADLINE_SUFFIX}
-          </m.span>
+              {HERO_HEADLINE_SUFFIX}
+            </m.span>
+          </span>
         </LazyMotion>
       </span>
     </h1>

--- a/apps/web/src/components/landing/hero-headline.tsx
+++ b/apps/web/src/components/landing/hero-headline.tsx
@@ -10,20 +10,33 @@ import {
   m,
   useReducedMotion,
 } from "motion/react";
-import { createElement, type HTMLAttributes, type ReactNode } from "react";
+import { createElement, useSyncExternalStore, type ReactNode } from "react";
 
 import {
   HERO_HEADLINE_LINE_ONE,
   HERO_HEADLINE_LINE_TWO_PREFIX,
   HERO_HEADLINE_SUFFIX,
-  HERO_HEADLINE_WIDTH_WORD,
 } from "@/constants/landing/hero";
 import type { HeroCycleWord, HeroHeadlineProps } from "@/types/landing/hero";
 
 const ICON_SLOT_CLASS =
-  "relative ml-[0.22em] inline-block size-[0.75em] overflow-visible align-baseline [&_svg]:size-full";
+  "relative ml-[0.22em] inline-flex size-[1cap] shrink-0 items-center justify-center overflow-visible align-baseline";
 
-const ICON_SWAP = tween("slower", "emphasized");
+const ICON_SWAP = tween("slower", "emphasizedInOut");
+const ICON_HIDDEN = { opacity: 0, transform: "scale(0.94)" } as const;
+const ICON_SHOWN = { opacity: 1, transform: "scale(1)" } as const;
+
+function subscribeIsClient() {
+  return () => {};
+}
+
+function useIsClient() {
+  return useSyncExternalStore(
+    subscribeIsClient,
+    () => true,
+    () => false
+  );
+}
 
 function EngineMark({
   engine,
@@ -33,10 +46,10 @@ function EngineMark({
     <span className={ICON_SLOT_CLASS}>
       <AnimatePresence initial={false}>
         <m.span
-          animate={{ opacity: 1 }}
-          className="absolute inset-0"
-          exit={animated ? { opacity: 0 } : undefined}
-          initial={animated ? { opacity: 0 } : false}
+          animate={ICON_SHOWN}
+          className="absolute inset-0 flex items-center justify-center [&_svg]:size-full"
+          exit={animated ? ICON_HIDDEN : undefined}
+          initial={animated ? ICON_HIDDEN : false}
           key={engine}
           transition={animated ? ICON_SWAP : { duration: 0 }}
         >
@@ -47,23 +60,14 @@ function EngineMark({
   );
 }
 
-function ScrittoFlow({
+function HeadlineFlow({
   children,
-  ...props
-}: HTMLAttributes<HTMLElement> & { children?: ReactNode }) {
-  return createElement(
-    "scritto-flow",
-    {
-      ...props,
-      ref: (el: HTMLElement | null) => {
-        if (el) {
-          el.style.display = "inline-flex";
-          el.style.alignItems = "baseline";
-        }
-      },
-    },
-    children
-  );
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return createElement("scritto-flow", { className }, children);
 }
 
 function HeadlineLineTwo({
@@ -73,25 +77,34 @@ function HeadlineLineTwo({
   word: HeroCycleWord;
   animated: boolean;
 }) {
-  return (
-    <span className="flex items-baseline whitespace-nowrap">
+  const morph = useIsClient();
+  const name = morph ? (
+    <Scritto
+      animated={animated}
+      className="ml-[0.16em] align-baseline"
+      value={word.text}
+    />
+  ) : (
+    <span className="ml-[0.16em]">{word.text}</span>
+  );
+  const line = (
+    <>
       {HERO_HEADLINE_LINE_TWO_PREFIX}
       <EngineMark animated={animated} engine={word.engine} />
-      <ScrittoFlow className="ml-[0.16em]">
-        <Scritto
-          animated={animated}
-          className="align-baseline leading-none"
-          value={word.text}
-        />
-      </ScrittoFlow>
+      {name}
       {HERO_HEADLINE_SUFFIX}
-    </span>
+    </>
   );
+
+  if (!morph) {
+    return <span className="block whitespace-nowrap">{line}</span>;
+  }
+
+  return <HeadlineFlow className="whitespace-nowrap">{line}</HeadlineFlow>;
 }
 
 export function HeroHeadline({ word }: HeroHeadlineProps) {
-  const reduceMotion = useReducedMotion();
-  const animated = !reduceMotion;
+  const animated = useReducedMotion() === false;
 
   return (
     <LazyMotion features={domAnimation}>
@@ -99,17 +112,7 @@ export function HeroHeadline({ word }: HeroHeadlineProps) {
         <span className="block whitespace-nowrap">
           {HERO_HEADLINE_LINE_ONE}
         </span>
-        <span className="relative mx-auto block w-fit">
-          <span aria-hidden className="invisible whitespace-nowrap">
-            {HERO_HEADLINE_LINE_TWO_PREFIX}
-            <span className={ICON_SLOT_CLASS} />
-            <span className="ml-[0.16em]">{HERO_HEADLINE_WIDTH_WORD.text}</span>
-            {HERO_HEADLINE_SUFFIX}
-          </span>
-          <span className="absolute inset-0 flex justify-center">
-            <HeadlineLineTwo animated={animated} word={word} />
-          </span>
-        </span>
+        <HeadlineLineTwo animated={animated} word={word} />
       </h1>
     </LazyMotion>
   );

--- a/apps/web/src/components/landing/hero-headline.tsx
+++ b/apps/web/src/components/landing/hero-headline.tsx
@@ -1,121 +1,79 @@
 "use client";
 
 import { EngineIcon } from "@notra/ui/components/geo/engine-icon";
-import { cn } from "@notra/ui/lib/utils";
-import { AnimatePresence, domMax, LazyMotion, m } from "motion/react";
+import Scritto from "@scritto/react";
+import { useReducedMotion } from "motion/react";
+import { createElement, type HTMLAttributes, type ReactNode } from "react";
 
-import { GEO_ENGINE_NAMES } from "@/constants/landing/geo-engines";
 import {
-  HERO_HEADLINE_CYCLE,
   HERO_HEADLINE_LINE_ONE,
   HERO_HEADLINE_LINE_TWO_PREFIX,
   HERO_HEADLINE_SUFFIX,
-  HERO_WORD_SIZE_DESCENDER_EM,
-  HERO_WORD_SIZE_EM,
+  HERO_HEADLINE_WIDTH_WORD,
 } from "@/constants/landing/hero";
 import type { HeroCycleWord, HeroHeadlineProps } from "@/types/landing/hero";
 
-const WORD_TRANSITION = { duration: 0.5, ease: [0.22, 1, 0.36, 1] } as const;
+const ICON_SLOT_CLASS =
+  "ml-[0.22em] inline-block size-[0.75em] overflow-visible align-baseline [&_svg]:block [&_svg]:size-full";
 
-const WORD_CONTENT_CLASS =
-  "inline-flex items-center gap-[0.16em] whitespace-nowrap px-[0.22em] leading-none";
-
-const DESCENDER_PATTERN = /[gjpqy]/;
-
-function wordSizeEm(word: HeroCycleWord): number {
-  return DESCENDER_PATTERN.test(word.text)
-    ? HERO_WORD_SIZE_DESCENDER_EM
-    : HERO_WORD_SIZE_EM;
-}
-
-function listEngineNames(): string {
-  const names = HERO_HEADLINE_CYCLE.map(
-    (word) => GEO_ENGINE_NAMES[word.engine]
-  );
-  const last = names.at(-1);
-  if (names.length < 2 || !last) {
-    return names.join("");
-  }
-  return `${names.slice(0, -1).join(", ")} or ${last}`;
-}
-
-function WordContent({ word }: { word: HeroCycleWord }) {
+function EngineMark({ engine }: Pick<HeroCycleWord, "engine">) {
   return (
-    <>
-      <EngineIcon className="size-[0.68em] shrink-0" engine={word.engine} />
-      <span className="inline-block leading-none [text-box-edge:cap_alphabetic] [text-box-trim:trim-both]">
-        {word.text}
-      </span>
-    </>
+    <span className={ICON_SLOT_CLASS}>
+      <EngineIcon className="size-full" engine={engine} />
+    </span>
+  );
+}
+
+function ScrittoFlow({
+  children,
+  ...props
+}: HTMLAttributes<HTMLElement> & { children?: ReactNode }) {
+  return createElement("scritto-flow", props, children);
+}
+
+function HeadlineLineTwo({
+  word,
+  animated,
+}: {
+  word: HeroCycleWord;
+  animated: boolean;
+}) {
+  return (
+    <span className="whitespace-nowrap">
+      {HERO_HEADLINE_LINE_TWO_PREFIX}
+      <EngineMark engine={word.engine} />
+      {/* Inline style: at connect, ScrittoFlow stamps display:block if it still sees inline. */}
+      <ScrittoFlow
+        className="ml-[0.16em] align-baseline"
+        style={{ display: "inline-block" }}
+      >
+        <Scritto
+          animated={animated}
+          className="align-baseline leading-none"
+          value={word.text}
+        />
+      </ScrittoFlow>
+      {HERO_HEADLINE_SUFFIX}
+    </span>
   );
 }
 
 export function HeroHeadline({ word }: HeroHeadlineProps) {
+  const reduceMotion = useReducedMotion();
+
   return (
-    <h1 className="font-display mx-auto w-fit max-w-[20.5rem] text-left text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:max-w-[56.875rem] sm:text-[3.25rem] sm:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
+    <h1 className="font-display mx-auto w-fit max-w-[20.5rem] text-center text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:max-w-[56.875rem] sm:text-[3.25rem] sm:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
       <span className="block whitespace-nowrap">{HERO_HEADLINE_LINE_ONE}</span>
-      <span className="flex items-center gap-[0.22em] whitespace-nowrap">
-        <LazyMotion features={domMax}>
-          <m.span
-            className="inline-block"
-            layout="position"
-            transition={WORD_TRANSITION}
-          >
-            {HERO_HEADLINE_LINE_TWO_PREFIX}
-          </m.span>
-          <span className="sr-only">{listEngineNames()}</span>
-          <span className="inline-flex items-center">
-            <m.span
-              aria-hidden
-              className={cn(
-                "relative inline-grid h-[1em] items-center overflow-hidden",
-                "bg-white text-[#1E1E1E] shadow-[0_0.05em_0.22em_rgba(0,0,0,0.1),0_0_0_0.0625rem_rgba(0,0,0,0.04)] dark:bg-white/[0.08] dark:text-white dark:shadow-[0_0_0_0.0625rem_rgba(255,255,255,0.12)]"
-              )}
-              layout
-              style={{ borderRadius: "0.24em" }}
-              transition={WORD_TRANSITION}
-            >
-              <span
-                aria-hidden
-                className={cn(
-                  WORD_CONTENT_CLASS,
-                  "invisible col-start-1 row-start-1"
-                )}
-                style={{ fontSize: `${wordSizeEm(word)}em` }}
-              >
-                <WordContent word={word} />
-              </span>
-              <span
-                className="absolute inset-0"
-                style={{ fontSize: `${wordSizeEm(word)}em` }}
-              >
-                <AnimatePresence initial={false}>
-                  <m.span
-                    animate={{ opacity: 1, y: 0 }}
-                    className={cn(
-                      WORD_CONTENT_CLASS,
-                      "absolute inset-0 justify-center"
-                    )}
-                    exit={{ opacity: 0, y: "-0.3em" }}
-                    initial={{ opacity: 0, y: "0.3em" }}
-                    key={word.text}
-                    layout="position"
-                    transition={WORD_TRANSITION}
-                  >
-                    <WordContent word={word} />
-                  </m.span>
-                </AnimatePresence>
-              </span>
-            </m.span>
-            <m.span
-              className="inline-block"
-              layout="position"
-              transition={WORD_TRANSITION}
-            >
-              {HERO_HEADLINE_SUFFIX}
-            </m.span>
-          </span>
-        </LazyMotion>
+      <span className="relative mx-auto block w-fit">
+        <span aria-hidden className="invisible whitespace-nowrap">
+          {HERO_HEADLINE_LINE_TWO_PREFIX}
+          <span className={ICON_SLOT_CLASS} />
+          <span className="ml-[0.16em]">{HERO_HEADLINE_WIDTH_WORD.text}</span>
+          {HERO_HEADLINE_SUFFIX}
+        </span>
+        <span className="absolute inset-0 flex justify-center">
+          <HeadlineLineTwo animated={!reduceMotion} word={word} />
+        </span>
       </span>
     </h1>
   );

--- a/apps/web/src/components/landing/hero-headline.tsx
+++ b/apps/web/src/components/landing/hero-headline.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { EngineIcon } from "@notra/ui/components/geo/engine-icon";
+import { tween } from "@notra/ui/lib/motion";
 import Scritto from "@scritto/react";
-import { useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m,
+  useReducedMotion,
+} from "motion/react";
 import { createElement, type HTMLAttributes, type ReactNode } from "react";
 
 import {
@@ -14,12 +21,32 @@ import {
 import type { HeroCycleWord, HeroHeadlineProps } from "@/types/landing/hero";
 
 const ICON_SLOT_CLASS =
-  "ml-[0.22em] inline-block size-[0.75em] overflow-visible align-baseline [&_svg]:block [&_svg]:size-full";
+  "relative ml-[0.22em] inline-block size-[0.75em] overflow-visible align-baseline [&_svg]:size-full";
 
-function EngineMark({ engine }: Pick<HeroCycleWord, "engine">) {
+const ICON_SWAP = tween("slower", "emphasized");
+
+function EngineMark({
+  engine,
+  animated,
+}: Pick<HeroCycleWord, "engine"> & { animated: boolean }) {
   return (
     <span className={ICON_SLOT_CLASS}>
-      <EngineIcon className="size-full" engine={engine} />
+      {animated ? (
+        <AnimatePresence initial={false}>
+          <m.span
+            animate={{ opacity: 1 }}
+            className="absolute inset-0"
+            exit={{ opacity: 0 }}
+            initial={{ opacity: 0 }}
+            key={engine}
+            transition={ICON_SWAP}
+          >
+            <EngineIcon className="size-full" engine={engine} />
+          </m.span>
+        </AnimatePresence>
+      ) : (
+        <EngineIcon className="size-full" engine={engine} />
+      )}
     </span>
   );
 }
@@ -28,7 +55,19 @@ function ScrittoFlow({
   children,
   ...props
 }: HTMLAttributes<HTMLElement> & { children?: ReactNode }) {
-  return createElement("scritto-flow", props, children);
+  return createElement(
+    "scritto-flow",
+    {
+      ...props,
+      ref: (el: HTMLElement | null) => {
+        if (el) {
+          el.style.display = "inline-flex";
+          el.style.alignItems = "baseline";
+        }
+      },
+    },
+    children
+  );
 }
 
 function HeadlineLineTwo({
@@ -39,14 +78,10 @@ function HeadlineLineTwo({
   animated: boolean;
 }) {
   return (
-    <span className="whitespace-nowrap">
+    <span className="flex items-baseline whitespace-nowrap">
       {HERO_HEADLINE_LINE_TWO_PREFIX}
-      <EngineMark engine={word.engine} />
-      {/* Inline style: at connect, ScrittoFlow stamps display:block if it still sees inline. */}
-      <ScrittoFlow
-        className="ml-[0.16em] align-baseline"
-        style={{ display: "inline-block" }}
-      >
+      <EngineMark animated={animated} engine={word.engine} />
+      <ScrittoFlow className="ml-[0.16em]">
         <Scritto
           animated={animated}
           className="align-baseline leading-none"
@@ -60,21 +95,26 @@ function HeadlineLineTwo({
 
 export function HeroHeadline({ word }: HeroHeadlineProps) {
   const reduceMotion = useReducedMotion();
+  const animated = !reduceMotion;
 
   return (
-    <h1 className="font-display mx-auto w-fit max-w-[20.5rem] text-center text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:max-w-[56.875rem] sm:text-[3.25rem] sm:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
-      <span className="block whitespace-nowrap">{HERO_HEADLINE_LINE_ONE}</span>
-      <span className="relative mx-auto block w-fit">
-        <span aria-hidden className="invisible whitespace-nowrap">
-          {HERO_HEADLINE_LINE_TWO_PREFIX}
-          <span className={ICON_SLOT_CLASS} />
-          <span className="ml-[0.16em]">{HERO_HEADLINE_WIDTH_WORD.text}</span>
-          {HERO_HEADLINE_SUFFIX}
+    <LazyMotion features={domAnimation}>
+      <h1 className="font-display mx-auto w-fit max-w-[20.5rem] text-center text-[clamp(1.5rem,calc(10.1vw-0.42rem),2.0625rem)] leading-[1.08] font-medium tracking-[-0.015em] text-[#1E1E1E] sm:max-w-[56.875rem] sm:text-[3.25rem] sm:font-semibold lg:text-[4.75rem] lg:leading-[1.12] dark:text-white">
+        <span className="block whitespace-nowrap">
+          {HERO_HEADLINE_LINE_ONE}
         </span>
-        <span className="absolute inset-0 flex justify-center">
-          <HeadlineLineTwo animated={!reduceMotion} word={word} />
+        <span className="relative mx-auto block w-fit">
+          <span aria-hidden className="invisible whitespace-nowrap">
+            {HERO_HEADLINE_LINE_TWO_PREFIX}
+            <span className={ICON_SLOT_CLASS} />
+            <span className="ml-[0.16em]">{HERO_HEADLINE_WIDTH_WORD.text}</span>
+            {HERO_HEADLINE_SUFFIX}
+          </span>
+          <span className="absolute inset-0 flex justify-center">
+            <HeadlineLineTwo animated={animated} word={word} />
+          </span>
         </span>
-      </span>
-    </h1>
+      </h1>
+    </LazyMotion>
   );
 }

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/constants/landing/hero";
 
 const CTA_BUTTON_CLASSNAME =
-  "h-auto rounded-[2.5625rem] px-6 py-3 font-display font-medium text-[1.125rem] leading-[1.14] tracking-[-0.015em]";
+  "h-auto rounded-[2.5625rem] px-4 py-3 font-display font-medium text-[1.125rem] leading-[1.14] tracking-[-0.015em] sm:px-6";
 
 export function HeroSection() {
   const reduceMotion = useReducedMotion();
@@ -55,7 +55,7 @@ export function HeroSection() {
               </p>
             </div>
 
-            <div className="flex flex-col items-center gap-7 sm:flex-row">
+            <div className="flex flex-row items-center justify-center gap-4 sm:gap-7">
               <CtaButton
                 className={CTA_BUTTON_CLASSNAME}
                 nativeButton={false}

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -26,7 +26,7 @@ export function HeroSection() {
   const word = HERO_HEADLINE_CYCLE[index] ?? HERO_HEADLINE_CYCLE[0];
 
   useEffect(() => {
-    if (reduceMotion) {
+    if (reduceMotion !== false) {
       return;
     }
     const interval = window.setInterval(() => {

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -43,7 +43,7 @@ export function HeroSection() {
     <section className="w-full px-6 pt-6 antialiased [font-synthesis:none]">
       <div className="relative isolate overflow-clip rounded-3xl bg-[#C8B2EE40] lg:h-[59.9375rem] dark:bg-[#2a2140]">
         <div className="pointer-events-none absolute inset-0 overflow-clip rounded-3xl">
-          <HeroDither />
+          <HeroDither eager />
         </div>
 
         <div className="relative flex h-full w-full flex-col items-center">

--- a/apps/web/src/components/landing/live-traffic-log.tsx
+++ b/apps/web/src/components/landing/live-traffic-log.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ScrollArea, ScrollBar } from "@notra/ui/components/ui/scroll-area";
 import { useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 
@@ -33,14 +32,11 @@ export function LiveTrafficLog({ engine }: HeroCollageProps) {
   }, [engine, live]);
 
   return (
-    <ScrollArea className="h-full [&_[data-slot=table-container]]:overflow-visible">
-      <CitationRows
-        animated={live}
-        base={base}
-        headers={HERO_COLLAGE_CITATION_HEADERS}
-        rows={rows}
-      />
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+    <CitationRows
+      animated={live}
+      base={base}
+      headers={HERO_COLLAGE_CITATION_HEADERS}
+      rows={rows}
+    />
   );
 }

--- a/apps/web/src/components/landing/live-traffic-log.tsx
+++ b/apps/web/src/components/landing/live-traffic-log.tsx
@@ -20,7 +20,8 @@ export function LiveTrafficLog({ engine }: HeroCollageProps) {
   const [rows, setRows] = useState(() =>
     seedLiveRows(HERO_COLLAGE_CITATION_ROWS)
   );
-  const live = !reduceMotion;
+  const [enteringId, setEnteringId] = useState<string | null>(null);
+  const live = reduceMotion === false;
 
   useEffect(() => {
     if (!live || previousEngine.current === engine) {
@@ -28,6 +29,7 @@ export function LiveTrafficLog({ engine }: HeroCollageProps) {
     }
     previousEngine.current = engine;
     const row = randomLiveRow(pageClockElapsedMs(), engine);
+    setEnteringId(row.id);
     setRows((previous) => [row, ...previous].slice(0, LIVE_TRAFFIC_MAX_ROWS));
   }, [engine, live]);
 
@@ -35,6 +37,7 @@ export function LiveTrafficLog({ engine }: HeroCollageProps) {
     <CitationRows
       animated={live}
       base={base}
+      enteringId={enteringId}
       headers={HERO_COLLAGE_CITATION_HEADERS}
       rows={rows}
     />

--- a/apps/web/src/components/landing/live-traffic-log.tsx
+++ b/apps/web/src/components/landing/live-traffic-log.tsx
@@ -39,6 +39,9 @@ export function LiveTrafficLog({ engine }: HeroCollageProps) {
       base={base}
       enteringId={enteringId}
       headers={HERO_COLLAGE_CITATION_HEADERS}
+      onEntered={(id) => {
+        setEnteringId((current) => (current === id ? null : current));
+      }}
       rows={rows}
     />
   );

--- a/apps/web/src/components/landing/mock-frame.tsx
+++ b/apps/web/src/components/landing/mock-frame.tsx
@@ -13,7 +13,7 @@ export function MockFrame({
     <div
       aria-hidden
       className={cn(
-        "border-border bg-background pointer-events-none h-full w-full min-w-0 rounded-2xl border p-4 text-left shadow-[0_0.125rem_1.4375rem_#0000001A,0_0.0625rem_0.125rem_#0000000A] select-none dark:shadow-none",
+        "border-border bg-background @container pointer-events-none h-full w-full min-w-0 rounded-2xl border p-4 text-left shadow-[0_0.125rem_1.4375rem_#0000001A,0_0.0625rem_0.125rem_#0000000A] select-none dark:shadow-none",
         className
       )}
     >

--- a/apps/web/src/components/landing/mock-frame.tsx
+++ b/apps/web/src/components/landing/mock-frame.tsx
@@ -13,7 +13,7 @@ export function MockFrame({
     <div
       aria-hidden
       className={cn(
-        "border-border bg-background pointer-events-none rounded-2xl border p-4 text-left shadow-[0_0.125rem_1.4375rem_#0000001A,0_0.0625rem_0.125rem_#0000000A] select-none dark:shadow-none",
+        "border-border bg-background pointer-events-none h-full w-full min-w-0 rounded-2xl border p-4 text-left shadow-[0_0.125rem_1.4375rem_#0000001A,0_0.0625rem_0.125rem_#0000000A] select-none dark:shadow-none",
         className
       )}
     >

--- a/apps/web/src/components/landing/share-of-voice-rows.tsx
+++ b/apps/web/src/components/landing/share-of-voice-rows.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from "@notra/ui/lib/utils";
 import Image from "next/image";
 
+import { FEATURES_TABLE_OPTIONAL_COL } from "@/constants/landing/features";
 import type { ShareRow, ShareRowLogo } from "@/types/landing/geo";
 
 const HEADER_CLASS = "text-muted-foreground text-xs";
@@ -58,18 +59,22 @@ export function ShareOfVoiceRows({
   headers: { brand: string; share: string; mentions: string };
 }) {
   return (
-    <Table>
+    <Table className="table-fixed">
       <TableHeader className="bg-muted/60">
         <TableRow>
           <TableHead className={HEADER_CLASS}>{headers.brand}</TableHead>
-          <TableHead className={HEADER_CLASS}>{headers.share}</TableHead>
-          <TableHead className={HEADER_CLASS}>{headers.mentions}</TableHead>
+          <TableHead className={cn(HEADER_CLASS, "w-[6.75rem] sm:w-auto")}>
+            {headers.share}
+          </TableHead>
+          <TableHead className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}>
+            {headers.mentions}
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
           <TableRow key={row.id}>
-            <TableCell className="py-2.5">
+            <TableCell className="min-w-0 py-3">
               <span className="flex items-center gap-2 text-sm">
                 <BrandLogo brand={row.brand} logo={row.logo} />
                 <span className={cn("truncate", row.isYou && "font-medium")}>
@@ -77,10 +82,10 @@ export function ShareOfVoiceRows({
                 </span>
               </span>
             </TableCell>
-            <TableCell className="py-2.5">
+            <TableCell className="w-[6.75rem] py-3 sm:w-auto">
               <span className="flex items-center gap-2">
                 <GeoBar
-                  className="h-2 w-16"
+                  className="h-1.5 w-10 sm:w-16"
                   fillColor={row.color}
                   max={SHARE_MAX}
                   value={row.share}
@@ -88,7 +93,12 @@ export function ShareOfVoiceRows({
                 <span className="text-sm tabular-nums">{row.share}%</span>
               </span>
             </TableCell>
-            <TableCell className="text-muted-foreground py-2.5 text-sm tabular-nums">
+            <TableCell
+              className={cn(
+                "text-muted-foreground w-[4.75rem] py-3 text-sm tabular-nums",
+                FEATURES_TABLE_OPTIONAL_COL
+              )}
+            >
               {row.mentions}
             </TableCell>
           </TableRow>

--- a/apps/web/src/components/landing/share-of-voice-rows.tsx
+++ b/apps/web/src/components/landing/share-of-voice-rows.tsx
@@ -93,7 +93,7 @@ export function ShareOfVoiceRows({
             <TableCell className={cn("py-3", SHARE_COL)}>
               <span className="flex items-center gap-2">
                 <GeoBar
-                  className="h-1.5 w-10 @2xl:w-16"
+                  className="h-1.5 w-10 @lg:w-16"
                   fillColor={row.color}
                   max={SHARE_MAX}
                   value={row.share}

--- a/apps/web/src/components/landing/share-of-voice-rows.tsx
+++ b/apps/web/src/components/landing/share-of-voice-rows.tsx
@@ -15,6 +15,8 @@ import type { ShareRow, ShareRowLogo } from "@/types/landing/geo";
 
 const HEADER_CLASS = "text-muted-foreground text-xs";
 const SHARE_MAX = 100;
+const SHARE_COL = "w-[8.25rem]";
+const MENTIONS_COL = "w-[4.75rem]";
 const LOGO_SIZE_PX = 40;
 const LOGO_CLASS = "size-5 shrink-0 rounded-sm object-contain";
 
@@ -63,10 +65,16 @@ export function ShareOfVoiceRows({
       <TableHeader className="bg-muted/60">
         <TableRow>
           <TableHead className={HEADER_CLASS}>{headers.brand}</TableHead>
-          <TableHead className={cn(HEADER_CLASS, "w-[6.75rem] sm:w-auto")}>
+          <TableHead className={cn(HEADER_CLASS, SHARE_COL)}>
             {headers.share}
           </TableHead>
-          <TableHead className={cn(HEADER_CLASS, FEATURES_TABLE_OPTIONAL_COL)}>
+          <TableHead
+            className={cn(
+              HEADER_CLASS,
+              FEATURES_TABLE_OPTIONAL_COL,
+              MENTIONS_COL
+            )}
+          >
             {headers.mentions}
           </TableHead>
         </TableRow>
@@ -74,18 +82,18 @@ export function ShareOfVoiceRows({
       <TableBody>
         {rows.map((row) => (
           <TableRow key={row.id}>
-            <TableCell className="min-w-0 py-3">
-              <span className="flex items-center gap-2 text-sm">
+            <TableCell className="min-w-0 overflow-hidden py-3">
+              <span className="flex min-w-0 items-center gap-2 text-sm">
                 <BrandLogo brand={row.brand} logo={row.logo} />
                 <span className={cn("truncate", row.isYou && "font-medium")}>
                   {row.brand}
                 </span>
               </span>
             </TableCell>
-            <TableCell className="w-[6.75rem] py-3 sm:w-auto">
+            <TableCell className={cn("py-3", SHARE_COL)}>
               <span className="flex items-center gap-2">
                 <GeoBar
-                  className="h-1.5 w-10 sm:w-16"
+                  className="h-1.5 w-10 @2xl:w-16"
                   fillColor={row.color}
                   max={SHARE_MAX}
                   value={row.share}
@@ -95,8 +103,9 @@ export function ShareOfVoiceRows({
             </TableCell>
             <TableCell
               className={cn(
-                "text-muted-foreground w-[4.75rem] py-3 text-sm tabular-nums",
-                FEATURES_TABLE_OPTIONAL_COL
+                "text-muted-foreground py-3 text-sm tabular-nums",
+                FEATURES_TABLE_OPTIONAL_COL,
+                MENTIONS_COL
               )}
             >
               {row.mentions}

--- a/apps/web/src/components/mobile-nav-inert.tsx
+++ b/apps/web/src/components/mobile-nav-inert.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+export function MobileNavInert({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="flex w-full flex-col items-stretch justify-start"
+      data-mobile-nav-inert=""
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/navbar-glyphs.tsx
+++ b/apps/web/src/components/navbar-glyphs.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Cancel01Icon, Menu02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { SPRING } from "@notra/ui/lib/motion";
+import { cn } from "@notra/ui/lib/utils";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
+
+const MENU_ICON_HIDDEN = {
+  filter: "blur(4px)",
+  opacity: 0,
+  rotate: -90,
+  scale: 0.25,
+} as const;
+
+const MENU_ICON_VISIBLE = {
+  filter: "blur(0px)",
+  opacity: 1,
+  rotate: 0,
+  scale: 1,
+} as const;
+
+export function NavbarChevron({
+  flipped,
+  className,
+}: {
+  flipped: boolean;
+  className?: string;
+}) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={cn("transition-transform", flipped && "rotate-180", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M6 9l6 6l6 -6" />
+    </svg>
+  );
+}
+
+export function NavbarMenuToggle({ isOpen }: { isOpen: boolean }) {
+  const reduceMotion = useReducedMotion();
+  const transition = reduceMotion ? { duration: 0 } : SPRING.indicatorFlat;
+
+  return (
+    <span className="relative flex size-5 items-center justify-center">
+      <AnimatePresence initial={false} mode="popLayout">
+        <m.span
+          animate={MENU_ICON_VISIBLE}
+          className="absolute inset-0 flex items-center justify-center"
+          exit={
+            reduceMotion ? { opacity: 0 } : { ...MENU_ICON_HIDDEN, rotate: 90 }
+          }
+          initial={reduceMotion ? { opacity: 0 } : MENU_ICON_HIDDEN}
+          key={isOpen ? "close" : "menu"}
+          transition={transition}
+        >
+          <HugeiconsIcon
+            className="size-5"
+            icon={isOpen ? Cancel01Icon : Menu02Icon}
+          />
+        </m.span>
+      </AnimatePresence>
+    </span>
+  );
+}

--- a/apps/web/src/components/navbar-href.tsx
+++ b/apps/web/src/components/navbar-href.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+import type { NavbarHrefProps } from "@/types/navbar";
+
+export function NavbarHref({
+  href,
+  external,
+  className,
+  onClick,
+  children,
+  role,
+}: NavbarHrefProps) {
+  if (external) {
+    return (
+      <a
+        className={className}
+        href={href}
+        onClick={onClick}
+        rel="noopener noreferrer"
+        role={role}
+        target="_blank"
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link className={className} href={href} onClick={onClick} role={role}>
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/src/components/navbar-mobile-menu.tsx
+++ b/apps/web/src/components/navbar-mobile-menu.tsx
@@ -15,7 +15,7 @@ import {
   useReducedMotion,
 } from "motion/react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { AUTH_DASHBOARD_URL, AUTH_SIGNIN_URL } from "@/constants/auth";
 import {
@@ -49,7 +49,7 @@ const TRIGGER_CLASSNAME =
 
 const PANEL_CLASSNAME = "overflow-hidden";
 
-const AUTH_BUTTON_CLASSNAME =
+const MENU_FOOTER_BUTTON_CLASSNAME =
   "font-display flex h-12 items-center justify-center rounded-full text-base tracking-[-0.015em]";
 
 const STAGGER_IN = 0.028;
@@ -118,92 +118,113 @@ export function NavbarMobileMenu({
   overlayLayout,
   onNavigate,
 }: NavbarMobileMenuProps) {
-  const [openGroup, setOpenGroup] = useState<string | null>(null);
   const reduceMotion = useReducedMotion();
   const overlay = reduceMotion ? reducedOverlayVariants : overlayVariants;
   const stagger = reduceMotion ? reducedItemVariants : staggerVariants;
   const item = reduceMotion ? reducedItemVariants : itemVariants;
   const layout = NAVBAR_MOBILE_OVERLAY_LAYOUT[overlayLayout];
 
-  useEffect(() => {
-    if (!open) {
-      setOpenGroup(null);
-    }
-  }, [open]);
-
   return (
     <AnimatePresence>
       {open ? (
-        <m.div
-          animate="visible"
-          aria-label="Navigation"
-          aria-modal="true"
-          className={cn(
-            "pointer-events-none fixed inset-0 z-40 flex flex-col overflow-hidden overscroll-none bg-white lg:hidden dark:bg-neutral-950",
-            layout.shell
-          )}
-          exit="exit"
-          id="mobile-navigation"
-          initial="hidden"
-          role="dialog"
-          variants={overlay}
-        >
-          <m.nav
-            className={cn(
-              "pointer-events-auto flex min-h-0 flex-1 [scrollbar-width:none] flex-col overflow-y-auto overscroll-contain pb-4 [&::-webkit-scrollbar]:hidden",
-              layout.inset
-            )}
-            variants={stagger}
-          >
-            {MARKETING_NAV.map((entry) => {
-              if (entry.type === "link") {
-                return (
-                  <m.div key={entry.href} variants={item}>
-                    <Link
-                      className={TRIGGER_CLASSNAME}
-                      href={entry.href}
-                      onClick={onNavigate}
-                    >
-                      {entry.label}
-                    </Link>
-                  </m.div>
-                );
-              }
-
-              return (
-                <m.div key={entry.label} variants={item}>
-                  <GroupDropdown
-                    group={entry}
-                    item={item}
-                    onOpenChange={(next) =>
-                      setOpenGroup(next ? entry.label : null)
-                    }
-                    onSelect={onNavigate}
-                    open={openGroup === entry.label}
-                    stagger={stagger}
-                  />
-                </m.div>
-              );
-            })}
-          </m.nav>
-
-          <m.div
-            className={cn(
-              "pointer-events-auto flex shrink-0 flex-col gap-3 border-t border-[#1E1E1E14] bg-white pt-4 pb-[max(1.5rem,env(safe-area-inset-bottom))] dark:border-white/10 dark:bg-neutral-950",
-              layout.inset
-            )}
-            variants={stagger}
-          >
-            <MobileAuthActions
-              isAuthenticated={isAuthenticated}
-              isResolved={isResolved}
-              item={item}
-              onNavigate={onNavigate}
-            />
-          </m.div>
-        </m.div>
+        <MobileNavOverlay
+          isAuthenticated={isAuthenticated}
+          isResolved={isResolved}
+          item={item}
+          layout={layout}
+          onNavigate={onNavigate}
+          overlay={overlay}
+          stagger={stagger}
+        />
       ) : null}
     </AnimatePresence>
+  );
+}
+
+function MobileNavOverlay({
+  isAuthenticated,
+  isResolved,
+  item,
+  layout,
+  onNavigate,
+  overlay,
+  stagger,
+}: NavbarAuthActionsProps & {
+  item: Variants;
+  layout: (typeof NAVBAR_MOBILE_OVERLAY_LAYOUT)[keyof typeof NAVBAR_MOBILE_OVERLAY_LAYOUT];
+  onNavigate: () => void;
+  overlay: Variants;
+  stagger: Variants;
+}) {
+  const [openGroup, setOpenGroup] = useState<string | null>(null);
+
+  return (
+    <m.div
+      animate="visible"
+      aria-label="Navigation"
+      aria-modal="true"
+      className={cn(
+        "pointer-events-none fixed inset-0 z-40 flex flex-col overflow-hidden overscroll-none bg-white lg:hidden dark:bg-neutral-950",
+        layout.shell
+      )}
+      exit="exit"
+      id="mobile-navigation"
+      initial="hidden"
+      role="dialog"
+      variants={overlay}
+    >
+      <m.nav
+        className={cn(
+          "pointer-events-auto flex min-h-0 flex-1 [scrollbar-width:none] flex-col overflow-y-auto overscroll-contain pb-4 [&::-webkit-scrollbar]:hidden",
+          layout.inset
+        )}
+        variants={stagger}
+      >
+        {MARKETING_NAV.map((entry) => {
+          if (entry.type === "link") {
+            return (
+              <m.div key={entry.href} variants={item}>
+                <Link
+                  className={TRIGGER_CLASSNAME}
+                  href={entry.href}
+                  onClick={onNavigate}
+                >
+                  {entry.label}
+                </Link>
+              </m.div>
+            );
+          }
+
+          return (
+            <m.div key={entry.label} variants={item}>
+              <GroupDropdown
+                group={entry}
+                item={item}
+                onOpenChange={(next) => setOpenGroup(next ? entry.label : null)}
+                onSelect={onNavigate}
+                open={openGroup === entry.label}
+                stagger={stagger}
+              />
+            </m.div>
+          );
+        })}
+      </m.nav>
+
+      <m.div
+        className={cn(
+          "pointer-events-auto flex shrink-0 flex-col gap-3 border-t border-[#1E1E1E14] bg-white pt-4 pb-[max(1.5rem,env(safe-area-inset-bottom))] dark:border-white/10 dark:bg-neutral-950",
+          layout.inset
+        )}
+        variants={stagger}
+      >
+        <MobileAuthActions
+          isAuthenticated={isAuthenticated}
+          isResolved={isResolved}
+          item={item}
+          onNavigate={onNavigate}
+        />
+      </m.div>
+    </m.div>
   );
 }
 
@@ -220,7 +241,7 @@ function GroupDropdown({
       <CollapsibleTrigger className={TRIGGER_CLASSNAME}>
         {group.label}
         <NavbarChevron
-          className="size-5 shrink-0 text-[#1E1E1E73] duration-200 dark:text-white/50"
+          className="size-5 shrink-0 text-[#1E1E1E73] transition-transform duration-200 dark:text-white/50"
           flipped={open}
         />
       </CollapsibleTrigger>
@@ -347,7 +368,7 @@ function MobileAuthActions({
     return (
       <m.div variants={item}>
         <Link
-          className={`cta-gradient-primary ${AUTH_BUTTON_CLASSNAME} font-medium text-white`}
+          className={`cta-gradient-primary ${MENU_FOOTER_BUTTON_CLASSNAME} font-medium text-white`}
           href={AUTH_DASHBOARD_URL}
           onClick={onNavigate}
         >
@@ -361,7 +382,7 @@ function MobileAuthActions({
     <>
       <m.div variants={item}>
         <Link
-          className={`${AUTH_BUTTON_CLASSNAME} border border-[#1E1E1E26] text-[#1E1E1E] dark:border-white/15 dark:text-white`}
+          className={`${MENU_FOOTER_BUTTON_CLASSNAME} border border-[#1E1E1E26] text-[#1E1E1E] dark:border-white/15 dark:text-white`}
           href={AUTH_SIGNIN_URL}
           onClick={onNavigate}
         >
@@ -370,7 +391,7 @@ function MobileAuthActions({
       </m.div>
       <m.div variants={item}>
         <TrackedSignupLink
-          className={`cta-gradient-primary ${AUTH_BUTTON_CLASSNAME} font-medium text-white`}
+          className={`cta-gradient-primary ${MENU_FOOTER_BUTTON_CLASSNAME} font-medium text-white`}
           onClick={onNavigate}
           source={NAVBAR_MOBILE_SIGNUP_SOURCE}
         >

--- a/apps/web/src/components/navbar-mobile-menu.tsx
+++ b/apps/web/src/components/navbar-mobile-menu.tsx
@@ -125,7 +125,7 @@ export function NavbarMobileMenu({
   const layout = NAVBAR_MOBILE_OVERLAY_LAYOUT[overlayLayout];
 
   return (
-    <AnimatePresence>
+    <AnimatePresence mode="wait">
       {open ? (
         <MobileNavOverlay
           isAuthenticated={isAuthenticated}

--- a/apps/web/src/components/navbar-mobile-menu.tsx
+++ b/apps/web/src/components/navbar-mobile-menu.tsx
@@ -15,7 +15,7 @@ import {
   useReducedMotion,
 } from "motion/react";
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import { AUTH_DASHBOARD_URL, AUTH_SIGNIN_URL } from "@/constants/auth";
 import {
@@ -123,13 +123,15 @@ export function NavbarMobileMenu({
   const stagger = reduceMotion ? reducedItemVariants : staggerVariants;
   const item = reduceMotion ? reducedItemVariants : itemVariants;
   const layout = NAVBAR_MOBILE_OVERLAY_LAYOUT[overlayLayout];
-  const overlaySession = useRef(0);
-  const wasOpen = useRef(open);
+  const [overlaySession, setOverlaySession] = useState(0);
+  const [wasOpen, setWasOpen] = useState(open);
 
-  if (open && !wasOpen.current) {
-    overlaySession.current += 1;
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setOverlaySession((session) => session + 1);
+    }
   }
-  wasOpen.current = open;
 
   return (
     <AnimatePresence mode="wait">
@@ -138,7 +140,7 @@ export function NavbarMobileMenu({
           isAuthenticated={isAuthenticated}
           isResolved={isResolved}
           item={item}
-          key={overlaySession.current}
+          key={overlaySession}
           layout={layout}
           onNavigate={onNavigate}
           overlay={overlay}

--- a/apps/web/src/components/navbar-mobile-menu.tsx
+++ b/apps/web/src/components/navbar-mobile-menu.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@notra/ui/components/ui/collapsible";
+import { TRANSITION, tween } from "@notra/ui/lib/motion";
+import { cn } from "@notra/ui/lib/utils";
+import {
+  AnimatePresence,
+  m,
+  type Variants,
+  useReducedMotion,
+} from "motion/react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { AUTH_DASHBOARD_URL, AUTH_SIGNIN_URL } from "@/constants/auth";
+import {
+  NAVBAR_MOBILE_OVERLAY_LAYOUT,
+  NAVBAR_MOBILE_SIGNUP_SOURCE,
+} from "@/constants/navbar";
+import type {
+  NavbarAuthActionsProps,
+  NavbarMobileGroupProps,
+  NavbarMobileMenuProps,
+} from "@/types/navbar";
+import {
+  MARKETING_NAV,
+  type MarketingNavCard,
+  type MarketingNavGroup,
+  type MarketingNavRailItem,
+} from "@/utils/navigation";
+
+import { NavbarChevron } from "./navbar-glyphs";
+import { NavbarHref } from "./navbar-href";
+import { TrackedSignupLink } from "./tracked-signup-link";
+
+const CARD_CLASSNAME =
+  "flex min-w-0 items-start gap-3 rounded-2xl border border-[#1E1E1E1A] bg-[#C8B2EE40] px-3.5 py-3 shadow-[0_0_0_0.0625rem_#ECECEC,0_0.0625rem_0.125rem_#28282814] transition-[background,border-color,transform] hover:bg-[linear-gradient(180deg,#C8B2EE40_0%,#C8B2EE66_100%)] active:scale-[0.98] focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none dark:border-white/10 dark:bg-white/5 dark:shadow-none dark:hover:bg-white/10 dark:hover:bg-none";
+
+const RAIL_CLASSNAME =
+  "flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-[#C8B2EE26] focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none dark:hover:bg-white/6";
+
+const TRIGGER_CLASSNAME =
+  "flex min-h-14 w-full cursor-pointer items-center justify-between py-3 text-left font-sans text-[1.375rem] leading-none font-medium tracking-[-0.03em] text-[#1E1E1E] focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none dark:text-white";
+
+const PANEL_CLASSNAME = "overflow-hidden";
+
+const AUTH_BUTTON_CLASSNAME =
+  "font-display flex h-12 items-center justify-center rounded-full text-base tracking-[-0.015em]";
+
+const STAGGER_IN = 0.028;
+const STAGGER_OUT = 0.018;
+
+const overlayVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      ...tween("normal", "emphasized"),
+      delayChildren: 0.02,
+      staggerChildren: 0.04,
+    },
+  },
+  exit: {
+    opacity: 0,
+    transition: {
+      ...TRANSITION.exit,
+      staggerChildren: STAGGER_OUT,
+      staggerDirection: -1,
+    },
+  },
+};
+
+const staggerVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: STAGGER_IN },
+  },
+  exit: {
+    transition: { staggerChildren: STAGGER_OUT, staggerDirection: -1 },
+  },
+};
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: tween("fast", "emphasized"),
+  },
+  exit: {
+    opacity: 0,
+    y: 4,
+    transition: TRANSITION.exit,
+  },
+};
+
+const reducedOverlayVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0 } },
+  exit: { opacity: 0, transition: { duration: 0 } },
+};
+
+const reducedItemVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0 } },
+  exit: { opacity: 0, transition: { duration: 0 } },
+};
+
+export function NavbarMobileMenu({
+  open,
+  isAuthenticated,
+  isResolved,
+  overlayLayout,
+  onNavigate,
+}: NavbarMobileMenuProps) {
+  const [openGroup, setOpenGroup] = useState<string | null>(null);
+  const reduceMotion = useReducedMotion();
+  const overlay = reduceMotion ? reducedOverlayVariants : overlayVariants;
+  const stagger = reduceMotion ? reducedItemVariants : staggerVariants;
+  const item = reduceMotion ? reducedItemVariants : itemVariants;
+  const layout = NAVBAR_MOBILE_OVERLAY_LAYOUT[overlayLayout];
+
+  useEffect(() => {
+    if (!open) {
+      setOpenGroup(null);
+    }
+  }, [open]);
+
+  return (
+    <AnimatePresence>
+      {open ? (
+        <m.div
+          animate="visible"
+          aria-label="Navigation"
+          aria-modal="true"
+          className={cn(
+            "pointer-events-none fixed inset-0 z-40 flex flex-col overflow-hidden overscroll-none bg-white lg:hidden dark:bg-neutral-950",
+            layout.shell
+          )}
+          exit="exit"
+          id="mobile-navigation"
+          initial="hidden"
+          role="dialog"
+          variants={overlay}
+        >
+          <m.nav
+            className={cn(
+              "pointer-events-auto flex min-h-0 flex-1 [scrollbar-width:none] flex-col overflow-y-auto overscroll-contain pb-4 [&::-webkit-scrollbar]:hidden",
+              layout.inset
+            )}
+            variants={stagger}
+          >
+            {MARKETING_NAV.map((entry) => {
+              if (entry.type === "link") {
+                return (
+                  <m.div key={entry.href} variants={item}>
+                    <Link
+                      className={TRIGGER_CLASSNAME}
+                      href={entry.href}
+                      onClick={onNavigate}
+                    >
+                      {entry.label}
+                    </Link>
+                  </m.div>
+                );
+              }
+
+              return (
+                <m.div key={entry.label} variants={item}>
+                  <GroupDropdown
+                    group={entry}
+                    item={item}
+                    onOpenChange={(next) =>
+                      setOpenGroup(next ? entry.label : null)
+                    }
+                    onSelect={onNavigate}
+                    open={openGroup === entry.label}
+                    stagger={stagger}
+                  />
+                </m.div>
+              );
+            })}
+          </m.nav>
+
+          <m.div
+            className={cn(
+              "pointer-events-auto flex shrink-0 flex-col gap-3 border-t border-[#1E1E1E14] bg-white pt-4 pb-[max(1.5rem,env(safe-area-inset-bottom))] dark:border-white/10 dark:bg-neutral-950",
+              layout.inset
+            )}
+            variants={stagger}
+          >
+            <MobileAuthActions
+              isAuthenticated={isAuthenticated}
+              isResolved={isResolved}
+              item={item}
+              onNavigate={onNavigate}
+            />
+          </m.div>
+        </m.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}
+
+function GroupDropdown({
+  group,
+  open,
+  onOpenChange,
+  onSelect,
+  stagger,
+  item,
+}: NavbarMobileGroupProps) {
+  return (
+    <Collapsible onOpenChange={onOpenChange} open={open}>
+      <CollapsibleTrigger className={TRIGGER_CLASSNAME}>
+        {group.label}
+        <NavbarChevron
+          className="size-5 shrink-0 text-[#1E1E1E73] duration-200 dark:text-white/50"
+          flipped={open}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className={PANEL_CLASSNAME}>
+        {open ? (
+          <GroupPanel
+            group={group}
+            item={item}
+            onSelect={onSelect}
+            stagger={stagger}
+          />
+        ) : null}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function GroupPanel({
+  group,
+  onSelect,
+  stagger,
+  item,
+}: {
+  group: MarketingNavGroup;
+  onSelect: () => void;
+  stagger: Variants;
+  item: Variants;
+}) {
+  return (
+    <m.div
+      animate="visible"
+      className="flex flex-col gap-2 pt-1 pb-5"
+      initial="hidden"
+      variants={stagger}
+    >
+      <m.div className="flex flex-col gap-2" variants={stagger}>
+        {group.cards.map((card) => (
+          <m.div key={card.href} variants={item}>
+            <MobileNavCard card={card} onSelect={onSelect} />
+          </m.div>
+        ))}
+      </m.div>
+      {group.rail.length > 0 ? (
+        <m.div className="mt-1 flex flex-col" variants={stagger}>
+          {group.rail.map((railItem) => (
+            <m.div key={railItem.href} variants={item}>
+              <MobileRailItem item={railItem} onSelect={onSelect} />
+            </m.div>
+          ))}
+        </m.div>
+      ) : null}
+    </m.div>
+  );
+}
+
+function MobileNavCard({
+  card,
+  onSelect,
+}: {
+  card: MarketingNavCard;
+  onSelect: () => void;
+}) {
+  return (
+    <NavbarHref
+      className={CARD_CLASSNAME}
+      external={card.external}
+      href={card.href}
+      onClick={onSelect}
+    >
+      <span className="flex size-7 shrink-0 items-center justify-center leading-none [&_svg]:block">
+        <HugeiconsIcon
+          className="size-7 text-[#1E1E1E] dark:text-white"
+          icon={card.icon}
+        />
+      </span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-sans text-base leading-5 font-semibold text-[#1E1E1E] dark:text-white">
+          {card.label}
+        </span>
+        <span className="font-sans text-sm leading-5 font-medium text-[#1E1E1EBF] dark:text-neutral-400">
+          {card.description}
+        </span>
+      </span>
+    </NavbarHref>
+  );
+}
+
+function MobileRailItem({
+  item,
+  onSelect,
+}: {
+  item: MarketingNavRailItem;
+  onSelect: () => void;
+}) {
+  return (
+    <NavbarHref
+      className={RAIL_CLASSNAME}
+      external={item.external}
+      href={item.href}
+      onClick={onSelect}
+    >
+      <HugeiconsIcon
+        className="size-5 shrink-0 text-[#1E1E1E99] dark:text-neutral-400"
+        icon={item.icon}
+      />
+      <span className="font-sans text-sm leading-5 font-medium tracking-[-0.02em] text-[#1E1E1EA6] dark:text-neutral-400">
+        {item.label}
+      </span>
+    </NavbarHref>
+  );
+}
+
+function MobileAuthActions({
+  isAuthenticated,
+  isResolved,
+  onNavigate,
+  item,
+}: NavbarAuthActionsProps & { onNavigate: () => void; item: Variants }) {
+  if (!isResolved) {
+    return null;
+  }
+
+  if (isAuthenticated) {
+    return (
+      <m.div variants={item}>
+        <Link
+          className={`cta-gradient-primary ${AUTH_BUTTON_CLASSNAME} font-medium text-white`}
+          href={AUTH_DASHBOARD_URL}
+          onClick={onNavigate}
+        >
+          Dashboard
+        </Link>
+      </m.div>
+    );
+  }
+
+  return (
+    <>
+      <m.div variants={item}>
+        <Link
+          className={`${AUTH_BUTTON_CLASSNAME} border border-[#1E1E1E26] text-[#1E1E1E] dark:border-white/15 dark:text-white`}
+          href={AUTH_SIGNIN_URL}
+          onClick={onNavigate}
+        >
+          Sign In
+        </Link>
+      </m.div>
+      <m.div variants={item}>
+        <TrackedSignupLink
+          className={`cta-gradient-primary ${AUTH_BUTTON_CLASSNAME} font-medium text-white`}
+          onClick={onNavigate}
+          source={NAVBAR_MOBILE_SIGNUP_SOURCE}
+        >
+          Sign Up
+        </TrackedSignupLink>
+      </m.div>
+    </>
+  );
+}

--- a/apps/web/src/components/navbar-mobile-menu.tsx
+++ b/apps/web/src/components/navbar-mobile-menu.tsx
@@ -15,7 +15,7 @@ import {
   useReducedMotion,
 } from "motion/react";
 import Link from "next/link";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { AUTH_DASHBOARD_URL, AUTH_SIGNIN_URL } from "@/constants/auth";
 import {
@@ -123,6 +123,13 @@ export function NavbarMobileMenu({
   const stagger = reduceMotion ? reducedItemVariants : staggerVariants;
   const item = reduceMotion ? reducedItemVariants : itemVariants;
   const layout = NAVBAR_MOBILE_OVERLAY_LAYOUT[overlayLayout];
+  const overlaySession = useRef(0);
+  const wasOpen = useRef(open);
+
+  if (open && !wasOpen.current) {
+    overlaySession.current += 1;
+  }
+  wasOpen.current = open;
 
   return (
     <AnimatePresence mode="wait">
@@ -131,6 +138,7 @@ export function NavbarMobileMenu({
           isAuthenticated={isAuthenticated}
           isResolved={isResolved}
           item={item}
+          key={overlaySession.current}
           layout={layout}
           onNavigate={onNavigate}
           overlay={overlay}

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import {
-  Cancel01Icon,
   Copy01Icon,
   Download01Icon,
-  Menu02Icon,
   PaintBoardIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -31,39 +29,39 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { NavbarChevron, NavbarMenuToggle } from "@/components/navbar-glyphs";
+import { NavbarHref } from "@/components/navbar-href";
+import { NavbarMobileMenu } from "@/components/navbar-mobile-menu";
+import { NotraMark, notraMarkSvgString } from "@/components/notra-mark";
+import { SignedOutLandingRedirect } from "@/components/signed-out-landing-redirect";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { TrackedSignupLink } from "@/components/tracked-signup-link";
 import {
   AUTH_APP_HOTKEY,
   AUTH_DASHBOARD_URL,
   AUTH_SIGNIN_HOTKEY,
   AUTH_SIGNIN_URL,
 } from "@/constants/auth";
-import {
-  NAVBAR_DESKTOP_SIGNUP_SOURCE,
-  NAVBAR_MOBILE_SIGNUP_SOURCE,
-} from "@/constants/navbar";
+import { NAVBAR_DESKTOP_SIGNUP_SOURCE } from "@/constants/navbar";
 import { useDashboardSession } from "@/lib/auth/use-dashboard-session";
 import { useNavbarAuthHotkeys } from "@/lib/auth/use-navbar-auth-hotkeys";
 import { BRAND_ASSETS } from "@/lib/brand/constants";
 import { getNavbarVariantForPath } from "@/lib/navigation/navbar-variant";
+import { useMobileNavMenu } from "@/lib/navigation/use-mobile-nav-menu";
 import type {
   NavbarAuthActionsProps,
   NavbarKbdProps,
   NavbarProps,
-  NavbarVariant,
 } from "@/types/navbar";
 import { copySvgAsset } from "@/utils/copy-svg-asset";
 import { copyToClipboard } from "@/utils/copy-to-clipboard";
+import { getNavbarChromePresentation } from "@/utils/navbar-presentation";
 import {
   MARKETING_NAV,
   type MarketingNavCard,
   type MarketingNavGroup,
   type MarketingNavRailItem,
 } from "@/utils/navigation";
-
-import { NotraMark, notraMarkSvgString } from "./notra-mark";
-import { SignedOutLandingRedirect } from "./signed-out-landing-redirect";
-import { ThemeToggle } from "./theme-toggle";
-import { TrackedSignupLink } from "./tracked-signup-link";
 
 const HOVER_CLOSE_DELAY = 120;
 const CONTENT_SLIDE = 48;
@@ -116,10 +114,14 @@ function MegaCard({
   card: MarketingNavCard;
   onSelect: () => void;
 }) {
-  const className =
-    "flex h-52.5 w-52 shrink-0 cursor-pointer flex-col items-stretch justify-between rounded-2xl border border-[#1E1E1E1A] bg-[#C8B2EE40] p-6 shadow-[0_0_0_0.0625rem_#ECECEC,0_0.0625rem_0.125rem_#28282814] transition-[background,border-color] hover:bg-[linear-gradient(180deg,#C8B2EE40_0%,#C8B2EE66_100%)] dark:border-white/10 dark:bg-white/5 dark:shadow-none dark:hover:bg-white/10 dark:hover:bg-none";
-  const body = (
-    <>
+  return (
+    <NavbarHref
+      className="flex h-52.5 w-52 shrink-0 cursor-pointer flex-col items-stretch justify-between rounded-2xl border border-[#1E1E1E1A] bg-[#C8B2EE40] p-6 shadow-[0_0_0_0.0625rem_#ECECEC,0_0.0625rem_0.125rem_#28282814] transition-[background,border-color] hover:bg-[linear-gradient(180deg,#C8B2EE40_0%,#C8B2EE66_100%)] dark:border-white/10 dark:bg-white/5 dark:shadow-none dark:hover:bg-white/10 dark:hover:bg-none"
+      external={card.external}
+      href={card.href}
+      onClick={onSelect}
+      role="menuitem"
+    >
       <span className="flex size-8 shrink-0 items-center justify-center leading-none [&_svg]:block">
         <HugeiconsIcon
           className="size-8 text-[#1E1E1E] dark:text-white"
@@ -134,33 +136,7 @@ function MegaCard({
           {card.description}
         </span>
       </span>
-    </>
-  );
-
-  if (card.external) {
-    return (
-      <a
-        className={className}
-        href={card.href}
-        onClick={onSelect}
-        rel="noopener noreferrer"
-        role="menuitem"
-        target="_blank"
-      >
-        {body}
-      </a>
-    );
-  }
-
-  return (
-    <Link
-      className={className}
-      href={card.href}
-      onClick={onSelect}
-      role="menuitem"
-    >
-      {body}
-    </Link>
+    </NavbarHref>
   );
 }
 
@@ -171,10 +147,14 @@ function RailItem({
   item: MarketingNavRailItem;
   onSelect: () => void;
 }) {
-  const className =
-    "-mx-2 -my-1.5 flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-[#C8B2EE26] focus-visible:bg-[#C8B2EE26] focus-visible:outline-none dark:hover:bg-white/6 dark:focus-visible:bg-white/6";
-  const body = (
-    <>
+  return (
+    <NavbarHref
+      className="-mx-2 -my-1.5 flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-[#C8B2EE26] focus-visible:bg-[#C8B2EE26] focus-visible:outline-none dark:hover:bg-white/6 dark:focus-visible:bg-white/6"
+      external={item.external}
+      href={item.href}
+      onClick={onSelect}
+      role="menuitem"
+    >
       <HugeiconsIcon
         className="size-6 shrink-0 text-[#1E1E1E] dark:text-neutral-200"
         icon={item.icon}
@@ -182,33 +162,7 @@ function RailItem({
       <span className="font-sans text-base leading-[1.5625rem] font-medium tracking-[-0.02em] text-[#1E1E1E] dark:text-neutral-200">
         {item.label}
       </span>
-    </>
-  );
-
-  if (item.external) {
-    return (
-      <a
-        className={className}
-        href={item.href}
-        onClick={onSelect}
-        rel="noopener noreferrer"
-        role="menuitem"
-        target="_blank"
-      >
-        {body}
-      </a>
-    );
-  }
-
-  return (
-    <Link
-      className={className}
-      href={item.href}
-      onClick={onSelect}
-      role="menuitem"
-    >
-      {body}
-    </Link>
+    </NavbarHref>
   );
 }
 
@@ -260,40 +214,11 @@ function getSlideDirection(
   return currentIndex > previousIndex ? 1 : -1;
 }
 
-function getNavbarPresentation(
-  variant: NavbarVariant,
-  scrolled: boolean,
-  reduceMotion: boolean
-) {
-  const isLanding = variant === "landing";
-  const tracksScroll = variant === "island" || isLanding;
-  const chrome = variant === "pinned" || (tracksScroll && scrolled);
-  const isLandingTop = isLanding && !chrome;
-  let positionClass = "w-full sticky top-4";
-
-  if (isLanding) {
-    positionClass = "fixed inset-x-4 sm:inset-x-6";
-  } else if (variant === "static") {
-    positionClass = "w-full";
-  }
-
+function getNavbarMotion(reduceMotion: boolean) {
   return {
-    chrome,
     contentTransition: reduceMotion ? { duration: 0 } : SWAP_TRANSITION,
     enterExitTransition: reduceMotion ? { duration: 0 } : ENTER_EXIT_TRANSITION,
-    innerPaddingClass: isLandingTop
-      ? "px-7 sm:px-5 lg:px-6 min-[87rem]:px-0"
-      : "px-4 sm:px-6",
-    isLandingTop,
     morphTransition: reduceMotion ? { duration: 0 } : MORPH_TRANSITION,
-    positionClass,
-    rowHeightClass: isLandingTop ? "h-11 lg:h-[2.4375rem]" : "h-16",
-    shellAnimate: isLanding
-      ? {
-          maxWidth: chrome ? "64rem" : "80.9375rem",
-          top: chrome ? "1rem" : "2.5rem",
-        }
-      : { maxWidth: chrome ? "64rem" : "80rem" },
     shellTransition: reduceMotion ? { duration: 0 } : SHELL_TRANSITION,
   };
 }
@@ -303,6 +228,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
   const resolvedVariant = variant ?? getNavbarVariantForPath(pathname);
 
   const [isOpen, setIsOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   const [{ active: activeGroup, previous: previousGroup }, setNavGroup] =
     useState<{ active: string | null; previous: string | null }>({
       active: null,
@@ -391,16 +317,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
 
   const closePanel = useCallback(() => setActiveGroup(null), [setActiveGroup]);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isOpen]);
+  const closeMobileMenu = useMobileNavMenu(isOpen, setIsOpen, menuButtonRef);
 
   useEffect(
     () => () => {
@@ -415,6 +332,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
     function handleKey(event: globalThis.KeyboardEvent) {
       if (event.key === "Escape") {
         setActiveGroup(null);
+        setIsOpen(false);
       }
     }
     document.addEventListener("keydown", handleKey);
@@ -449,16 +367,18 @@ export function Navbar({ variant }: NavbarProps = {}) {
   const direction = reduceMotion ? 0 : slideDirection;
   const {
     chrome,
-    contentTransition,
-    enterExitTransition,
     innerPaddingClass,
-    isLandingTop,
-    morphTransition,
+    overlayLayout,
     positionClass,
     rowHeightClass,
     shellAnimate,
+  } = getNavbarChromePresentation(resolvedVariant, scrolled);
+  const {
+    contentTransition,
+    enterExitTransition,
+    morphTransition,
     shellTransition,
-  } = getNavbarPresentation(resolvedVariant, scrolled, reduceMotion ?? false);
+  } = getNavbarMotion(reduceMotion ?? false);
   const mutedNavClass =
     "text-[#1E1E1EA6] hover:text-[#1E1E1E] dark:text-neutral-400 dark:hover:text-white";
 
@@ -476,7 +396,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
       >
         <m.header
           animate={{ borderRadius: chrome ? "1rem" : "0rem" }}
-          className={`duration-slow transition-[background-color,box-shadow] ease-out ${
+          className={`duration-slow relative z-50 transition-[background-color,box-shadow] ease-out ${
             chrome ? ISLAND_CHROME : "bg-transparent"
           }`}
           initial={false}
@@ -606,7 +526,10 @@ export function Navbar({ variant }: NavbarProps = {}) {
                       type="button"
                     >
                       {entry.label}
-                      <ChevronIcon flipped={isActive} />
+                      <NavbarChevron
+                        className="duration-normal size-3.5"
+                        flipped={isActive}
+                      />
                     </button>
                   );
                 })}
@@ -699,143 +622,25 @@ export function Navbar({ variant }: NavbarProps = {}) {
                   aria-label={isOpen ? "Close menu" : "Open menu"}
                   className="relative inline-flex size-9 items-center justify-center rounded-md text-[#1E1E1E] hover:bg-[#C8B2EE26] lg:hidden dark:text-white dark:hover:bg-white/6"
                   onClick={() => setIsOpen((prev) => !prev)}
+                  ref={menuButtonRef}
                   type="button"
                 >
-                  <HugeiconsIcon
-                    className="size-5"
-                    icon={isOpen ? Cancel01Icon : Menu02Icon}
-                  />
+                  <NavbarMenuToggle isOpen={isOpen} />
                 </button>
               </div>
             </div>
           </div>
         </m.header>
 
-        <AnimatePresence>
-          {isOpen && (
-            <m.div
-              animate={{ opacity: 1, y: 0 }}
-              className={`absolute top-[calc(100%+0.5rem)] z-40 max-h-[calc(100dvh-6.5rem)] overflow-y-auto overscroll-contain rounded-2xl bg-white p-3 pb-[max(1.75rem,env(safe-area-inset-bottom))] shadow-[0_0.125rem_2.0625rem_#1E1E1E1A,0_0.0625rem_0.125rem_#28282814] ring-1 ring-[#1E1E1E14] lg:hidden dark:bg-neutral-950 dark:shadow-black/50 dark:ring-white/10 ${isLandingTop ? "inset-x-6" : "inset-x-4"}`}
-              exit={{ opacity: 0, y: -6 }}
-              id="mobile-navigation"
-              initial={{ opacity: 0, y: -6 }}
-              transition={enterExitTransition}
-            >
-              <MobileNav
-                isAuthenticated={isAuthenticated}
-                isResolved={isResolved}
-                onNavigate={() => setIsOpen(false)}
-              />
-            </m.div>
-          )}
-        </AnimatePresence>
-      </m.div>
-    </LazyMotion>
-  );
-}
-
-function MobileNav({
-  isAuthenticated,
-  isResolved,
-  onNavigate,
-}: NavbarAuthActionsProps & { onNavigate: () => void }) {
-  return (
-    <div className="flex flex-col gap-3">
-      <nav className="flex flex-col gap-1">
-        {MARKETING_NAV.map((entry) => {
-          if (entry.type === "link") {
-            return (
-              <Link
-                className="rounded-md px-3 py-2 text-sm text-neutral-600 hover:bg-neutral-100 hover:text-neutral-950 dark:text-neutral-300 dark:hover:bg-white/6 dark:hover:text-white"
-                href={entry.href}
-                key={entry.href}
-                onClick={onNavigate}
-              >
-                {entry.label}
-              </Link>
-            );
-          }
-          return (
-            <div className="flex flex-col gap-0.5" key={entry.label}>
-              <div className="px-3 pt-2 pb-1 text-xs font-medium tracking-wide text-neutral-400 uppercase dark:text-neutral-500">
-                {entry.label}
-              </div>
-              {[...entry.cards, ...entry.rail].map((item) =>
-                item.external ? (
-                  <a
-                    className="rounded-md px-3 py-2 font-sans text-sm text-[#1E1E1E] hover:bg-[#C8B2EE26] dark:text-neutral-300 dark:hover:bg-white/6"
-                    href={item.href}
-                    key={item.href}
-                    onClick={onNavigate}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {item.label}
-                  </a>
-                ) : (
-                  <Link
-                    className="rounded-md px-3 py-2 font-sans text-sm text-[#1E1E1E] hover:bg-[#C8B2EE26] dark:text-neutral-300 dark:hover:bg-white/6"
-                    href={item.href}
-                    key={item.href}
-                    onClick={onNavigate}
-                  >
-                    {item.label}
-                  </Link>
-                )
-              )}
-            </div>
-          );
-        })}
-      </nav>
-      <div className="flex flex-col gap-2 border-t border-[#1E1E1E14] pt-3 dark:border-white/10">
-        <MobileAuthActions
+        <NavbarMobileMenu
           isAuthenticated={isAuthenticated}
           isResolved={isResolved}
-          onNavigate={onNavigate}
+          onNavigate={closeMobileMenu}
+          open={isOpen}
+          overlayLayout={overlayLayout}
         />
-      </div>
-    </div>
-  );
-}
-
-function MobileAuthActions({
-  isAuthenticated,
-  isResolved,
-  onNavigate,
-}: NavbarAuthActionsProps & { onNavigate: () => void }) {
-  if (!isResolved) {
-    return null;
-  }
-
-  if (isAuthenticated) {
-    return (
-      <Link
-        className="cta-gradient-primary font-display rounded-full px-3 py-2.5 text-center text-sm font-medium tracking-[-0.015em] text-white"
-        href={AUTH_DASHBOARD_URL}
-        onClick={onNavigate}
-      >
-        Dashboard
-      </Link>
-    );
-  }
-
-  return (
-    <>
-      <Link
-        className="font-display rounded-md px-3 py-2 text-center text-sm tracking-[-0.015em] text-[#1E1E1E] hover:bg-[#C8B2EE26] dark:text-neutral-300 dark:hover:bg-white/6"
-        href={AUTH_SIGNIN_URL}
-        onClick={onNavigate}
-      >
-        Sign In
-      </Link>
-      <TrackedSignupLink
-        className="cta-gradient-primary font-display rounded-full px-3 py-2.5 text-center text-sm font-medium tracking-[-0.015em] text-white"
-        onClick={onNavigate}
-        source={NAVBAR_MOBILE_SIGNUP_SOURCE}
-      >
-        Sign Up
-      </TrackedSignupLink>
-    </>
+      </m.div>
+    </LazyMotion>
   );
 }
 
@@ -900,23 +705,5 @@ function NavbarKbd({ children, onLight = false }: NavbarKbdProps) {
     >
       {children}
     </Kbd>
-  );
-}
-
-function ChevronIcon({ flipped }: { flipped: boolean }) {
-  return (
-    <svg
-      aria-hidden="true"
-      className={`duration-normal size-3.5 transition-transform ${flipped ? "rotate-180" : ""}`}
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path d="M6 9l6 6l6 -6" />
-    </svg>
   );
 }

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -383,7 +383,7 @@ export function Navbar({ variant }: NavbarProps = {}) {
     "text-[#1E1E1EA6] hover:text-[#1E1E1E] dark:text-neutral-400 dark:hover:text-white";
 
   return (
-    <LazyMotion features={domAnimation} strict>
+    <LazyMotion features={domAnimation}>
       <SignedOutLandingRedirect
         isAuthenticated={isAuthenticated}
         isResolved={isResolved}

--- a/apps/web/src/components/not-found-numeral.tsx
+++ b/apps/web/src/components/not-found-numeral.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { cn } from "@notra/ui/lib/utils";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { DitheringShader } from "@/components/dithering-shader";
+import { NOT_FOUND_DITHERING, NOT_FOUND_HEADING } from "@/constants/not-found";
+import { useDitherPointer } from "@/lib/dithering/use-dither-pointer";
+import { createTextMaskDataUrl } from "@/utils/create-text-mask-data-url";
+import {
+  getDitherEnvironmentServerSnapshot,
+  getPageVisibleSnapshot,
+  subscribeToPageVisibility,
+} from "@/utils/dither-environment";
+import {
+  getReducedMotionServerSnapshot,
+  getReducedMotionSnapshot,
+  subscribeToReducedMotion,
+} from "@/utils/reduced-motion";
+
+const NUMERAL_CLASSNAME =
+  "font-display px-[0.04em] py-[0.12em] text-[clamp(5.75rem,28vw,16rem)] leading-none font-medium tracking-[-0.015em] text-transparent forced-colors:text-primary";
+
+export function NotFoundNumeral() {
+  const textRef = useRef<HTMLHeadingElement>(null);
+  const maskSizeRef = useRef("");
+  const [maskUrl, setMaskUrl] = useState<string | null>(null);
+  const [shaderPainted, setShaderPainted] = useState(false);
+  const ready = Boolean(maskUrl && shaderPainted);
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot
+  );
+  const isPageVisible = useSyncExternalStore(
+    subscribeToPageVisibility,
+    getPageVisibleSnapshot,
+    getDitherEnvironmentServerSnapshot
+  );
+  const { offsetX, offsetY, speed, pointerProps } = useDitherPointer({
+    restSpeed: NOT_FOUND_DITHERING.speed,
+    offsetRange: NOT_FOUND_DITHERING.hover.offsetRange,
+    lerp: NOT_FOUND_DITHERING.hover.lerp,
+    visibleYRatio: NOT_FOUND_DITHERING.hover.visibleYRatio,
+  });
+  const handlePainted = useCallback(() => setShaderPainted(true), []);
+
+  useLayoutEffect(() => {
+    const node = textRef.current;
+    if (!node) {
+      return;
+    }
+
+    const updateMask = () => {
+      const size = `${node.offsetWidth}x${node.offsetHeight}`;
+      if (size === maskSizeRef.current) {
+        return;
+      }
+      const nextMask = createTextMaskDataUrl(node, NOT_FOUND_HEADING);
+      if (!nextMask) {
+        return;
+      }
+      maskSizeRef.current = size;
+      setMaskUrl(nextMask);
+    };
+
+    const fontsReady = document.fonts?.ready ?? Promise.resolve();
+    void fontsReady.then(updateMask);
+
+    const observer = new ResizeObserver(updateMask);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="relative w-fit">
+      <div className="pointer-events-none mask-[linear-gradient(to_bottom,black_45%,transparent)]">
+        <h1 className={NUMERAL_CLASSNAME} ref={textRef}>
+          {NOT_FOUND_HEADING}
+        </h1>
+        <div
+          aria-hidden="true"
+          className={cn(
+            "absolute inset-0 forced-colors:hidden",
+            "duration-slower transition-opacity ease-out motion-reduce:transition-none",
+            ready ? "opacity-100" : "opacity-0"
+          )}
+          style={
+            maskUrl
+              ? {
+                  maskImage: `url("${maskUrl}")`,
+                  maskRepeat: "no-repeat",
+                  maskSize: "100% 100%",
+                  WebkitMaskImage: `url("${maskUrl}")`,
+                  WebkitMaskRepeat: "no-repeat",
+                  WebkitMaskSize: "100% 100%",
+                }
+              : undefined
+          }
+        >
+          <DitheringShader
+            animate={!prefersReducedMotion && isPageVisible}
+            className="h-full w-full"
+            colorBack={NOT_FOUND_DITHERING.colorBack}
+            colorFront={NOT_FOUND_DITHERING.colorFront}
+            fit={NOT_FOUND_DITHERING.fit}
+            offsetX={offsetX}
+            offsetY={offsetY}
+            onPainted={handlePainted}
+            scale={NOT_FOUND_DITHERING.scale}
+            shape={NOT_FOUND_DITHERING.shape}
+            size={NOT_FOUND_DITHERING.size}
+            speed={speed}
+            type={NOT_FOUND_DITHERING.type}
+          />
+        </div>
+      </div>
+      <div aria-hidden="true" className="absolute inset-0" {...pointerProps} />
+    </div>
+  );
+}

--- a/apps/web/src/components/not-found-numeral.tsx
+++ b/apps/web/src/components/not-found-numeral.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
-import { useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { DitheringShader } from "@/components/dithering-shader";
 import { NOT_FOUND_DITHERING, NOT_FOUND_HEADING } from "@/constants/not-found";
@@ -43,6 +49,9 @@ export function NotFoundNumeral() {
     lerp: NOT_FOUND_DITHERING.hover.lerp,
     visibleYRatio: NOT_FOUND_DITHERING.hover.visibleYRatio,
   });
+  const handlePainted = useCallback(() => {
+    setShaderPainted(true);
+  }, []);
 
   useLayoutEffect(() => {
     const node = textRef.current;
@@ -105,7 +114,7 @@ export function NotFoundNumeral() {
             fit={NOT_FOUND_DITHERING.fit}
             offsetX={offsetX}
             offsetY={offsetY}
-            onPainted={() => setShaderPainted(true)}
+            onPainted={handlePainted}
             scale={NOT_FOUND_DITHERING.scale}
             shape={NOT_FOUND_DITHERING.shape}
             size={NOT_FOUND_DITHERING.size}

--- a/apps/web/src/components/not-found-numeral.tsx
+++ b/apps/web/src/components/not-found-numeral.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { cn } from "@notra/ui/lib/utils";
-import {
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import { DitheringShader } from "@/components/dithering-shader";
 import { NOT_FOUND_DITHERING, NOT_FOUND_HEADING } from "@/constants/not-found";
@@ -49,7 +43,6 @@ export function NotFoundNumeral() {
     lerp: NOT_FOUND_DITHERING.hover.lerp,
     visibleYRatio: NOT_FOUND_DITHERING.hover.visibleYRatio,
   });
-  const handlePainted = useCallback(() => setShaderPainted(true), []);
 
   useLayoutEffect(() => {
     const node = textRef.current;
@@ -112,7 +105,7 @@ export function NotFoundNumeral() {
             fit={NOT_FOUND_DITHERING.fit}
             offsetX={offsetX}
             offsetY={offsetY}
-            onPainted={handlePainted}
+            onPainted={() => setShaderPainted(true)}
             scale={NOT_FOUND_DITHERING.scale}
             shape={NOT_FOUND_DITHERING.shape}
             size={NOT_FOUND_DITHERING.size}

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -5,6 +5,11 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@notra/ui/components/ui/button";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useTheme } from "next-themes";
+import { useSyncExternalStore } from "react";
+
+function subscribeIsClient() {
+  return () => {};
+}
 
 function ThemeToggleGlyph() {
   return (
@@ -20,8 +25,12 @@ function ThemeToggleGlyph() {
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
-  const themeReady = resolvedTheme !== undefined;
-  const isDark = resolvedTheme === "dark";
+  const themeReady = useSyncExternalStore(
+    subscribeIsClient,
+    () => true,
+    () => false
+  );
+  const isDark = themeReady && resolvedTheme === "dark";
 
   function handleToggle() {
     const dark = document.documentElement.classList.contains("dark");

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -3,102 +3,51 @@
 import { Moon02Icon, Sun02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@notra/ui/components/ui/button";
-import { SPRING } from "@notra/ui/lib/motion";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import {
-  AnimatePresence,
-  domAnimation,
-  LazyMotion,
-  m,
-  useReducedMotion,
-} from "motion/react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
 
-const ICON_HIDDEN = {
-  filter: "blur(4px)",
-  opacity: 0,
-  rotate: -90,
-  scale: 0.25,
-} as const;
-
-const ICON_VISIBLE = {
-  filter: "blur(0px)",
-  opacity: 1,
-  rotate: 0,
-  scale: 1,
-} as const;
-
-const ICON_EXIT = {
-  ...ICON_HIDDEN,
-  rotate: 90,
-} as const;
-
-function ThemeToggleGlyph({ isDark }: { isDark: boolean }) {
-  const reduceMotion = useReducedMotion();
-  const transition = reduceMotion ? { duration: 0 } : SPRING.indicatorFlat;
-
+function ThemeToggleGlyph() {
   return (
     <span className="relative flex size-4 items-center justify-center">
-      <AnimatePresence initial={false} mode="popLayout">
-        <m.span
-          animate={ICON_VISIBLE}
-          className="absolute inset-0 flex items-center justify-center"
-          exit={reduceMotion ? { opacity: 0 } : ICON_EXIT}
-          initial={reduceMotion ? { opacity: 0 } : ICON_HIDDEN}
-          key={isDark ? "sun" : "moon"}
-          transition={transition}
-        >
-          <HugeiconsIcon
-            className="size-4"
-            icon={isDark ? Sun02Icon : Moon02Icon}
-          />
-        </m.span>
-      </AnimatePresence>
+      <HugeiconsIcon className="size-4 dark:hidden" icon={Moon02Icon} />
+      <HugeiconsIcon
+        className="absolute inset-0 hidden size-4 dark:block"
+        icon={Sun02Icon}
+      />
     </span>
   );
 }
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
+  const themeReady = resolvedTheme !== undefined;
   const isDark = resolvedTheme === "dark";
 
   function handleToggle() {
-    setTheme(isDark ? "light" : "dark");
+    const dark = document.documentElement.classList.contains("dark");
+    setTheme(dark ? "light" : "dark");
   }
 
-  useHotkey("D", handleToggle, { enabled: mounted });
+  useHotkey("D", handleToggle, { enabled: themeReady });
 
   let ariaLabel = "Toggle theme";
-  if (mounted && isDark) {
+  if (themeReady && isDark) {
     ariaLabel = "Switch to light mode";
-  } else if (mounted) {
+  } else if (themeReady) {
     ariaLabel = "Switch to dark mode";
   }
 
   return (
-    <LazyMotion features={domAnimation} strict>
-      <Button
-        aria-keyshortcuts="d"
-        aria-label={ariaLabel}
-        aria-pressed={mounted ? isDark : undefined}
-        className="text-foreground h-9 w-9 overflow-visible rounded-lg p-0"
-        onClick={handleToggle}
-        type="button"
-        variant="ghost"
-      >
-        {mounted ? (
-          <ThemeToggleGlyph isDark={isDark} />
-        ) : (
-          <span className="size-4" />
-        )}
-      </Button>
-    </LazyMotion>
+    <Button
+      aria-keyshortcuts="d"
+      aria-label={ariaLabel}
+      aria-pressed={themeReady ? isDark : undefined}
+      className="text-foreground h-9 w-9 overflow-visible rounded-lg p-0"
+      onClick={handleToggle}
+      type="button"
+      variant="ghost"
+    >
+      <ThemeToggleGlyph />
+    </Button>
   );
 }

--- a/apps/web/src/constants/dithering.ts
+++ b/apps/web/src/constants/dithering.ts
@@ -1,4 +1,5 @@
 export const DITHER_MOBILE_QUERY = "(width < 640px)";
+export const DITHER_FINE_POINTER_QUERY = "(hover: hover) and (pointer: fine)";
 export const DITHER_MOBILE_MAX_PIXELS = 1_000_000;
 
 export const BLOG_CARD_DITHER_MAX_PIXELS = 200_000;

--- a/apps/web/src/constants/landing/features.ts
+++ b/apps/web/src/constants/landing/features.ts
@@ -7,7 +7,7 @@ import type {
   TrafficSourceRow,
 } from "@/types/landing/geo";
 
-export const FEATURES_TABLE_OPTIONAL_COL = "hidden @2xl:table-cell";
+export const FEATURES_TABLE_OPTIONAL_COL = "hidden @lg:table-cell";
 
 export const FEATURES_HEADING = "Every number the dashboard shows you.";
 

--- a/apps/web/src/constants/landing/features.ts
+++ b/apps/web/src/constants/landing/features.ts
@@ -7,7 +7,7 @@ import type {
   TrafficSourceRow,
 } from "@/types/landing/geo";
 
-export const FEATURES_TABLE_OPTIONAL_COL = "hidden sm:table-cell";
+export const FEATURES_TABLE_OPTIONAL_COL = "hidden @2xl:table-cell";
 
 export const FEATURES_HEADING = "Every number the dashboard shows you.";
 

--- a/apps/web/src/constants/landing/features.ts
+++ b/apps/web/src/constants/landing/features.ts
@@ -7,6 +7,8 @@ import type {
   TrafficSourceRow,
 } from "@/types/landing/geo";
 
+export const FEATURES_TABLE_OPTIONAL_COL = "hidden sm:table-cell";
+
 export const FEATURES_HEADING = "Every number the dashboard shows you.";
 
 export const FEATURES_SUBCOPY_LINE_ONE =
@@ -90,6 +92,14 @@ export const FEATURES_ENGINE_ROWS: EngineRateRow[] = [
     mentions: 9,
     checks: 28,
     avgPosition: 3.8,
+    lastChecked: "3h ago",
+  },
+  {
+    id: "kimi",
+    mentionRate: 21,
+    mentions: 6,
+    checks: 28,
+    avgPosition: 4.4,
     lastChecked: "3h ago",
   },
 ];

--- a/apps/web/src/constants/landing/hero.ts
+++ b/apps/web/src/constants/landing/hero.ts
@@ -17,9 +17,9 @@ export const HERO_HEADLINE_CYCLE: HeroCycleWord[] = [
 
 export const HERO_HEADLINE_CYCLE_MS = 2600;
 
-export const HERO_WORD_SIZE_EM = 0.9;
-
-export const HERO_WORD_SIZE_DESCENDER_EM = 0.78;
+export const HERO_HEADLINE_WIDTH_WORD = HERO_HEADLINE_CYCLE.reduce(
+  (longest, word) => (word.text.length > longest.text.length ? word : longest)
+);
 
 export const HERO_SUBHEAD =
   "Notra asks ChatGPT, Claude, Gemini and Perplexity the questions your buyers ask. You see whether you come up, who comes up instead, and what to write about it.";

--- a/apps/web/src/constants/landing/hero.ts
+++ b/apps/web/src/constants/landing/hero.ts
@@ -17,10 +17,6 @@ export const HERO_HEADLINE_CYCLE: HeroCycleWord[] = [
 
 export const HERO_HEADLINE_CYCLE_MS = 2600;
 
-export const HERO_HEADLINE_WIDTH_WORD = HERO_HEADLINE_CYCLE.reduce(
-  (longest, word) => (word.text.length > longest.text.length ? word : longest)
-);
-
 export const HERO_SUBHEAD =
   "Notra asks ChatGPT, Claude, Gemini and Perplexity the questions your buyers ask. You see whether you come up, who comes up instead, and what to write about it.";
 

--- a/apps/web/src/constants/navbar.ts
+++ b/apps/web/src/constants/navbar.ts
@@ -1,3 +1,16 @@
 export const NAVBAR_DESKTOP_SIGNUP_SOURCE = "navbar_desktop_signup";
 export const NAVBAR_MOBILE_SIGNUP_SOURCE = "navbar_mobile_signup";
 export const NAVBAR_HOTKEY_SIGNUP_SOURCE = "navbar_hotkey_signup";
+
+export const MOBILE_NAV_INERT_SELECTOR = "[data-mobile-nav-inert]";
+
+export const NAVBAR_MOBILE_OVERLAY_LAYOUT = {
+  hero: {
+    shell: "pt-[6.5rem]",
+    inset: "px-11",
+  },
+  compact: {
+    shell: "pt-20",
+    inset: "px-7",
+  },
+} as const;

--- a/apps/web/src/constants/not-found.ts
+++ b/apps/web/src/constants/not-found.ts
@@ -1,4 +1,4 @@
-import type { NotFoundDitheringConfig } from "@/types/not-found";
+import type { NotFoundDitheringConfig, NotFoundLink } from "@/types/not-found";
 import { DOCS_URL, SITE_URL } from "@/utils/urls";
 
 export const MARKDOWN_CACHE_CONTROL = "public, max-age=300";
@@ -7,14 +7,26 @@ export const NOT_FOUND_HEADING = "404";
 export const NOT_FOUND_MESSAGE = "This page doesn't exist yet.";
 export const NOT_FOUND_HOME_LABEL = "Back to home";
 
+const NOT_FOUND_INDEX_PROMPT = "Looking for an index?";
+
+const NOT_FOUND_AGENT_LINKS: NotFoundLink[] = [
+  { label: "llms.txt", href: `${SITE_URL}/llms.txt` },
+  { label: "sitemap.xml", href: `${SITE_URL}/sitemap.xml` },
+  { label: "Docs", href: DOCS_URL },
+];
+
+const notFoundIndexMarkdown = NOT_FOUND_AGENT_LINKS.map(
+  (link) => `[${link.label}](${link.href})`
+).join(" · ");
+
 export const NOT_FOUND_DITHERING: NotFoundDitheringConfig = {
   speed: 0.4,
   shape: "wave",
   type: "4x4",
   size: 5,
-  scale: 0.68,
+  scale: 0.55,
   colorBack: "#00000000",
-  colorFront: "#8B5CF6",
+  colorFront: "#8B5CF6A6",
   fit: "cover",
   hover: {
     offsetRange: 0.08,
@@ -27,12 +39,9 @@ export const NOT_FOUND_MARKDOWN = `# 404 Not Found
 
 There is no page at this URL on ${new URL(SITE_URL).hostname}.
 
-Start from one of these instead:
+[${NOT_FOUND_HOME_LABEL}](${SITE_URL}/)
 
-- [Site index for agents](${SITE_URL}/llms.txt)
-- [Full site context](${SITE_URL}/llms-full.txt)
-- [Sitemap](${SITE_URL}/sitemap.xml)
-- [Documentation](${DOCS_URL})
+${NOT_FOUND_INDEX_PROMPT} ${notFoundIndexMarkdown}
 
 Markdown versions of pages are served with \`Accept: text/markdown\` or by appending \`.md\` to the path.
 `;

--- a/apps/web/src/constants/not-found.ts
+++ b/apps/web/src/constants/not-found.ts
@@ -1,13 +1,27 @@
-import type { NotFoundLink } from "@/types/not-found";
+import type { NotFoundDitheringConfig } from "@/types/not-found";
 import { DOCS_URL, SITE_URL } from "@/utils/urls";
 
 export const MARKDOWN_CACHE_CONTROL = "public, max-age=300";
 
-export const NOT_FOUND_AGENT_LINKS: NotFoundLink[] = [
-  { label: "llms.txt", href: `${SITE_URL}/llms.txt` },
-  { label: "sitemap.xml", href: `${SITE_URL}/sitemap.xml` },
-  { label: "Docs", href: DOCS_URL },
-];
+export const NOT_FOUND_HEADING = "404";
+export const NOT_FOUND_MESSAGE = "This page doesn't exist yet.";
+export const NOT_FOUND_HOME_LABEL = "Back to home";
+
+export const NOT_FOUND_DITHERING: NotFoundDitheringConfig = {
+  speed: 0.4,
+  shape: "wave",
+  type: "4x4",
+  size: 5,
+  scale: 0.68,
+  colorBack: "#00000000",
+  colorFront: "#8B5CF6",
+  fit: "cover",
+  hover: {
+    offsetRange: 0.08,
+    lerp: 0.08,
+    visibleYRatio: 0.5,
+  },
+};
 
 export const NOT_FOUND_MARKDOWN = `# 404 Not Found
 

--- a/apps/web/src/lib/brand/constants.ts
+++ b/apps/web/src/lib/brand/constants.ts
@@ -64,7 +64,7 @@ export const BRAND_FONTS: BrandFont[] = [
   },
   {
     name: "Instrument Serif",
-    fontClassName: "font-serif",
+    fontClassName: "font-instrument",
     role: "Display typeface for editorial accents.",
     googleFontsUrl: "https://fonts.google.com/specimen/Instrument+Serif",
   },

--- a/apps/web/src/lib/dithering/use-dither-painted.ts
+++ b/apps/web/src/lib/dithering/use-dither-painted.ts
@@ -4,9 +4,11 @@ import { useEffect, useRef } from "react";
 
 export function useDitherPainted(onPainted?: () => void) {
   const ref = useRef<HTMLDivElement>(null);
+  const onPaintedRef = useRef(onPainted);
+  onPaintedRef.current = onPainted;
 
   useEffect(() => {
-    if (!onPainted) {
+    if (!onPaintedRef.current) {
       return;
     }
     const root = ref.current;
@@ -17,12 +19,14 @@ export function useDitherPainted(onPainted?: () => void) {
     let cancelled = false;
     let frameA = 0;
     let frameB = 0;
+    let fired = false;
 
     const finish = () => {
-      if (cancelled) {
+      if (cancelled || fired) {
         return;
       }
-      onPainted();
+      fired = true;
+      onPaintedRef.current?.();
     };
 
     const arm = () => {
@@ -56,7 +60,7 @@ export function useDitherPainted(onPainted?: () => void) {
       cancelAnimationFrame(frameA);
       cancelAnimationFrame(frameB);
     };
-  }, [onPainted]);
+  }, []);
 
   return ref;
 }

--- a/apps/web/src/lib/dithering/use-dither-painted.ts
+++ b/apps/web/src/lib/dithering/use-dither-painted.ts
@@ -5,10 +5,14 @@ import { useEffect, useRef } from "react";
 export function useDitherPainted(onPainted?: () => void) {
   const ref = useRef<HTMLDivElement>(null);
   const onPaintedRef = useRef(onPainted);
-  onPaintedRef.current = onPainted;
+  const hasPaintedCallback = Boolean(onPainted);
 
   useEffect(() => {
-    if (!onPaintedRef.current) {
+    onPaintedRef.current = onPainted;
+  }, [onPainted]);
+
+  useEffect(() => {
+    if (!hasPaintedCallback) {
       return;
     }
     const root = ref.current;
@@ -60,7 +64,7 @@ export function useDitherPainted(onPainted?: () => void) {
       cancelAnimationFrame(frameA);
       cancelAnimationFrame(frameB);
     };
-  }, []);
+  }, [hasPaintedCallback]);
 
   return ref;
 }

--- a/apps/web/src/lib/dithering/use-dither-painted.ts
+++ b/apps/web/src/lib/dithering/use-dither-painted.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function useDitherPainted(onPainted?: () => void) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!onPainted) {
+      return;
+    }
+    const root = ref.current;
+    if (!root) {
+      return;
+    }
+
+    let cancelled = false;
+    let frameA = 0;
+    let frameB = 0;
+
+    const finish = () => {
+      if (cancelled) {
+        return;
+      }
+      onPainted();
+    };
+
+    const arm = () => {
+      if (!root.querySelector("canvas")) {
+        return false;
+      }
+      frameA = requestAnimationFrame(() => {
+        frameB = requestAnimationFrame(finish);
+      });
+      return true;
+    };
+
+    if (arm()) {
+      return () => {
+        cancelled = true;
+        cancelAnimationFrame(frameA);
+        cancelAnimationFrame(frameB);
+      };
+    }
+
+    const observer = new MutationObserver(() => {
+      if (arm()) {
+        observer.disconnect();
+      }
+    });
+    observer.observe(root, { childList: true, subtree: true });
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      cancelAnimationFrame(frameA);
+      cancelAnimationFrame(frameB);
+    };
+  }, [onPainted]);
+
+  return ref;
+}

--- a/apps/web/src/lib/dithering/use-dither-pointer.ts
+++ b/apps/web/src/lib/dithering/use-dither-pointer.ts
@@ -62,8 +62,6 @@ export function useDitherPointer({
     current.current = REST_OFFSET;
     cancelAnimationFrame(frame.current);
     frame.current = 0;
-    setOffset(REST_OFFSET);
-    setIsHovering(false);
   }, [enabled]);
 
   useEffect(
@@ -72,6 +70,15 @@ export function useDitherPointer({
     },
     []
   );
+
+  if (!enabled) {
+    if (offset.offsetX !== 0 || offset.offsetY !== 0) {
+      setOffset(REST_OFFSET);
+    }
+    if (isHovering) {
+      setIsHovering(false);
+    }
+  }
 
   function tick() {
     const { lerp: follow } = optionsRef.current;

--- a/apps/web/src/lib/dithering/use-dither-pointer.ts
+++ b/apps/web/src/lib/dithering/use-dither-pointer.ts
@@ -52,7 +52,7 @@ export function useDitherPointer({
 
   useEffect(() => {
     optionsRef.current = { enabled, offsetRange, lerp, visibleYRatio };
-  });
+  }, [enabled, offsetRange, lerp, visibleYRatio]);
 
   useEffect(() => {
     if (enabled) {
@@ -62,8 +62,6 @@ export function useDitherPointer({
     current.current = REST_OFFSET;
     cancelAnimationFrame(frame.current);
     frame.current = 0;
-    setOffset(REST_OFFSET);
-    setIsHovering(false);
   }, [enabled]);
 
   useEffect(
@@ -72,6 +70,15 @@ export function useDitherPointer({
     },
     []
   );
+
+  if (!enabled) {
+    if (offset.offsetX !== 0 || offset.offsetY !== 0) {
+      setOffset(REST_OFFSET);
+    }
+    if (isHovering) {
+      setIsHovering(false);
+    }
+  }
 
   function tick() {
     const { lerp: follow } = optionsRef.current;

--- a/apps/web/src/lib/dithering/use-dither-pointer.ts
+++ b/apps/web/src/lib/dithering/use-dither-pointer.ts
@@ -62,6 +62,8 @@ export function useDitherPointer({
     current.current = REST_OFFSET;
     cancelAnimationFrame(frame.current);
     frame.current = 0;
+    setOffset(REST_OFFSET);
+    setIsHovering(false);
   }, [enabled]);
 
   useEffect(
@@ -70,15 +72,6 @@ export function useDitherPointer({
     },
     []
   );
-
-  if (!enabled) {
-    if (offset.offsetX !== 0 || offset.offsetY !== 0) {
-      setOffset(REST_OFFSET);
-    }
-    if (isHovering) {
-      setIsHovering(false);
-    }
-  }
 
   function tick() {
     const { lerp: follow } = optionsRef.current;

--- a/apps/web/src/lib/dithering/use-dither-pointer.ts
+++ b/apps/web/src/lib/dithering/use-dither-pointer.ts
@@ -1,0 +1,188 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import type {
+  DitherPointerOffset,
+  DitherPointerOptions,
+  DitherPointerResult,
+} from "@/types/dithering";
+import {
+  getDitherEnvironmentServerSnapshot,
+  getFinePointerSnapshot,
+  subscribeToFinePointer,
+} from "@/utils/dither-environment";
+import { getDitherPointerOffset } from "@/utils/dither-pointer-offset";
+import {
+  getReducedMotionServerSnapshot,
+  getReducedMotionSnapshot,
+  subscribeToReducedMotion,
+} from "@/utils/reduced-motion";
+
+const SETTLE_DISTANCE_SQUARED = 1e-6;
+
+const REST_OFFSET: DitherPointerOffset = { offsetX: 0, offsetY: 0 };
+
+export function useDitherPointer({
+  restSpeed,
+  hoverSpeed = restSpeed,
+  offsetRange,
+  lerp,
+  visibleYRatio = 1,
+}: DitherPointerOptions): DitherPointerResult {
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot
+  );
+  const hasFinePointer = useSyncExternalStore(
+    subscribeToFinePointer,
+    getFinePointerSnapshot,
+    getDitherEnvironmentServerSnapshot
+  );
+  const enabled = hasFinePointer && !prefersReducedMotion;
+
+  const [offset, setOffset] = useState<DitherPointerOffset>(REST_OFFSET);
+  const [isHovering, setIsHovering] = useState(false);
+
+  const current = useRef(REST_OFFSET);
+  const target = useRef(REST_OFFSET);
+  const frame = useRef(0);
+  const optionsRef = useRef({ enabled, offsetRange, lerp, visibleYRatio });
+  optionsRef.current = { enabled, offsetRange, lerp, visibleYRatio };
+
+  const tick = useCallback(() => {
+    const { lerp: follow } = optionsRef.current;
+    const nextX =
+      current.current.offsetX +
+      (target.current.offsetX - current.current.offsetX) * follow;
+    const nextY =
+      current.current.offsetY +
+      (target.current.offsetY - current.current.offsetY) * follow;
+    const distanceSquared =
+      (target.current.offsetX - nextX) ** 2 +
+      (target.current.offsetY - nextY) ** 2;
+    const nextOffset =
+      distanceSquared < SETTLE_DISTANCE_SQUARED
+        ? target.current
+        : { offsetX: nextX, offsetY: nextY };
+
+    current.current = nextOffset;
+    setOffset(nextOffset);
+
+    if (distanceSquared < SETTLE_DISTANCE_SQUARED) {
+      frame.current = 0;
+      return;
+    }
+
+    frame.current = requestAnimationFrame(tick);
+  }, []);
+
+  const startLoop = useCallback(() => {
+    if (frame.current) {
+      return;
+    }
+    frame.current = requestAnimationFrame(tick);
+  }, [tick]);
+
+  const aimAtPointer = useCallback(
+    (event: {
+      clientX: number;
+      clientY: number;
+      currentTarget: EventTarget;
+    }) => {
+      const {
+        enabled: canTrack,
+        offsetRange: range,
+        visibleYRatio: yRatio,
+      } = optionsRef.current;
+      if (!canTrack) {
+        return;
+      }
+      const node = event.currentTarget;
+      if (!(node instanceof HTMLElement)) {
+        return;
+      }
+      target.current = getDitherPointerOffset(
+        event.clientX,
+        event.clientY,
+        node.getBoundingClientRect(),
+        range,
+        yRatio
+      );
+      startLoop();
+    },
+    [startLoop]
+  );
+
+  const onPointerEnter = useCallback(
+    (event: {
+      clientX: number;
+      clientY: number;
+      currentTarget: EventTarget;
+    }) => {
+      if (!optionsRef.current.enabled) {
+        return;
+      }
+      setIsHovering(true);
+      aimAtPointer(event);
+    },
+    [aimAtPointer]
+  );
+
+  const onPointerMove = useCallback(
+    (event: {
+      clientX: number;
+      clientY: number;
+      currentTarget: EventTarget;
+    }) => {
+      aimAtPointer(event);
+    },
+    [aimAtPointer]
+  );
+
+  const onPointerLeave = useCallback(() => {
+    setIsHovering(false);
+    target.current = REST_OFFSET;
+    if (optionsRef.current.enabled) {
+      startLoop();
+    }
+  }, [startLoop]);
+
+  useEffect(() => {
+    if (enabled) {
+      return;
+    }
+    target.current = REST_OFFSET;
+    current.current = REST_OFFSET;
+    setOffset(REST_OFFSET);
+    setIsHovering(false);
+    cancelAnimationFrame(frame.current);
+    frame.current = 0;
+  }, [enabled]);
+
+  useEffect(
+    () => () => {
+      cancelAnimationFrame(frame.current);
+    },
+    []
+  );
+
+  return {
+    offsetX: offset.offsetX,
+    offsetY: offset.offsetY,
+    speed: isHovering ? hoverSpeed : restSpeed,
+    isHovering,
+    pointerProps: {
+      onPointerEnter,
+      onPointerMove,
+      onPointerLeave,
+    },
+  };
+}

--- a/apps/web/src/lib/dithering/use-dither-pointer.ts
+++ b/apps/web/src/lib/dithering/use-dither-pointer.ts
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import type {
   DitherPointerOffset,
@@ -55,9 +49,29 @@ export function useDitherPointer({
   const target = useRef(REST_OFFSET);
   const frame = useRef(0);
   const optionsRef = useRef({ enabled, offsetRange, lerp, visibleYRatio });
-  optionsRef.current = { enabled, offsetRange, lerp, visibleYRatio };
 
-  const tick = useCallback(() => {
+  useEffect(() => {
+    optionsRef.current = { enabled, offsetRange, lerp, visibleYRatio };
+  });
+
+  useEffect(() => {
+    if (enabled) {
+      return;
+    }
+    target.current = REST_OFFSET;
+    current.current = REST_OFFSET;
+    cancelAnimationFrame(frame.current);
+    frame.current = 0;
+  }, [enabled]);
+
+  useEffect(
+    () => () => {
+      cancelAnimationFrame(frame.current);
+    },
+    []
+  );
+
+  function tick() {
     const { lerp: follow } = optionsRef.current;
     const nextX =
       current.current.offsetX +
@@ -82,103 +96,77 @@ export function useDitherPointer({
     }
 
     frame.current = requestAnimationFrame(tick);
-  }, []);
+  }
 
-  const startLoop = useCallback(() => {
+  function startLoop() {
     if (frame.current) {
       return;
     }
     frame.current = requestAnimationFrame(tick);
-  }, [tick]);
+  }
 
-  const aimAtPointer = useCallback(
-    (event: {
-      clientX: number;
-      clientY: number;
-      currentTarget: EventTarget;
-    }) => {
-      const {
-        enabled: canTrack,
-        offsetRange: range,
-        visibleYRatio: yRatio,
-      } = optionsRef.current;
-      if (!canTrack) {
-        return;
-      }
-      const node = event.currentTarget;
-      if (!(node instanceof HTMLElement)) {
-        return;
-      }
-      target.current = getDitherPointerOffset(
-        event.clientX,
-        event.clientY,
-        node.getBoundingClientRect(),
-        range,
-        yRatio
-      );
-      startLoop();
-    },
-    [startLoop]
-  );
+  function aimAtPointer(event: {
+    clientX: number;
+    clientY: number;
+    currentTarget: EventTarget;
+  }) {
+    const {
+      enabled: canTrack,
+      offsetRange: range,
+      visibleYRatio: yRatio,
+    } = optionsRef.current;
+    if (!canTrack) {
+      return;
+    }
+    const node = event.currentTarget;
+    if (!(node instanceof HTMLElement)) {
+      return;
+    }
+    target.current = getDitherPointerOffset(
+      event.clientX,
+      event.clientY,
+      node.getBoundingClientRect(),
+      range,
+      yRatio
+    );
+    startLoop();
+  }
 
-  const onPointerEnter = useCallback(
-    (event: {
-      clientX: number;
-      clientY: number;
-      currentTarget: EventTarget;
-    }) => {
-      if (!optionsRef.current.enabled) {
-        return;
-      }
-      setIsHovering(true);
-      aimAtPointer(event);
-    },
-    [aimAtPointer]
-  );
+  function onPointerEnter(event: {
+    clientX: number;
+    clientY: number;
+    currentTarget: EventTarget;
+  }) {
+    if (!optionsRef.current.enabled) {
+      return;
+    }
+    setIsHovering(true);
+    aimAtPointer(event);
+  }
 
-  const onPointerMove = useCallback(
-    (event: {
-      clientX: number;
-      clientY: number;
-      currentTarget: EventTarget;
-    }) => {
-      aimAtPointer(event);
-    },
-    [aimAtPointer]
-  );
+  function onPointerMove(event: {
+    clientX: number;
+    clientY: number;
+    currentTarget: EventTarget;
+  }) {
+    aimAtPointer(event);
+  }
 
-  const onPointerLeave = useCallback(() => {
+  function onPointerLeave() {
     setIsHovering(false);
     target.current = REST_OFFSET;
     if (optionsRef.current.enabled) {
       startLoop();
     }
-  }, [startLoop]);
+  }
 
-  useEffect(() => {
-    if (enabled) {
-      return;
-    }
-    target.current = REST_OFFSET;
-    current.current = REST_OFFSET;
-    setOffset(REST_OFFSET);
-    setIsHovering(false);
-    cancelAnimationFrame(frame.current);
-    frame.current = 0;
-  }, [enabled]);
-
-  useEffect(
-    () => () => {
-      cancelAnimationFrame(frame.current);
-    },
-    []
-  );
+  const shownOffset = enabled ? offset : REST_OFFSET;
 
   return {
-    offsetX: offset.offsetX,
-    offsetY: offset.offsetY,
-    speed: isHovering ? hoverSpeed : restSpeed,
-    isHovering,
+    offsetX: shownOffset.offsetX,
+    offsetY: shownOffset.offsetY,
+    speed: enabled && isHovering ? hoverSpeed : restSpeed,
+    isHovering: enabled && isHovering,
     pointerProps: {
       onPointerEnter,
       onPointerMove,

--- a/apps/web/src/lib/dithering/use-dither-pointer.ts
+++ b/apps/web/src/lib/dithering/use-dither-pointer.ts
@@ -62,6 +62,8 @@ export function useDitherPointer({
     current.current = REST_OFFSET;
     cancelAnimationFrame(frame.current);
     frame.current = 0;
+    setOffset(REST_OFFSET);
+    setIsHovering(false);
   }, [enabled]);
 
   useEffect(

--- a/apps/web/src/lib/dithering/use-dither-visibility.ts
+++ b/apps/web/src/lib/dithering/use-dither-visibility.ts
@@ -18,7 +18,8 @@ const VIEWPORT_MARGIN = "200px";
 const IDLE_FALLBACK_MS = 1500;
 
 export function useDitherVisibility(
-  unmountOffscreen = false
+  unmountOffscreen = false,
+  eager = false
 ): DitherVisibilityState {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isIdle, setIsIdle] = useState(false);
@@ -69,7 +70,8 @@ export function useDitherVisibility(
   return {
     containerRef,
     shouldRender:
-      isIdle && (unmountOffscreen ? isInView && isPageVisible : hasEntered),
+      (eager || isIdle) &&
+      (eager || (unmountOffscreen ? isInView && isPageVisible : hasEntered)),
     isAnimating: isInView && isPageVisible && !prefersReducedMotion,
   };
 }

--- a/apps/web/src/lib/navigation/use-mobile-nav-menu.ts
+++ b/apps/web/src/lib/navigation/use-mobile-nav-menu.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
+
+import { MOBILE_NAV_INERT_SELECTOR } from "@/constants/navbar";
+
+const DESKTOP_NAV_QUERY = "(min-width: 64rem)";
+
+export function useMobileNavMenu(
+  isOpen: boolean,
+  setOpen: Dispatch<SetStateAction<boolean>>,
+  triggerRef: RefObject<HTMLButtonElement | null>
+) {
+  const pathname = usePathname();
+  const wasOpenRef = useRef(false);
+
+  const closeAfterPaint = useCallback(() => {
+    // Let the click commit before unmounting the overlay.
+    requestAnimationFrame(() => setOpen(false));
+  }, [setOpen]);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname, setOpen]);
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    if (isOpen) {
+      html.style.overflow = "hidden";
+      body.style.overflow = "hidden";
+    } else {
+      html.style.overflow = "";
+      body.style.overflow = "";
+    }
+    return () => {
+      html.style.overflow = "";
+      body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const nodes = document.querySelectorAll(MOBILE_NAV_INERT_SELECTOR);
+    for (const node of nodes) {
+      node.setAttribute("inert", "");
+    }
+    return () => {
+      for (const node of nodes) {
+        node.removeAttribute("inert");
+      }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (wasOpenRef.current && !isOpen) {
+      triggerRef.current?.focus();
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen, triggerRef]);
+
+  useEffect(() => {
+    const media = window.matchMedia(DESKTOP_NAV_QUERY);
+    const onChange = () => {
+      if (media.matches) {
+        setOpen(false);
+      }
+    };
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, [setOpen]);
+
+  return closeAfterPaint;
+}

--- a/apps/web/src/lib/navigation/use-mobile-nav-menu.ts
+++ b/apps/web/src/lib/navigation/use-mobile-nav-menu.ts
@@ -5,7 +5,6 @@ import {
   type Dispatch,
   type RefObject,
   type SetStateAction,
-  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -22,11 +21,6 @@ export function useMobileNavMenu(
 ) {
   const pathname = usePathname();
   const wasOpenRef = useRef(false);
-
-  const closeAfterPaint = useCallback(() => {
-    // Let the click commit before unmounting the overlay.
-    requestAnimationFrame(() => setOpen(false));
-  }, [setOpen]);
 
   useEffect(() => {
     setOpen(false);
@@ -81,5 +75,8 @@ export function useMobileNavMenu(
     return () => media.removeEventListener("change", onChange);
   }, [setOpen]);
 
-  return closeAfterPaint;
+  return function closeAfterPaint() {
+    // Let the click commit before unmounting the overlay.
+    requestAnimationFrame(() => setOpen(false));
+  };
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -15,6 +15,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  color-scheme: light;
   --background: hsl(0 0% 100%);
   --foreground: hsl(0 0% 9%);
   --card: hsl(0 0% 100%);
@@ -59,6 +60,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: hsl(233 7% 8%);
   --foreground: hsl(0 0% 98%);
   --card: hsl(240 6% 10%);

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -92,7 +92,7 @@
   --sidebar-border: oklch(0.258 0 0);
   --sidebar-ring: oklch(0.709 0.1592 293.5412);
   --font-sans: ui-sans-serif, system-ui, sans-serif;
-  --font-serif: ui-serif, Georgia, Cambria, Times New Roman, Times, serif;
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
     Courier New, monospace;
@@ -120,7 +120,8 @@
 @theme inline {
   --font-sans: var(--font-inter);
   --font-display: var(--font-satoshi);
-  --font-serif: var(--font-instrument-serif);
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-instrument: var(--font-instrument-serif);
   --font-mono:
     ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo,
     monospace;

--- a/apps/web/src/types/dithering.ts
+++ b/apps/web/src/types/dithering.ts
@@ -1,7 +1,7 @@
 import type { DitheringProps } from "@paper-design/shaders-react";
-import type { RefObject } from "react";
+import type { PointerEvent, RefObject } from "react";
 
-export type DeferredDitheringProps = Pick<
+export type DitheringCanvasProps = Pick<
   DitheringProps,
   | "colorBack"
   | "colorFront"
@@ -13,8 +13,15 @@ export type DeferredDitheringProps = Pick<
   | "frame"
   | "fit"
   | "maxPixelCount"
+  | "offsetX"
+  | "offsetY"
 > & {
   className?: string;
+  animate?: boolean;
+  onPainted?: () => void;
+};
+
+export type DeferredDitheringProps = Omit<DitheringCanvasProps, "animate"> & {
   unmountOffscreen?: boolean;
 };
 
@@ -22,4 +29,32 @@ export interface DitherVisibilityState {
   containerRef: RefObject<HTMLDivElement | null>;
   shouldRender: boolean;
   isAnimating: boolean;
+}
+
+export interface DitherPointerOffset {
+  offsetX: number;
+  offsetY: number;
+}
+
+export interface DitherPointerOptions {
+  restSpeed: number;
+  hoverSpeed?: number;
+  offsetRange: number;
+  lerp: number;
+  visibleYRatio?: number;
+}
+
+interface DitherPointerHandlers {
+  onPointerEnter: (event: PointerEvent<HTMLElement>) => void;
+  onPointerMove: (event: PointerEvent<HTMLElement>) => void;
+  onPointerLeave: () => void;
+}
+
+interface DitherPointerState extends DitherPointerOffset {
+  speed: number;
+  isHovering: boolean;
+}
+
+export interface DitherPointerResult extends DitherPointerState {
+  pointerProps: DitherPointerHandlers;
 }

--- a/apps/web/src/types/dithering.ts
+++ b/apps/web/src/types/dithering.ts
@@ -26,6 +26,10 @@ export type DeferredDitheringProps = Omit<DitheringCanvasProps, "animate"> & {
   eager?: boolean;
 };
 
+export interface HeroDitherProps {
+  eager?: boolean;
+}
+
 export interface DitherVisibilityState {
   containerRef: RefObject<HTMLDivElement | null>;
   shouldRender: boolean;

--- a/apps/web/src/types/dithering.ts
+++ b/apps/web/src/types/dithering.ts
@@ -23,6 +23,7 @@ export type DitheringCanvasProps = Pick<
 
 export type DeferredDitheringProps = Omit<DitheringCanvasProps, "animate"> & {
   unmountOffscreen?: boolean;
+  eager?: boolean;
 };
 
 export interface DitherVisibilityState {

--- a/apps/web/src/types/landing/geo.ts
+++ b/apps/web/src/types/landing/geo.ts
@@ -67,6 +67,7 @@ export interface CitationRowsProps {
   rows: LiveCitationRow[];
   base: number | null;
   animated: boolean;
+  enteringId?: string | null;
   headers: { when: string; provider: string; path: string; purpose: string };
 }
 

--- a/apps/web/src/types/landing/geo.ts
+++ b/apps/web/src/types/landing/geo.ts
@@ -68,6 +68,7 @@ export interface CitationRowsProps {
   base: number | null;
   animated: boolean;
   enteringId?: string | null;
+  onEntered?: (id: string) => void;
   headers: { when: string; provider: string; path: string; purpose: string };
 }
 

--- a/apps/web/src/types/navbar.ts
+++ b/apps/web/src/types/navbar.ts
@@ -1,4 +1,11 @@
-export type NavbarVariant = "island" | "landing" | "pinned" | "static";
+import type { Variants } from "motion/react";
+import type { ReactNode } from "react";
+
+import type { MarketingNavGroup } from "@/utils/navigation";
+
+export type NavbarVariant = "island" | "landing" | "page" | "pinned" | "static";
+
+export type NavbarMobileOverlayLayout = "compact" | "hero";
 
 export interface NavbarProps {
   variant?: NavbarVariant;
@@ -9,7 +16,40 @@ export interface NavbarAuthActionsProps {
   isResolved: boolean;
 }
 
+export interface NavbarMobileMenuProps extends NavbarAuthActionsProps {
+  open: boolean;
+  onNavigate: () => void;
+  overlayLayout: NavbarMobileOverlayLayout;
+}
+
+export interface NavbarMobileGroupProps {
+  group: MarketingNavGroup;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: () => void;
+  item: Variants;
+  stagger: Variants;
+}
+
 export interface NavbarKbdProps {
   children: string;
   onLight?: boolean;
+}
+
+export interface NavbarHrefProps {
+  href: string;
+  external?: boolean;
+  className: string;
+  onClick?: () => void;
+  children: ReactNode;
+  role?: string;
+}
+
+export interface NavbarChromePresentation {
+  chrome: boolean;
+  innerPaddingClass: string;
+  overlayLayout: NavbarMobileOverlayLayout;
+  positionClass: string;
+  rowHeightClass: string;
+  shellAnimate: { maxWidth: string; top?: string };
 }

--- a/apps/web/src/types/not-found.ts
+++ b/apps/web/src/types/not-found.ts
@@ -5,6 +5,11 @@ interface NotFoundDitherHoverConfig {
   visibleYRatio: number;
 }
 
+export interface NotFoundLink {
+  label: string;
+  href: string;
+}
+
 export interface NotFoundDitheringConfig {
   speed: number;
   shape: "wave";

--- a/apps/web/src/types/not-found.ts
+++ b/apps/web/src/types/not-found.ts
@@ -1,4 +1,18 @@
-export interface NotFoundLink {
-  label: string;
-  href: string;
+interface NotFoundDitherHoverConfig {
+  offsetRange: number;
+  lerp: number;
+  /** Fraction of the numeral height that maps to the full Y offset. Match the fade. */
+  visibleYRatio: number;
+}
+
+export interface NotFoundDitheringConfig {
+  speed: number;
+  shape: "wave";
+  type: "4x4";
+  size: number;
+  scale: number;
+  colorBack: string;
+  colorFront: string;
+  fit: "cover";
+  hover: NotFoundDitherHoverConfig;
 }

--- a/apps/web/src/utils/create-text-mask-data-url.ts
+++ b/apps/web/src/utils/create-text-mask-data-url.ts
@@ -1,0 +1,44 @@
+const MASK_DPR_CAP = 2;
+
+export function createTextMaskDataUrl(
+  element: HTMLElement,
+  text: string
+): string | null {
+  const width = element.offsetWidth;
+  const height = element.offsetHeight;
+  if (width < 1 || height < 1) {
+    return null;
+  }
+
+  const dpr = Math.min(window.devicePixelRatio || 1, MASK_DPR_CAP);
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.ceil(width * dpr);
+  canvas.height = Math.ceil(height * dpr);
+  const context = canvas.getContext("2d");
+  if (!context) {
+    return null;
+  }
+
+  const style = getComputedStyle(element);
+  const paddingLeft = Number.parseFloat(style.paddingLeft);
+  const paddingRight = Number.parseFloat(style.paddingRight);
+  const paddingTop = Number.parseFloat(style.paddingTop);
+  const contentWidth = width - paddingLeft - paddingRight;
+
+  context.scale(dpr, dpr);
+  context.clearRect(0, 0, width, height);
+  context.fillStyle = "#fff";
+  context.font = style.font;
+  context.letterSpacing = style.letterSpacing;
+  context.textAlign = "center";
+  context.textBaseline = "alphabetic";
+
+  const metrics = context.measureText(text);
+  const ascent =
+    metrics.fontBoundingBoxAscent ||
+    metrics.actualBoundingBoxAscent ||
+    Number.parseFloat(style.fontSize) * 0.8;
+
+  context.fillText(text, paddingLeft + contentWidth / 2, paddingTop + ascent);
+  return canvas.toDataURL("image/png");
+}

--- a/apps/web/src/utils/dither-environment.ts
+++ b/apps/web/src/utils/dither-environment.ts
@@ -1,4 +1,7 @@
-import { DITHER_MOBILE_QUERY } from "@/constants/dithering";
+import {
+  DITHER_FINE_POINTER_QUERY,
+  DITHER_MOBILE_QUERY,
+} from "@/constants/dithering";
 
 export function subscribeToDitherViewport(onChange: () => void) {
   const query = window.matchMedia(DITHER_MOBILE_QUERY);
@@ -8,6 +11,16 @@ export function subscribeToDitherViewport(onChange: () => void) {
 
 export function getDitherMobileSnapshot() {
   return window.matchMedia(DITHER_MOBILE_QUERY).matches;
+}
+
+export function subscribeToFinePointer(onChange: () => void) {
+  const query = window.matchMedia(DITHER_FINE_POINTER_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+export function getFinePointerSnapshot() {
+  return window.matchMedia(DITHER_FINE_POINTER_QUERY).matches;
 }
 
 export function subscribeToPageVisibility(onChange: () => void) {

--- a/apps/web/src/utils/dither-pointer-offset.ts
+++ b/apps/web/src/utils/dither-pointer-offset.ts
@@ -1,0 +1,24 @@
+import type { DitherPointerOffset } from "@/types/dithering";
+
+function clampUnit(value: number) {
+  return Math.min(1, Math.max(-1, value));
+}
+
+export function getDitherPointerOffset(
+  clientX: number,
+  clientY: number,
+  rect: Pick<DOMRect, "left" | "top" | "width" | "height">,
+  range: number,
+  visibleYRatio = 1
+): DitherPointerOffset {
+  const width = rect.width || 1;
+  const height = rect.height || 1;
+  const ySpan = height * Math.max(visibleYRatio, 0.01);
+  const nx = clampUnit(((clientX - rect.left) / width) * 2 - 1);
+  const ny = clampUnit(((clientY - rect.top) / ySpan) * 2 - 1);
+
+  return {
+    offsetX: nx * range,
+    offsetY: ny * range,
+  };
+}

--- a/apps/web/src/utils/navbar-presentation.ts
+++ b/apps/web/src/utils/navbar-presentation.ts
@@ -1,0 +1,103 @@
+import type {
+  NavbarChromePresentation,
+  NavbarMobileOverlayLayout,
+  NavbarVariant,
+} from "@/types/navbar";
+
+const FLOATING_ROW = "h-11 lg:h-[2.4375rem]";
+const CHROME_ROW = "h-16";
+const CHROME_PADDING = "px-4 sm:px-6";
+const ISLAND_MAX_WIDTH = "64rem";
+
+interface NavbarVariantSpec {
+  positionClass: string;
+  overlayLayout: NavbarMobileOverlayLayout;
+  tracksScroll: boolean;
+  pinnedChrome: boolean;
+  canFloat: boolean;
+  floatsShell: boolean;
+  floatingPadding: string;
+  floatingTop: string;
+  expandedMaxWidth: string;
+}
+
+const NAVBAR_VARIANT_SPEC: Record<NavbarVariant, NavbarVariantSpec> = {
+  island: {
+    positionClass: "w-full sticky top-4",
+    overlayLayout: "hero",
+    tracksScroll: true,
+    pinnedChrome: false,
+    canFloat: false,
+    floatsShell: false,
+    floatingPadding: CHROME_PADDING,
+    floatingTop: "1rem",
+    expandedMaxWidth: "80rem",
+  },
+  landing: {
+    positionClass: "fixed inset-x-4 sm:inset-x-6",
+    overlayLayout: "hero",
+    tracksScroll: true,
+    pinnedChrome: false,
+    canFloat: true,
+    floatsShell: true,
+    floatingPadding: "px-7 sm:px-5 lg:px-6 min-[87rem]:px-0",
+    floatingTop: "2.5rem",
+    expandedMaxWidth: "80.9375rem",
+  },
+  page: {
+    positionClass: "fixed inset-x-3 sm:inset-x-4",
+    overlayLayout: "compact",
+    tracksScroll: true,
+    pinnedChrome: false,
+    canFloat: true,
+    floatsShell: true,
+    floatingPadding: "px-4 sm:px-5",
+    floatingTop: "1rem",
+    expandedMaxWidth: "80.9375rem",
+  },
+  pinned: {
+    positionClass: "w-full sticky top-4",
+    overlayLayout: "hero",
+    tracksScroll: false,
+    pinnedChrome: true,
+    canFloat: false,
+    floatsShell: false,
+    floatingPadding: CHROME_PADDING,
+    floatingTop: "1rem",
+    expandedMaxWidth: "80rem",
+  },
+  static: {
+    positionClass: "w-full",
+    overlayLayout: "hero",
+    tracksScroll: false,
+    pinnedChrome: false,
+    canFloat: false,
+    floatsShell: false,
+    floatingPadding: CHROME_PADDING,
+    floatingTop: "1rem",
+    expandedMaxWidth: "80rem",
+  },
+};
+
+export function getNavbarChromePresentation(
+  variant: NavbarVariant,
+  scrolled: boolean
+): NavbarChromePresentation {
+  const spec = NAVBAR_VARIANT_SPEC[variant];
+  const chrome = spec.pinnedChrome || (spec.tracksScroll && scrolled);
+  const floating = spec.canFloat && !chrome;
+
+  return {
+    chrome,
+    innerPaddingClass: floating ? spec.floatingPadding : CHROME_PADDING,
+    overlayLayout: spec.overlayLayout,
+    positionClass: spec.positionClass,
+    rowHeightClass: floating ? FLOATING_ROW : CHROME_ROW,
+    shellAnimate: spec.floatsShell
+      ? {
+          maxWidth: chrome ? ISLAND_MAX_WIDTH : spec.expandedMaxWidth,
+          top: chrome ? "1rem" : spec.floatingTop,
+        }
+      : { maxWidth: chrome ? ISLAND_MAX_WIDTH : spec.expandedMaxWidth },
+  };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -275,6 +275,7 @@
         "@remotion/fonts": "4.0.487",
         "@remotion/player": "4.0.487",
         "@remotion/renderer": "4.0.487",
+        "@scritto/react": "^0.1.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-form": "^1.33.5",
         "@tanstack/react-hotkeys": "^0.3.0",
@@ -2043,6 +2044,10 @@
     "@scalar/types": ["@scalar/types@0.18.3", "", { "dependencies": { "@scalar/helpers": "0.11.2", "nanoid": "^5.1.6", "type-fest": "^5.8.0", "zod": "^4.4.3" } }, "sha512-hPLLxVt/ah4RpCVp5UrLEpnBEgTwf+RvPtRiSEty3QqfBJUfADMXHz+oWK6UAa/vALg2AWuJLCD8hRlyQ2ET9w=="],
 
     "@scalar/validation": ["@scalar/validation@0.6.3", "", {}, "sha512-j3s9XPv8Wo1EG5/naBi4XGF0uXYQ2A3QZNI0NKWgCMxRHVrDJGlZEYymcHDHY7fquRm73P8U3c8xqJqB5yad6w=="],
+
+    "@scritto/core": ["@scritto/core@0.1.0", "", {}, "sha512-8itfD3jc+DvoDcMYAcWJHyLXZvBNaorlL091Fp/4Toe4trGErbQOtyptO9Qexyb/qvGO0S1WRWDrGO/2KURnxg=="],
+
+    "@scritto/react": ["@scritto/react@0.1.0", "", { "dependencies": { "@scritto/core": "0.1.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-fNeX/ZjXUBtNMo/aQ03t1AG9+5vbitfEDfrLbO5qVCAcus7xq8kWhuv1LNuGGcBLA6pngo5otymCCkZDNRY84Q=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 


### PR DESCRIPTION
## Summary
- Full-viewport mobile nav overlay (header stays put, page content goes inert) plus a `page` navbar variant for 404
- Dithered Satoshi 404 numeral with a one-shot fade-in; landing still lazy-loads the shader
- Landing: hero CTAs in one row, headline lines share a left edge, feature mocks fit small screens, hero traffic table hides path on mobile

## Test plan
- [ ] Homepage at ~390px: hero CTAs side by side, headline two lines share a left edge, traffic table is Provider + Purpose only
- [ ] Homepage desktop: Path column still in the hero log; feature tables (mention rate / share of voice) match height
- [ ] Open the mobile menu: overlay covers the page, Escape/route change/desktop breakpoint close it, focus returns to the toggle
- [ ] 404: dithered 404 fades in once, Back to home works, mobile menu still works
- [ ] Dark and light: Claude chat sample still uses a real serif, brand page Instrument Serif sample still loads


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the marketing site's mobile nav, 404 page, and landing hero for small screens, while clearing React Doctor compiler errors in the nav and dither components.

**Mobile nav**
- Uses a full-viewport overlay that keeps the header fixed and makes page content inert.
- Escape, route changes, and crossing the desktop breakpoint close the menu and restore focus to its toggle.
- Adds a `page` navbar variant for the 404 page.

**Landing, 404, and fonts**
- Keeps hero CTAs side by side and aligns the two mobile headline lines.
- Morphs engine names with `@scritto/react` on a shared baseline while reserving the longest label for centering.
- Makes feature tables responsive with fixed columns and optional columns shown at `@lg`; the hero traffic log hides its path column on mobile.
- Adds a dithered 404 numeral with a one-shot post-paint fade, reduced-motion support, and fine-pointer hover response.
- Paints the hero dither eagerly while keeping other dithers lazy; the theme toggle waits for client hydration before setting aria attributes.
- Restores 404 index links to llms.txt, sitemap.xml, and Docs.
- Maps `font-serif` to the system serif stack and moves Instrument Serif to `font-instrument`.

<sup>Written for commit 79764503eccc38393828a6f9b9fe1c3ce1da8234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

