### PR TITLE
fix(dashboard): align geo prefetch with tab-gated overview hooks

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/gaps/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/gaps/page-client.tsx
@@ -1,36 +1,16 @@
 "use client";
 
-import { GEO_SEARCH_GAP_DISMISSED_TOAST } from "@notra/geo-core/constants/geo";
 import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
-import { toast } from "sonner";
 
 import { Button } from "@/components/button";
 import { GeoGapsTable } from "@/components/geo/gaps-table";
 import { GeoWriterNeedsSetup } from "@/components/geo/writer/page-gate";
 import { PageContainer } from "@/components/layout/container";
 import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
-import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { GEO_WRITE_DIALOG_ENTRIES } from "@/constants/geo-analytics";
-import {
-  useGeoCompetitors,
-  useGeoRescanPrompt,
-  useGeoSettings,
-  useGeoStartScan,
-  useGeoSuggestionDismiss,
-  useIsGeoScanning,
-} from "@/lib/hooks/use-geo";
+import { useGeoGapsPage } from "@/lib/hooks/use-geo-gaps-page";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
-import { useGeoWriterGaps } from "@/lib/hooks/use-geo-writer";
-import type { GeoGapsPageContentProps } from "@/types/components/geo-gaps";
-import type { WriteDialogInitialState } from "@/types/components/geo-writer";
 import type { GeoPageClientProps } from "@/types/geo";
-import {
-  emptyWriteDialogState,
-  geoContentPath,
-  writeDialogStateFromGap,
-} from "@/utils/geo-write-entry";
 
 import { GeoGapsSkeleton } from "./skeleton";
 
@@ -50,38 +30,10 @@ export default function PageClient({ organizationSlug }: GeoPageClientProps) {
   );
 }
 
