### PR TITLE
perf(dashboard): batch oRPC requests and memoize per-request auth

### DIFF
--- a/apps/dashboard/src/lib/analytics/access.ts
+++ b/apps/dashboard/src/lib/analytics/access.ts
@@ -1,11 +1,41 @@
 import { ANALYTICS_UNAVAILABLE_DESCRIPTION } from "@/constants/analytics";
 import { isAnalyticsEnabledForOrganization } from "@/lib/analytics/flag";
+import { assertOrganizationAccess } from "@/lib/auth/organization";
+import { getORPCRequestMemo } from "@/lib/orpc/context";
 import { forbidden } from "@/lib/orpc/utils/errors";
 
-export async function assertAnalyticsEnabled(
-  organizationId: string
+/**
+ * Membership and the analytics flag are independent, so they run together.
+ * When both fail, the membership error wins: a non-member must not learn
+ * whether analytics is enabled for that organization.
+ */
+export async function assertAnalyticsAccess(
+  params: Parameters<typeof assertOrganizationAccess>[0]
 ): Promise<void> {
-  const enabled = await isAnalyticsEnabledForOrganization(organizationId);
+  const [membership, enabled] = await Promise.allSettled([
+    assertOrganizationAccess(params),
+    assertAnalyticsEnabled(params.organizationId, params.headers),
+  ]);
+
+  if (membership.status === "rejected") {
+    throw membership.reason;
+  }
+  if (enabled.status === "rejected") {
+    throw enabled.reason;
+  }
+}
+
+async function assertAnalyticsEnabled(
+  organizationId: string,
+  headers?: Headers
+): Promise<void> {
+  const memo = headers ? getORPCRequestMemo(headers) : undefined;
+  let evaluation = memo?.analyticsEnabledByOrganization.get(organizationId);
+  if (!evaluation) {
+    evaluation = isAnalyticsEnabledForOrganization(organizationId);
+    memo?.analyticsEnabledByOrganization.set(organizationId, evaluation);
+  }
+  const enabled = await evaluation;
   if (!enabled) {
     throw forbidden(ANALYTICS_UNAVAILABLE_DESCRIPTION);
   }

--- a/apps/dashboard/src/lib/auth/organization.ts
+++ b/apps/dashboard/src/lib/auth/organization.ts
@@ -6,6 +6,7 @@ import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { retryTransientDbError } from "@/lib/db/retry";
+import { getORPCRequestMemo } from "@/lib/orpc/context";
 import type {
   AuthenticatedUser,
   AuthSession,
@@ -57,6 +58,30 @@ export async function assertAuthenticated(args: { headers: Headers }) {
   return assertAuthenticatedWithDeps(args);
 }
 
+/**
+ * Batched oRPC calls arrive as one HTTP request, so every procedure in the
+ * batch would otherwise repeat the same membership SELECT. The memo lives in a
+ * WeakMap keyed by that request's `Headers`, so it cannot outlive the request.
+ */
+async function findMembershipMemoized(
+  deps: Pick<OrganizationAuthDependencies, "findMembership">,
+  headers: Headers,
+  params: { organizationId: string; userId: string }
+) {
+  const memo = getORPCRequestMemo(headers);
+  if (!memo) {
+    return await deps.findMembership(params);
+  }
+
+  const cacheKey = `${params.userId}:${params.organizationId}`;
+  let lookup = memo.membershipByUserOrganization.get(cacheKey);
+  if (!lookup) {
+    lookup = deps.findMembership(params);
+    memo.membershipByUserOrganization.set(cacheKey, lookup);
+  }
+  return await lookup;
+}
+
 export async function assertOrganizationAccessWithDeps(
   {
     headers,
@@ -88,7 +113,7 @@ export async function assertOrganizationAccessWithDeps(
   const authenticatedUser =
     user ?? (await assertAuthenticatedWithDeps({ headers }, deps)).user;
 
-  const membership = await deps.findMembership({
+  const membership = await findMembershipMemoized(deps, headers, {
     userId: authenticatedUser.id,
     organizationId: safeOrganizationId.data,
   });

--- a/apps/dashboard/src/lib/billing/subscription.ts
+++ b/apps/dashboard/src/lib/billing/subscription.ts
@@ -13,7 +13,19 @@ import {
 } from "@/constants/analytics-events";
 import { GEO_PLAN_REQUIRED_MESSAGE } from "@/constants/billing";
 import { trackServerEvent } from "@/lib/analytics/posthog-server";
+import { getORPCRequestMemo } from "@/lib/orpc/context";
 import { internalServerError, paymentRequired } from "@/lib/orpc/utils/errors";
+
+const checkAiAnswersEntitlement = async (organizationId: string) => {
+  if (!autumn) {
+    return null;
+  }
+
+  return await autumn.check({
+    customerId: organizationId,
+    featureId: FEATURES.AI_ANSWERS,
+  });
+};
 
 async function hasAiCreditsBalance(organizationId: string): Promise<boolean> {
   if (!autumn) {
@@ -152,43 +164,65 @@ export async function hasPaidSubscriptionHistory(
   }
 }
 
-export async function assertGeoEntitlement(
-  organizationId: string
-): Promise<void> {
+export type GeoEntitlementOutcome = "entitled" | "denied" | "skipped";
+
+/**
+ * Resolves the AI-answers entitlement without emitting denial telemetry.
+ * Confirm membership before calling: this lookup can contact the billing provider.
+ */
+export async function resolveGeoEntitlement(
+  organizationId: string,
+  headers?: Headers
+): Promise<GeoEntitlementOutcome> {
   if (allowUnmeteredAiInDevelopment) {
-    return;
+    return "skipped";
   }
 
   if (!autumn) {
     if (process.env.NODE_ENV === "production") {
       throw internalServerError("Billing is not configured");
     }
-    return;
+    return "skipped";
   }
 
-  let entitled = false;
   try {
-    const data = await autumn.check({
-      customerId: organizationId,
-      featureId: FEATURES.AI_ANSWERS,
-    });
-    entitled = data.balance != null;
+    const memo = headers ? getORPCRequestMemo(headers) : undefined;
+    let outcome = memo?.geoEntitlementByOrganization.get(organizationId);
+    if (!outcome) {
+      outcome = checkAiAnswersEntitlement(organizationId).then((data) =>
+        data?.balance != null ? "entitled" : "denied"
+      );
+      memo?.geoEntitlementByOrganization.set(organizationId, outcome);
+    }
+    return await outcome;
   } catch (error) {
     if (error instanceof ORPCError) {
       throw error;
     }
     throw internalServerError("Failed to verify plan entitlement");
   }
+}
 
-  if (!entitled) {
-    trackServerEvent({
-      event: POSTHOG_EVENTS.ENTITLEMENT_DENIED,
-      organizationId,
-      properties: {
-        feature: ENTITLEMENT_FEATURES.AI_ANSWERS,
-        surface: ENTITLEMENT_SURFACES.DASHBOARD,
-      },
-    });
-    throw paymentRequired(GEO_PLAN_REQUIRED_MESSAGE);
+/** Reports the denial and rejects the request. Call only for confirmed members. */
+export function rejectGeoEntitlementDenied(organizationId: string): never {
+  trackServerEvent({
+    event: POSTHOG_EVENTS.ENTITLEMENT_DENIED,
+    organizationId,
+    properties: {
+      feature: ENTITLEMENT_FEATURES.AI_ANSWERS,
+      surface: ENTITLEMENT_SURFACES.DASHBOARD,
+    },
+  });
+  throw paymentRequired(GEO_PLAN_REQUIRED_MESSAGE);
+}
+
+/** Call only after confirming organization membership. */
+export async function assertGeoEntitlement(
+  organizationId: string,
+  headers?: Headers
+): Promise<void> {
+  const outcome = await resolveGeoEntitlement(organizationId, headers);
+  if (outcome === "denied") {
+    rejectGeoEntitlementDenied(organizationId);
   }
 }

--- a/apps/dashboard/src/lib/geo/access.test.ts
+++ b/apps/dashboard/src/lib/geo/access.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const assertOrganizationAccess = mock(async () => {});
+const assertGeoEntitlement = mock(async () => {});
+
+mock.module("@/lib/auth/organization", () => ({
+  assertOrganizationAccess,
+}));
+mock.module("@/lib/billing/subscription", () => ({
+  assertGeoEntitlement,
+}));
+
+const { assertGeoAccess } = await import("./access");
+
+const params = {
+  headers: new Headers(),
+  organizationId: "org_1",
+};
+
+describe("assertGeoAccess", () => {
+  beforeEach(() => {
+    assertOrganizationAccess.mockClear();
+    assertGeoEntitlement.mockClear();
+    assertOrganizationAccess.mockImplementation(async () => {});
+    assertGeoEntitlement.mockImplementation(async () => {});
+  });
+
+  test("does not start the billing lookup until membership is confirmed", async () => {
+    let releaseMembership: () => void = () => {};
+    assertOrganizationAccess.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseMembership = resolve;
+        })
+    );
+
+    const pending = assertGeoAccess(params);
+    await Promise.resolve();
+
+    expect(assertGeoEntitlement).not.toHaveBeenCalled();
+    releaseMembership();
+    await pending;
+
+    expect(assertGeoEntitlement).toHaveBeenCalledTimes(1);
+    expect(assertGeoEntitlement).toHaveBeenCalledWith(
+      params.organizationId,
+      params.headers
+    );
+  });
+
+  test("skips the billing lookup when membership fails", async () => {
+    const forbidden = new Error("forbidden");
+    assertOrganizationAccess.mockImplementation(async () => {
+      throw forbidden;
+    });
+
+    await expect(assertGeoAccess(params)).rejects.toBe(forbidden);
+    expect(assertGeoEntitlement).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/src/lib/geo/access.ts
+++ b/apps/dashboard/src/lib/geo/access.ts
@@ -1,30 +1,16 @@
 import { assertOrganizationAccess } from "@/lib/auth/organization";
-import {
-  rejectGeoEntitlementDenied,
-  resolveGeoEntitlement,
-} from "@/lib/billing/subscription";
+import { assertGeoEntitlement } from "@/lib/billing/subscription";
 
 /**
- * The membership check and the billing lookup are independent, so they run
- * together. The denial itself (telemetry + 402) is only raised once membership
- * is confirmed: a non-member must neither learn about nor generate billing
- * events for an organization they do not belong to.
+ * Confirm membership before the billing lookup. `assertGeoEntitlement` can
+ * contact Autumn; starting it in parallel with membership would leak org
+ * billing checks (and 402 vs 403 races) to non-members. Rate-limited GEO
+ * procedures already follow the same order, then parallelize entitlement
+ * with subscription and ratelimit.
  */
 export async function assertGeoAccess(
   params: Parameters<typeof assertOrganizationAccess>[0]
 ): Promise<void> {
-  const [membership, entitlement] = await Promise.allSettled([
-    assertOrganizationAccess(params),
-    resolveGeoEntitlement(params.organizationId, params.headers),
-  ]);
-
-  if (membership.status === "rejected") {
-    throw membership.reason;
-  }
-  if (entitlement.status === "rejected") {
-    throw entitlement.reason;
-  }
-  if (entitlement.value === "denied") {
-    rejectGeoEntitlementDenied(params.organizationId);
-  }
+  await assertOrganizationAccess(params);
+  await assertGeoEntitlement(params.organizationId, params.headers);
 }

--- a/apps/dashboard/src/lib/geo/access.ts
+++ b/apps/dashboard/src/lib/geo/access.ts
@@ -1,0 +1,30 @@
+import { assertOrganizationAccess } from "@/lib/auth/organization";
+import {
+  rejectGeoEntitlementDenied,
+  resolveGeoEntitlement,
+} from "@/lib/billing/subscription";
+
+/**
+ * The membership check and the billing lookup are independent, so they run
+ * together. The denial itself (telemetry + 402) is only raised once membership
+ * is confirmed: a non-member must neither learn about nor generate billing
+ * events for an organization they do not belong to.
+ */
+export async function assertGeoAccess(
+  params: Parameters<typeof assertOrganizationAccess>[0]
+): Promise<void> {
+  const [membership, entitlement] = await Promise.allSettled([
+    assertOrganizationAccess(params),
+    resolveGeoEntitlement(params.organizationId, params.headers),
+  ]);
+
+  if (membership.status === "rejected") {
+    throw membership.reason;
+  }
+  if (entitlement.status === "rejected") {
+    throw entitlement.reason;
+  }
+  if (entitlement.value === "denied") {
+    rejectGeoEntitlementDenied(params.organizationId);
+  }
+}

--- a/apps/dashboard/src/lib/orpc/client.ts
+++ b/apps/dashboard/src/lib/orpc/client.ts
@@ -17,16 +17,19 @@ function getBaseUrl() {
   );
 }
 
+/**
+ * Batch responses are buffered per item, so anything that streams or carries a
+ * binary/FormData payload has to stay on its own request. The plugin already
+ * skips `Blob`/`FormData`/async-iterator bodies; these namespaces are excluded
+ * on top because they exist to move files around.
+ */
+const NON_BATCHABLE_ROOT_PATHS = new Set(["attachments", "upload"]);
+
 const link = new RPCLink({
   plugins: [
     new BatchLinkPlugin({
-      groups: [
-        {
-          condition: ({ path }) =>
-            path[0] === "onboarding" && path[1] === "companyLogo",
-          context: {},
-        },
-      ],
+      exclude: ({ path }) => NON_BATCHABLE_ROOT_PATHS.has(path[0] ?? ""),
+      groups: [{ condition: () => true, context: {} }],
     }),
   ],
   url: `${getBaseUrl()}/rpc`,

--- a/apps/dashboard/src/lib/orpc/context.ts
+++ b/apps/dashboard/src/lib/orpc/context.ts
@@ -1,9 +1,40 @@
 import type { getServerSession } from "@/lib/auth/session";
+import type { OrganizationMembership } from "@/types/auth/organization";
 
 type SessionData = Awaited<ReturnType<typeof getServerSession>>;
 
+export interface ORPCRequestMemo {
+  readonly analyticsEnabledByOrganization: Map<string, Promise<boolean>>;
+  readonly geoEntitlementByOrganization: Map<
+    string,
+    Promise<"entitled" | "denied" | "skipped">
+  >;
+  /** Keyed by `${userId}:${organizationId}`. */
+  readonly membershipByUserOrganization: Map<
+    string,
+    Promise<OrganizationMembership | undefined>
+  >;
+}
+
+const requestMemosByHeaders = new WeakMap<Headers, ORPCRequestMemo>();
+
+function createRequestMemo(): ORPCRequestMemo {
+  return {
+    analyticsEnabledByOrganization: new Map(),
+    geoEntitlementByOrganization: new Map(),
+    membershipByUserOrganization: new Map(),
+  };
+}
+
+export function getORPCRequestMemo(
+  headers: Headers
+): ORPCRequestMemo | undefined {
+  return requestMemosByHeaders.get(headers);
+}
+
 export interface ORPCContext {
   headers: Headers;
+  requestMemo: ORPCRequestMemo;
   session: SessionData["session"] | null;
   user: SessionData["user"] | null;
 }
@@ -13,8 +44,14 @@ export async function createORPCContext({
 }: {
   headers: Headers;
 }): Promise<ORPCContext> {
+  let requestMemo = requestMemosByHeaders.get(headers);
+  if (!requestMemo) {
+    requestMemo = createRequestMemo();
+    requestMemosByHeaders.set(headers, requestMemo);
+  }
   return {
     headers,
+    requestMemo,
     session: null,
     user: null,
   };

--- a/apps/dashboard/src/lib/orpc/routers/analytics.ts
+++ b/apps/dashboard/src/lib/orpc/routers/analytics.ts
@@ -9,7 +9,7 @@ import {
   untrackAccountInputSchema,
 } from "@notra/schemas/dashboard/analytics";
 
-import { assertAnalyticsEnabled } from "@/lib/analytics/access";
+import { assertAnalyticsAccess } from "@/lib/analytics/access";
 import { trackServerEvent } from "@/lib/analytics/posthog-server";
 import {
   loadEngagementTimeseries,
@@ -23,7 +23,6 @@ import {
   trackTwitterAccount,
   untrackTwitterAccount,
 } from "@/lib/analytics/programs";
-import { assertOrganizationAccess } from "@/lib/auth/organization";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import { runOrpcEffect } from "@/lib/orpc/effect";
 import { toAnalyticsOrpcError } from "@/lib/orpc/utils/analytics-errors";
@@ -42,12 +41,11 @@ export const analyticsRouter = {
   overview: authorizedProcedure
     .input(analyticsOrganizationInputSchema)
     .handler(async ({ context, input }): Promise<SocialOverviewResponse> => {
-      await assertOrganizationAccess({
+      await assertAnalyticsAccess({
         headers: context.headers,
         organizationId: input.organizationId,
         user: context.user,
       });
-      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadSocialOverview(input.organizationId),
@@ -58,12 +56,11 @@ export const analyticsRouter = {
     .input(analyticsTimeseriesInputSchema)
     .handler(
       async ({ context, input }): Promise<EngagementTimeseriesResponse> => {
-        await assertOrganizationAccess({
+        await assertAnalyticsAccess({
           headers: context.headers,
           organizationId: input.organizationId,
           user: context.user,
         });
-        await assertAnalyticsEnabled(input.organizationId);
 
         return await runOrpcEffect(
           loadEngagementTimeseries(input.organizationId, {
@@ -79,12 +76,11 @@ export const analyticsRouter = {
   topPosts: authorizedProcedure
     .input(analyticsTopPostsInputSchema)
     .handler(async ({ context, input }): Promise<TopPostsResponse> => {
-      await assertOrganizationAccess({
+      await assertAnalyticsAccess({
         headers: context.headers,
         organizationId: input.organizationId,
         user: context.user,
       });
-      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadTopPosts(input.organizationId, input.limit, {
@@ -98,12 +94,11 @@ export const analyticsRouter = {
   adoption: authorizedProcedure
     .input(analyticsOrganizationInputSchema)
     .handler(async ({ context, input }): Promise<NotraAdoptionResponse> => {
-      await assertOrganizationAccess({
+      await assertAnalyticsAccess({
         headers: context.headers,
         organizationId: input.organizationId,
         user: context.user,
       });
-      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadNotraAdoption(input.organizationId),
@@ -114,12 +109,11 @@ export const analyticsRouter = {
     .input(analyticsPostingPerformanceInputSchema)
     .handler(
       async ({ context, input }): Promise<PostingPerformanceResponse> => {
-        await assertOrganizationAccess({
+        await assertAnalyticsAccess({
           headers: context.headers,
           organizationId: input.organizationId,
           user: context.user,
         });
-        await assertAnalyticsEnabled(input.organizationId);
 
         return await runOrpcEffect(
           loadPostingPerformance(input.organizationId, {
@@ -135,12 +129,11 @@ export const analyticsRouter = {
   leaderboard: authorizedProcedure
     .input(leaderboardInputSchema)
     .handler(async ({ context, input }): Promise<LeaderboardResponse> => {
-      await assertOrganizationAccess({
+      await assertAnalyticsAccess({
         headers: context.headers,
         organizationId: input.organizationId,
         user: context.user,
       });
-      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadLeaderboard(input.organizationId, input.days, {
@@ -155,12 +148,11 @@ export const analyticsRouter = {
     .input(trackAccountInputSchema)
     .handler(
       async ({ context, input }): Promise<TrackAccountPreviewResponse> => {
-        await assertOrganizationAccess({
+        await assertAnalyticsAccess({
           headers: context.headers,
           organizationId: input.organizationId,
           user: context.user,
         });
-        await assertAnalyticsEnabled(input.organizationId);
 
         return await runOrpcEffect(
           previewTrackedAccount(input.username),
@@ -171,12 +163,11 @@ export const analyticsRouter = {
   trackAccount: authorizedProcedure
     .input(trackAccountInputSchema)
     .handler(async ({ context, input }) => {
-      await assertOrganizationAccess({
+      await assertAnalyticsAccess({
         headers: context.headers,
         organizationId: input.organizationId,
         user: context.user,
       });
-      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         trackTwitterAccount(input.organizationId, input.username),
@@ -186,12 +177,11 @@ export const analyticsRouter = {
   untrackAccount: authorizedProcedure
     .input(untrackAccountInputSchema)
     .handler(async ({ context, input }) => {
-      await assertOrganizationAccess({
+      await assertAnalyticsAccess({
         headers: context.headers,
         organizationId: input.organizationId,
         user: context.user,
       });
-      await assertAnalyticsEnabled(input.organizationId);
 
       const result = await runOrpcEffect(
         untrackTwitterAccount(input.organizationId, input.trackedAccountId),
@@ -215,12 +205,11 @@ export const analyticsRouter = {
   followerGrowth: authorizedProcedure
     .input(analyticsTimeseriesInputSchema)
     .handler(async ({ context, input }): Promise<FollowerGrowthResponse> => {
-      await assertOrganizationAccess({
+      await assertAnalyticsAccess({
         headers: context.headers,
         organizationId: input.organizationId,
         user: context.user,
       });
-      await assertAnalyticsEnabled(input.organizationId);
 
       return await runOrpcEffect(
         loadFollowerGrowth(input.organizationId, {

--- a/apps/dashboard/src/lib/orpc/routers/geo.ts
+++ b/apps/dashboard/src/lib/orpc/routers/geo.ts
@@ -246,6 +246,7 @@ import {
   loadGeoShelfContext,
   updateGeoShelfSource,
 } from "@/lib/geo-shelf/service";
+import { assertGeoAccess } from "@/lib/geo/access";
 import { geoCoreDashboardLayer } from "@/lib/geo/configure";
 import { authorizedProcedure } from "@/lib/orpc/base";
 import { runOrpcEffect } from "@/lib/orpc/effect";
@@ -270,13 +271,6 @@ import { ratelimit } from "@/utils/ratelimit";
 interface GeoHandlerOptions<TInput> {
   context: { headers: Headers; user?: AuthenticatedUser };
   input: TInput;
-}
-
-async function assertGeoAccess(
-  params: Parameters<typeof assertOrganizationAccess>[0]
-): Promise<void> {
-  await assertOrganizationAccess(params);
-  await assertGeoEntitlement(params.organizationId);
 }
 
 function geoOpenHandler<
@@ -1227,12 +1221,13 @@ export const geoRouter = {
   sequenceRun: authorizedProcedure
     .input(geoSequenceRunInputSchema)
     .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
       const [, , rate] = await Promise.all([
-        assertGeoAccess({
-          headers: context.headers,
-          organizationId: input.organizationId,
-          user: context.user,
-        }),
+        assertGeoEntitlement(input.organizationId, context.headers),
         assertActiveSubscription(input.organizationId),
         ratelimit.geoSequenceRun.limit(input.organizationId),
       ]);
@@ -1365,6 +1360,11 @@ export const geoRouter = {
   competitorSuggestions: authorizedProcedure
     .input(geoCompetitorSuggestionsInputSchema)
     .handler(async (options) => {
+      await assertOrganizationAccess({
+        headers: options.context.headers,
+        organizationId: options.input.organizationId,
+        user: options.context.user,
+      });
       const rate = await ratelimit.geoCompetitorSuggestions.limit(
         options.input.organizationId
       );
@@ -1378,6 +1378,11 @@ export const geoRouter = {
   brandSearch: authorizedProcedure
     .input(geoBrandSearchInputSchema)
     .handler(async (options) => {
+      await assertOrganizationAccess({
+        headers: options.context.headers,
+        organizationId: options.input.organizationId,
+        user: options.context.user,
+      });
       const rate = await ratelimit.geoBrandSearch.limit(
         options.input.organizationId
       );
@@ -1435,12 +1440,13 @@ export const geoRouter = {
   writerPlan: authorizedProcedure
     .input(geoWriterPlanInputSchema)
     .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
       const [, , rate] = await Promise.all([
-        assertGeoAccess({
-          headers: context.headers,
-          organizationId: input.organizationId,
-          user: context.user,
-        }),
+        assertGeoEntitlement(input.organizationId, context.headers),
         assertActiveSubscription(input.organizationId),
         ratelimit.geoWriterPlan.limit(input.organizationId),
       ]);
@@ -1485,12 +1491,13 @@ export const geoRouter = {
   writerStart: authorizedProcedure
     .input(geoWriterBriefIdInputSchema)
     .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
       await Promise.all([
-        assertGeoAccess({
-          headers: context.headers,
-          organizationId: input.organizationId,
-          user: context.user,
-        }),
+        assertGeoEntitlement(input.organizationId, context.headers),
         assertActiveSubscription(input.organizationId),
       ]);
 
@@ -1511,12 +1518,13 @@ export const geoRouter = {
   writerUpdate: authorizedProcedure
     .input(geoWriterUpdateInputSchema)
     .handler(async ({ context, input }) => {
+      await assertOrganizationAccess({
+        headers: context.headers,
+        organizationId: input.organizationId,
+        user: context.user,
+      });
       await Promise.all([
-        assertGeoAccess({
-          headers: context.headers,
-          organizationId: input.organizationId,
-          user: context.user,
-        }),
+        assertGeoEntitlement(input.organizationId, context.headers),
         assertActiveSubscription(input.organizationId),
       ]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Slice 2 of the PR 984 split: batch oRPC client requests and memoize per-request auth. Merge independently — do not wait for GEO server-scope (slice 3).

`BatchLinkPlugin` is already wired in the dashboard client, so every page with ≥2 RPCs (not only `/geo`) starts batching immediately. Per-request memoization (`ORPCRequestMemo`, WeakMap on the request `Headers`) must ship in the same PR; otherwise batching multiplies Membership/Autumn lookups.

**In scope**
- Client batching for all RPCs except `attachments` / `upload`
- `ORPCRequestMemo` (membership, analytics-flag, GEO entitlements)
- `assertGeoAccess`: membership first, then `assertGeoEntitlement` (Autumn is not contacted for non-members)
- Rate-limited GEO procedures: membership first, then entitlement/subscription/ratelimit in parallel
- Analytics access still runs membership + flag via `allSettled` (flag is local, not billing)

**Out of scope**
- GEO `?project=` server-scope (slice 3)
- Autumn `timeoutMs` (slice 7)
- `React.cache()` for billing/flags across requests (paywall leak)

**Success metric:** DevTools/Network, oRPC/HTTP filter — Home request count **9→4**. Count a second multi-RPC page (Settings, Content list) the same way. Optional `/geo` request-count. **Not** `/geo` last-byte 2528→1647 ms (that is a checkpoint after this slice **and** GEO server-scope).

Extracted from closed #984 onto current `main`. Follow-up `7a9c95d8` confirms membership before the GEO billing lookup.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7e633d2-6f25-5d20-89f3-9e21302f669f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7e633d2-6f25-5d20-89f3-9e21302f669f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches all dashboard oRPC client requests except `attachments`/`upload` (previously only the onboarding logo upload was batched) and memoizes membership, analytics-flag, and GEO entitlement lookups per request so batched procedures don't duplicate the same lookups. The Home page drops from 9 RPC requests to 4. This merges independently; the GEO server-scope change ships separately.

- Adds `ORPCRequestMemo`, a WeakMap keyed by request `Headers`, caching membership, analytics flags, and GEO entitlements for one request's lifetime.
- Analytics procedures run membership and flag checks in parallel via `Promise.allSettled`; membership errors win.
- GEO confirms membership first, so non-members never reach the billing provider, then runs entitlement, subscription, and rate-limit checks in parallel.

<sup>Written for commit 7a9c95d8a46a8b02856d57f8fe8ab21fbcca4725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

