### PR TITLE
fix(web): refresh generated shared UI sources

### DIFF
--- a/apps/web/src/styles/ui-sources.css
+++ b/apps/web/src/styles/ui-sources.css
@@ -56,6 +56,7 @@
 @source "../../../../packages/ui/src/components/ui/carousel-progress.tsx";
 @source "../../../../packages/ui/src/components/ui/collapsible.tsx";
 @source "../../../../packages/ui/src/components/ui/command-tabs.tsx";
+@source "../../../../packages/ui/src/components/ui/context-menu.tsx";
 @source "../../../../packages/ui/src/components/ui/dialog.tsx";
 @source "../../../../packages/ui/src/components/ui/dropdown-menu.tsx";
 @source "../../../../packages/ui/src/components/ui/expandable-tabs.tsx";
@@ -145,7 +146,9 @@
 @source "../../../../packages/ui/src/constants/command-tabs.ts";
 @source "../../../../packages/ui/src/constants/gemini-models.ts";
 @source "../../../../packages/ui/src/constants/geo.ts";
+@source "../../../../packages/ui/src/constants/message-table.ts";
 @source "../../../../packages/ui/src/constants/perplexity-models.ts";
+@source "../../../../packages/ui/src/constants/table.ts";
 @source "../../../../packages/ui/src/hooks/use-mobile.tsx";
 @source "../../../../packages/ui/src/lib/chatgpt-model.ts";
 @source "../../../../packages/ui/src/lib/claude-chat-model.ts";
@@ -159,6 +162,7 @@
 @source "../../../../packages/ui/src/lib/geo-model-display.ts";
 @source "../../../../packages/ui/src/lib/geo-perplexity-sources.ts";
 @source "../../../../packages/ui/src/lib/geo-prompt-engines.ts";
+@source "../../../../packages/ui/src/lib/message-table.ts";
 @source "../../../../packages/ui/src/lib/motion.ts";
 @source "../../../../packages/ui/src/lib/perplexity-model.ts";
 @source "../../../../packages/ui/src/lib/utils.ts";
@@ -168,4 +172,5 @@
 @source "../../../../packages/ui/src/types/gemini.ts";
 @source "../../../../packages/ui/src/types/geo.ts";
 @source "../../../../packages/ui/src/types/instrument.ts";
+@source "../../../../packages/ui/src/types/message-table.ts";
 @source "../../../../packages/ui/src/types/perplexity.ts";


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the generated shared UI source list in `apps/web` so Tailwind picks up newly added UI files. Adds `context-menu`, `message-table`, and `table` sources to `ui-sources.css`.

<sup>Written for commit 6166b8a30ab05362a9dfa78a40708253fe4f676d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

