### PR TITLE
perf(db): make Drizzle Upstash cache opt-in

### DIFF
--- a/packages/db/src/drizzle-http.ts
+++ b/packages/db/src/drizzle-http.ts
@@ -16,9 +16,9 @@ export function createDb(databaseUrl: string) {
         ? upstashCache({
             url: upstashUrl,
             token: upstashToken,
-            // Opt-in only: with `global: true` every select builder query paid a
-            // Redis GET plus a write-back pipeline for a 1 s default TTL, i.e.
-            // three round trips instead of one with practically no hits.
+            // Opt-in only: with `global: true` a cache miss paid 2 Upstash HTTP
+            // round trips (HGET, then a write-back pipeline of HSET + HEXPIRE +
+            // SADD) for a 1 s TTL. Query hashing is local, not a Redis RT.
             // Expensive, slowly changing queries opt in via `.$withCache(...)`.
             global: false,
           })

--- a/packages/db/src/drizzle-http.ts
+++ b/packages/db/src/drizzle-http.ts
@@ -16,7 +16,11 @@ export function createDb(databaseUrl: string) {
         ? upstashCache({
             url: upstashUrl,
             token: upstashToken,
-            global: true,
+            // Opt-in only: with `global: true` every select builder query paid a
+            // Redis GET plus a write-back pipeline for a 1 s default TTL, i.e.
+            // three round trips instead of one with practically no hits.
+            // Expensive, slowly changing queries opt in via `.$withCache(...)`.
+            global: false,
           })
         : undefined,
     schema,

--- a/packages/db/src/drizzle.ts
+++ b/packages/db/src/drizzle.ts
@@ -22,7 +22,11 @@ export function createDb(databaseUrl: string): NodePgDatabase<typeof schema> {
         ? upstashCache({
             url: upstashUrl,
             token: upstashToken,
-            global: true,
+            // Opt-in only: with `global: true` every select builder query paid a
+            // Redis GET plus a write-back pipeline for a 1 s default TTL, i.e.
+            // three round trips instead of one with practically no hits.
+            // Expensive, slowly changing queries opt in via `.$withCache(...)`.
+            global: false,
           })
         : undefined,
     schema,

--- a/packages/db/src/drizzle.ts
+++ b/packages/db/src/drizzle.ts
@@ -22,9 +22,9 @@ export function createDb(databaseUrl: string): NodePgDatabase<typeof schema> {
         ? upstashCache({
             url: upstashUrl,
             token: upstashToken,
-            // Opt-in only: with `global: true` every select builder query paid a
-            // Redis GET plus a write-back pipeline for a 1 s default TTL, i.e.
-            // three round trips instead of one with practically no hits.
+            // Opt-in only: with `global: true` a cache miss paid 2 Upstash HTTP
+            // round trips (HGET, then a write-back pipeline of HSET + HEXPIRE +
+            // SADD) for a 1 s TTL. Query hashing is local, not a Redis RT.
             // Expensive, slowly changing queries opt in via `.$withCache(...)`.
             global: false,
           })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Make Drizzle's Upstash cache opt-in (`global: false`) on both the TCP and HTTP clients.

With `global: true`, every select-builder query that missed cache paid **2 Upstash HTTP round trips** plus the DB query: local `hashQuery` (not Redis), then `HGET`, then a write-back **pipeline** (`HSET` + `HEXPIRE` + `SADD` per table — 4 Redis commands for a one-table select). Default TTL is 1s, so that miss path is the common case. Queries that should still cache must opt in with `.$withCache(...)`.

This PR does **not** add GEO `.$withCache` on aggregates. After merge, reads are uncached: the repo has no positive `.$withCache(...)`, only `$withCache(false)` opt-outs. `INSERT`/`UPDATE`/`DELETE` still call `onMutate` (one Upstash `EVAL`) even though nothing is cached — leftover invalidation tax, fine for a stepwise rollout until explicit `$withCache` lands. Success is **not** `/geo` last-byte (2528→1647 ms is a later checkpoint).

**Measure after merge:** Redis HTTP RTs per uncached `select` **2→0** (commands **4→0** for a one-table miss). Original benchmark: Select-Builder **~75→26 ms** (those Redis RTs). Not GEO aggregate hit rate.

### Screenshot/Recording (if applicable)
N/A — no UI change.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd3e3da3-1388-53ab-94ce-6c97a6cdb37c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd3e3da3-1388-53ab-94ce-6c97a6cdb37c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Drizzle's Upstash cache opt-in on both the TCP and HTTP clients. With `global: true`, a cache miss paid two Upstash HTTP round trips (HGET, then a write-back pipeline of HSET + HEXPIRE + SADD) for a 1s TTL and almost no hits; with `global: false`, those queries skip Redis entirely. Queries that should still cache must opt in with `.$withCache`; this PR does not add `.$withCache` on GEO aggregates.

<sup>Written for commit ae0103d6bd3e73ee944c6a45a0958d9bb6e3d553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

