### PR TITLE
refactor(api): migrate feedback list/get/patch to Effect programs

### DIFF
--- a/apps/api/src/errors/feedback.ts
+++ b/apps/api/src/errors/feedback.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable unicorn/throw-new-error -- Schema.TaggedError is a curried class factory, not a constructor. */
 import { Schema } from "effect";
 
 export class FeedbackProjectNotFoundError extends Schema.TaggedError<FeedbackProjectNotFoundError>()(

--- a/apps/api/src/programs/feedback.ts
+++ b/apps/api/src/programs/feedback.ts
@@ -1,6 +1,6 @@
 import { classifyAgentFeedback } from "@notra/ai/jobs/feedback-classifier";
 import { agentFeedback, projects } from "@notra/db/schema";
-import { and, eq } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 import { Effect } from "effect";
 import { nanoid } from "nanoid";
 
@@ -10,8 +10,12 @@ import {
   FeedbackProjectNotFoundError,
 } from "../errors/feedback";
 import type {
+  ListFeedbackProgramInput,
+  ListFeedbackProgramSuccess,
+  NamedFeedbackProgramInput,
   SubmitFeedbackProgramInput,
   SubmitFeedbackProgramSuccess,
+  UpdateFeedbackProgramInput,
 } from "../types/feedback";
 
 const database = <A>(operation: () => Promise<A>) =>
@@ -56,6 +60,111 @@ const findByIdempotencyKey = (
       ),
     })
   );