-function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
-  const router = useRouter();
-  const { getOrganization, activeOrganization } = useOrganizationsContext();
-  const orgFromList = getOrganization(organizationSlug);
-  const organization =
-    activeOrganization?.slug === organizationSlug
-      ? activeOrganization
-      : orgFromList;
-  const organizationId = organization?.id ?? "";
+function GeoGapsPageContent({ organizationSlug }: GeoPageClientProps) {
+  const page = useGeoGapsPage(organizationSlug);
 
-  const settingsQuery = useGeoSettings(organizationId);
-  const { data: settingsData, isPending: isSettingsPending } = settingsQuery;
-  const gapsQuery = useGeoWriterGaps(organizationId);
-  const competitorsQuery = useGeoCompetitors(organizationId);
-  const startScan = useGeoStartScan(organizationId);
-  const rescanPrompt = useGeoRescanPrompt(organizationId);
-  const isScanning = useIsGeoScanning(organizationId);
-  const dismissSuggestion = useGeoSuggestionDismiss(organizationId);
-
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [dialogInitial, setDialogInitial] =
-    useState<WriteDialogInitialState | null>(null);
-
-  const openDialog = useCallback((initial?: WriteDialogInitialState) => {
-    setDialogInitial(initial ?? emptyWriteDialogState());
-    setDialogOpen(true);
-  }, []);
-
-  if (
-    (settingsQuery.isError && !settingsData) ||
-    (settingsData?.settings && gapsQuery.isError && !gapsQuery.data)
-  ) {
+  if (page.status === "error") {
     return (
       <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:py-6">
         <div className="space-y-4 px-4 lg:px-6" role="alert">
@@ -90,15 +42,8 @@ function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
             We couldn&apos;t load content gaps. Try again.
           </p>
           <Button
-            disabled={settingsQuery.isFetching || gapsQuery.isFetching}
-            onClick={() => {
-              if (settingsQuery.isError) {
-                void settingsQuery.refetch();
-              }
-              if (gapsQuery.isError) {
-                void gapsQuery.refetch();
-              }
-            }}
+            disabled={page.isRetrying}
+            onClick={page.retry}
             variant="outline"
           >
             Retry
@@ -108,17 +53,17 @@ function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
     );
   }
 
-  if (!(isSettingsPending || settingsData?.settings)) {
+  if (page.status === "setup") {
     return (
       <GeoWriterNeedsSetup
         description="Questions engines answer without mentioning you"
-        organizationId={organizationId}
+        organizationId={page.organizationId}
         title="Content Gaps"
       />
     );
   }
 
-  if (isSettingsPending && !gapsQuery.data) {
+  if (page.status === "loading") {
     return <GeoGapsSkeleton />;
   }
 
@@ -137,70 +82,39 @@ function GeoGapsPageContent({ organizationSlug }: GeoGapsPageContentProps) {
           </div>
         </header>
 
-        {gapsQuery.isPending ? (
+        {page.gapsQuery.isPending ? (
           <GeoGapsSkeleton embedded />
         ) : (
           <GeoGapsTable
-            competitors={competitorsQuery.data?.competitors ?? []}
-            hasScanData={gapsQuery.data?.hasScanData ?? false}
-            isScanning={isScanning}
-            onOpenPost={(postId) => {
-              router.push(geoContentPath(organizationSlug, postId));
-            }}
-            onRescanPrompt={(row) => rescanPrompt.mutate(row.id)}
-            onRunScan={() => startScan.mutate("gaps_empty")}
-            onWritePrompt={(row) => {
-              openDialog(
-                writeDialogStateFromGap({
-                  promptId: row.id,
-                  prompt: row.prompt,
-                  mentionedEngines: row.mentionedEngines,
-                  missingEngines: row.engines,
-                  mentionedCompetitors: [
-                    ...row.competitors,
-                    ...row.discoveredCompetitors,
-                  ],
-                })
-              );
-            }}
+            competitors={page.competitors}
             dismissingSearchId={
-              dismissSuggestion.isPending
-                ? (dismissSuggestion.variables?.suggestionId ?? null)
+              page.dismissSuggestion.isPending
+                ? (page.dismissSuggestion.variables?.suggestionId ?? null)
                 : null
             }
-            onDismissSearch={(row) => {
-              dismissSuggestion.mutate(
-                { suggestionId: row.id },
-                {
-                  onSuccess: () => {
-                    toast.success(GEO_SEARCH_GAP_DISMISSED_TOAST);
-                  },
-                }
-              );
-            }}
-            onWriteSearch={(row, existingPageUrl) => {
-              openDialog({
-                sourceKind: "search_console",
-                sourceId: row.id,
-                topic: row.prompt,
-                existingPageUrl,
-              });
-            }}
-            organizationSlug={organizationSlug}
-            promptGaps={gapsQuery.data?.promptGaps ?? []}
-            searchGaps={gapsQuery.data?.searchGaps ?? []}
+            hasScanData={page.gapsQuery.data?.hasScanData ?? false}
+            isScanning={page.isScanning}
+            onDismissSearch={(row) => page.dismissSearch(row.id)}
+            onOpenPost={page.openPost}
+            onRescanPrompt={(row) => page.rescanPromptRow(row.id)}
+            onRunScan={page.runScan}
+            onWritePrompt={page.writePrompt}
+            onWriteSearch={page.writeSearch}
+            organizationSlug={page.organizationSlug}
+            promptGaps={page.gapsQuery.data?.promptGaps ?? []}
+            searchGaps={page.gapsQuery.data?.searchGaps ?? []}
           />
         )}
       </div>
 
-      {organizationId && dialogInitial ? (
+      {page.dialogInitial ? (
         <WriteDialog
           entry={GEO_WRITE_DIALOG_ENTRIES.GAP}
-          initial={dialogInitial}
-          onOpenChange={setDialogOpen}
-          open={dialogOpen}
-          organizationId={organizationId}
-          organizationSlug={organizationSlug}
+          initial={page.dialogInitial}
+          onOpenChange={page.setDialogOpen}
+          open={page.dialogOpen}
+          organizationId={page.organizationId}
+          organizationSlug={page.organizationSlug}
         />
       ) : null}
     </PageContainer>

--- a/apps/dashboard/src/app/(dashboard)/[slug]/geo/shelf-space/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/geo/shelf-space/page-client.tsx
@@ -2,12 +2,9 @@
 
 import { PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { POSTHOG_EVENTS } from "@notra/posthog/events";
 import { Kbd } from "@notra/ui/components/ui/kbd";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import Link from "next/link";
-import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
-import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/button";
 import { EmptyState } from "@/components/empty-state";
@@ -17,11 +14,7 @@ import { ShelfDetailDialog } from "@/components/geo/shelf/shelf-detail-dialog";
 import { ShelfPageControls } from "@/components/geo/shelf/shelf-page-controls";
 import { ShelfView } from "@/components/geo/shelf/shelf-view";
 import { PageContainer } from "@/components/layout/container";
-import {
-  GeoProjectProvider,
-  useGeoProjectScope,
-} from "@/components/providers/geo-project-provider";
-import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import { GeoProjectProvider } from "@/components/providers/geo-project-provider";
 import {
   EMPTY_STATE_TABLE_COLUMNS,
   EMPTY_STATE_TABLE_ROWS,
@@ -29,27 +22,12 @@ import {
 import {
   GEO_SHELF_ADD_HOTKEY,
   GEO_SHELF_ADD_LABEL,
-  GEO_SHELF_SHELF_FILTERS,
-  GEO_SHELF_TICKET_FILTERS,
-  GEO_SHELF_VIEWS,
 } from "@/constants/geo-shelf";
-import { trackEvent } from "@/lib/analytics/posthog-client";
-import { useGeoSettings } from "@/lib/hooks/use-geo";
-import { useGeoActiveProject } from "@/lib/hooks/use-geo-active-project";
-import { useGeoCompetitorsDb, useGeoShelfDb } from "@/lib/hooks/use-geo-db";
+import { useGeoShelfPage } from "@/lib/hooks/use-geo-shelf-page";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
-import { useGeoShelfMembers } from "@/lib/hooks/use-geo-shelf";
 import type { GeoPageClientProps } from "@/types/geo";
-import type {
-  GeoShelfPageContentProps,
-  GeoShelfSelection,
-} from "@/types/geo-shelf";
 import { withGeoProject } from "@/utils/geo-paths";
-import {
-  buildOptimisticShelfSource,
-  filterShelfRows,
-  toShelfRows,
-} from "@/utils/geo-shelf";
+import { buildOptimisticShelfSource } from "@/utils/geo-shelf";
 
 import { GeoShelfSkeleton } from "./skeleton";
 
@@ -67,83 +45,14 @@ export default function PageClient({ organizationSlug }: GeoPageClientProps) {
   );
 }
 
-function GeoShelfPageContent({ organizationSlug }: GeoShelfPageContentProps) {
-  const { projectId } = useGeoProjectScope();
-  const { getOrganization, activeOrganization } = useOrganizationsContext();
-  const orgFromList = getOrganization(organizationSlug);
-  const organization =
-    activeOrganization?.slug === organizationSlug
-      ? activeOrganization
-      : orgFromList;
-  const organizationId = organization?.id ?? "";
+function GeoShelfPageContent({ organizationSlug }: GeoPageClientProps) {
+  const page = useGeoShelfPage(organizationSlug);
 
-  const { data: settingsData, isPending: isSettingsPending } =
-    useGeoSettings(organizationId);
-  const { competitors } = useGeoCompetitorsDb(organizationId);
-  const { domain: ownDomain } = useGeoActiveProject(organizationId);
-  const membersQuery = useGeoShelfMembers(organizationId);
-  const shelf = useGeoShelfDb(organizationId);
-
-  const [search, setSearch] = useQueryState(
-    "q",
-    parseAsString.withDefault("").withOptions({ clearOnDefault: true })
-  );
-  const [shelfFilter, setShelfFilter] = useQueryState(
-    "shelf",
-    parseAsStringLiteral(GEO_SHELF_SHELF_FILTERS)
-      .withDefault("all")
-      .withOptions({ clearOnDefault: true })
-  );
-  const [ticketFilter, setTicketFilter] = useQueryState(
-    "ticket",
-    parseAsStringLiteral(GEO_SHELF_TICKET_FILTERS)
-      .withDefault("any")
-      .withOptions({ clearOnDefault: true })
-  );
-  const [view, setView] = useQueryState(
-    "view",
-    parseAsStringLiteral(GEO_SHELF_VIEWS)
-      .withDefault("table")
-      .withOptions({ clearOnDefault: true })
-  );
-  const [addOpen, setAddOpen] = useState(false);
-  const [selected, setSelected] = useState<GeoShelfSelection | null>(null);
-
-  useHotkey(GEO_SHELF_ADD_HOTKEY, () => setAddOpen(true), {
-    enabled: !addOpen && selected === null,
-  });
-
-  const settings = settingsData?.settings ?? null;
-  const hasSettings = settings !== null;
-  const shelfCount = shelf.sources.length;
-  const { isSampleData } = shelf;
-  const viewedRef = useRef(false);
-
-  useEffect(() => {
-    if (viewedRef.current || isSettingsPending || shelf.isLoading) {
-      return;
-    }
-    viewedRef.current = true;
-    trackEvent(POSTHOG_EVENTS.GEO_SHELF_VIEWED, {
-      view,
-      has_settings: hasSettings,
-      shelf_count: shelfCount,
-      is_sample_data: isSampleData,
-    });
-  }, [
-    isSettingsPending,
-    shelf.isLoading,
-    hasSettings,
-    shelfCount,
-    isSampleData,
-    view,
-  ]);
-
-  if (isSettingsPending || (hasSettings && shelf.isLoading)) {
+  if (page.status === "loading") {
     return <GeoShelfSkeleton />;
   }
 
-  if (!settings) {
+  if (page.status === "setup") {
     return (
       <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
         <div className="w-full space-y-6 px-4 lg:px-6">
@@ -157,7 +66,10 @@ function GeoShelfPageContent({ organizationSlug }: GeoShelfPageContentProps) {
                 nativeButton={false}
                 render={
                   <Link
-                    href={withGeoProject(`/${organizationSlug}/geo`, projectId)}
+                    href={withGeoProject(
+                      `/${page.organizationSlug}/geo`,
+                      page.projectId
+                    )}
                   />
                 }
               >
@@ -178,27 +90,20 @@ function GeoShelfPageContent({ organizationSlug }: GeoShelfPageContentProps) {
     );
   }
 
-  const members = membersQuery.data?.members ?? [];
-  const currentMemberId = membersQuery.data?.currentMemberId ?? null;
-  const currentMember =
-    members.find((member) => member.id === currentMemberId) ?? null;
-  const ownBrandName = settings.companyName;
-  const rows = toShelfRows(shelf.sources, members);
-  const filters = {
-    search,
-    shelf: shelfFilter,
-    ticket: ticketFilter,
-    currentMemberId,
-  };
-  const filteredRows = filterShelfRows(rows, filters);
-  // A freshly created row swaps its optimistic id for the server id on refetch:
-  // fall back to the canonical URL so the open dialog survives that swap.
-  const selectedRow =
-    rows.find((row) => row.id === selected?.id) ??
-    rows.find((row) => row.url === selected?.url) ??
-    null;
-  const openRow = (row: (typeof rows)[number]) =>
-    setSelected({ id: row.id, url: row.url });
+  return <GeoShelfReadyContent page={page} />;
+}
+
+function GeoShelfReadyContent({
+  page,
+}: {
+  page: Extract<
+    ReturnType<typeof useGeoShelfPage>,
+    { status: "ready" }
+  >;
+}) {
+  useHotkey(GEO_SHELF_ADD_HOTKEY, () => page.setAddOpen(true), {
+    enabled: !page.addOpen && page.selectedRow === null,
+  });
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
@@ -208,7 +113,7 @@ function GeoShelfPageContent({ organizationSlug }: GeoShelfPageContentProps) {
             <h1 className="text-3xl font-bold tracking-tight">{PAGE_TITLE}</h1>
             <p className="text-muted-foreground">{PAGE_DESCRIPTION}</p>
           </div>
-          <Button className="gap-1.5" onClick={() => setAddOpen(true)}>
+          <Button className="gap-1.5" onClick={() => page.setAddOpen(true)}>
             <HugeiconsIcon className="size-4" icon={PlusSignIcon} />
             {GEO_SHELF_ADD_LABEL}
             <Kbd className="ml-1 hidden sm:inline-flex">
@@ -218,72 +123,74 @@ function GeoShelfPageContent({ organizationSlug }: GeoShelfPageContentProps) {
         </header>
 
         <div className="space-y-3">
-          {rows.length > 0 ? (
+          {page.rows.length > 0 ? (
             <ShelfPageControls
-              filters={filters}
+              filters={page.filters}
               hasRows
-              onSearchChange={setSearch}
-              onShelfFilterChange={setShelfFilter}
-              onTicketFilterChange={setTicketFilter}
-              onViewChange={setView}
-              view={view}
+              onSearchChange={page.setSearch}
+              onShelfFilterChange={page.setShelfFilter}
+              onTicketFilterChange={page.setTicketFilter}
+              onViewChange={page.setView}
+              view={page.view}
             />
           ) : null}
           <ShelfView
-            currentMemberId={currentMemberId}
-            hasScanData={shelf.sources.some(
+            currentMemberId={page.currentMemberId}
+            hasScanData={page.shelf.sources.some(
               (source) => source.origin === "scan"
             )}
-            onAddShelf={() => setAddOpen(true)}
-            onRowClick={openRow}
-            onSetPlacementStatus={shelf.setPlacementStatus}
-            onUpdateOpportunity={shelf.updateOpportunity}
-            pendingSourceIds={shelf.pendingSourceIds}
-            rows={filteredRows}
-            ticketFilter={ticketFilter}
-            totalCount={rows.length}
-            view={view}
+            onAddShelf={() => page.setAddOpen(true)}
+            onRowClick={page.openRow}
+            onSetPlacementStatus={page.shelf.setPlacementStatus}
+            onUpdateOpportunity={page.shelf.updateOpportunity}
+            pendingSourceIds={page.shelf.pendingSourceIds}
+            rows={page.filteredRows}
+            ticketFilter={page.ticketFilter}
+            totalCount={page.rows.length}
+            view={page.view}
           />
         </div>
       </div>
 
       <ShelfDetailDialog
-        currentMemberId={currentMemberId}
+        currentMemberId={page.currentMemberId}
         isPending={
-          selectedRow ? shelf.pendingSourceIds.has(selectedRow.id) : false
+          page.selectedRow
+            ? page.shelf.pendingSourceIds.has(page.selectedRow.id)
+            : false
         }
-        members={members}
+        members={page.members}
         onOpenChange={(open) => {
           if (!open) {
-            setSelected(null);
+            page.setSelected(null);
           }
         }}
-        onSetPlacementStatus={shelf.setPlacementStatus}
-        onUpdateOpportunity={shelf.updateOpportunity}
-        open={selectedRow !== null}
-        ownBrandName={ownBrandName}
-        row={selectedRow}
+        onSetPlacementStatus={page.shelf.setPlacementStatus}
+        onUpdateOpportunity={page.shelf.updateOpportunity}
+        open={page.selectedRow !== null}
+        ownBrandName={page.ownBrandName}
+        row={page.selectedRow}
       />
 
       <ShelfAddDialog
-        competitors={competitors}
-        currentMemberId={currentMemberId}
-        existingUrls={rows.map((row) => row.url)}
-        members={members}
-        onOpenChange={setAddOpen}
-        organizationId={organizationId}
+        competitors={page.competitors}
+        currentMemberId={page.currentMemberId}
+        existingUrls={page.rows.map((row) => row.url)}
+        members={page.members}
+        onOpenChange={page.setAddOpen}
+        organizationId={page.organizationId}
         onSubmit={(draft) => {
-          shelf.addSource(
+          page.shelf.addSource(
             buildOptimisticShelfSource(draft, {
-              ownBrandName,
-              ownDomain,
-              competitors,
-              createdByUserId: currentMember?.userId ?? null,
+              ownBrandName: page.ownBrandName,
+              ownDomain: page.ownDomain,
+              competitors: page.competitors,
+              createdByUserId: page.currentMember?.userId ?? null,
             })
           );
         }}
-        open={addOpen}
-        ownBrandName={ownBrandName}
+        open={page.addOpen}
+        ownBrandName={page.ownBrandName}
       />
     </PageContainer>
   );

--- a/apps/dashboard/src/lib/hooks/use-geo-gaps-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-gaps-page.ts
@@ -1,0 +1,163 @@
+"use client";
+
+import { GEO_SEARCH_GAP_DISMISSED_TOAST } from "@notra/geo-core/constants/geo";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import {
+  useGeoCompetitors,
+  useGeoRescanPrompt,
+  useGeoSettings,
+  useGeoStartScan,
+  useGeoSuggestionDismiss,
+  useIsGeoScanning,
+} from "@/lib/hooks/use-geo";
+import { useGeoWriterGaps } from "@/lib/hooks/use-geo-writer";
+import type { WriteDialogInitialState } from "@/types/components/geo-writer";
+import {
+  emptyWriteDialogState,
+  geoContentPath,
+  writeDialogStateFromGap,
+} from "@/utils/geo-write-entry";
+import { resolveOrganizationId } from "@/utils/geo-overview-organization";
+
+export function useGeoGapsPage(organizationSlug: string) {
+  const router = useRouter();
+  const { getOrganization, activeOrganization } = useOrganizationsContext();
+  const organizationId = resolveOrganizationId(
+    organizationSlug,
+    activeOrganization,
+    getOrganization(organizationSlug)
+  );
+
+  const settingsQuery = useGeoSettings(organizationId);
+  const gapsQuery = useGeoWriterGaps(organizationId);
+  const competitorsQuery = useGeoCompetitors(organizationId);
+  const startScan = useGeoStartScan(organizationId);
+  const rescanPrompt = useGeoRescanPrompt(organizationId);
+  const isScanning = useIsGeoScanning(organizationId);
+  const dismissSuggestion = useGeoSuggestionDismiss(organizationId);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogInitial, setDialogInitial] =
+    useState<WriteDialogInitialState | null>(null);
+
+  const openDialog = useCallback((initial?: WriteDialogInitialState) => {
+    setDialogInitial(initial ?? emptyWriteDialogState());
+    setDialogOpen(true);
+  }, []);
+
+  const retry = useCallback(() => {
+    if (settingsQuery.isError) {
+      void settingsQuery.refetch();
+    }
+    if (gapsQuery.isError) {
+      void gapsQuery.refetch();
+    }
+  }, [gapsQuery, settingsQuery]);
+
+  const openPost = useCallback(
+    (postId: string) => {
+      router.push(geoContentPath(organizationSlug, postId));
+    },
+    [organizationSlug, router]
+  );
+
+  const writePrompt = useCallback(
+    (row: {
+      id: string;
+      prompt: string;
+      mentionedEngines: readonly string[];
+      engines: readonly string[];
+      competitors: readonly string[];
+      discoveredCompetitors: readonly string[];
+    }) => {
+      openDialog(
+        writeDialogStateFromGap({
+          promptId: row.id,
+          prompt: row.prompt,
+          mentionedEngines: row.mentionedEngines,
+          missingEngines: row.engines,
+          mentionedCompetitors: [...row.competitors, ...row.discoveredCompetitors],
+        })
+      );
+    },
+    [openDialog]
+  );
+
+  const dismissSearch = useCallback(
+    (suggestionId: string) => {
+      dismissSuggestion.mutate(
+        { suggestionId },
+        {
+          onSuccess: () => {
+            toast.success(GEO_SEARCH_GAP_DISMISSED_TOAST);
+          },
+        }
+      );
+    },
+    [dismissSuggestion]
+  );
+
+  const writeSearch = useCallback(
+    (
+      row: { id: string; prompt: string },
+      existingPageUrl: string | undefined
+    ) => {
+      openDialog({
+        sourceKind: "search_console",
+        sourceId: row.id,
+        topic: row.prompt,
+        existingPageUrl,
+      });
+    },
+    [openDialog]
+  );
+
+  const { data: settingsData, isPending: isSettingsPending } = settingsQuery;
+
+  if (
+    (settingsQuery.isError && !settingsData) ||
+    (settingsData?.settings && gapsQuery.isError && !gapsQuery.data)
+  ) {
+    return {
+      status: "error" as const,
+      isRetrying: settingsQuery.isFetching || gapsQuery.isFetching,
+      retry,
+    };
+  }
+
+  if (!(isSettingsPending || settingsData?.settings)) {
+    return {
+      status: "setup" as const,
+      organizationId,
+    };
+  }
+
+  if (isSettingsPending && !gapsQuery.data) {
+    return { status: "loading" as const };
+  }
+
+  return {
+    status: "ready" as const,
+    organizationId,
+    organizationSlug,
+    gapsQuery,
+    competitors: competitorsQuery.data?.competitors ?? [],
+    isScanning,
+    startScan,
+    rescanPrompt,
+    dismissSuggestion,
+    dialogOpen,
+    dialogInitial,
+    setDialogOpen,
+    openPost,
+    writePrompt,
+    dismissSearch,
+    writeSearch,
+    runScan: () => startScan.mutate("gaps_empty"),
+    rescanPromptRow: (promptId: string) => rescanPrompt.mutate(promptId),
+  };
+}

--- a/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
@@ -119,14 +119,18 @@ export function useGeoOverviewPage(
     geoRange.query,
     activeTab === "visibility" || activeTab === "prompts"
   );
+  const visibilityTabActive = activeTab === "visibility";
   const { data: competitorShare } = useGeoCompetitorShare(
     organizationId,
-    geoRange.query
+    geoRange.query,
+    false,
+    visibilityTabActive
   );
   const { data: competitorList } = useGeoCompetitors(organizationId);
   const { data: languageShare } = useGeoLanguageShare(
     organizationId,
-    geoRange.query
+    geoRange.query,
+    visibilityTabActive
   );
   const { data: trafficJourneys } = useGeoTrafficJourneys(
     organizationId,

--- a/apps/dashboard/src/lib/hooks/use-geo-shelf-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-shelf-page.ts
@@ -1,0 +1,148 @@
+"use client";
+
+import { POSTHOG_EVENTS } from "@notra/posthog/events";
+import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
+import { useEffect, useRef, useState } from "react";
+
+import { useGeoProjectScope } from "@/components/providers/geo-project-provider";
+import { useOrganizationsContext } from "@/components/providers/organization-provider";
+import {
+  GEO_SHELF_SHELF_FILTERS,
+  GEO_SHELF_TICKET_FILTERS,
+  GEO_SHELF_VIEWS,
+} from "@/constants/geo-shelf";
+import { trackEvent } from "@/lib/analytics/posthog-client";
+import { useGeoSettings } from "@/lib/hooks/use-geo";
+import { useGeoActiveProject } from "@/lib/hooks/use-geo-active-project";
+import { useGeoCompetitorsDb, useGeoShelfDb } from "@/lib/hooks/use-geo-db";
+import { useGeoShelfMembers } from "@/lib/hooks/use-geo-shelf";
+import type { GeoShelfSelection } from "@/types/geo-shelf";
+import { resolveOrganizationId } from "@/utils/geo-overview-organization";
+import { filterShelfRows, toShelfRows } from "@/utils/geo-shelf";
+
+export function useGeoShelfPage(organizationSlug: string) {
+  const { projectId } = useGeoProjectScope();
+  const { getOrganization, activeOrganization } = useOrganizationsContext();
+  const organizationId = resolveOrganizationId(
+    organizationSlug,
+    activeOrganization,
+    getOrganization(organizationSlug)
+  );
+
+  const { data: settingsData, isPending: isSettingsPending } =
+    useGeoSettings(organizationId);
+  const { competitors } = useGeoCompetitorsDb(organizationId);
+  const { domain: ownDomain } = useGeoActiveProject(organizationId);
+  const membersQuery = useGeoShelfMembers(organizationId);
+  const shelf = useGeoShelfDb(organizationId);
+
+  const [search, setSearch] = useQueryState(
+    "q",
+    parseAsString.withDefault("").withOptions({ clearOnDefault: true })
+  );
+  const [shelfFilter, setShelfFilter] = useQueryState(
+    "shelf",
+    parseAsStringLiteral(GEO_SHELF_SHELF_FILTERS)
+      .withDefault("all")
+      .withOptions({ clearOnDefault: true })
+  );
+  const [ticketFilter, setTicketFilter] = useQueryState(
+    "ticket",
+    parseAsStringLiteral(GEO_SHELF_TICKET_FILTERS)
+      .withDefault("any")
+      .withOptions({ clearOnDefault: true })
+  );
+  const [view, setView] = useQueryState(
+    "view",
+    parseAsStringLiteral(GEO_SHELF_VIEWS)
+      .withDefault("table")
+      .withOptions({ clearOnDefault: true })
+  );
+  const [addOpen, setAddOpen] = useState(false);
+  const [selected, setSelected] = useState<GeoShelfSelection | null>(null);
+
+  const settings = settingsData?.settings ?? null;
+  const hasSettings = settings !== null;
+  const shelfCount = shelf.sources.length;
+  const { isSampleData } = shelf;
+  const viewedRef = useRef(false);
+
+  useEffect(() => {
+    if (viewedRef.current || isSettingsPending || shelf.isLoading) {
+      return;
+    }
+    viewedRef.current = true;
+    trackEvent(POSTHOG_EVENTS.GEO_SHELF_VIEWED, {
+      view,
+      has_settings: hasSettings,
+      shelf_count: shelfCount,
+      is_sample_data: isSampleData,
+    });
+  }, [
+    isSettingsPending,
+    shelf.isLoading,
+    hasSettings,
+    shelfCount,
+    isSampleData,
+    view,
+  ]);
+
+  const members = membersQuery.data?.members ?? [];
+  const currentMemberId = membersQuery.data?.currentMemberId ?? null;
+  const currentMember =
+    members.find((member) => member.id === currentMemberId) ?? null;
+  const rows = hasSettings ? toShelfRows(shelf.sources, members) : [];
+  const filters = {
+    search,
+    shelf: shelfFilter,
+    ticket: ticketFilter,
+    currentMemberId,
+  };
+  const filteredRows = filterShelfRows(rows, filters);
+  const selectedRow =
+    rows.find((row) => row.id === selected?.id) ??
+    rows.find((row) => row.url === selected?.url) ??
+    null;
+
+  if (isSettingsPending || (hasSettings && shelf.isLoading)) {
+    return { status: "loading" as const };
+  }
+
+  if (!settings) {
+    return {
+      status: "setup" as const,
+      organizationSlug,
+      projectId,
+    };
+  }
+
+  return {
+    status: "ready" as const,
+    organizationId,
+    organizationSlug,
+    projectId,
+    settings,
+    competitors,
+    ownDomain,
+    members,
+    currentMemberId,
+    currentMember,
+    ownBrandName: settings.companyName,
+    shelf,
+    rows,
+    filteredRows,
+    filters,
+    selectedRow,
+    view,
+    ticketFilter,
+    addOpen,
+    setAddOpen,
+    setSelected,
+    setSearch,
+    setShelfFilter,
+    setTicketFilter,
+    setView,
+    openRow: (row: (typeof rows)[number]) =>
+      setSelected({ id: row.id, url: row.url }),
+  };
+}

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -378,7 +378,8 @@ export function useGeoChanges(organizationId: string) {
 export function useGeoCompetitorShare(
   organizationId: string,
   range?: GeoRangeQuery,
-  summaryOnly = false
+  summaryOnly = false,
+  enabled = true
 ) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoCompetitorShareResponse>({
@@ -390,7 +391,7 @@ export function useGeoCompetitorShare(
         summaryOnly: summaryOnly || undefined,
       },
     }),
-    enabled: !!organizationId,
+    enabled: enabled && !!organizationId,
     placeholderData: keepPreviousData,
     meta: { errorMessage: "Failed to load competitor share" },
   });
@@ -502,14 +503,15 @@ export function useGeoCompetitors(organizationId: string) {
 
 export function useGeoLanguageShare(
   organizationId: string,
-  range?: GeoRangeQuery
+  range?: GeoRangeQuery,
+  enabled = true
 ) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoLanguageShareResponse>({
     ...dashboardOrpc.geo.languageShare.queryOptions({
       input: { organizationId, projectId, ...toGeoWindowInput(range) },
     }),
-    enabled: !!organizationId,
+    enabled: enabled && !!organizationId,
     placeholderData: keepPreviousData,
     meta: { errorMessage: "Failed to load language performance" },
   });

--- a/apps/dashboard/src/utils/geo-hydration.ts
+++ b/apps/dashboard/src/utils/geo-hydration.ts
@@ -1,10 +1,14 @@
-import { GEO_DEFAULT_RANGE } from "@notra/geo-core/constants/geo";
+import {
+  GEO_DEFAULT_RANGE,
+  GEO_DEFAULT_TAB,
+} from "@notra/geo-core/constants/geo";
 
 import {
   geoOverviewQueryInput,
   geoSettingsQueryInput,
 } from "@/utils/geo-query-input";
 import { parseGeoRangeParam } from "@/utils/geo-range";
+import { toGeoTab } from "@/utils/geo-tabs";
 
 function firstSearchParam(
   value: string | string[] | undefined
@@ -23,12 +27,22 @@ export function geoHydrationInputs(
   const { range } = parseGeoRangeParam(
     firstSearchParam(search.range) ?? GEO_DEFAULT_RANGE
   );
+  const activeTab = toGeoTab(firstSearchParam(search.tab) ?? GEO_DEFAULT_TAB);
+  const windowed = geoOverviewQueryInput(scope, {
+    from: range.dateFrom,
+    to: range.dateTo,
+  });
 
   return {
+    activeTab,
     settings: geoSettingsQueryInput(scope),
-    overview: geoOverviewQueryInput(scope, {
-      from: range.dateFrom,
-      to: range.dateTo,
-    }),
+    overview: windowed,
+    timeseries: windowed,
+    promptResultSummaries: windowed,
+    competitorShare: windowed,
+    languageShare: windowed,
+    trafficJourneys: windowed,
+    prompts: geoSettingsQueryInput(scope),
+    competitors: geoSettingsQueryInput(scope),
   };
 }

--- a/apps/dashboard/src/utils/geo-prefetch.server.ts
+++ b/apps/dashboard/src/utils/geo-prefetch.server.ts
@@ -32,6 +32,51 @@ export async function dehydrateGeoOverviewQueries(
     ...dashboardOrpc.geo.overview.queryOptions({ input: input.overview }),
     queryFn: () => client.geo.overview(input.overview),
   });
+  void queryClient.prefetchQuery({
+    ...dashboardOrpc.geo.timeseries.queryOptions({ input: input.timeseries }),
+    queryFn: () => client.geo.timeseries(input.timeseries),
+  });
+  void queryClient.prefetchQuery({
+    ...dashboardOrpc.geo.promptsList.queryOptions({ input: input.prompts }),
+    queryFn: () => client.geo.promptsList(input.prompts),
+  });
+  void queryClient.prefetchQuery({
+    ...dashboardOrpc.geo.competitors.queryOptions({ input: input.competitors }),
+    queryFn: () => client.geo.competitors(input.competitors),
+  });
+
+  // Tab-specific queries mirror `useGeoOverviewPage` enablement.
+  if (input.activeTab === "journeys") {
+    void queryClient.prefetchQuery({
+      ...dashboardOrpc.geo.trafficJourneys.queryOptions({
+        input: input.trafficJourneys,
+      }),
+      queryFn: () => client.geo.trafficJourneys(input.trafficJourneys),
+    });
+  }
+  if (input.activeTab === "visibility" || input.activeTab === "prompts") {
+    void queryClient.prefetchQuery({
+      ...dashboardOrpc.geo.promptResultSummaries.queryOptions({
+        input: input.promptResultSummaries,
+      }),
+      queryFn: () =>
+        client.geo.promptResultSummaries(input.promptResultSummaries),
+    });
+  }
+  if (input.activeTab === "visibility") {
+    void queryClient.prefetchQuery({
+      ...dashboardOrpc.geo.competitorShare.queryOptions({
+        input: input.competitorShare,
+      }),
+      queryFn: () => client.geo.competitorShare(input.competitorShare),
+    });
+    void queryClient.prefetchQuery({
+      ...dashboardOrpc.geo.languageShare.queryOptions({
+        input: input.languageShare,
+      }),
+      queryFn: () => client.geo.languageShare(input.languageShare),
+    });
+  }
 
   return dehydrate(queryClient);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93c00090-4c1c-5de5-bc04-5042563ad146?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93c00090-4c1c-5de5-bc04-5042563ad146&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns geo overview server prefetch with the tab-gated hooks so each tab warms the queries it actually uses, and extracts gaps and shelf-space page logic into dedicated hooks.

- Competitor share and language share queries now only run when the visibility tab is active.
- Server prefetch now warms timeseries, prompts, competitors, and tab-specific queries to match hook enablement.
- `useGeoGapsPage` and `useGeoShelfPage` consolidate page state, handlers, and query orchestration out of the page components.

<sup>Written for commit 42d96d1dc061163364931fcf481d6f4206c6aac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

