### PR TITLE
fix(geo-core): inspect unicode code points for brand mention boundaries

### DIFF
--- a/packages/geo-core/src/geo/scan.ts
+++ b/packages/geo-core/src/geo/scan.ts
@@ -70,6 +70,7 @@ import type {
   GeoSkipFields,
   GeoZdrMode,
 } from "../types/geo";
+import { findBrandMention } from "../utils/geo-brand-mention";
 import {
   geoBoxAgentForEngine,
   isGeoBoxCodingAgent,
@@ -231,7 +232,7 @@ ${answer}
 """
 
 Analyze the answer and report:
-- mentioned: true if the company or any alias appears in the answer.
+- mentioned: true only if the company name or an alias appears in the answer as the name of that specific company or product. Generic phrases that share words with the name (for example "an email SDK" when the company is "Email SDK") are not mentions.
 - position: the 1-based rank of the company among the recommended brands if the answer contains an ordered or bulleted list of brands, otherwise null.
 - sentiment: the sentiment expressed toward the company ("positive", "neutral" or "negative"), or null if it is not mentioned.
 - competitors: up to ${MAX_JUDGE_COMPETITORS} other brand or product names mentioned in the answer, excluding the company and its aliases.
@@ -416,10 +417,29 @@ const judgeAnswer = Effect.fn("geo.judgeAnswer")(function* (
   answer: string
 ) {
   const models = yield* GeoModelService;
-  return yield* models.judge({
+  const judged = yield* models.judge({
     organizationId: context.organizationId,
     prompt: buildJudgePrompt(context, promptText, answer),
   });
+  const mentioned =
+    findBrandMention(answer, context.companyName, context.aliases) !== null;
+  if (judged.mentioned !== mentioned) {
+    yield* geoLogWarn({
+      event: "geo.check.judge_mention_mismatch",
+      organizationId: context.organizationId,
+      projectId: context.projectId,
+      scanId: context.scanId,
+      companyName: context.companyName,
+      judgeMentioned: judged.mentioned,
+      excerpt: judged.excerpt,
+    });
+  }
+  return {
+    ...judged,
+    mentioned,
+    position: mentioned ? judged.position : null,
+    sentiment: mentioned ? judged.sentiment : null,
+  };
 });
 
 const translatePrompts = Effect.fn("geo.translatePrompts")(function* (

--- a/packages/geo-core/src/utils/geo-brand-mention.ts
+++ b/packages/geo-core/src/utils/geo-brand-mention.ts
@@ -1,5 +1,9 @@
 const SEPARATOR_PATTERN = /[\s\-_/@.]+/g;
-const WORD_CHARACTER_PATTERN = /[\p{L}\p{N}]/u;
+const WORD_CHARACTER_PATTERN = /[\p{L}\p{N}\p{M}]/u;
+const LEAD_SURROGATE_MIN = 0xd800;
+const LEAD_SURROGATE_MAX = 0xdbff;
+const TRAIL_SURROGATE_MIN = 0xdc00;
+const TRAIL_SURROGATE_MAX = 0xdfff;
 
 /**
  * Collapses casing, whitespace and package-style punctuation so that
@@ -13,6 +17,50 @@ function isWordCharacter(character: string | undefined): boolean {
   return character !== undefined && WORD_CHARACTER_PATTERN.test(character);
 }
 
+function isLeadSurrogate(unit: number): boolean {
+  return unit >= LEAD_SURROGATE_MIN && unit <= LEAD_SURROGATE_MAX;
+}
+
+function isTrailSurrogate(unit: number): boolean {
+  return unit >= TRAIL_SURROGATE_MIN && unit <= TRAIL_SURROGATE_MAX;
+}
+
+function codePointStringAt(
+  text: string,
+  index: number
+): string | undefined {
+  if (index < 0 || index >= text.length) {
+    return undefined;
+  }
+  const codePoint = text.codePointAt(index);
+  if (codePoint === undefined) {
+    return undefined;
+  }
+  return String.fromCodePoint(codePoint);
+}
+
+/**
+ * Returns the code point that ends immediately before `index`. JavaScript
+ * string indexes are UTF-16 units, so `text[index - 1]` can be a trail
+ * surrogate rather than the preceding letter.
+ */
+function codePointStringBefore(
+  text: string,
+  index: number
+): string | undefined {
+  if (index <= 0 || index > text.length) {
+    return undefined;
+  }
+  const trail = text.charCodeAt(index - 1);
+  if (index >= 2 && isTrailSurrogate(trail)) {
+    const lead = text.charCodeAt(index - 2);
+    if (isLeadSurrogate(lead)) {
+      return codePointStringAt(text, index - 2);
+    }
+  }
+  return text[index - 1];
+}
+
 function containsTerm(haystack: string, term: string): boolean {
   let from = 0;
   while (from <= haystack.length - term.length) {
@@ -20,8 +68,8 @@ function containsTerm(haystack: string, term: string): boolean {
     if (index === -1) {
       return false;
     }
-    const before = haystack[index - 1];
-    const after = haystack[index + term.length];
+    const before = codePointStringBefore(haystack, index);
+    const after = codePointStringAt(haystack, index + term.length);
     if (!isWordCharacter(before) && !isWordCharacter(after)) {
       return true;
     }

--- a/packages/geo-core/src/utils/geo-brand-mention.ts
+++ b/packages/geo-core/src/utils/geo-brand-mention.ts
@@ -1,0 +1,54 @@
+const SEPARATOR_PATTERN = /[\s\-_/@.]+/g;
+const WORD_CHARACTER_PATTERN = /[\p{L}\p{N}]/u;
+
+/**
+ * Collapses casing, whitespace and package-style punctuation so that
+ * `@acme/email-sdk`, `email_sdk` and `Email SDK` share one form.
+ */
+function normalizeBrandText(text: string): string {
+  return text.toLowerCase().replace(SEPARATOR_PATTERN, " ").trim();
+}
+
+function isWordCharacter(character: string | undefined): boolean {
+  return character !== undefined && WORD_CHARACTER_PATTERN.test(character);
+}
+
+function containsTerm(haystack: string, term: string): boolean {
+  let from = 0;
+  while (from <= haystack.length - term.length) {
+    const index = haystack.indexOf(term, from);
+    if (index === -1) {
+      return false;
+    }
+    const before = haystack[index - 1];
+    const after = haystack[index + term.length];
+    if (!isWordCharacter(before) && !isWordCharacter(after)) {
+      return true;
+    }
+    from = index + 1;
+  }
+  return false;
+}
+
+/**
+ * Returns the company name or alias that literally appears in the answer, or
+ * null when none does. This is the source of truth for `mentioned`; the judge
+ * model only supplies position, sentiment, competitors and excerpt.
+ */
+export function findBrandMention(
+  answer: string,
+  companyName: string,
+  aliases: readonly string[]
+): string | null {
+  const haystack = normalizeBrandText(answer);
+  if (haystack.length === 0) {
+    return null;
+  }
+  for (const term of [companyName, ...aliases]) {
+    const needle = normalizeBrandText(term);
+    if (needle.length > 0 && containsTerm(haystack, needle)) {
+      return term;
+    }
+  }
+  return null;
+}

--- a/packages/geo-core/tests/geo-brand-mention.test.ts
+++ b/packages/geo-core/tests/geo-brand-mention.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { findBrandMention } from "../src/utils/geo-brand-mention";
+
+describe("findBrandMention", () => {
+  test("matches the company name regardless of casing", () => {
+    expect(findBrandMention("Try RESEND for this.", "Resend", [])).toBe(
+      "Resend"
+    );
+  });
+
+  test("matches an alias and returns the alias as configured", () => {
+    expect(
+      findBrandMention(
+        "Install @opencoredev/email-sdk and you are done.",
+        "Mail Kit",
+        ["@opencoredev/email-sdk"]
+      )
+    ).toBe("@opencoredev/email-sdk");
+  });
+
+  test("treats spaces, hyphens, underscores and scopes as the same separator", () => {
+    expect(
+      findBrandMention("The email_sdk package is typed.", "Email SDK", [])
+    ).toBe("Email SDK");
+    expect(
+      findBrandMention(
+        "Use `email-sdk` for transactional mail.",
+        "Email SDK",
+        []
+      )
+    ).toBe("Email SDK");
+  });
+
+  test("rejects answers that only share words with the company name", () => {
+    const answer = `4. SendGrid, Mailgun, or Brevo — established all-rounders
+- All have typed Node SDKs (@sendgrid/mail, mailgun.js, @getbrevo/brevo)
+- Email sandbox for testing plus production sending, with a TypeScript SDK`;
+    expect(findBrandMention(answer, "Email SDK", [])).toBeNull();
+  });
+
+  test("does not match inside a longer word", () => {
+    expect(findBrandMention("Notrap is unrelated.", "Notra", [])).toBeNull();
+    expect(findBrandMention("Pick Notra.", "Notra", [])).toBe("Notra");
+  });
+
+  test("ignores empty aliases", () => {
+    expect(findBrandMention("Nothing here.", "Acme", ["", "  "])).toBeNull();
+  });
+});

--- a/packages/geo-core/tests/geo-brand-mention.test.ts
+++ b/packages/geo-core/tests/geo-brand-mention.test.ts
@@ -44,6 +44,28 @@ describe("findBrandMention", () => {
     expect(findBrandMention("Pick Notra.", "Notra", [])).toBe("Notra");
   });
 
+  test("does not match when a combining mark continues the word", () => {
+    expect(
+      findBrandMention("Notra\u0301xyz is unrelated.", "Notra", [])
+    ).toBeNull();
+    expect(findBrandMention("Pick Notra\u0301.", "Notra", [])).toBeNull();
+  });
+
+  test("does not match when a supplementary-plane letter continues the word", () => {
+    expect(
+      findBrandMention("Notra\u{1D400} is unrelated.", "Notra", [])
+    ).toBeNull();
+    expect(
+      findBrandMention("\u{1D400}Notra is unrelated.", "Notra", [])
+    ).toBeNull();
+  });
+
+  test("still matches when a supplementary-plane letter is a separate word", () => {
+    expect(findBrandMention("Pick Notra \u{1D400}.", "Notra", [])).toBe(
+      "Notra"
+    );
+  });
+
   test("ignores empty aliases", () => {
     expect(findBrandMention("Nothing here.", "Acme", ["", "  "])).toBeNull();
   });

--- a/packages/geo-core/tests/model-scan.test.ts
+++ b/packages/geo-core/tests/model-scan.test.ts
@@ -271,6 +271,45 @@ describe("model service in real scan batches", () => {
     expect(row?.answer).toBe("The selected brand is a good choice.");
   });
 
+  test("judge mention is rejected when the brand never appears in the answer", async () => {
+    const scope = await seedProject("absent");
+    await testDb.insert(geoScans).values({ id: "scan-test", ...scope });
+    const result = await Effect.runPromise(
+      runGeoScanTaskBatch(
+        {
+          ...scope,
+          scanId: "scan-test",
+          runId: "test-run",
+          companyName: "Email SDK",
+          aliases: ["@opencoredev/email-sdk"],
+          gate: testBillingGate,
+          startedAtMs: Date.now(),
+        },
+        [
+          {
+            engine: "openai/gpt-4o-mini",
+            groundedKey: null,
+            prompt: {
+              id: "custom-absent",
+              text: "Which tools should I choose?",
+            },
+            language: "English",
+            zdr: "none",
+          },
+        ]
+      ).pipe(
+        Effect.provideService(GeoModelService, fakeModels),
+        Effect.provideService(GeoFeatureFlagService, testFeatureFlags)
+      )
+    );
+    expect(result.checks).toBe(1);
+    expect(result.mentions).toBe(0);
+    const [row] = await testDb.select().from(geoMentionChecks);
+    expect(row?.mentioned).toBe(false);
+    expect(row?.position).toBeNull();
+    expect(row?.sentiment).toBeNull();
+  });
+
   test("typed provider refusal drops the check without a domain retry", async () => {
     const scope = await seedProject("selected");
     let attempts = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Continues #1021. Brand mention matching indexed UTF-16 code units and treated combining marks as non-word characters, so a name next to a combining mark or a supplementary-plane letter could match inside a longer Unicode word. Boundary checks now read full code points, and combining marks count as word characters.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5e2b4e9-764a-47cf-939a-b28a16c01109?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5e2b4e9-764a-47cf-939a-b28a16c01109&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes brand mention detection in `geo-core` so a company name no longer matches inside a longer Unicode word. Boundary checks now read full code points and treat combining marks as word characters instead of using UTF-16 indexes.

Also makes the literal brand mention string match the source of truth for the `mentioned` flag, overriding the judge model when they disagree. The judge still supplies position, sentiment, competitors, and excerpt, but only when the brand actually appears in the answer.

**Bug Fixes**
- The judge prompt now instructs the model to ignore generic phrases that only share words with the brand name.
- When the judge and string match disagree, a `geo.check.judge_mention_mismatch` warning is logged with scan context.

<sup>Written for commit 893ad5654c01a5a313103cb4e1e9e0b82dbf803b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

