### PR TITLE
ci(blog): comment on pull requests with link check results

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -3,12 +3,17 @@ name: Blog
 on:
   push:
     branches: ["main"]
-    paths: ["apps/web/src/content/blog/**/*.mdx"]
+    paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml"]
   pull_request:
-    paths: ["apps/web/src/content/blog/**/*.mdx"]
+    paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml"]
 
 permissions:
   contents: read
+  pull-requests: write
+
+concurrency:
+  group: blog-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -17,11 +22,71 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Lint blog links
+        id: links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
+          format: json
+          output: lychee/out.json
           # X profiles load in browsers but return 403 to GitHub-hosted crawlers.
           args: >-
             --no-progress --max-redirects 0 --accept '200..=299'
             --exclude '^https://x\.com/'
             --base-url https://www.usenotra.com/blog/
             'apps/web/src/content/blog/**/*.mdx'
+      - name: Comment on blog links
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          LINK_CHECK_OUTCOME: ${{ steps.links.outcome }}
+        with:
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- notra-blog-links -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const escape = (value) => String(value).replace(/[&<>`]/g, (character) => ({
+              '&': '&amp;', '<': '&lt;', '>': '&gt;', '`': '&#96;'
+            })[character]);
+            const lines = [marker, '### Blog link checker', ''];
+
+            if (fs.existsSync('lychee/out.json')) {
+              const report = JSON.parse(fs.readFileSync('lychee/out.json', 'utf8'));
+              const checked = report.total - report.excludes;
+              const passed = process.env.LINK_CHECK_OUTCOME === 'success';
+              lines.push(`${passed ? '✅' : '❌'} **${report.successful}/${checked} valid links**`);
+              if (report.excludes > 0) {
+                lines.push(`\n${report.excludes} excluded links were skipped.`);
+              }
+              for (const map of [report.error_map, report.timeout_map]) {
+                for (const [file, errors] of Object.entries(map ?? {}).sort()) {
+                  lines.push(`\n**${escape(file)}**`);
+                  for (const error of errors) {
+                    const location = error.span?.line ? ` (line ${error.span.line})` : '';
+                    lines.push(`- <code>${escape(error.url)}</code>${location}: ${escape(error.status.text)}${error.status.details ? ` — ${escape(error.status.details)}` : ''}`);
+                  }
+                }
+              }
+              if (!passed) {
+                lines.push('\nThe link check failed. See the workflow run for full details.');
+              }
+            } else {
+              lines.push('❌ The link checker could not produce a report. See the workflow run for details.');
+            }
+
+            // Stay below GitHub's comment limit, even for large failure reports.
+            const body = `${lines.join('\n').slice(0, 60000)}\n\n[View workflow run](${runUrl})`;
+            await core.summary.addRaw(body).write();
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo, issue_number: context.issue.number
+            });
+            const previous = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker)
+            );
+            if (previous) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: previous.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: context.issue.number, body
+              });
+            }

--- a/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
+++ b/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
@@ -42,6 +42,3 @@ Because good communication is **very** important!
 - This is not a scientific claim, and it is not backed by formal research or a strict scientific standard.
 - It is our belief based on what we have observed while building developer products.
 - This belief is a big part of why we are building Notra: to help teams turn real shipping activity into consistent, authentic distribution.
-<!-- Temporary PR test: removed after verifying the link checker comment. -->
-[Malformed blog link test](https://www.usenotra.comhttps/blog/)
-[Missing blog page test](https://www.usenotra.com/blog/notra-link-check-test-missing-20260910)

--- a/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
+++ b/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
@@ -43,5 +43,5 @@ Because good communication is **very** important!
 - It is our belief based on what we have observed while building developer products.
 - This belief is a big part of why we are building Notra: to help teams turn real shipping activity into consistent, authentic distribution.
 <!-- Temporary PR test: removed after verifying the link checker comment. -->
-[Malformed blog link test](https://blog-link-check-test.invalid/broken)
+[Malformed blog link test](https://www.usenotra.comhttps/blog/)
 [Missing blog page test](https://www.usenotra.com/blog/notra-link-check-test-missing-20260910)

--- a/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
+++ b/apps/web/src/content/blog/engineers-are-great-for-marketing.mdx
@@ -42,3 +42,6 @@ Because good communication is **very** important!
 - This is not a scientific claim, and it is not backed by formal research or a strict scientific standard.
 - It is our belief based on what we have observed while building developer products.
 - This belief is a big part of why we are building Notra: to help teams turn real shipping activity into consistent, authentic distribution.
+<!-- Temporary PR test: removed after verifying the link checker comment. -->
+[Malformed blog link test](https://blog-link-check-test.invalid/broken)
+[Missing blog page test](https://www.usenotra.com/blog/notra-link-check-test-missing-20260910)


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts blog link check results as a comment on pull requests, so authors and reviewers see link failures without opening the workflow run. Previously the check ran silently; now the PR gets a comment that updates on subsequent pushes.

- Replaces the previous comment instead of creating duplicates.
- Runs the workflow when the workflow file itself changes.
- Cancels in-progress runs for the same branch.

<sup>Written for commit 498b16a57b9e3527122ffe601bebfa5e308dd015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

