### PR TITLE
fix(dashboard): navigate to overview when switching sidebar mode

### DIFF
--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -4,9 +4,9 @@ import { usePathname, useRouter } from "next/navigation";
 
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { SIDEBAR_MODE_HOME_LINKS } from "@/constants/nav";
-import type { SidebarMode } from "@/types/components/nav";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { useSidebarMode } from "@/lib/hooks/use-sidebar-mode";
+import type { SidebarMode } from "@/types/components/nav";
 import { geoNavHref } from "@/utils/geo-paths";
 import { sidebarRouteFromPathname } from "@/utils/nav";
 

--- a/apps/dashboard/src/components/dashboard/nav-main.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-main.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { SIDEBAR_MODE_HOME_LINKS } from "@/constants/nav";
+import type { SidebarMode } from "@/types/components/nav";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import { useSidebarMode } from "@/lib/hooks/use-sidebar-mode";
+import { geoNavHref } from "@/utils/geo-paths";
 import { sidebarRouteFromPathname } from "@/utils/nav";
 
 import { NavGeo } from "./nav-geo";
@@ -17,6 +19,7 @@ import { SidebarSwap } from "./sidebar-swap";
 export function NavMain() {
   const { activeOrganization } = useOrganizationsContext();
   const pathname = usePathname();
+  const router = useRouter();
   const [projectParam] = useGeoProjectQueryState();
   const route = sidebarRouteFromPathname(pathname);
   const { mode, setMode, pendingMode } = useSidebarMode(route);
@@ -36,11 +39,16 @@ export function NavMain() {
     ? `/${slug}${SIDEBAR_MODE_HOME_LINKS[pendingMode]}`
     : pathname;
 
+  const handleModeChange = (next: SidebarMode) => {
+    setMode(next);
+    router.push(geoNavHref(slug, SIDEBAR_MODE_HOME_LINKS[next], projectId));
+  };
+
   return (
     <>
       <NavModeSwitch
         mode={mode}
-        onModeChange={setMode}
+        onModeChange={handleModeChange}
         projectId={projectId}
         slug={slug}
       />

--- a/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-import type { MouseEvent } from "react";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import {
   SidebarGroup,
@@ -10,6 +9,7 @@ import {
   SidebarMenuItem,
 } from "@notra/ui/components/ui/sidebar";
 import { cn } from "@notra/ui/lib/utils";
+import type { MouseEvent } from "react";
 
 import {
   SIDEBAR_MODE_HOME_LINKS,

--- a/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-mode-switch.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { HugeiconsIcon } from "@hugeicons/react";
+import type { MouseEvent } from "react";
 import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import {
   SidebarGroup,
@@ -28,7 +29,11 @@ export function NavModeSwitch({
   projectId,
   onModeChange,
 }: NavModeSwitchProps) {
-  const handleModeSelect = (next: SidebarMode) => {
+  const handleModeSelect = (
+    next: SidebarMode,
+    event: MouseEvent<HTMLAnchorElement>
+  ) => {
+    event.preventDefault();
     if (next !== mode) {
       trackEvent(POSTHOG_EVENTS.SIDEBAR_MODE_SWITCHED, {
         from: mode,
@@ -67,7 +72,7 @@ export function NavModeSwitch({
                   projectId
                 )}
                 key={option.id}
-                onClick={() => handleModeSelect(option.id)}
+                onClick={(event) => handleModeSelect(option.id, event)}
               >
                 <HugeiconsIcon className="size-3.5" icon={option.icon} />
                 {option.label}
@@ -88,7 +93,7 @@ export function NavModeSwitch({
                     SIDEBAR_MODE_HOME_LINKS[option.id],
                     projectId
                   )}
-                  onClick={() => handleModeSelect(option.id)}
+                  onClick={(event) => handleModeSelect(option.id, event)}
                 >
                   <HugeiconsIcon icon={option.icon} />
                   <SidebarLabel>{option.label}</SidebarLabel>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
When switching between GEO and Studio in the sidebar, navigate to each mode's home page (GEO overview at `/geo` or Studio home) instead of only swapping the sidebar panel while staying on the current route.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45be5c1d-3e8d-4f3c-8518-56c9d76d419d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45be5c1d-3e8d-4f3c-8518-56c9d76d419d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switching between GEO and Studio in the sidebar now routes to the selected mode's home page (GEO overview at `/geo` or Studio home) instead of staying on the current route.

<sup>Written for commit 661378db47bf0c0f5bb0b5722d2ec19dfdd1d2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