+
+const findByOrganizationAndId = (
+  db: NamedFeedbackProgramInput["db"],
+  organizationId: string,
+  feedbackId: string
+) =>
+  database(() =>
+    db.query.agentFeedback.findFirst({
+      where: and(
+        eq(agentFeedback.organizationId, organizationId),
+        eq(agentFeedback.id, feedbackId)
+      ),
+    })
+  );
+
+export const listFeedback = Effect.fn("feedback.list")(function* ({
+  db,
+  organizationId,
+  query,
+}: ListFeedbackProgramInput) {
+  const conditions = [eq(agentFeedback.organizationId, organizationId)];
+  if (query.status) {
+    conditions.push(eq(agentFeedback.status, query.status));
+  }
+  if (query.kind) {
+    conditions.push(eq(agentFeedback.kind, query.kind));
+  }
+  if (query.projectId) {
+    conditions.push(eq(agentFeedback.projectId, query.projectId));
+  }
+  const where = and(...conditions);
+
+  const [[totals], rows] = yield* database(() =>
+    Promise.all([
+      db.select({ total: count() }).from(agentFeedback).where(where),
+      db
+        .select()
+        .from(agentFeedback)
+        .where(where)
+        .orderBy(desc(agentFeedback.createdAt))
+        .limit(query.limit)
+        .offset((query.page - 1) * query.limit),
+    ])
+  );
+
+  const totalItems = totals?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / query.limit));
+
+  return {
+    feedback: rows,
+    pagination: {
+      limit: query.limit,
+      currentPage: query.page,
+      nextPage: query.page < totalPages ? query.page + 1 : null,
+      previousPage: query.page > 1 ? query.page - 1 : null,
+      totalPages,
+      totalItems,
+    },
+  } satisfies ListFeedbackProgramSuccess;
+});
+
+export const getFeedback = Effect.fn("feedback.get")(function* (
+  input: NamedFeedbackProgramInput
+) {
+  const row = yield* findByOrganizationAndId(
+    input.db,
+    input.organizationId,
+    input.feedbackId
+  );
+
+  if (!row) {
+    return yield* new FeedbackNotFoundError();
+  }
+
+  return row;
+});
+
+export const updateFeedback = Effect.fn("feedback.update")(function* ({
+  db,
+  organizationId,
+  feedbackId,
+  body,
+}: UpdateFeedbackProgramInput) {
+  const [updated] = yield* database(() =>
+    db
+      .update(agentFeedback)
+      .set({
+        status: body.status,
+        resolvedAt: body.status === "resolved" ? new Date() : null,
+      })
+      .where(
+        and(
+          eq(agentFeedback.organizationId, organizationId),
+          eq(agentFeedback.id, feedbackId)
+        )
+      )
+      .returning()
+  );
+
+  if (!updated) {
+    return yield* new FeedbackNotFoundError();
+  }
+
+  return updated;
+});
 
 export const submitFeedback = Effect.fn("feedback.submit")(function* ({
   db,

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -1,5 +1,4 @@
 import { createRoute } from "@hono/zod-openapi";
-import { agentFeedback } from "@notra/db/schema";
 import {
   feedbackOrganizationParamsSchema,
   feedbackParamsSchema,
@@ -10,7 +9,6 @@ import {
   submitFeedbackResponseSchema,
   updateFeedbackRequestSchema,
 } from "@notra/schemas/api/feedback";
-import { and, count, desc, eq } from "drizzle-orm";
 
 import { API_FEEDBACK_VIA } from "../constants/analytics";
 import {
@@ -19,7 +17,12 @@ import {
   FEEDBACK_PROJECT_NOT_FOUND_ERROR,
 } from "../constants/feedback";
 import { ORGANIZATION_SCOPED_API_KEY_ERROR } from "../constants/skills";
-import { submitFeedback as submitFeedbackProgram } from "../programs/feedback";
+import {
+  getFeedback as getFeedbackProgram,
+  listFeedback as listFeedbackProgram,
+  submitFeedback as submitFeedbackProgram,
+  updateFeedback as updateFeedbackProgram,
+} from "../programs/feedback";
 import { trackFeedbackReceived } from "../utils/analytics";
 import { getOrganizationId } from "../utils/auth";
 import {
@@ -275,45 +278,23 @@ feedbackRoutes.openapi(listFeedbackRoute, async (c) => {
     return c.json({ error: ORGANIZATION_SCOPED_API_KEY_ERROR }, 403);
   }
 
-  const query = c.req.valid("query");
-  const conditions = [eq(agentFeedback.organizationId, organizationId)];
-  if (query.status) {
-    conditions.push(eq(agentFeedback.status, query.status));
+  const result = await runFeedbackProgram(
+    listFeedbackProgram({
+      db: c.get("db"),
+      organizationId,
+      query: c.req.valid("query"),
+    })
+  );
+  if (result._tag === "Failure") {
+    throw result.failure;
   }
-  if (query.kind) {
-    conditions.push(eq(agentFeedback.kind, query.kind));
-  }
-  if (query.projectId) {
-    conditions.push(eq(agentFeedback.projectId, query.projectId));
-  }
-  const where = and(...conditions);
 
-  const db = c.get("db");
-  const [[totals], rows] = await Promise.all([
-    db.select({ total: count() }).from(agentFeedback).where(where),
-    db
-      .select()
-      .from(agentFeedback)
-      .where(where)
-      .orderBy(desc(agentFeedback.createdAt))
-      .limit(query.limit)
-      .offset((query.page - 1) * query.limit),
-  ]);
-
-  const totalItems = totals?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(totalItems / query.limit));
+  const { feedback, pagination } = result.success;
 
   return c.json(
     {
-      feedback: rows.map(serializeFeedback),
-      pagination: {
-        limit: query.limit,
-        currentPage: query.page,
-        nextPage: query.page < totalPages ? query.page + 1 : null,
-        previousPage: query.page > 1 ? query.page - 1 : null,
-        totalPages,
-        totalItems,
-      },
+      feedback: feedback.map(serializeFeedback),
+      pagination,
     },
     200
   );
@@ -326,18 +307,21 @@ feedbackRoutes.openapi(getFeedbackRoute, async (c) => {
   }
 
   const { feedbackId } = c.req.valid("param");
-  const row = await c.get("db").query.agentFeedback.findFirst({
-    where: and(
-      eq(agentFeedback.organizationId, organizationId),
-      eq(agentFeedback.id, feedbackId)
-    ),
-  });
-
-  if (!row) {
-    return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+  const result = await runFeedbackProgram(
+    getFeedbackProgram({
+      db: c.get("db"),
+      organizationId,
+      feedbackId,
+    })
+  );
+  if (result._tag === "Failure") {
+    if (result.failure._tag === "FeedbackNotFoundError") {
+      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    }
+    throw result.failure;
   }
 
-  return c.json({ feedback: serializeFeedback(row) }, 200);
+  return c.json({ feedback: serializeFeedback(result.success) }, 200);
 });
 
 feedbackRoutes.openapi(updateFeedbackRoute, async (c) => {
@@ -347,26 +331,20 @@ feedbackRoutes.openapi(updateFeedbackRoute, async (c) => {
   }
 
   const { feedbackId } = c.req.valid("param");
-  const body = c.req.valid("json");
-
-  const [updated] = await c
-    .get("db")
-    .update(agentFeedback)
-    .set({
-      status: body.status,
-      resolvedAt: body.status === "resolved" ? new Date() : null,
+  const result = await runFeedbackProgram(
+    updateFeedbackProgram({
+      db: c.get("db"),
+      organizationId,
+      feedbackId,
+      body: c.req.valid("json"),
     })
-    .where(
-      and(
-        eq(agentFeedback.organizationId, organizationId),
-        eq(agentFeedback.id, feedbackId)
-      )
-    )
-    .returning();
-
-  if (!updated) {
-    return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+  );
+  if (result._tag === "Failure") {
+    if (result.failure._tag === "FeedbackNotFoundError") {
+      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    }
+    throw result.failure;
   }
 
-  return c.json({ feedback: serializeFeedback(updated) }, 200);
+  return c.json({ feedback: serializeFeedback(result.success) }, 200);
 });

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -28,6 +28,7 @@ import { getOrganizationId } from "../utils/auth";
 import {
   findOrganizationIdBySlug,
   getIngestProjectId,
+  respondToFeedbackFailure,
   runFeedbackProgram,
   serializeFeedback,
 } from "../utils/feedback";
@@ -209,11 +210,9 @@ feedbackRoutes.openapi(submitOrganizationFeedbackRoute, async (c) => {
     })
   );
   if (result._tag === "Failure") {
-    if (result.failure._tag === "FeedbackProjectNotFoundError") {
-      return c.json({ error: FEEDBACK_PROJECT_NOT_FOUND_ERROR }, 404);
-    }
-    if (result.failure._tag === "FeedbackNotFoundError") {
-      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    const response = respondToFeedbackFailure(c, result.failure);
+    if (response) {
+      return response;
     }
     throw result.failure;
   }
@@ -251,11 +250,9 @@ feedbackRoutes.openapi(submitFeedbackRoute, async (c) => {
     })
   );
   if (result._tag === "Failure") {
-    if (result.failure._tag === "FeedbackProjectNotFoundError") {
-      return c.json({ error: FEEDBACK_PROJECT_NOT_FOUND_ERROR }, 404);
-    }
-    if (result.failure._tag === "FeedbackNotFoundError") {
-      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    const response = respondToFeedbackFailure(c, result.failure);
+    if (response) {
+      return response;
     }
     throw result.failure;
   }
@@ -315,8 +312,9 @@ feedbackRoutes.openapi(getFeedbackRoute, async (c) => {
     })
   );
   if (result._tag === "Failure") {
-    if (result.failure._tag === "FeedbackNotFoundError") {
-      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    const response = respondToFeedbackFailure(c, result.failure);
+    if (response) {
+      return response;
     }
     throw result.failure;
   }
@@ -340,8 +338,9 @@ feedbackRoutes.openapi(updateFeedbackRoute, async (c) => {
     })
   );
   if (result._tag === "Failure") {
-    if (result.failure._tag === "FeedbackNotFoundError") {
-      return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+    const response = respondToFeedbackFailure(c, result.failure);
+    if (response) {
+      return response;
     }
     throw result.failure;
   }

--- a/apps/api/src/types/feedback.ts
+++ b/apps/api/src/types/feedback.ts
@@ -1,6 +1,10 @@
 import type { z } from "@hono/zod-openapi";
 import type { agentFeedback } from "@notra/db/schema";
-import type { submitFeedbackRequestSchema } from "@notra/schemas/api/feedback";
+import type {
+  listFeedbackQuerySchema,
+  submitFeedbackRequestSchema,
+  updateFeedbackRequestSchema,
+} from "@notra/schemas/api/feedback";
 import type { IngestTokenIdentity } from "@notra/utils/types/ingest-token";
 
 import type {
@@ -17,18 +21,45 @@ export type FeedbackDomainError =
   | FeedbackProjectNotFoundError
   | FeedbackNotFoundError;
 
-export interface SubmitFeedbackProgramInput {
+interface FeedbackProgramInput {
   db: DbClient;
   organizationId: string;
+}
+
+export interface SubmitFeedbackProgramInput extends FeedbackProgramInput {
   body: SubmitFeedbackBody;
   /** Set when the request is authenticated with a project-bound ingest token. */
   ingestProjectId?: string;
   userAgent?: string | null;
 }
 
+export interface ListFeedbackProgramInput extends FeedbackProgramInput {
+  query: z.infer<typeof listFeedbackQuerySchema>;
+}
+
+export interface NamedFeedbackProgramInput extends FeedbackProgramInput {
+  feedbackId: string;
+}
+
+export interface UpdateFeedbackProgramInput extends NamedFeedbackProgramInput {
+  body: z.infer<typeof updateFeedbackRequestSchema>;
+}
+
 export interface SubmitFeedbackProgramSuccess {
   feedback: AgentFeedbackRow;
   deduplicated: boolean;
+}
+
+export interface ListFeedbackProgramSuccess {
+  feedback: AgentFeedbackRow[];
+  pagination: {
+    limit: number;
+    currentPage: number;
+    nextPage: number | null;
+    previousPage: number | null;
+    totalPages: number;
+    totalItems: number;
+  };
 }
 
 export type SerializedAgentFeedback = Omit<

--- a/apps/api/src/utils/feedback.ts
+++ b/apps/api/src/utils/feedback.ts
@@ -3,6 +3,10 @@ import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 import type { Context } from "hono";
 
+import {
+  FEEDBACK_NOT_FOUND_ERROR,
+  FEEDBACK_PROJECT_NOT_FOUND_ERROR,
+} from "../constants/feedback";
 import type { FeedbackDatabaseError } from "../errors/feedback";
 import { isIngestAuth } from "../types/auth";
 import type {
@@ -64,4 +68,16 @@ export function runFeedbackProgram<A, E extends FeedbackDomainError>(
       )
     )
   );
+}
+
+export function respondToFeedbackFailure(
+  c: Context,
+  failure: FeedbackDomainError
+) {
+  if (failure._tag === "FeedbackProjectNotFoundError") {
+    return c.json({ error: FEEDBACK_PROJECT_NOT_FOUND_ERROR }, 404);
+  }
+  if (failure._tag === "FeedbackNotFoundError") {
+    return c.json({ error: FEEDBACK_NOT_FOUND_ERROR }, 404);
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Extend the feedback Effect migration to list, get, and patch handlers. Business logic moves into `programs/feedback.ts`; route handlers delegate through `runFeedbackProgram`. Submit handlers are unchanged.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cc3af53-92fc-5c97-8a37-78a8456193df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cc3af53-92fc-5c97-8a37-78a8456193df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates feedback list, get, and patch route handlers to Effect programs, moving business logic into `programs/feedback.ts`. Route handlers now delegate through `runFeedbackProgram`; behavior is unchanged.

**Refactors**
- Adds `listFeedback`, `getFeedback`, and `updateFeedback` programs with shared program input types.
- Moves not-found handling for get and update into the programs, returning `FeedbackNotFoundError` for the routes to map to 404s.
- Centralizes 404 error responses in `respondToFeedbackFailure`, now also used by submit handlers, and removes an unused oxlint-disable.

<sup>Written for commit de06cd323ff3a5bd760799c8f1ae882a8f604dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

