### PR TITLE
refactor(api): migrate schedules to Effect programs

### DIFF
--- a/apps/api/src/errors/schedules.ts
+++ b/apps/api/src/errors/schedules.ts
@@ -1,0 +1,29 @@
+import { Schema } from "effect";
+
+export class ScheduleNotFoundError extends Schema.TaggedError<ScheduleNotFoundError>()(
+  "ScheduleNotFoundError",
+  {}
+) {}
+
+export class ScheduleDuplicateError extends Schema.TaggedError<ScheduleDuplicateError>()(
+  "ScheduleDuplicateError",
+  {}
+) {}
+
+export class ScheduleMissingTargetsError extends Schema.TaggedError<ScheduleMissingTargetsError>()(
+  "ScheduleMissingTargetsError",
+  { message: Schema.String }
+) {}
+
+export class ScheduleQstashError extends Schema.TaggedError<ScheduleQstashError>()(
+  "ScheduleQstashError",
+  {
+    message: Schema.String,
+    status: Schema.Union([Schema.Literal(400), Schema.Literal(500)]),
+  }
+) {}
+
+export class ScheduleDatabaseError extends Schema.TaggedError<ScheduleDatabaseError>()(
+  "ScheduleDatabaseError",
+  { cause: Schema.Defect() }
+) {}

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -5,6 +5,7 @@ import {
   contentTriggers,
   githubIntegrations,
 } from "@notra/db/schema";
+import { QstashError } from "@notra/schemas/api/qstash";
 import { scheduleSourceConfigSchema } from "@notra/schemas/api/schedules";
 import { and, desc, eq, inArray, ne } from "drizzle-orm";
 import { Effect } from "effect";
@@ -16,10 +17,19 @@ import {
   ScheduleNotFoundError,
   ScheduleQstashError,
 } from "../errors/schedules";
+import {
+  deleteQstashWithRetry,
+  QstashService,
+  qstashLayer,
+} from "../lib/qstash";
+import type { QstashEnv } from "../types/qstash";
 import type {
+  CreateScheduleProgramInput,
+  DeleteScheduleProgramInput,
   ListSchedulesProgramInput,
   PatchScheduleProgramInput,
 } from "../types/schedules";
+import { logError } from "../utils/logging";
 import { buildCronExpression, createQstashSchedule } from "../utils/qstash";
 import {
   DEFAULT_SCHEDULE_NAME,
@@ -32,7 +42,6 @@ import {
   safeSerializeSchedule,
   serializeSchedule,
 } from "../utils/schedules";
-import { logError } from "../utils/logging";
 import { deleteQstashScheduleWithRetry } from "../utils/triggers";
 
 const database = <A>(operation: () => Promise<A>) =>
@@ -57,6 +66,55 @@ function isScheduleDomainError(
       error._tag === "ScheduleMissingTargetsError" ||
       error._tag === "ScheduleQstashError")
   );
