### PR TITLE
fix(geo-core): decide brand mentions by string match on name and aliases

### DIFF
--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -70,6 +70,7 @@ import type {
   GeoSkipFields,
   GeoZdrMode,
 } from "../types/geo";
+import { findBrandMention } from "../utils/geo-brand-mention";
 import {
   geoBoxAgentForEngine,
   isGeoBoxCodingAgent,
@@ -231,7 +232,7 @@ ${answer}
 """
 
 Analyze the answer and report:
-- mentioned: true if the company or any alias appears in the answer.
+- mentioned: true only if the company name or an alias appears in the answer as the name of that specific company or product. Generic phrases that share words with the name (for example "an email SDK" when the company is "Email SDK") are not mentions.
 - position: the 1-based rank of the company among the recommended brands if the answer contains an ordered or bulleted list of brands, otherwise null.
 - sentiment: the sentiment expressed toward the company ("positive", "neutral" or "negative"), or null if it is not mentioned.
 - competitors: up to ${MAX_JUDGE_COMPETITORS} other brand or product names mentioned in the answer, excluding the company and its aliases.
@@ -416,10 +417,29 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
   answer: string
 ) {
   const models = yield* GeoModelService;
-  return yield* models.judge({
+  const judged = yield* models.judge({
     organizationId: context.organizationId,
     prompt: buildJudgePrompt(context, promptText, answer),
   });
+  const mentioned =
+    findBrandMention(answer, context.companyName, context.aliases) !== null;
+  if (judged.mentioned !== mentioned) {
+    yield* geoLogWarn({
+      event: "geo.check.judge_mention_mismatch",
+      organizationId: context.organizationId,
+      projectId: context.projectId,
+      scanId: context.scanId,
+      companyName: context.companyName,
+      judgeMentioned: judged.mentioned,
+      excerpt: judged.excerpt,
+    });
+  }
+  return {
+    ...judged,
+    mentioned,
+    position: mentioned ? judged.position : null,
+    sentiment: mentioned ? judged.sentiment : null,
+  };
 });
 
 const translatePrompts = Effect.fn("geo.translatePrompts")(function* (

--- a/packages/geo-core/src/utils/geo-brand-mention.ts
+++ b/packages/geo-core/src/utils/geo-brand-mention.ts
@@ -1,16 +1,46 @@
 const SEPARATOR_PATTERN = /[\s\-_/@.]+/g;
-const WORD_CHARACTER_PATTERN = /[\p{L}\p{N}]/u;
+const WORD_CHARACTER_PATTERN = /^[\p{L}\p{M}\p{N}]$/u;
+/** Scripts written without spaces between words; a Latin brand embedded in
+ * their running text still counts as a whole word. */
+const UNSPACED_SCRIPT_PATTERN =
+  /^[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Lao}\p{Script=Khmer}\p{Script=Myanmar}]$/u;
 
 /**
  * Collapses casing, whitespace and package-style punctuation so that
  * `@acme/email-sdk`, `email_sdk` and `Email SDK` share one form.
  */
 function normalizeBrandText(text: string): string {
-  return text.toLowerCase().replace(SEPARATOR_PATTERN, " ").trim();
+  return text
+    .normalize("NFC")
+    .toLowerCase()
+    .replace(SEPARATOR_PATTERN, " ")
+    .trim();
 }
 
-function isWordCharacter(character: string | undefined): boolean {
-  return character !== undefined && WORD_CHARACTER_PATTERN.test(character);
+function codePointBefore(text: string, index: number): string | undefined {
+  if (index <= 0) {
+    return undefined;
+  }
+  const low = text.charCodeAt(index - 1);
+  if (low >= 0xdc00 && low <= 0xdfff && index >= 2) {
+    const high = text.charCodeAt(index - 2);
+    if (high >= 0xd800 && high <= 0xdbff) {
+      return text.slice(index - 2, index);
+    }
+  }
+  return text[index - 1];
+}
+
+function codePointAt(text: string, index: number): string | undefined {
+  const codePoint = text.codePointAt(index);
+  return codePoint === undefined ? undefined : String.fromCodePoint(codePoint);
+}
+
+function isWordBoundary(character: string | undefined): boolean {
+  if (character === undefined || !WORD_CHARACTER_PATTERN.test(character)) {
+    return true;
+  }
+  return UNSPACED_SCRIPT_PATTERN.test(character);
 }
 
 function containsTerm(haystack: string, term: string): boolean {
@@ -20,9 +50,10 @@ function containsTerm(haystack: string, term: string): boolean {
     if (index === -1) {
       return false;
     }
-    const before = haystack[index - 1];
-    const after = haystack[index + term.length];
-    if (!isWordCharacter(before) && !isWordCharacter(after)) {
+    if (
+      isWordBoundary(codePointBefore(haystack, index)) &&
+      isWordBoundary(codePointAt(haystack, index + term.length))
+    ) {
       return true;
     }
     from = index + 1;

--- a/packages/geo-core/src/utils/geo-brand-mention.ts
+++ b/packages/geo-core/src/utils/geo-brand-mention.ts
@@ -1,0 +1,54 @@
+const SEPARATOR_PATTERN = /[\s\-_/@.]+/g;
+const WORD_CHARACTER_PATTERN = /[\p{L}\p{N}]/u;
+
+/**
+ * Collapses casing, whitespace and package-style punctuation so that
+ * `@acme/email-sdk`, `email_sdk` and `Email SDK` share one form.
+ */
+function normalizeBrandText(text: string): string {
+  return text.toLowerCase().replace(SEPARATOR_PATTERN, " ").trim();
+}
+
+function isWordCharacter(character: string | undefined): boolean {
+  return character !== undefined && WORD_CHARACTER_PATTERN.test(character);
+}
+
+function containsTerm(haystack: string, term: string): boolean {
+  let from = 0;
+  while (from <= haystack.length - term.length) {
+    const index = haystack.indexOf(term, from);
+    if (index === -1) {
+      return false;
+    }
+    const before = haystack[index - 1];
+    const after = haystack[index + term.length];
+    if (!isWordCharacter(before) && !isWordCharacter(after)) {
+      return true;
+    }
+    from = index + 1;
+  }
+  return false;
+}
+
+/**
+ * Returns the company name or alias that literally appears in the answer, or
+ * null when none does. This is the source of truth for `mentioned`; the judge
+ * model only supplies position, sentiment, competitors and excerpt.
+ */
+export function findBrandMention(
+  answer: string,
+  companyName: string,
+  aliases: readonly string[]
+): string | null {
+  const haystack = normalizeBrandText(answer);
+  if (haystack.length === 0) {
+    return null;
+  }
+  for (const term of [companyName, ...aliases]) {
+    const needle = normalizeBrandText(term);
+    if (needle.length > 0 && containsTerm(haystack, needle)) {
+      return term;
+    }
+  }
+  return null;
+}

--- a/packages/geo-core/tests/geo-brand-mention.test.ts
+++ b/packages/geo-core/tests/geo-brand-mention.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { findBrandMention } from "../src/utils/geo-brand-mention";
+
+describe("findBrandMention", () => {
+  test("matches the company name regardless of casing", () => {
+    expect(findBrandMention("Try RESEND for this.", "Resend", [])).toBe(
+      "Resend"
+    );
+  });
+
+  test("matches an alias and returns the alias as configured", () => {
+    expect(
+      findBrandMention(
+        "Install @opencoredev/email-sdk and you are done.",
+        "Mail Kit",
+        ["@opencoredev/email-sdk"]
+      )
+    ).toBe("@opencoredev/email-sdk");
+  });
+
+  test("treats spaces, hyphens, underscores and scopes as the same separator", () => {
+    expect(
+      findBrandMention("The email_sdk package is typed.", "Email SDK", [])
+    ).toBe("Email SDK");
+    expect(
+      findBrandMention(
+        "Use `email-sdk` for transactional mail.",
+        "Email SDK",
+        []
+      )
+    ).toBe("Email SDK");
+  });
+
+  test("rejects answers that only share words with the company name", () => {
+    const answer = `4. SendGrid, Mailgun, or Brevo — established all-rounders
+- All have typed Node SDKs (@sendgrid/mail, mailgun.js, @getbrevo/brevo)
+- Email sandbox for testing plus production sending, with a TypeScript SDK`;
+    expect(findBrandMention(answer, "Email SDK", [])).toBeNull();
+  });
+
+  test("does not match inside a longer word", () => {
+    expect(findBrandMention("Notrap is unrelated.", "Notra", [])).toBeNull();
+    expect(findBrandMention("Pick Notra.", "Notra", [])).toBe("Notra");
+  });
+
+  test("ignores empty aliases", () => {
+    expect(findBrandMention("Nothing here.", "Acme", ["", "  "])).toBeNull();
+  });
+});

--- a/packages/geo-core/tests/geo-brand-mention.test.ts
+++ b/packages/geo-core/tests/geo-brand-mention.test.ts
@@ -44,6 +44,31 @@ describe("findBrandMention", () => {
     expect(findBrandMention("Pick Notra.", "Notra", [])).toBe("Notra");
   });
 
+  test("treats combining marks and supplementary-plane letters as word characters", () => {
+    expect(
+      findBrandMention("Notra\u0301 is unrelated.", "Notra", [])
+    ).toBeNull();
+    expect(
+      findBrandMention("\u{1D400}Notra is unrelated.", "Notra", [])
+    ).toBeNull();
+    expect(
+      findBrandMention("Notra\u{1D400} is unrelated.", "Notra", [])
+    ).toBeNull();
+  });
+
+  test("matches a Latin brand embedded in unspaced scripts", () => {
+    expect(findBrandMention("メール送信にはResendを使う", "Resend", [])).toBe(
+      "Resend"
+    );
+    expect(findBrandMention("ใช้Resendสำหรับอีเมล", "Resend", [])).toBe("Resend");
+  });
+
+  test("matches decomposed and composed forms of the same name", () => {
+    expect(findBrandMention("Try Cafe\u0301 today.", "Caf\u00e9", [])).toBe(
+      "Caf\u00e9"
+    );
+  });
+
   test("ignores empty aliases", () => {
     expect(findBrandMention("Nothing here.", "Acme", ["", "  "])).toBeNull();
   });

--- a/packages/geo-core/tests/geo-brand-mention.test.ts
+++ b/packages/geo-core/tests/geo-brand-mention.test.ts
@@ -44,29 +44,22 @@ describe("findBrandMention", () => {
     expect(findBrandMention("Pick Notra.", "Notra", [])).toBe("Notra");
   });
 
-  test("treats combining marks and supplementary-plane letters as word characters", () => {
-    expect(
-      findBrandMention("Notra\u0301 is unrelated.", "Notra", [])
-    ).toBeNull();
-    expect(
-      findBrandMention("\u{1D400}Notra is unrelated.", "Notra", [])
-    ).toBeNull();
-    expect(
-      findBrandMention("Notra\u{1D400} is unrelated.", "Notra", [])
-    ).toBeNull();
-  });
-
-  test("matches a Latin brand embedded in unspaced scripts", () => {
-    expect(findBrandMention("メール送信にはResendを使う", "Resend", [])).toBe(
-      "Resend"
-    );
-    expect(findBrandMention("ใช้Resendสำหรับอีเมล", "Resend", [])).toBe("Resend");
-  });
-
-  test("matches decomposed and composed forms of the same name", () => {
-    expect(findBrandMention("Try Cafe\u0301 today.", "Caf\u00e9", [])).toBe(
+  test("compares names after NFC normalization", () => {
+    expect(findBrandMention("Try cafe\u0301 today.", "Caf\u00e9", [])).toBe(
       "Caf\u00e9"
     );
+  });
+
+  test("treats combining marks and supplementary-plane letters as word characters", () => {
+    expect(findBrandMention("Try cafe\u0305 today.", "cafe", [])).toBeNull();
+    expect(findBrandMention("Try foo\u{1D400} today.", "foo", [])).toBeNull();
+    expect(findBrandMention("\u{1D400}foo today.", "foo", [])).toBeNull();
+  });
+
+  test("matches brands inside scripts written without spaces", () => {
+    expect(findBrandMention("推荐腾讯云和相关产品。", "腾讯", [])).toBe("腾讯");
+    expect(findBrandMention("推荐Notra给团队。", "Notra", [])).toBe("Notra");
+    expect(findBrandMention("ใช้Notraสำหรับอีเมล", "Notra", [])).toBe("Notra");
   });
 
   test("ignores empty aliases", () => {

--- a/packages/geo-core/tests/model-scan.test.ts
+++ b/packages/geo-core/tests/model-scan.test.ts
@@ -271,6 +271,45 @@ describe("model service in real scan batches", () => {
     expect(row?.answer).toBe("The selected brand is a good choice.");
   });
 
+  test("judge mention is rejected when the brand never appears in the answer", async () => {
+    const scope = await seedProject("absent");
+    await testDb.insert(geoScans).values({ id: "scan-test", ...scope });
+    const result = await Effect.runPromise(
+      runGeoScanTaskBatch(
+        {
+          ...scope,
+          scanId: "scan-test",
+          runId: "test-run",
+          companyName: "Email SDK",
+          aliases: ["@opencoredev/email-sdk"],
+          gate: testBillingGate,
+          startedAtMs: Date.now(),
+        },
+        [
+          {
+            engine: "openai/gpt-4o-mini",
+            groundedKey: null,
+            prompt: {
+              id: "custom-absent",
+              text: "Which tools should I choose?",
+            },
+            language: "English",
+            zdr: "none",
+          },
+        ]
+      ).pipe(
+        Effect.provideService(GeoModelService, fakeModels),
+        Effect.provideService(GeoFeatureFlagService, testFeatureFlags)
+      )
+    );
+    expect(result.checks).toBe(1);
+    expect(result.mentions).toBe(0);
+    const [row] = await testDb.select().from(geoMentionChecks);
+    expect(row?.mentioned).toBe(false);
+    expect(row?.position).toBeNull();
+    expect(row?.sentiment).toBeNull();
+  });
+
   test("typed provider refusal drops the check without a domain retry", async () => {
     const scope = await seedProject("selected");
     let attempts = 0;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes geo scan brand detection so the judge model no longer decides whether a brand was mentioned. Previously, generic or contextual matches could count; now `mentioned` requires the company name or an alias to appear as a whole-word match, otherwise position and sentiment are cleared.

- Normalizes casing, Unicode, spaces, hyphens, underscores, scopes, slashes, and periods when matching.
- Checks boundaries by code point, including Latin brands in scripts without spaces, and logs disagreements with the judge.

<sup>Written for commit 2d8ab95fe302cf36eafa87513216327ad08731b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

