### PR TITLE
refactor(api): consolidate GEO runtime bridge into runtime/geo

### DIFF
--- a/apps/api/src/routes/geo-agent-readiness.ts
+++ b/apps/api/src/routes/geo-agent-readiness.ts
@@ -22,9 +22,9 @@ import {
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
 import { geoCoreApiLayer } from "../lib/geo/configure";
+import { runGeoEffect } from "../runtime/geo";
 import { trackApiEvent } from "../utils/analytics";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { logError } from "../utils/logging";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { rateLimitResponse } from "../utils/openapi-responses";

--- a/apps/api/src/routes/geo-briefs.ts
+++ b/apps/api/src/routes/geo-briefs.ts
@@ -24,9 +24,9 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect, runRemoteGeoEffect } from "../runtime/geo";
 import { trackApiEvent } from "../utils/analytics";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect, runRemoteGeoEffect } from "../utils/geo-effect";
 import {
   getInternalWorkflowUrl,
   SYNCHRONOUS_INTERNAL_CALL_TIMEOUT_MS,

--- a/apps/api/src/routes/geo-competitors.ts
+++ b/apps/api/src/routes/geo-competitors.ts
@@ -27,8 +27,8 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect } from "../runtime/geo";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { rateLimitResponse } from "../utils/openapi-responses";
 import { enforceRatelimit, RATE_LIMITS, ratelimit } from "../utils/ratelimit";

--- a/apps/api/src/routes/geo-projects.ts
+++ b/apps/api/src/routes/geo-projects.ts
@@ -18,8 +18,8 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect } from "../runtime/geo";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { createOpenApiApp } from "../utils/openapi-app";
 
 export const geoProjectsRoutes = createOpenApiApp();

--- a/apps/api/src/routes/geo-prompts.ts
+++ b/apps/api/src/routes/geo-prompts.ts
@@ -26,8 +26,8 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect } from "../runtime/geo";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { rateLimitResponse } from "../utils/openapi-responses";
 import { enforceRatelimit, RATE_LIMITS, ratelimit } from "../utils/ratelimit";

--- a/apps/api/src/routes/geo-scans.ts
+++ b/apps/api/src/routes/geo-scans.ts
@@ -19,9 +19,9 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect } from "../runtime/geo";
 import { trackApiEvent } from "../utils/analytics";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { rateLimitResponse } from "../utils/openapi-responses";
 import { enforceRatelimit, RATE_LIMITS, ratelimit } from "../utils/ratelimit";

--- a/apps/api/src/routes/geo-sequences.ts
+++ b/apps/api/src/routes/geo-sequences.ts
@@ -26,9 +26,9 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect, runRemoteGeoEffect } from "../runtime/geo";
 import { trackApiEvent } from "../utils/analytics";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect, runRemoteGeoEffect } from "../utils/geo-effect";
 import {
   getInternalWorkflowUrl,
   SYNCHRONOUS_INTERNAL_CALL_TIMEOUT_MS,

--- a/apps/api/src/routes/geo-settings.ts
+++ b/apps/api/src/routes/geo-settings.ts
@@ -13,8 +13,8 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect } from "../runtime/geo";
 import { findGeoSelectionError, geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { createOpenApiApp } from "../utils/openapi-app";
 
 export const geoSettingsRoutes = createOpenApiApp();

--- a/apps/api/src/routes/geo-traffic.ts
+++ b/apps/api/src/routes/geo-traffic.ts
@@ -34,8 +34,8 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect } from "../runtime/geo";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { logError } from "../utils/logging";
 import { createOpenApiApp } from "../utils/openapi-app";
 

--- a/apps/api/src/routes/geo-visibility.ts
+++ b/apps/api/src/routes/geo-visibility.ts
@@ -24,8 +24,8 @@ import {
   GEO_COMMON_ERROR_RESPONSES,
   GEO_OPENAPI_TAG,
 } from "../constants/geo-openapi";
+import { runGeoEffect } from "../runtime/geo";
 import { geoErrorResponse } from "../utils/geo";
-import { runGeoEffect } from "../utils/geo-effect";
 import { createOpenApiApp } from "../utils/openapi-app";
 
 /**

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -32,6 +32,7 @@ import {
 import { and, count, eq, inArray, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 
+import { runGeoEffect } from "../runtime/geo";
 import { addActiveGeneration } from "../utils/active-generations";
 import { getOrganizationId } from "../utils/auth";
 import {
@@ -42,7 +43,6 @@ import {
   resolveRequestedRepositoryIds,
   triggerContentGenerationWorkflow,
 } from "../utils/content-generation";
-import { runGeoEffect } from "../utils/geo-effect";
 import {
   extractTitleFromMarkdown,
   renderMarkdownToHtml,

--- a/apps/api/src/runtime/geo.ts
+++ b/apps/api/src/runtime/geo.ts
@@ -17,8 +17,8 @@ import {
   callDashboardInternal,
   InternalDashboardError,
   InternalDashboardTimeoutError,
-} from "./internal-workflow";
-import { logError } from "./logging";
+} from "../utils/internal-workflow";
+import { logError } from "../utils/logging";
 
 /**
  * Maps a tagged GEO failure onto an HTTP status and a client-safe message.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Move `runGeoEffect` and `runRemoteGeoEffect` from `utils/geo-effect.ts` to `runtime/geo.ts` per Effect migration Phase 5. Updates all GEO route imports; behavior unchanged (remote timeout → 409, paywall, error mapping).

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4553a28-fca5-57f7-a3a6-95155c78172b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4553a28-fca5-57f7-a3a6-95155c78172b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `runGeoEffect` and `runRemoteGeoEffect` from `utils/geo-effect.ts` to `runtime/geo.ts` as part of the Effect migration, updating all GEO route imports. Behavior is unchanged; remote timeout → 409, paywall, and error mapping stay the same.

**Refactors**
- Removes the deprecated `utils/geo-effect` shim.
- Updates `runtime/geo.ts` to import `internal-workflow` and `logging` from `utils/` instead of local paths.

<sup>Written for commit f3b15ce92bf6e02cd6f8f539403c1289ec900e8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