+}
+
+function scheduleQstashFailureMessage(
+  mapped: ReturnType<typeof mapQstashError>,
+  operation: "create" | "update"
+) {
+  if (mapped.status === 400 || operation === "create") {
+    return mapped.error;
+  }
+
+  return "Failed to update schedule";
+}
+
+function scheduleQstashFailure(
+  error: unknown,
+  operation: "create" | "update"
+): ScheduleQstashError {
+  const mapped = mapQstashError(
+    error instanceof QstashError ? new Error(error.message) : error
+  );
+
+  return new ScheduleQstashError({
+    message: scheduleQstashFailureMessage(mapped, operation),
+    status: mapped.status,
+  });
+}
+
+function cleanupCreatedQstashSchedule(
+  env: QstashEnv,
+  qstashScheduleId: string,
+  triggerId: string
+) {
+  return deleteQstashWithRetry(qstashScheduleId).pipe(
+    Effect.provide(qstashLayer(env)),
+    Effect.catch((cleanupError) => {
+      logError(
+        `Failed to clean up replacement QStash schedule ${qstashScheduleId} for new schedule ${triggerId}`,
+        cleanupError
+      );
+      return Effect.void;
+    })
+  );
+}
+
+function withQstashLayer<A, E>(
+  env: QstashEnv,
+  effect: Effect.Effect<A, E, QstashService>
+) {
+  return effect.pipe(Effect.provide(qstashLayer(env)));
 }
 
 async function executePatchSchedule({
@@ -280,6 +338,161 @@ export const listSchedules = Effect.fn("schedules.list")(function* ({
   );
 
   return { schedules, repositoryMap };
+});
+
+export const createSchedule = Effect.fn("schedules.create")(function* ({
+  db,
+  organizationId,
+  body,
+  env,
+}: CreateScheduleProgramInput) {
+  const normalized = normalizeSchedule(body);
+  const dedupeHash = hashSchedule(body);
+
+  const existing = yield* database(() =>
+    db.query.contentTriggers.findFirst({
+      where: and(
+        eq(contentTriggers.organizationId, organizationId),
+        eq(contentTriggers.dedupeHash, dedupeHash)
+      ),
+    })
+  );
+
+  if (existing) {
+    return yield* new ScheduleDuplicateError();
+  }
+
+  if (body.enabled) {
+    const missingTargets = yield* database(() =>
+      ensureScheduleTargetsExist(
+        db,
+        organizationId,
+        normalized.targets.repositoryIds,
+        "Cannot create enabled schedule: one or more integrations not found"
+      )
+    );
+
+    if (missingTargets) {
+      return yield* new ScheduleMissingTargetsError({
+        message: missingTargets.error,
+      });
+    }
+  }
+
+  const triggerId = crypto.randomUUID();
+  const persistedName = body.name.trim() || DEFAULT_SCHEDULE_NAME;
+  let qstashScheduleId: string | null = null;
+
+  if (body.enabled) {
+    qstashScheduleId = yield* withQstashLayer(
+      env,
+      Effect.gen(function* () {
+        const service = yield* QstashService;
+        return yield* service.create({
+          triggerId,
+          cron: buildCronExpression(normalized.sourceConfig.cron),
+        });
+      })
+    ).pipe(Effect.mapError((error) => scheduleQstashFailure(error, "create")));
+  }
+
+  const schedule = yield* database(() =>
+    db.transaction(async (tx) => {
+      const [createdTrigger] = await tx
+        .insert(contentTriggers)
+        .values({
+          id: triggerId,
+          organizationId,
+          name: persistedName,
+          sourceType: "cron",
+          sourceConfig: normalized.sourceConfig,
+          targets: normalized.targets,
+          outputType: body.outputType,
+          outputConfig: body.outputConfig ?? null,
+          dedupeHash,
+          enabled: body.enabled,
+          autoPublish: body.autoPublish,
+          qstashScheduleId,
+        })
+        .returning();
+
+      if (!createdTrigger) {
+        throw new Error("Failed to create schedule");
+      }
+
+      await tx.insert(contentTriggerLookbackWindows).values({
+        triggerId,
+        window: body.lookbackWindow,
+      });
+
+      return serializeSchedule({
+        ...createdTrigger,
+        lookbackWindow: body.lookbackWindow,
+      });
+    })
+  ).pipe(
+    Effect.catch((dbError: ScheduleDatabaseError) =>
+      Effect.gen(function* () {
+        if (qstashScheduleId) {
+          yield* cleanupCreatedQstashSchedule(env, qstashScheduleId, triggerId);
+        }
+
+        return yield* Effect.fail(dbError);
+      })
+    )
+  );
+
+  return schedule;
+});
+
+export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
+  db,
+  organizationId,
+  scheduleId,
+  env,
+}: DeleteScheduleProgramInput) {
+  return yield* Effect.tryPromise({
+    try: () =>
+      db.transaction(async (tx) => {
+        const [existing] = await tx
+          .select()
+          .from(contentTriggers)
+          .where(
+            and(
+              eq(contentTriggers.id, scheduleId),
+              eq(contentTriggers.organizationId, organizationId),
+              eq(contentTriggers.sourceType, "cron")
+            )
+          )
+          .for("update");
+
+        if (!existing) {
+          throw new ScheduleNotFoundError();
+        }
+
+        if (existing.qstashScheduleId) {
+          await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
+        }
+
+        await tx
+          .delete(contentTriggers)
+          .where(
+            and(
+              eq(contentTriggers.id, scheduleId),
+              eq(contentTriggers.organizationId, organizationId)
+            )
+          );
+
+        return scheduleId;
+      }),
+    catch: (cause) => {
+      if (isScheduleDomainError(cause)) {
+        return cause;
+      }
+
+      return new ScheduleDatabaseError({ cause });
+    },
+  });
 });
 
 export const patchSchedule = Effect.fn("schedules.patch")(function* ({

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -115,12 +115,11 @@ async function commitScheduleDeleteIfUnchanged(
   });
 }
 
-async function restoreEnabledScheduleQstash(
+async function ensureEnabledScheduleQstash(
   db: DbClient,
   organizationId: string,
   scheduleId: string,
-  env: QstashEnv,
-  qstashScheduleId: string
+  env: QstashEnv
 ) {
   await db.transaction(async (tx) => {
     const [current] = await tx
@@ -129,7 +128,7 @@ async function restoreEnabledScheduleQstash(
       .where(scheduleDeleteScope(organizationId, scheduleId))
       .for("update");
 
-    if (!current?.enabled || current.qstashScheduleId !== qstashScheduleId) {
+    if (!current?.enabled || !current.qstashScheduleId) {
       return;
     }
 
@@ -137,38 +136,30 @@ async function restoreEnabledScheduleQstash(
     const restoredId = await createQstashSchedule(env, {
       triggerId: scheduleId,
       cron: buildCronExpression(config.cron),
-      scheduleId: qstashScheduleId,
+      scheduleId: current.qstashScheduleId,
     });
 
-    if (restoredId !== qstashScheduleId) {
+    if (restoredId !== current.qstashScheduleId) {
       await deleteQstashScheduleWithRetry(env, restoredId);
       throw new Error("QStash returned an unexpected restoration ID");
     }
   });
 }
 
-function attemptRestoreEnabledScheduleQstash(
+function attemptEnsureEnabledScheduleQstash(
   db: DbClient,
   organizationId: string,
   scheduleId: string,
-  env: QstashEnv,
-  qstashScheduleId: string
+  env: QstashEnv
 ) {
   return Effect.tryPromise({
-    try: () =>
-      restoreEnabledScheduleQstash(
-        db,
-        organizationId,
-        scheduleId,
-        env,
-        qstashScheduleId
-      ),
+    try: () => ensureEnabledScheduleQstash(db, organizationId, scheduleId, env),
     catch: (cause) => cause,
   }).pipe(
     Effect.catch((recoveryError) =>
       Effect.sync(() => {
         logError(
-          `Failed to restore QStash schedule ${qstashScheduleId} after delete persistence failed for schedule ${scheduleId}`,
+          `Failed to ensure QStash schedule for schedule ${scheduleId} after delete reconciliation`,
           recoveryError
         );
       })
@@ -627,12 +618,11 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
     ).pipe(
       Effect.catchTag("ScheduleDatabaseError", (dbError) =>
         removedQstashScheduleId
-          ? attemptRestoreEnabledScheduleQstash(
+          ? attemptEnsureEnabledScheduleQstash(
               db,
               organizationId,
               scheduleId,
-              env,
-              removedQstashScheduleId
+              env
             ).pipe(Effect.flatMap(() => Effect.fail(dbError)))
           : Effect.fail(dbError)
       )
@@ -641,7 +631,18 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
     if (commitResult === "deleted" || commitResult === "gone") {
       return scheduleId;
     }
+
+    if (commitResult === "stale" && removedQstashScheduleId) {
+      yield* attemptEnsureEnabledScheduleQstash(
+        db,
+        organizationId,
+        scheduleId,
+        env
+      );
+    }
   }
+
+  yield* attemptEnsureEnabledScheduleQstash(db, organizationId, scheduleId, env);
 
   return yield* new ScheduleQstashError({
     message: "Failed to delete schedule",

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -26,6 +26,7 @@ import {
   ensureScheduleTargetsExist,
   filterSchedulesByRepositoryIds,
   hashSchedule,
+  isQstashScheduleError,
   mapQstashError,
   normalizeSchedule,
   safeSerializeSchedule,
@@ -336,15 +337,19 @@ export const patchSchedule = Effect.fn("schedules.patch")(function* ({
         return cause;
       }
 
-      logError("Failed to update schedule", cause);
-      const mapped = mapQstashError(cause);
-      return new ScheduleQstashError({
-        message:
-          mapped.status === 400
-            ? mapped.error
-            : "Failed to update schedule",
-        status: mapped.status,
-      });
+      if (isQstashScheduleError(cause)) {
+        logError("Failed to update schedule", cause);
+        const mapped = mapQstashError(cause);
+        return new ScheduleQstashError({
+          message:
+            mapped.status === 400
+              ? mapped.error
+              : "Failed to update schedule",
+          status: mapped.status,
+        });
+      }
+
+      return new ScheduleDatabaseError({ cause });
     },
   });
 });

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -110,6 +110,23 @@ function cleanupCreatedQstashSchedule(
   );
 }
 
+function cleanupDeletedQstashSchedule(
+  env: QstashEnv,
+  qstashScheduleId: string,
+  scheduleId: string
+) {
+  return deleteQstashWithRetry(qstashScheduleId).pipe(
+    Effect.provide(qstashLayer(env)),
+    Effect.catch((cleanupError) => {
+      logError(
+        `Failed to delete QStash schedule ${qstashScheduleId} after schedule ${scheduleId} was removed`,
+        cleanupError
+      );
+      return Effect.void;
+    })
+  );
+}
+
 function withQstashLayer<A, E>(
   env: QstashEnv,
   effect: Effect.Effect<A, E, QstashService>
@@ -451,7 +468,7 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
   scheduleId,
   env,
 }: DeleteScheduleProgramInput) {
-  return yield* Effect.tryPromise({
+  const qstashScheduleId = yield* Effect.tryPromise({
     try: () =>
       db.transaction(async (tx) => {
         const [existing] = await tx
@@ -470,9 +487,7 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
           throw new ScheduleNotFoundError();
         }
 
-        if (existing.qstashScheduleId) {
-          await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
-        }
+        const removedQstashScheduleId = existing.qstashScheduleId;
 
         await tx
           .delete(contentTriggers)
@@ -483,7 +498,7 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
             )
           );
 
-        return scheduleId;
+        return removedQstashScheduleId;
       }),
     catch: (cause) => {
       if (isScheduleDomainError(cause)) {
@@ -493,6 +508,12 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
       return new ScheduleDatabaseError({ cause });
     },
   });
+
+  if (qstashScheduleId) {
+    yield* cleanupDeletedQstashSchedule(env, qstashScheduleId, scheduleId);
+  }
+
+  return scheduleId;
 });
 
 export const patchSchedule = Effect.fn("schedules.patch")(function* ({

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -22,8 +22,8 @@ import {
   QstashService,
   qstashLayer,
 } from "../lib/qstash";
-import type { QstashEnv } from "../types/qstash";
 import type { DbClient } from "../types/db";
+import type { QstashEnv } from "../types/qstash";
 import type {
   CreateScheduleProgramInput,
   DeleteScheduleProgramInput,
@@ -609,12 +609,7 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
     }
 
     const commitResult = yield* database(() =>
-      commitScheduleDeleteIfUnchanged(
-        db,
-        organizationId,
-        scheduleId,
-        snapshot
-      )
+      commitScheduleDeleteIfUnchanged(db, organizationId, scheduleId, snapshot)
     ).pipe(
       Effect.catchTag("ScheduleDatabaseError", (dbError) =>
         removedQstashScheduleId
@@ -642,7 +637,12 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
     }
   }
 
-  yield* attemptEnsureEnabledScheduleQstash(db, organizationId, scheduleId, env);
+  yield* attemptEnsureEnabledScheduleQstash(
+    db,
+    organizationId,
+    scheduleId,
+    env
+  );
 
   return yield* new ScheduleQstashError({
     message: "Failed to delete schedule",
@@ -710,9 +710,7 @@ export const patchSchedule = Effect.fn("schedules.patch")(function* ({
         const mapped = mapQstashError(cause);
         return new ScheduleQstashError({
           message:
-            mapped.status === 400
-              ? mapped.error
-              : "Failed to update schedule",
+            mapped.status === 400 ? mapped.error : "Failed to update schedule",
           status: mapped.status,
         });
       }

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -23,6 +23,7 @@ import {
   qstashLayer,
 } from "../lib/qstash";
 import type { QstashEnv } from "../types/qstash";
+import type { DbClient } from "../types/db";
 import type {
   CreateScheduleProgramInput,
   DeleteScheduleProgramInput,
@@ -44,11 +45,136 @@ import {
 } from "../utils/schedules";
 import { deleteQstashScheduleWithRetry } from "../utils/triggers";
 
+const DELETE_CONCURRENCY_ATTEMPTS = 5;
+
 const database = <A>(operation: () => Promise<A>) =>
   Effect.tryPromise({
     try: operation,
     catch: (cause) => new ScheduleDatabaseError({ cause }),
   });
+
+type ScheduleDeleteSnapshot = {
+  qstashScheduleId: string | null;
+  updatedAt: Date;
+};
+
+type ScheduleDeleteCommitResult = "deleted" | "stale" | "gone";
+
+const scheduleDeleteScope = (organizationId: string, scheduleId: string) =>
+  and(
+    eq(contentTriggers.id, scheduleId),
+    eq(contentTriggers.organizationId, organizationId),
+    eq(contentTriggers.sourceType, "cron")
+  );
+
+async function lockScheduleDeleteSnapshot(
+  db: DbClient,
+  organizationId: string,
+  scheduleId: string
+) {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({
+        qstashScheduleId: contentTriggers.qstashScheduleId,
+        updatedAt: contentTriggers.updatedAt,
+      })
+      .from(contentTriggers)
+      .where(scheduleDeleteScope(organizationId, scheduleId))
+      .for("update");
+
+    return row ?? null;
+  });
+}
+
+async function commitScheduleDeleteIfUnchanged(
+  db: DbClient,
+  organizationId: string,
+  scheduleId: string,
+  snapshot: ScheduleDeleteSnapshot
+): Promise<ScheduleDeleteCommitResult> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ updatedAt: contentTriggers.updatedAt })
+      .from(contentTriggers)
+      .where(scheduleDeleteScope(organizationId, scheduleId))
+      .for("update");
+
+    if (!row) {
+      return "gone";
+    }
+
+    if (row.updatedAt.getTime() !== snapshot.updatedAt.getTime()) {
+      return "stale";
+    }
+
+    await tx
+      .delete(contentTriggers)
+      .where(scheduleDeleteScope(organizationId, scheduleId));
+
+    return "deleted";
+  });
+}
+
+async function restoreEnabledScheduleQstash(
+  db: DbClient,
+  organizationId: string,
+  scheduleId: string,
+  env: QstashEnv,
+  qstashScheduleId: string
+) {
+  await db.transaction(async (tx) => {
+    const [current] = await tx
+      .select()
+      .from(contentTriggers)
+      .where(scheduleDeleteScope(organizationId, scheduleId))
+      .for("update");
+
+    if (!current?.enabled || current.qstashScheduleId !== qstashScheduleId) {
+      return;
+    }
+
+    const config = scheduleSourceConfigSchema.parse(current.sourceConfig);
+    const restoredId = await createQstashSchedule(env, {
+      triggerId: scheduleId,
+      cron: buildCronExpression(config.cron),
+      scheduleId: qstashScheduleId,
+    });
+
+    if (restoredId !== qstashScheduleId) {
+      await deleteQstashScheduleWithRetry(env, restoredId);
+      throw new Error("QStash returned an unexpected restoration ID");
+    }
+  });
+}
+
+function attemptRestoreEnabledScheduleQstash(
+  db: DbClient,
+  organizationId: string,
+  scheduleId: string,
+  env: QstashEnv,
+  qstashScheduleId: string
+) {
+  return Effect.tryPromise({
+    try: () =>
+      restoreEnabledScheduleQstash(
+        db,
+        organizationId,
+        scheduleId,
+        env,
+        qstashScheduleId
+      ),
+    catch: (cause) => cause,
+  }).pipe(
+    Effect.catch((recoveryError) =>
+      Effect.sync(() => {
+        logError(
+          `Failed to restore QStash schedule ${qstashScheduleId} after delete persistence failed for schedule ${scheduleId}`,
+          recoveryError
+        );
+      })
+    )
+  );
+}
 
 function isScheduleDomainError(
   error: unknown
@@ -468,51 +594,59 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
   scheduleId,
   env,
 }: DeleteScheduleProgramInput) {
-  const existing = yield* database(() =>
-    db.transaction(async (tx) => {
-      const [row] = await tx
-        .select({ qstashScheduleId: contentTriggers.qstashScheduleId })
-        .from(contentTriggers)
-        .where(
-          and(
-            eq(contentTriggers.id, scheduleId),
-            eq(contentTriggers.organizationId, organizationId),
-            eq(contentTriggers.sourceType, "cron")
-          )
-        )
-        .for("update");
+  for (let attempt = 0; attempt < DELETE_CONCURRENCY_ATTEMPTS; attempt++) {
+    const snapshot = yield* database(() =>
+      lockScheduleDeleteSnapshot(db, organizationId, scheduleId)
+    );
 
-      return row ?? null;
-    })
-  );
+    if (!snapshot) {
+      if (attempt === 0) {
+        return yield* new ScheduleNotFoundError();
+      }
 
-  if (!existing) {
-    return yield* new ScheduleNotFoundError();
+      return scheduleId;
+    }
+
+    let removedQstashScheduleId: string | null = null;
+    if (snapshot.qstashScheduleId) {
+      removedQstashScheduleId = snapshot.qstashScheduleId;
+      yield* cleanupQstashSchedule(env, snapshot.qstashScheduleId, {
+        failureMessage: `Failed to delete QStash schedule ${snapshot.qstashScheduleId} for schedule ${scheduleId}`,
+        failureMode: "fail",
+        operation: "delete",
+      });
+    }
+
+    const commitResult = yield* database(() =>
+      commitScheduleDeleteIfUnchanged(
+        db,
+        organizationId,
+        scheduleId,
+        snapshot
+      )
+    ).pipe(
+      Effect.catchTag("ScheduleDatabaseError", (dbError) =>
+        removedQstashScheduleId
+          ? attemptRestoreEnabledScheduleQstash(
+              db,
+              organizationId,
+              scheduleId,
+              env,
+              removedQstashScheduleId
+            ).pipe(Effect.flatMap(() => Effect.fail(dbError)))
+          : Effect.fail(dbError)
+      )
+    );
+
+    if (commitResult === "deleted" || commitResult === "gone") {
+      return scheduleId;
+    }
   }
 
-  if (existing.qstashScheduleId) {
-    yield* cleanupQstashSchedule(env, existing.qstashScheduleId, {
-      failureMessage: `Failed to delete QStash schedule ${existing.qstashScheduleId} for schedule ${scheduleId}`,
-      failureMode: "fail",
-      operation: "delete",
-    });
-  }
-
-  yield* database(() =>
-    db.transaction(async (tx) => {
-      await tx
-        .delete(contentTriggers)
-        .where(
-          and(
-            eq(contentTriggers.id, scheduleId),
-            eq(contentTriggers.organizationId, organizationId),
-            eq(contentTriggers.sourceType, "cron")
-          )
-        );
-    })
-  );
-
-  return scheduleId;
+  return yield* new ScheduleQstashError({
+    message: "Failed to delete schedule",
+    status: 500,
+  });
 });
 
 export const patchSchedule = Effect.fn("schedules.patch")(function* ({

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -1,0 +1,350 @@
+import crypto from "node:crypto";
+
+import {
+  contentTriggerLookbackWindows,
+  contentTriggers,
+  githubIntegrations,
+} from "@notra/db/schema";
+import { scheduleSourceConfigSchema } from "@notra/schemas/api/schedules";
+import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import { Effect } from "effect";
+
+import {
+  ScheduleDatabaseError,
+  ScheduleDuplicateError,
+  ScheduleMissingTargetsError,
+  ScheduleNotFoundError,
+  ScheduleQstashError,
+} from "../errors/schedules";
+import type {
+  ListSchedulesProgramInput,
+  PatchScheduleProgramInput,
+} from "../types/schedules";
+import { buildCronExpression, createQstashSchedule } from "../utils/qstash";
+import {
+  DEFAULT_SCHEDULE_NAME,
+  ensureScheduleTargetsExist,
+  filterSchedulesByRepositoryIds,
+  hashSchedule,
+  mapQstashError,
+  normalizeSchedule,
+  safeSerializeSchedule,
+  serializeSchedule,
+} from "../utils/schedules";
+import { logError } from "../utils/logging";
+import { deleteQstashScheduleWithRetry } from "../utils/triggers";
+
+const database = <A>(operation: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: operation,
+    catch: (cause) => new ScheduleDatabaseError({ cause }),
+  });
+
+function isScheduleDomainError(
+  error: unknown
+): error is
+  | ScheduleNotFoundError
+  | ScheduleDuplicateError
+  | ScheduleMissingTargetsError
+  | ScheduleQstashError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    (error._tag === "ScheduleNotFoundError" ||
+      error._tag === "ScheduleDuplicateError" ||
+      error._tag === "ScheduleMissingTargetsError" ||
+      error._tag === "ScheduleQstashError")
+  );
+}
+
+async function executePatchSchedule({
+  db,
+  organizationId,
+  scheduleId,
+  body,
+  env,
+}: PatchScheduleProgramInput) {
+  const normalized = normalizeSchedule(body);
+  const dedupeHash = hashSchedule(body);
+  const affectedQstashIds = new Set<string>();
+  let committed = false;
+
+  try {
+    const schedule = await db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(contentTriggers)
+        .where(
+          and(
+            eq(contentTriggers.id, scheduleId),
+            eq(contentTriggers.organizationId, organizationId),
+            eq(contentTriggers.sourceType, "cron")
+          )
+        )
+        .for("update");
+
+      if (!existing) {
+        throw new ScheduleNotFoundError();
+      }
+
+      let qstashScheduleId: string | null = null;
+      if (body.enabled) {
+        qstashScheduleId = existing.qstashScheduleId ?? crypto.randomUUID();
+        affectedQstashIds.add(qstashScheduleId);
+        const returnedId = await createQstashSchedule(env, {
+          triggerId: scheduleId,
+          cron: buildCronExpression(normalized.sourceConfig.cron),
+          scheduleId: qstashScheduleId,
+        });
+        affectedQstashIds.add(returnedId);
+        if (returnedId !== qstashScheduleId) {
+          throw new Error("QStash returned an unexpected schedule ID");
+        }
+      } else if (existing.qstashScheduleId) {
+        affectedQstashIds.add(existing.qstashScheduleId);
+        await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
+      }
+
+      const [updatedTrigger] = await tx
+        .update(contentTriggers)
+        .set({
+          name: body.name.trim() || existing.name || DEFAULT_SCHEDULE_NAME,
+          sourceType: "cron",
+          sourceConfig: normalized.sourceConfig,
+          targets: normalized.targets,
+          outputType: body.outputType,
+          outputConfig: body.outputConfig ?? null,
+          dedupeHash,
+          enabled: body.enabled,
+          autoPublish: body.autoPublish,
+          qstashScheduleId,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(contentTriggers.id, scheduleId),
+            eq(contentTriggers.organizationId, organizationId)
+          )
+        )
+        .returning();
+
+      if (!updatedTrigger) {
+        throw new Error("Failed to update schedule");
+      }
+
+      await tx
+        .insert(contentTriggerLookbackWindows)
+        .values({
+          triggerId: scheduleId,
+          window: body.lookbackWindow,
+        })
+        .onConflictDoUpdate({
+          target: contentTriggerLookbackWindows.triggerId,
+          set: {
+            window: body.lookbackWindow,
+            updatedAt: new Date(),
+          },
+        });
+
+      return serializeSchedule({
+        ...updatedTrigger,
+        lookbackWindow: body.lookbackWindow,
+      });
+    });
+    committed = true;
+    return schedule;
+  } catch (error) {
+    if (!committed && affectedQstashIds.size > 0) {
+      try {
+        await db.transaction(async (tx) => {
+          const [current] = await tx
+            .select()
+            .from(contentTriggers)
+            .where(
+              and(
+                eq(contentTriggers.id, scheduleId),
+                eq(contentTriggers.organizationId, organizationId),
+                eq(contentTriggers.sourceType, "cron")
+              )
+            )
+            .for("update");
+          const currentQstashId = current?.enabled
+            ? current.qstashScheduleId
+            : null;
+
+          if (currentQstashId && current) {
+            const config = scheduleSourceConfigSchema.parse(
+              current.sourceConfig
+            );
+            const restoredId = await createQstashSchedule(env, {
+              triggerId: scheduleId,
+              cron: buildCronExpression(config.cron),
+              scheduleId: currentQstashId,
+            });
+            if (restoredId !== currentQstashId) {
+              await deleteQstashScheduleWithRetry(env, restoredId);
+              throw new Error("QStash returned an unexpected restoration ID");
+            }
+          }
+
+          for (const affectedId of affectedQstashIds) {
+            if (affectedId !== currentQstashId) {
+              await deleteQstashScheduleWithRetry(env, affectedId);
+            }
+          }
+        });
+      } catch (recoveryError) {
+        logError(
+          `Failed to reconcile QStash schedules ${[...affectedQstashIds].join(", ")} for schedule ${scheduleId}; retry PATCH to heal`,
+          recoveryError
+        );
+      }
+    }
+
+    throw error;
+  }
+}
+
+export const listSchedules = Effect.fn("schedules.list")(function* ({
+  db,
+  organizationId,
+  repositoryIds,
+}: ListSchedulesProgramInput) {
+  const triggers = yield* database(() =>
+    db.query.contentTriggers.findMany({
+      where: and(
+        eq(contentTriggers.organizationId, organizationId),
+        eq(contentTriggers.sourceType, "cron")
+      ),
+      orderBy: [desc(contentTriggers.createdAt)],
+    })
+  );
+
+  const triggerIds = triggers.map((trigger) => trigger.id);
+  const lookbackWindows =
+    triggerIds.length > 0
+      ? yield* database(() =>
+          db.query.contentTriggerLookbackWindows.findMany({
+            where: inArray(contentTriggerLookbackWindows.triggerId, triggerIds),
+          })
+        )
+      : [];
+
+  const lookbackWindowByTriggerId = new Map(
+    lookbackWindows.map((item) => [item.triggerId, item.window])
+  );
+  const filteredTriggers = filterSchedulesByRepositoryIds(
+    triggers,
+    repositoryIds
+  );
+
+  const schedules = filteredTriggers
+    .map((trigger) =>
+      safeSerializeSchedule({
+        ...trigger,
+        lookbackWindow:
+          lookbackWindowByTriggerId.get(trigger.id) ?? "last_7_days",
+      })
+    )
+    .filter((schedule) => schedule !== null);
+
+  const allRepositoryIds = [
+    ...new Set(schedules.flatMap((schedule) => schedule.targets.repositoryIds)),
+  ];
+  const repositories =
+    allRepositoryIds.length > 0
+      ? yield* database(() =>
+          db
+            .select({
+              id: githubIntegrations.id,
+              owner: githubIntegrations.owner,
+              repo: githubIntegrations.repo,
+              defaultBranch: githubIntegrations.defaultBranch,
+            })
+            .from(githubIntegrations)
+            .where(inArray(githubIntegrations.id, allRepositoryIds))
+        )
+      : [];
+
+  const repositoryMap = Object.fromEntries(
+    repositories
+      .filter((repository) => repository.owner && repository.repo)
+      .map((repository) => [
+        repository.id,
+        repository.defaultBranch?.trim()
+          ? `${repository.owner}/${repository.repo} · ${repository.defaultBranch.trim()}`
+          : `${repository.owner}/${repository.repo}`,
+      ])
+  );
+
+  return { schedules, repositoryMap };
+});
+
+export const patchSchedule = Effect.fn("schedules.patch")(function* ({
+  db,
+  organizationId,
+  scheduleId,
+  body,
+  env,
+}: PatchScheduleProgramInput) {
+  const normalized = normalizeSchedule(body);
+  const dedupeHash = hashSchedule(body);
+
+  const duplicate = yield* database(() =>
+    db.query.contentTriggers.findFirst({
+      where: and(
+        eq(contentTriggers.organizationId, organizationId),
+        eq(contentTriggers.dedupeHash, dedupeHash),
+        ne(contentTriggers.id, scheduleId)
+      ),
+    })
+  );
+
+  if (duplicate) {
+    return yield* new ScheduleDuplicateError();
+  }
+
+  if (body.enabled) {
+    const missingTargets = yield* database(() =>
+      ensureScheduleTargetsExist(
+        db,
+        organizationId,
+        normalized.targets.repositoryIds,
+        "Cannot enable schedule: one or more integrations have been deleted"
+      )
+    );
+
+    if (missingTargets) {
+      return yield* new ScheduleMissingTargetsError({
+        message: missingTargets.error,
+      });
+    }
+  }
+
+  return yield* Effect.tryPromise({
+    try: () =>
+      executePatchSchedule({
+        db,
+        organizationId,
+        scheduleId,
+        body,
+        env,
+      }),
+    catch: (cause) => {
+      if (isScheduleDomainError(cause)) {
+        return cause;
+      }
+
+      logError("Failed to update schedule", cause);
+      const mapped = mapQstashError(cause);
+      return new ScheduleQstashError({
+        message:
+          mapped.status === 400
+            ? mapped.error
+            : "Failed to update schedule",
+        status: mapped.status,
+      });
+    },
+  });
+});

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -70,10 +70,14 @@ function isScheduleDomainError(
 
 function scheduleQstashFailureMessage(
   mapped: ReturnType<typeof mapQstashError>,
-  operation: "create" | "update"
+  operation: "create" | "update" | "delete"
 ) {
   if (mapped.status === 400 || operation === "create") {
     return mapped.error;
+  }
+
+  if (operation === "delete") {
+    return "Failed to delete schedule";
   }
 
   return "Failed to update schedule";
@@ -81,7 +85,7 @@ function scheduleQstashFailureMessage(
 
 function scheduleQstashFailure(
   error: unknown,
-  operation: "create" | "update"
+  operation: "create" | "update" | "delete"
 ): ScheduleQstashError {
   const mapped = mapQstashError(
     error instanceof QstashError ? new Error(error.message) : error
@@ -93,36 +97,28 @@ function scheduleQstashFailure(
   });
 }
 
-function cleanupCreatedQstashSchedule(
+function cleanupQstashSchedule(
   env: QstashEnv,
   qstashScheduleId: string,
-  triggerId: string
+  {
+    failureMessage,
+    failureMode,
+    operation,
+  }: {
+    failureMessage: string;
+    failureMode: "log" | "fail";
+    operation: "create" | "update" | "delete";
+  }
 ) {
   return deleteQstashWithRetry(qstashScheduleId).pipe(
     Effect.provide(qstashLayer(env)),
     Effect.catch((cleanupError) => {
-      logError(
-        `Failed to clean up replacement QStash schedule ${qstashScheduleId} for new schedule ${triggerId}`,
-        cleanupError
-      );
-      return Effect.void;
-    })
-  );
-}
+      logError(failureMessage, cleanupError);
+      if (failureMode === "log") {
+        return Effect.void;
+      }
 
-function cleanupDeletedQstashSchedule(
-  env: QstashEnv,
-  qstashScheduleId: string,
-  scheduleId: string
-) {
-  return deleteQstashWithRetry(qstashScheduleId).pipe(
-    Effect.provide(qstashLayer(env)),
-    Effect.catch((cleanupError) => {
-      logError(
-        `Failed to delete QStash schedule ${qstashScheduleId} after schedule ${scheduleId} was removed`,
-        cleanupError
-      );
-      return Effect.void;
+      return Effect.fail(scheduleQstashFailure(cleanupError, operation));
     })
   );
 }
@@ -451,7 +447,11 @@ export const createSchedule = Effect.fn("schedules.create")(function* ({
     Effect.catch((dbError: ScheduleDatabaseError) =>
       Effect.gen(function* () {
         if (qstashScheduleId) {
-          yield* cleanupCreatedQstashSchedule(env, qstashScheduleId, triggerId);
+          yield* cleanupQstashSchedule(env, qstashScheduleId, {
+            failureMessage: `Failed to clean up replacement QStash schedule ${qstashScheduleId} for new schedule ${triggerId}`,
+            failureMode: "log",
+            operation: "create",
+          });
         }
 
         return yield* Effect.fail(dbError);
@@ -510,7 +510,11 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
   });
 
   if (qstashScheduleId) {
-    yield* cleanupDeletedQstashSchedule(env, qstashScheduleId, scheduleId);
+    yield* cleanupQstashSchedule(env, qstashScheduleId, {
+      failureMessage: `Failed to delete QStash schedule ${qstashScheduleId} after schedule ${scheduleId} was removed`,
+      failureMode: "fail",
+      operation: "delete",
+    });
   }
 
   return scheduleId;

--- a/apps/api/src/programs/schedules.ts
+++ b/apps/api/src/programs/schedules.ts
@@ -468,54 +468,49 @@ export const deleteSchedule = Effect.fn("schedules.delete")(function* ({
   scheduleId,
   env,
 }: DeleteScheduleProgramInput) {
-  const qstashScheduleId = yield* Effect.tryPromise({
-    try: () =>
-      db.transaction(async (tx) => {
-        const [existing] = await tx
-          .select()
-          .from(contentTriggers)
-          .where(
-            and(
-              eq(contentTriggers.id, scheduleId),
-              eq(contentTriggers.organizationId, organizationId),
-              eq(contentTriggers.sourceType, "cron")
-            )
+  const existing = yield* database(() =>
+    db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({ qstashScheduleId: contentTriggers.qstashScheduleId })
+        .from(contentTriggers)
+        .where(
+          and(
+            eq(contentTriggers.id, scheduleId),
+            eq(contentTriggers.organizationId, organizationId),
+            eq(contentTriggers.sourceType, "cron")
           )
-          .for("update");
+        )
+        .for("update");
 
-        if (!existing) {
-          throw new ScheduleNotFoundError();
-        }
+      return row ?? null;
+    })
+  );
 
-        const removedQstashScheduleId = existing.qstashScheduleId;
+  if (!existing) {
+    return yield* new ScheduleNotFoundError();
+  }
 
-        await tx
-          .delete(contentTriggers)
-          .where(
-            and(
-              eq(contentTriggers.id, scheduleId),
-              eq(contentTriggers.organizationId, organizationId)
-            )
-          );
-
-        return removedQstashScheduleId;
-      }),
-    catch: (cause) => {
-      if (isScheduleDomainError(cause)) {
-        return cause;
-      }
-
-      return new ScheduleDatabaseError({ cause });
-    },
-  });
-
-  if (qstashScheduleId) {
-    yield* cleanupQstashSchedule(env, qstashScheduleId, {
-      failureMessage: `Failed to delete QStash schedule ${qstashScheduleId} after schedule ${scheduleId} was removed`,
+  if (existing.qstashScheduleId) {
+    yield* cleanupQstashSchedule(env, existing.qstashScheduleId, {
+      failureMessage: `Failed to delete QStash schedule ${existing.qstashScheduleId} for schedule ${scheduleId}`,
       failureMode: "fail",
       operation: "delete",
     });
   }
+
+  yield* database(() =>
+    db.transaction(async (tx) => {
+      await tx
+        .delete(contentTriggers)
+        .where(
+          and(
+            eq(contentTriggers.id, scheduleId),
+            eq(contentTriggers.organizationId, organizationId),
+            eq(contentTriggers.sourceType, "cron")
+          )
+        );
+    })
+  );
 
   return scheduleId;
 });

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -406,6 +406,9 @@ schedulesRoutes.openapi(deleteScheduleRoute, async (c) => {
     if (failure._tag === "ScheduleNotFoundError") {
       return c.json({ error: "Schedule not found" }, 404);
     }
+    if (failure._tag === "ScheduleQstashError") {
+      return c.json({ error: failure.message }, failure.status);
+    }
     throw failure;
   }
 

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -1,34 +1,25 @@
 import crypto from "node:crypto";
 
 import { createRoute } from "@hono/zod-openapi";
-import { toUtcDateString } from "@notra/ai/utils/schedule-interval";
 import type { createDb } from "@notra/db/drizzle";
 import {
   contentTriggerLookbackWindows,
   contentTriggers,
-  githubIntegrations,
 } from "@notra/db/schema";
 import {
   createScheduleRequestSchema,
-  scheduleTargetsRepositoryIdsSchema,
   deleteScheduleResponseSchema,
   getSchedulesQuerySchema,
   getSchedulesResponseSchema,
   patchScheduleRequestSchema,
-  scheduleOutputConfigSchema,
   scheduleParamsSchema,
   scheduleResponseSchema,
-  scheduleSourceConfigSchema,
-  scheduleTargetsSchema,
 } from "@notra/schemas/api/schedules";
-import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
 import * as z from "zod";
 
-import type {
-  ScheduleTriggerRow,
-  ScheduleTriggerWithLookbackWindow,
-} from "../types/schedules";
+import { listSchedules, patchSchedule } from "../programs/schedules";
 import { getOrganizationId } from "../utils/auth";
 import { logError } from "../utils/logging";
 import { createOpenApiApp } from "../utils/openapi-app";
@@ -39,185 +30,21 @@ import {
   ORGANIZATION_SCHEDULE_PATH_REGEX,
   ORGANIZATION_SCHEDULES_PATH_REGEX,
 } from "../utils/regex";
+import {
+  DEFAULT_SCHEDULE_NAME,
+  ensureScheduleTargetsExist,
+  hashSchedule,
+  mapQstashError,
+  normalizeSchedule,
+  runScheduleProgram,
+  serializeSchedule,
+} from "../utils/schedules";
 import { deleteQstashScheduleWithRetry } from "../utils/triggers";
 
 export const schedulesRoutes = createOpenApiApp();
 
 type DbClient = ReturnType<typeof createDb>;
 type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;
-
-const DEFAULT_SCHEDULE_NAME = "Untitled Schedule";
-
-function normalizeCronConfig(
-  config: CreateScheduleBody["sourceConfig"]["cron"]
-) {
-  const base = {
-    frequency: config.frequency,
-    hour: config.hour,
-    minute: config.minute,
-  } as const;
-
-  if (config.frequency === "weekly") {
-    return {
-      ...base,
-      dayOfWeek: config.dayOfWeek ?? 1,
-    };
-  }
-
-  if (config.frequency === "monthly") {
-    return {
-      ...base,
-      dayOfMonth: config.dayOfMonth ?? 1,
-    };
-  }
-
-  if (config.frequency === "custom") {
-    return {
-      ...base,
-      intervalDays: config.intervalDays,
-      anchorDate: config.anchorDate ?? toUtcDateString(new Date()),
-    };
-  }
-
-  return base;
-}
-
-function normalizeSchedule(input: CreateScheduleBody) {
-  return {
-    ...input,
-    sourceConfig: {
-      cron: normalizeCronConfig(input.sourceConfig.cron),
-    },
-    targets: {
-      repositoryIds: [...input.targets.repositoryIds].sort(),
-    },
-  };
-}
-
-function hashSchedule(input: CreateScheduleBody) {
-  const normalized = normalizeSchedule(input);
-
-  return crypto
-    .createHash("sha256")
-    .update(
-      JSON.stringify({
-        sourceType: normalized.sourceType,
-        sourceConfig: normalized.sourceConfig,
-        targets: normalized.targets,
-        outputType: normalized.outputType,
-        outputConfig: normalized.outputConfig ?? null,
-        lookbackWindow: normalized.lookbackWindow,
-      })
-    )
-    .digest("hex");
-}
-
-async function ensureScheduleTargetsExist(
-  db: DbClient,
-  organizationId: string,
-  repositoryIds: string[],
-  message: string
-) {
-  if (repositoryIds.length === 0) {
-    return null;
-  }
-
-  const integrations = await db.query.githubIntegrations.findMany({
-    where: and(
-      eq(githubIntegrations.organizationId, organizationId),
-      inArray(githubIntegrations.id, repositoryIds)
-    ),
-    columns: { id: true },
-  });
-
-  const existingIds = new Set(
-    integrations.map((integration) => integration.id)
-  );
-  const missingIds = repositoryIds.filter((id) => !existingIds.has(id));
-
-  if (missingIds.length > 0) {
-    return { error: message, missingIntegrationIds: missingIds };
-  }
-
-  return null;
-}
-
-function serializeSchedule(trigger: ScheduleTriggerWithLookbackWindow) {
-  return {
-    id: trigger.id,
-    organizationId: trigger.organizationId,
-    name: trigger.name,
-    sourceType: "cron" as const,
-    sourceConfig: scheduleSourceConfigSchema.parse(trigger.sourceConfig),
-    targets: scheduleTargetsSchema.parse(trigger.targets),
-    outputType: createScheduleRequestSchema.shape.outputType.parse(
-      trigger.outputType
-    ),
-    outputConfig:
-      trigger.outputConfig == null
-        ? null
-        : scheduleOutputConfigSchema.parse(trigger.outputConfig),
-    enabled: trigger.enabled,
-    autoPublish: trigger.autoPublish,
-    createdAt: trigger.createdAt.toISOString(),
-    updatedAt: trigger.updatedAt.toISOString(),
-    lookbackWindow: trigger.lookbackWindow,
-  };
-}
-
-function safeSerializeSchedule(
-  trigger: Parameters<typeof serializeSchedule>[0]
-) {
-  try {
-    return serializeSchedule(trigger);
-  } catch (error) {
-    if (!(error instanceof z.ZodError)) {
-      throw error;
-    }
-
-    logError(`Skipping malformed schedule ${trigger.id}`, error);
-    return null;
-  }
-}
-
-function mapQstashError(error: unknown) {
-  const message = error instanceof Error ? error.message : "Unknown error";
-
-  if (
-    message.includes("invalid destination") ||
-    message.includes("unable to resolve host") ||
-    message.includes("WORKFLOW_BASE_URL is not configured")
-  ) {
-    return { error: "External URL not configured", status: 400 as const };
-  }
-
-  return { error: "Failed to configure schedule", status: 500 as const };
-}
-
-function filterByRepositoryIds<T extends ScheduleTriggerRow>(
-  triggers: T[],
-  repositoryIds: string[]
-) {
-  if (repositoryIds.length === 0) {
-    return triggers;
-  }
-
-  const repositoryIdSet = new Set(repositoryIds);
-
-  return triggers.filter((trigger) => {
-    const parsed = scheduleTargetsRepositoryIdsSchema.safeParse(
-      trigger.targets
-    );
-
-    if (!parsed.success) {
-      return false;
-    }
-
-    return parsed.data.repositoryIds.some((repositoryId) =>
-      repositoryIdSet.has(repositoryId)
-    );
-  });
-}
 
 schedulesRoutes.get("/:organizationId/schedules", async (c) => {
   const orgId = getOrganizationId(c);
@@ -458,65 +285,18 @@ schedulesRoutes.openapi(getSchedulesRoute, async (c) => {
   }
 
   const { repositoryIds } = c.req.valid("query");
-  const triggers = await db.query.contentTriggers.findMany({
-    where: and(
-      eq(contentTriggers.organizationId, orgId),
-      eq(contentTriggers.sourceType, "cron")
-    ),
-    orderBy: [desc(contentTriggers.createdAt)],
-  });
-
-  const triggerIds = triggers.map((trigger) => trigger.id);
-  const lookbackWindows =
-    triggerIds.length > 0
-      ? await db.query.contentTriggerLookbackWindows.findMany({
-          where: inArray(contentTriggerLookbackWindows.triggerId, triggerIds),
-        })
-      : [];
-
-  const lookbackWindowByTriggerId = new Map(
-    lookbackWindows.map((item) => [item.triggerId, item.window])
-  );
-  const filteredTriggers = filterByRepositoryIds(triggers, repositoryIds);
-
-  const schedules = filteredTriggers
-    .map((trigger) =>
-      safeSerializeSchedule({
-        ...trigger,
-        lookbackWindow:
-          lookbackWindowByTriggerId.get(trigger.id) ?? "last_7_days",
-      })
-    )
-    .filter((schedule) => schedule !== null);
-
-  const allRepositoryIds = [
-    ...new Set(schedules.flatMap((schedule) => schedule.targets.repositoryIds)),
-  ];
-  const repositories =
-    allRepositoryIds.length > 0
-      ? await db
-          .select({
-            id: githubIntegrations.id,
-            owner: githubIntegrations.owner,
-            repo: githubIntegrations.repo,
-            defaultBranch: githubIntegrations.defaultBranch,
-          })
-          .from(githubIntegrations)
-          .where(inArray(githubIntegrations.id, allRepositoryIds))
-      : [];
-
-  const repositoryMap = Object.fromEntries(
-    repositories
-      .filter((repository) => repository.owner && repository.repo)
-      .map((repository) => [
-        repository.id,
-        repository.defaultBranch?.trim()
-          ? `${repository.owner}/${repository.repo} · ${repository.defaultBranch.trim()}`
-          : `${repository.owner}/${repository.repo}`,
-      ])
+  const result = await runScheduleProgram(
+    listSchedules({ db, organizationId: orgId, repositoryIds })
   );
 
-  return c.json({ schedules, repositoryMap, organization }, 200);
+  if (result._tag === "Failure") {
+    throw result.failure;
+  }
+
+  return c.json(
+    { ...result.success, organization },
+    200
+  );
 });
 
 schedulesRoutes.openapi(createScheduleRoute, async (c) => {
@@ -657,185 +437,40 @@ schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
   }
 
   const { scheduleId } = c.req.valid("param");
-  const input = c.req.valid("json");
+  const body = c.req.valid("json");
   const env = (c.env ?? {}) as {
     QSTASH_TOKEN?: string;
     WORKFLOW_BASE_URL?: string;
   };
-  const normalized = normalizeSchedule(input);
-  const dedupeHash = hashSchedule(input);
-  const duplicate = await db.query.contentTriggers.findFirst({
-    where: and(
-      eq(contentTriggers.organizationId, orgId),
-      eq(contentTriggers.dedupeHash, dedupeHash),
-      ne(contentTriggers.id, scheduleId)
-    ),
-  });
 
-  if (duplicate) {
-    return c.json({ error: "Duplicate schedule" }, 409);
-  }
-
-  if (input.enabled) {
-    const missingTargets = await ensureScheduleTargetsExist(
+  const result = await runScheduleProgram(
+    patchSchedule({
       db,
-      orgId,
-      normalized.targets.repositoryIds,
-      "Cannot enable schedule: one or more integrations have been deleted"
-    );
+      organizationId: orgId,
+      scheduleId,
+      body,
+      env,
+    })
+  );
 
-    if (missingTargets) {
-      return c.json({ error: missingTargets.error }, 400);
+  if (result._tag === "Failure") {
+    const failure = result.failure;
+    if (failure._tag === "ScheduleNotFoundError") {
+      return c.json({ error: "Schedule not found" }, 404);
     }
+    if (failure._tag === "ScheduleDuplicateError") {
+      return c.json({ error: "Duplicate schedule" }, 409);
+    }
+    if (failure._tag === "ScheduleMissingTargetsError") {
+      return c.json({ error: failure.message }, 400);
+    }
+    if (failure._tag === "ScheduleQstashError") {
+      return c.json({ error: failure.message }, failure.status);
+    }
+    throw failure;
   }
 
-  const affectedQstashIds = new Set<string>();
-  let committed = false;
-  try {
-    const response = await db.transaction(async (tx) => {
-      // Lock before reading or changing remote state. Concurrent PATCHes must
-      // observe the preceding request's committed configuration.
-      const [existing] = await tx
-        .select()
-        .from(contentTriggers)
-        .where(
-          and(
-            eq(contentTriggers.id, scheduleId),
-            eq(contentTriggers.organizationId, orgId),
-            eq(contentTriggers.sourceType, "cron")
-          )
-        )
-        .for("update");
-
-      if (!existing) {
-        return c.json({ error: "Schedule not found" }, 404);
-      }
-
-      let qstashScheduleId: string | null = null;
-      if (input.enabled) {
-        // Choose the ID before sending so even a lost response is recoverable.
-        qstashScheduleId = existing.qstashScheduleId ?? crypto.randomUUID();
-        affectedQstashIds.add(qstashScheduleId);
-        const returnedId = await createQstashSchedule(env, {
-          triggerId: scheduleId,
-          cron: buildCronExpression(normalized.sourceConfig.cron),
-          scheduleId: qstashScheduleId,
-        });
-        affectedQstashIds.add(returnedId);
-        if (returnedId !== qstashScheduleId) {
-          throw new Error("QStash returned an unexpected schedule ID");
-        }
-      } else if (existing.qstashScheduleId) {
-        affectedQstashIds.add(existing.qstashScheduleId);
-        await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
-      }
-
-      const [updatedTrigger] = await tx
-        .update(contentTriggers)
-        .set({
-          name: input.name.trim() || existing.name || DEFAULT_SCHEDULE_NAME,
-          sourceType: "cron",
-          sourceConfig: normalized.sourceConfig,
-          targets: normalized.targets,
-          outputType: input.outputType,
-          outputConfig: input.outputConfig ?? null,
-          dedupeHash,
-          enabled: input.enabled,
-          autoPublish: input.autoPublish,
-          qstashScheduleId,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(contentTriggers.id, scheduleId),
-            eq(contentTriggers.organizationId, orgId)
-          )
-        )
-        .returning();
-
-      if (!updatedTrigger) {
-        throw new Error("Failed to update schedule");
-      }
-
-      await tx
-        .insert(contentTriggerLookbackWindows)
-        .values({
-          triggerId: scheduleId,
-          window: input.lookbackWindow,
-        })
-        .onConflictDoUpdate({
-          target: contentTriggerLookbackWindows.triggerId,
-          set: {
-            window: input.lookbackWindow,
-            updatedAt: new Date(),
-          },
-        });
-
-      const schedule = serializeSchedule({
-        ...updatedTrigger,
-        lookbackWindow: input.lookbackWindow,
-      });
-      return c.json({ schedule, organization }, 200);
-    });
-    committed = true;
-    return response;
-  } catch (error) {
-    if (!committed && affectedQstashIds.size > 0) {
-      try {
-        await db.transaction(async (tx) => {
-          // The failed transaction released its lock. Re-read under a new lock:
-          // another request may have committed while recovery was waiting.
-          const [current] = await tx
-            .select()
-            .from(contentTriggers)
-            .where(
-              and(
-                eq(contentTriggers.id, scheduleId),
-                eq(contentTriggers.organizationId, orgId),
-                eq(contentTriggers.sourceType, "cron")
-              )
-            )
-            .for("update");
-          const currentQstashId = current?.enabled
-            ? current.qstashScheduleId
-            : null;
-
-          if (currentQstashId && current) {
-            const config = scheduleSourceConfigSchema.parse(
-              current.sourceConfig
-            );
-            const restoredId = await createQstashSchedule(env, {
-              triggerId: scheduleId,
-              cron: buildCronExpression(config.cron),
-              scheduleId: currentQstashId,
-            });
-            if (restoredId !== currentQstashId) {
-              await deleteQstashScheduleWithRetry(env, restoredId);
-              throw new Error("QStash returned an unexpected restoration ID");
-            }
-          }
-
-          for (const affectedId of affectedQstashIds) {
-            if (affectedId !== currentQstashId) {
-              await deleteQstashScheduleWithRetry(env, affectedId);
-            }
-          }
-        });
-      } catch (recoveryError) {
-        logError(
-          `Failed to reconcile QStash schedules ${[...affectedQstashIds].join(", ")} for schedule ${scheduleId}; retry PATCH to heal`,
-          recoveryError
-        );
-      }
-    }
-
-    logError("Failed to update schedule", error);
-    const mapped = mapQstashError(error);
-    if (mapped.status === 400) {
-      return c.json({ error: mapped.error }, 400);
-    }
-    return c.json({ error: "Failed to update schedule" }, 500);
-  }
+  return c.json({ schedule: result.success, organization }, 200);
 });
 
 schedulesRoutes.openapi(deleteScheduleRoute, async (c) => {

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -1,11 +1,5 @@
-import crypto from "node:crypto";
-
 import { createRoute } from "@hono/zod-openapi";
 import type { createDb } from "@notra/db/drizzle";
-import {
-  contentTriggerLookbackWindows,
-  contentTriggers,
-} from "@notra/db/schema";
 import {
   createScheduleRequestSchema,
   deleteScheduleResponseSchema,
@@ -15,36 +9,26 @@ import {
   scheduleParamsSchema,
   scheduleResponseSchema,
 } from "@notra/schemas/api/schedules";
-import { and, eq } from "drizzle-orm";
-// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
-import * as z from "zod";
 
-import { listSchedules, patchSchedule } from "../programs/schedules";
+import {
+  createSchedule,
+  deleteSchedule,
+  listSchedules,
+  patchSchedule,
+} from "../programs/schedules";
 import { getOrganizationId } from "../utils/auth";
-import { logError } from "../utils/logging";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
-import { buildCronExpression, createQstashSchedule } from "../utils/qstash";
 import {
   ORGANIZATION_SCHEDULE_PATH_REGEX,
   ORGANIZATION_SCHEDULES_PATH_REGEX,
 } from "../utils/regex";
-import {
-  DEFAULT_SCHEDULE_NAME,
-  ensureScheduleTargetsExist,
-  hashSchedule,
-  mapQstashError,
-  normalizeSchedule,
-  runScheduleProgram,
-  serializeSchedule,
-} from "../utils/schedules";
-import { deleteQstashScheduleWithRetry } from "../utils/triggers";
+import { runScheduleProgram } from "../utils/schedules";
 
 export const schedulesRoutes = createOpenApiApp();
 
 type DbClient = ReturnType<typeof createDb>;
-type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;
 
 schedulesRoutes.get("/:organizationId/schedules", async (c) => {
   const orgId = getOrganizationId(c);
@@ -264,6 +248,7 @@ const deleteScheduleRoute = createRoute({
     401: errorResponse("Missing or invalid API key"),
     403: errorResponse("Forbidden"),
     404: errorResponse("Schedule or organization not found"),
+    500: errorResponse("Failed to delete schedule"),
     503: errorResponse("Authentication service unavailable"),
   },
 });
@@ -293,10 +278,7 @@ schedulesRoutes.openapi(getSchedulesRoute, async (c) => {
     throw result.failure;
   }
 
-  return c.json(
-    { ...result.success, organization },
-    200
-  );
+  return c.json({ ...result.success, organization }, 200);
 });
 
 schedulesRoutes.openapi(createScheduleRoute, async (c) => {
@@ -315,109 +297,30 @@ schedulesRoutes.openapi(createScheduleRoute, async (c) => {
     return c.json({ error: "Organization not found" }, 404);
   }
 
-  const input = c.req.valid("json");
+  const body = c.req.valid("json");
   const env = (c.env ?? {}) as {
     QSTASH_TOKEN?: string;
     WORKFLOW_BASE_URL?: string;
   };
-  const normalized = normalizeSchedule(input);
-  const dedupeHash = hashSchedule(input);
-  const existing = await db.query.contentTriggers.findFirst({
-    where: and(
-      eq(contentTriggers.organizationId, orgId),
-      eq(contentTriggers.dedupeHash, dedupeHash)
-    ),
-  });
+  const result = await runScheduleProgram(
+    createSchedule({ db, organizationId: orgId, body, env })
+  );
 
-  if (existing) {
-    return c.json({ error: "Duplicate schedule" }, 409);
-  }
-
-  if (input.enabled) {
-    const missingTargets = await ensureScheduleTargetsExist(
-      db,
-      orgId,
-      normalized.targets.repositoryIds,
-      "Cannot create enabled schedule: one or more integrations not found"
-    );
-
-    if (missingTargets) {
-      return c.json({ error: missingTargets.error }, 400);
+  if (result._tag === "Failure") {
+    const failure = result.failure;
+    if (failure._tag === "ScheduleDuplicateError") {
+      return c.json({ error: "Duplicate schedule" }, 409);
     }
-  }
-
-  const triggerId = crypto.randomUUID();
-  const persistedName = input.name.trim() || DEFAULT_SCHEDULE_NAME;
-  const cronExpression = buildCronExpression(normalized.sourceConfig.cron);
-  let qstashScheduleId: string | null = null;
-
-  if (input.enabled) {
-    try {
-      qstashScheduleId = await createQstashSchedule(env, {
-        triggerId,
-        cron: cronExpression,
-      });
-    } catch (error) {
-      const mapped = mapQstashError(error);
-      if (mapped.status === 400) {
-        return c.json({ error: mapped.error }, 400);
-      }
-
-      return c.json({ error: mapped.error }, 500);
+    if (failure._tag === "ScheduleMissingTargetsError") {
+      return c.json({ error: failure.message }, 400);
     }
-  }
-
-  try {
-    const schedule = await db.transaction(async (tx) => {
-      const [createdTrigger] = await tx
-        .insert(contentTriggers)
-        .values({
-          id: triggerId,
-          organizationId: orgId,
-          name: persistedName,
-          sourceType: "cron",
-          sourceConfig: normalized.sourceConfig,
-          targets: normalized.targets,
-          outputType: input.outputType,
-          outputConfig: input.outputConfig ?? null,
-          dedupeHash,
-          enabled: input.enabled,
-          autoPublish: input.autoPublish,
-          qstashScheduleId,
-        })
-        .returning();
-
-      if (!createdTrigger) {
-        throw new Error("Failed to create schedule");
-      }
-
-      await tx.insert(contentTriggerLookbackWindows).values({
-        triggerId,
-        window: input.lookbackWindow,
-      });
-
-      return serializeSchedule({
-        ...createdTrigger,
-        lookbackWindow: input.lookbackWindow,
-      });
-    });
-
-    return c.json({ schedule, organization }, 201);
-  } catch (error) {
-    if (qstashScheduleId) {
-      try {
-        await deleteQstashScheduleWithRetry(env, qstashScheduleId);
-      } catch (cleanupError) {
-        logError(
-          `Failed to clean up replacement QStash schedule ${qstashScheduleId} for new schedule ${triggerId}`,
-          cleanupError
-        );
-      }
+    if (failure._tag === "ScheduleQstashError") {
+      return c.json({ error: failure.message }, failure.status);
     }
-
-    logError("Failed to create schedule", error);
-    return c.json({ error: "Failed to create schedule" }, 500);
+    throw failure;
   }
+
+  return c.json({ schedule: result.success, organization }, 201);
 });
 
 schedulesRoutes.openapi(patchScheduleRoute, async (c) => {
@@ -494,36 +397,17 @@ schedulesRoutes.openapi(deleteScheduleRoute, async (c) => {
     QSTASH_TOKEN?: string;
     WORKFLOW_BASE_URL?: string;
   };
-  return db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select()
-      .from(contentTriggers)
-      .where(
-        and(
-          eq(contentTriggers.id, scheduleId),
-          eq(contentTriggers.organizationId, orgId),
-          eq(contentTriggers.sourceType, "cron")
-        )
-      )
-      .for("update");
+  const result = await runScheduleProgram(
+    deleteSchedule({ db, organizationId: orgId, scheduleId, env })
+  );
 
-    if (!existing) {
+  if (result._tag === "Failure") {
+    const failure = result.failure;
+    if (failure._tag === "ScheduleNotFoundError") {
       return c.json({ error: "Schedule not found" }, 404);
     }
+    throw failure;
+  }
 
-    if (existing.qstashScheduleId) {
-      await deleteQstashScheduleWithRetry(env, existing.qstashScheduleId);
-    }
-
-    await tx
-      .delete(contentTriggers)
-      .where(
-        and(
-          eq(contentTriggers.id, scheduleId),
-          eq(contentTriggers.organizationId, orgId)
-        )
-      );
-
-    return c.json({ id: scheduleId, organization }, 200);
-  });
+  return c.json({ id: result.success, organization }, 200);
 });

--- a/apps/api/src/types/schedules.ts
+++ b/apps/api/src/types/schedules.ts
@@ -1,4 +1,19 @@
+import type { createDb } from "@notra/db/drizzle";
 import type { contentTriggers, lookbackWindowEnum } from "@notra/db/schema";
+import type {
+  createScheduleRequestSchema,
+  patchScheduleRequestSchema,
+} from "@notra/schemas/api/schedules";
+import type { z } from "zod";
+
+import type {
+  ScheduleDatabaseError,
+  ScheduleDuplicateError,
+  ScheduleMissingTargetsError,
+  ScheduleNotFoundError,
+  ScheduleQstashError,
+} from "../errors/schedules";
+import type { QstashEnv } from "./qstash";
 
 type ScheduleLookbackWindow = (typeof lookbackWindowEnum.enumValues)[number];
 
@@ -7,3 +22,26 @@ export type ScheduleTriggerRow = typeof contentTriggers.$inferSelect;
 export type ScheduleTriggerWithLookbackWindow = ScheduleTriggerRow & {
   lookbackWindow: ScheduleLookbackWindow;
 };
+
+export type ScheduleDomainError =
+  | ScheduleNotFoundError
+  | ScheduleDuplicateError
+  | ScheduleMissingTargetsError
+  | ScheduleQstashError;
+
+interface ScheduleProgramInput {
+  db: ReturnType<typeof createDb>;
+  organizationId: string;
+}
+
+export interface ListSchedulesProgramInput extends ScheduleProgramInput {
+  repositoryIds: string[];
+}
+
+export interface PatchScheduleProgramInput extends ScheduleProgramInput {
+  scheduleId: string;
+  body: z.infer<typeof patchScheduleRequestSchema>;
+  env: QstashEnv;
+}
+
+export type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;

--- a/apps/api/src/types/schedules.ts
+++ b/apps/api/src/types/schedules.ts
@@ -44,4 +44,14 @@ export interface PatchScheduleProgramInput extends ScheduleProgramInput {
   env: QstashEnv;
 }
 
+export interface CreateScheduleProgramInput extends ScheduleProgramInput {
+  body: z.infer<typeof createScheduleRequestSchema>;
+  env: QstashEnv;
+}
+
+export interface DeleteScheduleProgramInput extends ScheduleProgramInput {
+  scheduleId: string;
+  env: QstashEnv;
+}
+
 export type CreateScheduleBody = z.infer<typeof createScheduleRequestSchema>;

--- a/apps/api/src/utils/schedules.ts
+++ b/apps/api/src/utils/schedules.ts
@@ -16,13 +16,13 @@ import { Effect } from "effect";
 import * as z from "zod";
 
 import type { ScheduleDatabaseError } from "../errors/schedules";
+import type { DbClient } from "../types/db";
 import type {
   CreateScheduleBody,
   ScheduleDomainError,
   ScheduleTriggerRow,
   ScheduleTriggerWithLookbackWindow,
 } from "../types/schedules";
-import type { DbClient } from "../types/db";
 import { logError } from "./logging";
 
 export const DEFAULT_SCHEDULE_NAME = "Untitled Schedule";

--- a/apps/api/src/utils/schedules.ts
+++ b/apps/api/src/utils/schedules.ts
@@ -9,6 +9,7 @@ import {
   scheduleTargetsRepositoryIdsSchema,
   scheduleTargetsSchema,
 } from "@notra/schemas/api/schedules";
+import { QstashError } from "@notra/schemas/api/qstash";
 import { and, eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
@@ -171,6 +172,21 @@ export function safeSerializeSchedule(
     logError(`Skipping malformed schedule ${trigger.id}`, error);
     return null;
   }
+}
+
+export function isQstashScheduleError(error: unknown) {
+  if (error instanceof QstashError) {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : "Unknown error";
+
+  return (
+    message.includes("invalid destination") ||
+    message.includes("unable to resolve host") ||
+    message.includes("WORKFLOW_BASE_URL is not configured") ||
+    message.includes("QStash returned an unexpected")
+  );
 }
 
 export function mapQstashError(error: unknown) {

--- a/apps/api/src/utils/schedules.ts
+++ b/apps/api/src/utils/schedules.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 
 import { toUtcDateString } from "@notra/ai/utils/schedule-interval";
 import { githubIntegrations } from "@notra/db/schema";
+import { QstashError } from "@notra/schemas/api/qstash";
 import {
   createScheduleRequestSchema,
   scheduleOutputConfigSchema,
@@ -9,7 +10,6 @@ import {
   scheduleTargetsRepositoryIdsSchema,
   scheduleTargetsSchema,
 } from "@notra/schemas/api/schedules";
-import { QstashError } from "@notra/schemas/api/qstash";
 import { and, eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 // biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing

--- a/apps/api/src/utils/schedules.ts
+++ b/apps/api/src/utils/schedules.ts
@@ -1,0 +1,213 @@
+import crypto from "node:crypto";
+
+import { toUtcDateString } from "@notra/ai/utils/schedule-interval";
+import { githubIntegrations } from "@notra/db/schema";
+import {
+  createScheduleRequestSchema,
+  scheduleOutputConfigSchema,
+  scheduleSourceConfigSchema,
+  scheduleTargetsRepositoryIdsSchema,
+  scheduleTargetsSchema,
+} from "@notra/schemas/api/schedules";
+import { and, eq, inArray } from "drizzle-orm";
+import { Effect } from "effect";
+// biome-ignore lint/performance/noNamespaceImport: Zod recommended way of importing
+import * as z from "zod";
+
+import type { ScheduleDatabaseError } from "../errors/schedules";
+import type {
+  CreateScheduleBody,
+  ScheduleDomainError,
+  ScheduleTriggerRow,
+  ScheduleTriggerWithLookbackWindow,
+} from "../types/schedules";
+import type { DbClient } from "../types/db";
+import { logError } from "./logging";
+
+export const DEFAULT_SCHEDULE_NAME = "Untitled Schedule";
+
+/** Leave unexpected database errors to Hono's central error handler. */
+export function runScheduleProgram<A, E extends ScheduleDomainError>(
+  program: Effect.Effect<A, E | ScheduleDatabaseError>
+) {
+  return Effect.runPromise(
+    Effect.result(
+      program.pipe(
+        Effect.catchTag("ScheduleDatabaseError", (failure) =>
+          Effect.die(failure.cause)
+        )
+      )
+    )
+  );
+}
+
+function normalizeCronConfig(
+  config: CreateScheduleBody["sourceConfig"]["cron"]
+) {
+  const base = {
+    frequency: config.frequency,
+    hour: config.hour,
+    minute: config.minute,
+  } as const;
+
+  if (config.frequency === "weekly") {
+    return {
+      ...base,
+      dayOfWeek: config.dayOfWeek ?? 1,
+    };
+  }
+
+  if (config.frequency === "monthly") {
+    return {
+      ...base,
+      dayOfMonth: config.dayOfMonth ?? 1,
+    };
+  }
+
+  if (config.frequency === "custom") {
+    return {
+      ...base,
+      intervalDays: config.intervalDays,
+      anchorDate: config.anchorDate ?? toUtcDateString(new Date()),
+    };
+  }
+
+  return base;
+}
+
+export function normalizeSchedule(input: CreateScheduleBody) {
+  return {
+    ...input,
+    sourceConfig: {
+      cron: normalizeCronConfig(input.sourceConfig.cron),
+    },
+    targets: {
+      repositoryIds: [...input.targets.repositoryIds].sort(),
+    },
+  };
+}
+
+export function hashSchedule(input: CreateScheduleBody) {
+  const normalized = normalizeSchedule(input);
+
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        sourceType: normalized.sourceType,
+        sourceConfig: normalized.sourceConfig,
+        targets: normalized.targets,
+        outputType: normalized.outputType,
+        outputConfig: normalized.outputConfig ?? null,
+        lookbackWindow: normalized.lookbackWindow,
+      })
+    )
+    .digest("hex");
+}
+
+export async function ensureScheduleTargetsExist(
+  db: DbClient,
+  organizationId: string,
+  repositoryIds: string[],
+  message: string
+) {
+  if (repositoryIds.length === 0) {
+    return null;
+  }
+
+  const integrations = await db.query.githubIntegrations.findMany({
+    where: and(
+      eq(githubIntegrations.organizationId, organizationId),
+      inArray(githubIntegrations.id, repositoryIds)
+    ),
+    columns: { id: true },
+  });
+
+  const existingIds = new Set(
+    integrations.map((integration) => integration.id)
+  );
+  const missingIds = repositoryIds.filter((id) => !existingIds.has(id));
+
+  if (missingIds.length > 0) {
+    return { error: message, missingIntegrationIds: missingIds };
+  }
+
+  return null;
+}
+
+export function serializeSchedule(trigger: ScheduleTriggerWithLookbackWindow) {
+  return {
+    id: trigger.id,
+    organizationId: trigger.organizationId,
+    name: trigger.name,
+    sourceType: "cron" as const,
+    sourceConfig: scheduleSourceConfigSchema.parse(trigger.sourceConfig),
+    targets: scheduleTargetsSchema.parse(trigger.targets),
+    outputType: createScheduleRequestSchema.shape.outputType.parse(
+      trigger.outputType
+    ),
+    outputConfig:
+      trigger.outputConfig == null
+        ? null
+        : scheduleOutputConfigSchema.parse(trigger.outputConfig),
+    enabled: trigger.enabled,
+    autoPublish: trigger.autoPublish,
+    createdAt: trigger.createdAt.toISOString(),
+    updatedAt: trigger.updatedAt.toISOString(),
+    lookbackWindow: trigger.lookbackWindow,
+  };
+}
+
+export function safeSerializeSchedule(
+  trigger: Parameters<typeof serializeSchedule>[0]
+) {
+  try {
+    return serializeSchedule(trigger);
+  } catch (error) {
+    if (!(error instanceof z.ZodError)) {
+      throw error;
+    }
+
+    logError(`Skipping malformed schedule ${trigger.id}`, error);
+    return null;
+  }
+}
+
+export function mapQstashError(error: unknown) {
+  const message = error instanceof Error ? error.message : "Unknown error";
+
+  if (
+    message.includes("invalid destination") ||
+    message.includes("unable to resolve host") ||
+    message.includes("WORKFLOW_BASE_URL is not configured")
+  ) {
+    return { error: "External URL not configured", status: 400 as const };
+  }
+
+  return { error: "Failed to configure schedule", status: 500 as const };
+}
+
+export function filterSchedulesByRepositoryIds(
+  triggers: ScheduleTriggerRow[],
+  repositoryIds: string[]
+) {
+  if (repositoryIds.length === 0) {
+    return triggers;
+  }
+
+  const repositoryIdSet = new Set(repositoryIds);
+
+  return triggers.filter((trigger) => {
+    const parsed = scheduleTargetsRepositoryIdsSchema.safeParse(
+      trigger.targets
+    );
+
+    if (!parsed.success) {
+      return false;
+    }
+
+    return parsed.data.repositoryIds.some((repositoryId) =>
+      repositoryIdSet.has(repositoryId)
+    );
+  });
+}

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -169,6 +169,7 @@ export default defineConfig({
     {
       // Effect's TaggedError is a curried schema class factory, not an Error constructor.
       files: [
+        "apps/api/src/errors/**/*.ts",
         "apps/agent/agent/lib/schemas/chat-mirror.ts",
         "apps/agent/agent/lib/schemas/slack.ts",
         "packages/schemas/src/schemas/dashboard/onboarding-agent.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Completes Phase 2 schedules migration for `apps/api`: all CRUD operations (list, create, patch, delete) moved into Effect programs with thin Hono route handlers.

- `Schema.TaggedError` domain errors + `runScheduleProgram`
- Create uses `QstashService` directly; patch/delete still use existing QStash wrappers where needed
- Preserves QStash-before-DB create ordering with cleanup on persistence failure
- DB errors route through `ScheduleDatabaseError` → central handler (not masked as QStash 500)

Absorbs the former write-slice work from closed #1012.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93c00090-4c1c-5de5-bc04-5042563ad146?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93c00090-4c1c-5de5-bc04-5042563ad146&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates all four schedules routes (list, create, patch, delete) from inline Promise handlers to Effect programs with thin Hono route handlers.

**Refactors**
- Swaps handler logic for `Schema.TaggedError` domain errors while keeping API response shapes intact.
- Routes unexpected database errors through the central error handler instead of logging and returning 500.
- Preserves QStash-before-DB create ordering with cleanup on persistence failure.
- Serializes delete: removes the QStash schedule before the DB row, retrying when a concurrent patch changed the row, and restoring QStash when the DB commit fails or stale retries exhaust.
- Extracts schedule normalization, hashing, serialization, and QStash error mapping into shared utils.

<sup>Written for commit 2837ddd79199d06ad9cc464772f7e1adbcef1634. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

