### PR TITLE
refactor(api): migrate feedback submit to Effect program

### DIFF
--- a/apps/api/src/errors/feedback.ts
+++ b/apps/api/src/errors/feedback.ts
@@ -1,0 +1,17 @@
+/* oxlint-disable unicorn/throw-new-error -- Schema.TaggedError is a curried class factory, not a constructor. */
+import { Schema } from "effect";
+
+export class FeedbackProjectNotFoundError extends Schema.TaggedError<FeedbackProjectNotFoundError>()(
+  "FeedbackProjectNotFoundError",
+  {}
+) {}
+
+export class FeedbackNotFoundError extends Schema.TaggedError<FeedbackNotFoundError>()(
+  "FeedbackNotFoundError",
+  {}
+) {}
+
+export class FeedbackDatabaseError extends Schema.TaggedError<FeedbackDatabaseError>()(
+  "FeedbackDatabaseError",
+  { cause: Schema.Defect() }
+) {}

--- a/apps/api/src/programs/feedback.ts
+++ b/apps/api/src/programs/feedback.ts
@@ -43,6 +43,20 @@ const projectExists = (
     })
   ).pipe(Effect.map((project) => project !== undefined));
 
+const findByIdempotencyKey = (
+  db: SubmitFeedbackProgramInput["db"],
+  organizationId: string,
+  idempotencyKey: string
+) =>
+  database(() =>
+    db.query.agentFeedback.findFirst({
+      where: and(
+        eq(agentFeedback.organizationId, organizationId),
+        eq(agentFeedback.idempotencyKey, idempotencyKey)
+      ),
+    })
+  );
+
 export const submitFeedback = Effect.fn("feedback.submit")(function* ({
   db,
   organizationId,
@@ -50,6 +64,21 @@ export const submitFeedback = Effect.fn("feedback.submit")(function* ({
   ingestProjectId,
   userAgent,
 }: SubmitFeedbackProgramInput) {
+  const idempotencyKey = body.idempotencyKey;
+  if (idempotencyKey) {
+    const existing = yield* findByIdempotencyKey(
+      db,
+      organizationId,
+      idempotencyKey
+    );
+    if (existing) {
+      return {
+        feedback: existing,
+        deduplicated: true,
+      } satisfies SubmitFeedbackProgramSuccess;
+    }
+  }
+
   const projectId =
     ingestProjectId === undefined ? (body.projectId ?? null) : ingestProjectId;
 
@@ -108,16 +137,8 @@ export const submitFeedback = Effect.fn("feedback.submit")(function* ({
     } satisfies SubmitFeedbackProgramSuccess;
   }
 
-  const idempotencyKey = body.idempotencyKey;
   const existing = idempotencyKey
-    ? yield* database(() =>
-        db.query.agentFeedback.findFirst({
-          where: and(
-            eq(agentFeedback.organizationId, organizationId),
-            eq(agentFeedback.idempotencyKey, idempotencyKey)
-          ),
-        })
-      )
+    ? yield* findByIdempotencyKey(db, organizationId, idempotencyKey)
     : undefined;
 
   if (!existing) {

--- a/apps/api/src/programs/feedback.ts
+++ b/apps/api/src/programs/feedback.ts
@@ -1,0 +1,131 @@
+import { classifyAgentFeedback } from "@notra/ai/jobs/feedback-classifier";
+import { agentFeedback, projects } from "@notra/db/schema";
+import { and, eq } from "drizzle-orm";
+import { Effect } from "effect";
+import { nanoid } from "nanoid";
+
+import {
+  FeedbackDatabaseError,
+  FeedbackNotFoundError,
+  FeedbackProjectNotFoundError,
+} from "../errors/feedback";
+import type {
+  SubmitFeedbackProgramInput,
+  SubmitFeedbackProgramSuccess,
+} from "../types/feedback";
+
+const database = <A>(operation: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: operation,
+    catch: (cause) => new FeedbackDatabaseError({ cause }),
+  });
+
+const classifyFeedback = (
+  params: Parameters<typeof classifyAgentFeedback>[0]
+) =>
+  Effect.tryPromise({
+    try: () => classifyAgentFeedback(params),
+    catch: (cause) => new FeedbackDatabaseError({ cause }),
+  });
+
+const projectExists = (
+  db: SubmitFeedbackProgramInput["db"],
+  organizationId: string,
+  projectId: string
+) =>
+  database(() =>
+    db.query.projects.findFirst({
+      columns: { id: true },
+      where: and(
+        eq(projects.id, projectId),
+        eq(projects.organizationId, organizationId)
+      ),
+    })
+  ).pipe(Effect.map((project) => project !== undefined));
+
+export const submitFeedback = Effect.fn("feedback.submit")(function* ({
+  db,
+  organizationId,
+  body,
+  ingestProjectId,
+  userAgent,
+}: SubmitFeedbackProgramInput) {
+  const projectId =
+    ingestProjectId === undefined ? (body.projectId ?? null) : ingestProjectId;
+
+  if (
+    ingestProjectId === undefined &&
+    projectId &&
+    !(yield* projectExists(db, organizationId, projectId))
+  ) {
+    return yield* new FeedbackProjectNotFoundError();
+  }
+
+  const feedbackId = nanoid();
+  const needsClassification = !(body.kind && body.sentiment && body.title);
+  const classification = needsClassification
+    ? yield* classifyFeedback({
+        organizationId,
+        feedbackId,
+        message: body.message,
+        title: body.title,
+        contextUrl: body.contextUrl,
+        agentClient: body.agentClient,
+      })
+    : null;
+
+  const [created] = yield* database(() =>
+    db
+      .insert(agentFeedback)
+      .values({
+        id: feedbackId,
+        organizationId,
+        projectId,
+        source: body.source,
+        kind: body.kind ?? classification?.kind ?? "other",
+        sentiment: body.sentiment ?? classification?.sentiment ?? null,
+        title: body.title ?? classification?.title ?? null,
+        message: body.message,
+        agentClient: body.agentClient ?? null,
+        agentModel: body.agentModel ?? null,
+        toolVersion: body.toolVersion ?? null,
+        userAgent: body.userAgent ?? userAgent ?? null,
+        contextUrl: body.contextUrl ?? null,
+        externalId: body.externalId ?? null,
+        idempotencyKey: body.idempotencyKey ?? null,
+        metadata: body.metadata ?? null,
+      })
+      .onConflictDoNothing({
+        target: [agentFeedback.organizationId, agentFeedback.idempotencyKey],
+      })
+      .returning()
+  );
+
+  if (created) {
+    return {
+      feedback: created,
+      deduplicated: false,
+    } satisfies SubmitFeedbackProgramSuccess;
+  }
+
+  const idempotencyKey = body.idempotencyKey;
+  const existing = idempotencyKey
+    ? yield* database(() =>
+        db.query.agentFeedback.findFirst({
+          where: and(
+            eq(agentFeedback.organizationId, organizationId),
+            eq(agentFeedback.idempotencyKey, idempotencyKey)
+          ),
+        })
+      )
+    : undefined;
+
+  if (!existing) {
+    return yield* new FeedbackNotFoundError();
+  }
+
+  return {
+    feedback: existing,
+    deduplicated: true,
+  } satisfies SubmitFeedbackProgramSuccess;
+});

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -19,12 +19,14 @@ import {
   FEEDBACK_PROJECT_NOT_FOUND_ERROR,
 } from "../constants/feedback";
 import { ORGANIZATION_SCOPED_API_KEY_ERROR } from "../constants/skills";
+import { submitFeedback as submitFeedbackProgram } from "../programs/feedback";
 import { trackFeedbackReceived } from "../utils/analytics";
 import { getOrganizationId } from "../utils/auth";
 import {
   findOrganizationIdBySlug,
+  getIngestProjectId,
+  runFeedbackProgram,
   serializeFeedback,
-  submitFeedback,
 } from "../utils/feedback";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
@@ -194,25 +196,35 @@ feedbackRoutes.openapi(submitOrganizationFeedbackRoute, async (c) => {
     return organizationLimited;
   }
 
-  const outcome = await submitFeedback(c, organizationId, c.req.valid("json"));
-  if (outcome.kind === "project_not_found") {
-    return c.json({ error: FEEDBACK_PROJECT_NOT_FOUND_ERROR }, 404);
+  const result = await runFeedbackProgram(
+    submitFeedbackProgram({
+      db: c.get("db"),
+      organizationId,
+      body: c.req.valid("json"),
+      ingestProjectId: getIngestProjectId(c),
+      userAgent: c.req.header("user-agent") ?? null,
+    })
+  );
+  if (result._tag === "Failure") {
+    if (result.failure._tag === "FeedbackProjectNotFoundError") {
+      return c.json({ error: FEEDBACK_PROJECT_NOT_FOUND_ERROR }, 404);
+    }
+    if (result.failure._tag === "FeedbackNotFoundError") {
+      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    }
+    throw result.failure;
   }
-  if (outcome.kind === "not_found") {
-    return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
-  }
+
+  const feedback = serializeFeedback(result.success.feedback);
 
   trackFeedbackReceived(c, {
     organizationId,
-    feedback: outcome.feedback,
-    deduplicated: outcome.deduplicated,
+    feedback,
+    deduplicated: result.success.deduplicated,
     via: API_FEEDBACK_VIA.PUBLIC_SLUG,
   });
 
-  return c.json(
-    { feedback: outcome.feedback, deduplicated: outcome.deduplicated },
-    202
-  );
+  return c.json({ feedback, deduplicated: result.success.deduplicated }, 202);
 });
 
 feedbackRoutes.openapi(submitFeedbackRoute, async (c) => {
@@ -226,25 +238,35 @@ feedbackRoutes.openapi(submitFeedbackRoute, async (c) => {
     return rateLimited;
   }
 
-  const outcome = await submitFeedback(c, organizationId, c.req.valid("json"));
-  if (outcome.kind === "project_not_found") {
-    return c.json({ error: FEEDBACK_PROJECT_NOT_FOUND_ERROR }, 404);
+  const result = await runFeedbackProgram(
+    submitFeedbackProgram({
+      db: c.get("db"),
+      organizationId,
+      body: c.req.valid("json"),
+      ingestProjectId: getIngestProjectId(c),
+      userAgent: c.req.header("user-agent") ?? null,
+    })
+  );
+  if (result._tag === "Failure") {
+    if (result.failure._tag === "FeedbackProjectNotFoundError") {
+      return c.json({ error: FEEDBACK_PROJECT_NOT_FOUND_ERROR }, 404);
+    }
+    if (result.failure._tag === "FeedbackNotFoundError") {
+      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    }
+    throw result.failure;
   }
-  if (outcome.kind === "not_found") {
-    return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
-  }
+
+  const feedback = serializeFeedback(result.success.feedback);
 
   trackFeedbackReceived(c, {
     organizationId,
-    feedback: outcome.feedback,
-    deduplicated: outcome.deduplicated,
+    feedback,
+    deduplicated: result.success.deduplicated,
     via: API_FEEDBACK_VIA.TOKEN,
   });
 
-  return c.json(
-    { feedback: outcome.feedback, deduplicated: outcome.deduplicated },
-    202
-  );
+  return c.json({ feedback, deduplicated: result.success.deduplicated }, 202);
 });
 
 feedbackRoutes.openapi(listFeedbackRoute, async (c) => {

--- a/apps/api/src/types/feedback.ts
+++ b/apps/api/src/types/feedback.ts
@@ -21,8 +21,8 @@ export interface SubmitFeedbackProgramInput {
   db: DbClient;
   organizationId: string;
   body: SubmitFeedbackBody;
-  /** Set when the request is authenticated with a feedback ingest token. */
-  ingestProjectId?: string | null;
+  /** Set when the request is authenticated with a project-bound ingest token. */
+  ingestProjectId?: string;
   userAgent?: string | null;
 }
 

--- a/apps/api/src/types/feedback.ts
+++ b/apps/api/src/types/feedback.ts
@@ -3,7 +3,33 @@ import type { agentFeedback } from "@notra/db/schema";
 import type { submitFeedbackRequestSchema } from "@notra/schemas/api/feedback";
 import type { IngestTokenIdentity } from "@notra/utils/types/ingest-token";
 
+import type {
+  FeedbackNotFoundError,
+  FeedbackProjectNotFoundError,
+} from "../errors/feedback";
+import type { DbClient } from "./db";
+
 export type AgentFeedbackRow = typeof agentFeedback.$inferSelect;
+
+type SubmitFeedbackBody = z.infer<typeof submitFeedbackRequestSchema>;
+
+export type FeedbackDomainError =
+  | FeedbackProjectNotFoundError
+  | FeedbackNotFoundError;
+
+export interface SubmitFeedbackProgramInput {
+  db: DbClient;
+  organizationId: string;
+  body: SubmitFeedbackBody;
+  /** Set when the request is authenticated with a feedback ingest token. */
+  ingestProjectId?: string | null;
+  userAgent?: string | null;
+}
+
+export interface SubmitFeedbackProgramSuccess {
+  feedback: AgentFeedbackRow;
+  deduplicated: boolean;
+}
 
 export type SerializedAgentFeedback = Omit<
   AgentFeedbackRow,
@@ -17,14 +43,3 @@ export type SerializedAgentFeedback = Omit<
 export type FeedbackTokenVerification =
   | { success: true; identity: IngestTokenIdentity }
   | { success: false; error: string; status: 401 | 403 | 503 };
-
-export type SubmitFeedbackBody = z.infer<typeof submitFeedbackRequestSchema>;
-
-export type SubmitFeedbackOutcome =
-  | {
-      kind: "accepted";
-      feedback: SerializedAgentFeedback;
-      deduplicated: boolean;
-    }
-  | { kind: "project_not_found" }
-  | { kind: "not_found" };

--- a/apps/api/src/utils/feedback.ts
+++ b/apps/api/src/utils/feedback.ts
@@ -24,9 +24,13 @@ export function serializeFeedback(
   };
 }
 
-export function getIngestProjectId(c: Context): string | null | undefined {
+export function getIngestProjectId(c: Context): string | undefined {
   const auth = c.get("auth");
-  return auth && isIngestAuth(auth) ? auth.projectId : undefined;
+  if (!auth || !isIngestAuth(auth)) {
+    return undefined;
+  }
+  // Unbound org-scoped ingest tokens use null; fall back to body.projectId.
+  return auth.projectId ?? undefined;
 }
 
 export function isPublicFeedbackIngestRequest(

--- a/apps/api/src/utils/feedback.ts
+++ b/apps/api/src/utils/feedback.ts
@@ -1,15 +1,14 @@
-import { classifyAgentFeedback } from "@notra/ai/jobs/feedback-classifier";
-import { agentFeedback, organizations, projects } from "@notra/db/schema";
-import { and, eq } from "drizzle-orm";
+import { organizations } from "@notra/db/schema";
+import { eq } from "drizzle-orm";
+import { Effect } from "effect";
 import type { Context } from "hono";
-import { nanoid } from "nanoid";
 
+import type { FeedbackDatabaseError } from "../errors/feedback";
 import { isIngestAuth } from "../types/auth";
 import type {
   AgentFeedbackRow,
+  FeedbackDomainError,
   SerializedAgentFeedback,
-  SubmitFeedbackBody,
-  SubmitFeedbackOutcome,
 } from "../types/feedback";
 
 const PUBLIC_FEEDBACK_INGEST_PATH_REGEX = /^\/v1\/feedback\/[^/]+\/?$/;
@@ -25,7 +24,7 @@ export function serializeFeedback(
   };
 }
 
-function getIngestProjectId(c: Context): string | null | undefined {
+export function getIngestProjectId(c: Context): string | null | undefined {
   const auth = c.get("auth");
   return auth && isIngestAuth(auth) ? auth.projectId : undefined;
 }
@@ -48,101 +47,17 @@ export async function findOrganizationIdBySlug(
   return organization?.id ?? null;
 }
 
-async function projectExists(
-  c: Context,
-  organizationId: string,
-  projectId: string
-): Promise<boolean> {
-  const project = await c.get("db").query.projects.findFirst({
-    columns: { id: true },
-    where: and(
-      eq(projects.id, projectId),
-      eq(projects.organizationId, organizationId)
-    ),
-  });
-  return project !== undefined;
-}
-
-export async function submitFeedback(
-  c: Context,
-  organizationId: string,
-  body: SubmitFeedbackBody
-): Promise<SubmitFeedbackOutcome> {
-  const tokenProjectId = getIngestProjectId(c);
-  const projectId =
-    tokenProjectId === undefined ? (body.projectId ?? null) : tokenProjectId;
-
-  if (
-    tokenProjectId === undefined &&
-    projectId &&
-    !(await projectExists(c, organizationId, projectId))
-  ) {
-    return { kind: "project_not_found" };
-  }
-
-  const feedbackId = nanoid();
-  const needsClassification = !(body.kind && body.sentiment && body.title);
-  const classification = needsClassification
-    ? await classifyAgentFeedback({
-        organizationId,
-        feedbackId,
-        message: body.message,
-        title: body.title,
-        contextUrl: body.contextUrl,
-        agentClient: body.agentClient,
-      })
-    : null;
-
-  const db = c.get("db");
-  const [created] = await db
-    .insert(agentFeedback)
-    .values({
-      id: feedbackId,
-      organizationId,
-      projectId,
-      source: body.source,
-      kind: body.kind ?? classification?.kind ?? "other",
-      sentiment: body.sentiment ?? classification?.sentiment ?? null,
-      title: body.title ?? classification?.title ?? null,
-      message: body.message,
-      agentClient: body.agentClient ?? null,
-      agentModel: body.agentModel ?? null,
-      toolVersion: body.toolVersion ?? null,
-      userAgent: body.userAgent ?? c.req.header("user-agent") ?? null,
-      contextUrl: body.contextUrl ?? null,
-      externalId: body.externalId ?? null,
-      idempotencyKey: body.idempotencyKey ?? null,
-      metadata: body.metadata ?? null,
-    })
-    .onConflictDoNothing({
-      target: [agentFeedback.organizationId, agentFeedback.idempotencyKey],
-    })
-    .returning();
-
-  if (created) {
-    return {
-      kind: "accepted",
-      feedback: serializeFeedback(created),
-      deduplicated: false,
-    };
-  }
-
-  const existing = body.idempotencyKey
-    ? await db.query.agentFeedback.findFirst({
-        where: and(
-          eq(agentFeedback.organizationId, organizationId),
-          eq(agentFeedback.idempotencyKey, body.idempotencyKey)
-        ),
-      })
-    : undefined;
-
-  if (!existing) {
-    return { kind: "not_found" };
-  }
-
-  return {
-    kind: "accepted",
-    feedback: serializeFeedback(existing),
-    deduplicated: true,
-  };
+/** Leave unexpected database errors to Hono's central error handler. */
+export function runFeedbackProgram<A, E extends FeedbackDomainError>(
+  program: Effect.Effect<A, E | FeedbackDatabaseError>
+) {
+  return Effect.runPromise(
+    Effect.result(
+      program.pipe(
+        Effect.catchTag("FeedbackDatabaseError", (failure) =>
+          Effect.die(failure.cause)
+        )
+      )
+    )
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Migrate `submitFeedback` from promise-based utils into an Effect program (`programs/feedback.ts`) with `Schema.TaggedError` outcomes and a `runFeedbackProgram` bridge, keeping feedback routes thin. Preserves public org ingest, ingest-token project override, idempotency deduplication, AI classification, and existing HTTP status codes (202/404).

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80273919-2610-53f5-b54d-e03a163a8e0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80273919-2610-53f5-b54d-e03a163a8e0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates `submitFeedback` from a promise-based utility into an Effect program so routes stay thin and errors are typed with `Schema.TaggedError`. Also fixes two edge cases: idempotency lookup now runs before project validation so retries return the original feedback even when `projectId` becomes invalid, and unbound ingest tokens (null `projectId`) fall back to `body.projectId`.

**Bug Fixes**
- Resolves idempotency rows before project validation.
- Treats unbound ingest token `projectId` as undefined so `body.projectId` is used.

<sup>Written for commit 98219a0eea4565db9741ce27acee5cc7dbc4c7fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

