### PR TITLE
perf(dashboard): stop runaway client polls

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[slug]/iris/page-client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[slug]/iris/page-client.tsx
@@ -49,12 +49,14 @@ export default function PageClient({ organizationSlug }: IrisPageClientProps) {
       initialPageParam: undefined,
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
       enabled: isReady,
+      // Keep discovering runs started by the scheduler or another session.
       refetchInterval: (query: {
         state: { data?: { pages: IrisListRunsResult[] } };
       }) =>
         isIrisRunOpen(query.state.data?.pages.at(0)?.runs.at(0) ?? null)
           ? IRIS_ACTIVE_POLL_INTERVAL_MS
           : IRIS_IDLE_POLL_INTERVAL_MS,
+      refetchIntervalInBackground: false,
     })
   );
 
@@ -70,6 +72,7 @@ export default function PageClient({ organizationSlug }: IrisPageClientProps) {
       input: { organizationId },
       enabled: isReady,
       refetchInterval: pollInterval,
+      refetchIntervalInBackground: false,
     })
   );
 
@@ -81,6 +84,7 @@ export default function PageClient({ organizationSlug }: IrisPageClientProps) {
       input: { organizationId, limit: IRIS_SIGNALS_PREVIEW_LIMIT },
       enabled: isReady && mandate !== null,
       refetchInterval: pollInterval,
+      refetchIntervalInBackground: false,
     })
   );
 

--- a/apps/dashboard/src/components/command-palette/command-palette.tsx
+++ b/apps/dashboard/src/components/command-palette/command-palette.tsx
@@ -70,7 +70,7 @@ import {
 } from "./registry";
 
 const APPLE_PLATFORM_PATTERN = /Mac|iPhone|iPad|iPod/i;
-const SEARCH_DEBOUNCE_MS = 150;
+const SEARCH_DEBOUNCE_MS = 300;
 const SEARCH_MIN_LENGTH = 2;
 const REFERENCE_SNIPPET_MAX = 80;
 

--- a/apps/dashboard/src/components/dashboard/nav-recent-content.tsx
+++ b/apps/dashboard/src/components/dashboard/nav-recent-content.tsx
@@ -32,8 +32,14 @@ export function NavRecentContent({
   enabled = true,
 }: NavRecentContentProps) {
   const pathname = usePathname();
-  const { data, isPending } = usePosts(organizationId, 1, enabled);
-  const posts = (data?.posts ?? []).slice(0, NAV_RECENT_LIMIT);
+  // Request only what the sidebar shows — a full page ships every post body.
+  const { data, isPending } = usePosts(
+    organizationId,
+    1,
+    enabled,
+    NAV_RECENT_LIMIT
+  );
+  const posts = data?.posts ?? [];
 
   if (!enabled || (!isPending && posts.length === 0)) {
     return null;

--- a/apps/dashboard/src/components/geo/conversation-builder-dialog.tsx
+++ b/apps/dashboard/src/components/geo/conversation-builder-dialog.tsx
@@ -45,7 +45,9 @@ export function ConversationBuilderDialog({
   sequence,
 }: ConversationBuilderDialogProps) {
   const nameId = useId();
-  const { addSequence, updateSequence } = useGeoSequencesDb(organizationId);
+  const { addSequence, updateSequence } = useGeoSequencesDb(organizationId, {
+    enabled: open,
+  });
   const [name, setName] = useState(sequence?.name ?? "");
   const [steps, setSteps] = useState<ConversationTurnDraft[]>(() =>
     turnsFromSequence(sequence)

--- a/apps/dashboard/src/components/geo/prompt-add-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-add-dialog.tsx
@@ -64,7 +64,7 @@ export function PromptAddDialog({
   const [mode, setMode] = useState<PromptAddMode>("write");
   const [draft, setDraft] = useState("");
   const [url, setUrl] = useState("");
-  const { addPrompt } = useGeoPromptsDb(organizationId);
+  const { addPrompt } = useGeoPromptsDb(organizationId, { enabled: open });
   const generate = useGeoGenerateFromWebsite(organizationId);
   const { data: searchConsoleData } = useGscKeywords(organizationId, open);
   const searchConsoleKeywords = searchConsoleData?.keywords ?? [];

--- a/apps/dashboard/src/lib/hooks/use-active-generations.ts
+++ b/apps/dashboard/src/lib/hooks/use-active-generations.ts
@@ -6,7 +6,7 @@ import type {
 } from "@notra/geo-core/types/generation-tracking";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
 import { hasShownToast, markToastShown } from "@/utils/toast-dedupe";
@@ -14,7 +14,6 @@ import { hasShownToast, markToastShown } from "@/utils/toast-dedupe";
 import { dashboardOrpc } from "../orpc/query";
 
 const ACTIVE_POLL_INTERVAL = 3000;
-const IDLE_POLL_INTERVAL = 30_000;
 
 interface ActiveGenerationsResponse {
   generations: ActiveGeneration[];
@@ -36,11 +35,13 @@ export function useActiveGenerations(organizationId: string) {
       meta: { errorMessage: "Failed to load active generations" },
       refetchInterval: (query) => {
         const data = query.state.data;
-        if (data && data.generations.length > 0) {
-          return ACTIVE_POLL_INTERVAL;
+        // Scheduled work and other sessions cannot invalidate this browser's cache.
+        if (!data || data.generations.length === 0) {
+          return 15_000;
         }
-        return IDLE_POLL_INTERVAL;
+        return ACTIVE_POLL_INTERVAL;
       },
+      refetchIntervalInBackground: false,
     })
   );
 
@@ -48,71 +49,66 @@ export function useActiveGenerations(organizationId: string) {
     dashboardOrpc.content.activeGenerations.clearCompleted.mutationOptions()
   );
 
+  const clearResultMutate = clearResult.mutate;
+
   useEffect(() => {
     const generations = query.data?.generations ?? [];
     const currentCount = generations.length;
     const previousCount = previousCountRef.current;
+    let shouldRefreshContent =
+      previousCount !== null && previousCount > 0 && currentCount === 0;
+    previousCountRef.current = currentCount;
+    for (const result of query.data?.results ?? []) {
+      const toastKey = `generation-result:${result.runId}`;
 
-    if (previousCount !== null && previousCount > 0 && currentCount === 0) {
-      queryClient.invalidateQueries({
+      if (hasShownToast(toastKey)) {
+        continue;
+      }
+
+      markToastShown(toastKey);
+
+      if (result.status === "success") {
+        shouldRefreshContent = true;
+        toast.success(
+          result.title ? `"${result.title}" generated` : "Content generated",
+          { id: result.runId }
+        );
+      } else if (result.status === "skipped") {
+        toast.info("Content generation skipped", {
+          id: result.runId,
+          action: {
+            label: "View logs",
+            onClick: () => router.push(logsPath),
+          },
+        });
+      } else {
+        toast.error("Content generation failed", {
+          id: result.runId,
+          action: {
+            label: "View logs",
+            onClick: () => router.push(logsPath),
+          },
+        });
+      }
+
+      clearResultMutate({
+        organizationId,
+        runId: result.runId,
+      });
+    }
+    if (shouldRefreshContent) {
+      void queryClient.invalidateQueries({
         queryKey: dashboardOrpc.content.list.key(),
       });
     }
-
-    previousCountRef.current = currentCount;
-  }, [query.data?.generations?.length, queryClient, query.data?.generations]);
-
-  const clearResultMutate = clearResult.mutate;
-
-  const processResults = useCallback(
-    (results: GenerationResult[]) => {
-      for (const result of results) {
-        const toastKey = `generation-result:${result.runId}`;
-
-        if (hasShownToast(toastKey)) {
-          continue;
-        }
-
-        markToastShown(toastKey);
-
-        if (result.status === "success") {
-          toast.success(
-            result.title ? `"${result.title}" generated` : "Content generated",
-            { id: result.runId }
-          );
-        } else if (result.status === "skipped") {
-          toast.info("Content generation skipped", {
-            id: result.runId,
-            action: {
-              label: "View logs",
-              onClick: () => router.push(logsPath),
-            },
-          });
-        } else {
-          toast.error("Content generation failed", {
-            id: result.runId,
-            action: {
-              label: "View logs",
-              onClick: () => router.push(logsPath),
-            },
-          });
-        }
-
-        clearResultMutate({
-          organizationId,
-          runId: result.runId,
-        });
-      }
-    },
-    [clearResultMutate, logsPath, organizationId, router]
-  );
-
-  useEffect(() => {
-    const results = query.data?.results ?? [];
-    if (results.length > 0) {
-      processResults(results);
-    }
-  }, [processResults, query.data?.results]);
+  }, [
+    clearResultMutate,
+    logsPath,
+    organizationId,
+    queryClient,
+    query.data,
+    router,
+  ]);
 
   return {
     ...query,

--- a/apps/dashboard/src/lib/hooks/use-active-generations.ts
+++ b/apps/dashboard/src/lib/hooks/use-active-generations.ts
@@ -6,7 +6,7 @@ import type {
 } from "@notra/geo-core/types/generation-tracking";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { toast } from "sonner";
 
 import { hasShownToast, markToastShown } from "@/utils/toast-dedupe";
@@ -24,7 +24,6 @@ export function useActiveGenerations(organizationId: string) {
   const queryClient = useQueryClient();
   const pathname = usePathname();
   const router = useRouter();
-  const previousCountRef = useRef<number | null>(null);
   const slug = pathname.split("/").filter(Boolean)[0];
   const logsPath = slug ? `/${slug}/settings/logs` : "/settings/logs";
 
@@ -52,12 +51,7 @@ export function useActiveGenerations(organizationId: string) {
   const clearResultMutate = clearResult.mutate;
 
   useEffect(() => {
-    const generations = query.data?.generations ?? [];
-    const currentCount = generations.length;
-    const previousCount = previousCountRef.current;
-    let shouldRefreshContent =
-      previousCount !== null && previousCount > 0 && currentCount === 0;
-    previousCountRef.current = currentCount;
+    let shouldRefreshContent = false;
     for (const result of query.data?.results ?? []) {
       const toastKey = `generation-result:${result.runId}`;
 

--- a/apps/dashboard/src/lib/hooks/use-brand-analysis.ts
+++ b/apps/dashboard/src/lib/hooks/use-brand-analysis.ts
@@ -17,6 +17,9 @@ import { QUERY_KEYS } from "@/utils/query-keys";
 
 import { dashboardOrpc } from "../orpc/query";
 
+const ANALYSIS_POLL_INTERVAL_MS = 1000;
+const INITIAL_POLL_INTERVAL_MS = 2000;
+
 const IDLE_PROGRESS: ProgressResponse["progress"] = {
   status: "idle",
   currentStep: 0,
@@ -70,8 +73,10 @@ export function useBrandAnalysisProgress(
     enabled: !!organizationId,
     refetchInterval: (query) => {
       const progress = query.state.data?.progress;
+      // No data yet (still loading, or the last request failed): keep polling
+      // so a single transient failure cannot freeze the progress UI.
       if (!progress) {
-        return 2000;
+        return INITIAL_POLL_INTERVAL_MS;
       }
 
       if (progress.status === "completed" || progress.status === "failed") {
@@ -79,11 +84,12 @@ export function useBrandAnalysisProgress(
       }
 
       if (progress.status === "idle") {
-        return shouldForcePoll() ? 1000 : false;
+        return shouldForcePoll() ? ANALYSIS_POLL_INTERVAL_MS : false;
       }
 
-      return 1000;
+      return ANALYSIS_POLL_INTERVAL_MS;
     },
+    refetchIntervalInBackground: false,
   });
 
   const progress = query.data?.progress ?? IDLE_PROGRESS;

--- a/apps/dashboard/src/lib/hooks/use-geo-db.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-db.ts
@@ -88,7 +88,7 @@ export function useGeoPromptsDb(
 
   const { data } = useLiveQuery(
     (q) => (isEnabled ? q.from({ prompt: definition }) : undefined),
-    [isEnabled]
+    [definition, isEnabled]
   );
 
   const prompts: GeoTrackedPrompt[] = data ?? [];
@@ -174,7 +174,7 @@ export function useGeoCompetitorsDb(
 
   const { data } = useLiveQuery(
     (q) => (isEnabled ? q.from({ competitor: definition }) : undefined),
-    [isEnabled]
+    [definition, isEnabled]
   );
 
   const competitors: GeoCompetitor[] = data ?? [];
@@ -221,7 +221,7 @@ export function useGeoSequencesDb(
 
   const { data, isLoading } = useLiveQuery(
     (q) => (isEnabled ? q.from({ sequence: definition }) : undefined),
-    [isEnabled]
+    [definition, isEnabled]
   );
 
   const sequences: GeoPromptSequence[] = data ?? [];

--- a/apps/dashboard/src/lib/hooks/use-geo-db.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-db.ts
@@ -37,6 +37,15 @@ import type {
 import { toErrorMessage } from "@/utils/error-message";
 import { mergeShelfOpportunity } from "@/utils/geo-shelf";
 
+/**
+ * Dialogs that stay mounted while closed pass `enabled: false` so the collection
+ * does not start a full-table sync before the user opens them. A disabled live
+ * query returns no data but leaves the collection handle usable for mutations.
+ */
+interface GeoDbOptions {
+  enabled?: boolean;
+}
+
 function usePendingRows(name: string, scope: GeoScopeInput) {
   const collectionId = geoCollectionId(name, scope);
 
@@ -63,7 +72,11 @@ function usePendingRows(name: string, scope: GeoScopeInput) {
   return { pendingIds, track };
 }
 
-export function useGeoPromptsDb(organizationId: string) {
+export function useGeoPromptsDb(
+  organizationId: string,
+  options?: GeoDbOptions
+) {
+  const isEnabled = options?.enabled ?? true;
   const { projectId } = useGeoProjectScope();
   const dbClient = useDbClient();
   const definition = geoPromptsCollection({ organizationId, projectId });
@@ -73,9 +86,10 @@ export function useGeoPromptsDb(organizationId: string) {
     projectId,
   });
 
-  const { data } = useLiveQuery({
-    query: (q) => q.from({ prompt: definition }),
-  });
+  const { data } = useLiveQuery(
+    (q) => (isEnabled ? q.from({ prompt: definition }) : undefined),
+    [isEnabled]
+  );
 
   const prompts: GeoTrackedPrompt[] = data ?? [];
 
@@ -144,7 +158,11 @@ export function useGeoPromptsDb(organizationId: string) {
   };
 }
 
-export function useGeoCompetitorsDb(organizationId: string) {
+export function useGeoCompetitorsDb(
+  organizationId: string,
+  options?: GeoDbOptions
+) {
+  const isEnabled = options?.enabled ?? true;
   const { projectId } = useGeoProjectScope();
   const dbClient = useDbClient();
   const definition = geoCompetitorsCollection({ organizationId, projectId });
@@ -154,9 +172,10 @@ export function useGeoCompetitorsDb(organizationId: string) {
     projectId,
   });
 
-  const { data } = useLiveQuery({
-    query: (q) => q.from({ competitor: definition }),
-  });
+  const { data } = useLiveQuery(
+    (q) => (isEnabled ? q.from({ competitor: definition }) : undefined),
+    [isEnabled]
+  );
 
   const competitors: GeoCompetitor[] = data ?? [];
 
@@ -186,7 +205,11 @@ export function useGeoCompetitorsDb(organizationId: string) {
   };
 }
 
-export function useGeoSequencesDb(organizationId: string) {
+export function useGeoSequencesDb(
+  organizationId: string,
+  options?: GeoDbOptions
+) {
+  const isEnabled = options?.enabled ?? true;
   const { projectId } = useGeoProjectScope();
   const dbClient = useDbClient();
   const definition = geoSequencesCollection({ organizationId, projectId });
@@ -196,9 +219,10 @@ export function useGeoSequencesDb(organizationId: string) {
     projectId,
   });
 
-  const { data, isLoading } = useLiveQuery({
-    query: (q) => q.from({ sequence: definition }),
-  });
+  const { data, isLoading } = useLiveQuery(
+    (q) => (isEnabled ? q.from({ sequence: definition }) : undefined),
+    [isEnabled]
+  );
 
   const sequences: GeoPromptSequence[] = data ?? [];
 

--- a/apps/dashboard/src/lib/hooks/use-geo-writer.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-writer.ts
@@ -49,14 +49,14 @@ export function useGeoWriterBrief(
       input: { organizationId, projectId, briefId: briefId ?? "" },
     }),
     enabled: !!organizationId && !!briefId,
-    // Only "writing" is polled: `approveAndStartGeoWriter` claims the brief
-    // straight from "draft"/"failed" to "writing" in the same update that
-    // starts the run, so a brief never sits in "approved" waiting for the
-    // workflow. The status is kept in the UI's busy set for legacy rows only.
-    refetchInterval: (query) =>
-      query.state.data?.status === "writing"
+    // Poll while the writer is running. New runs skip "approved" (draft/failed
+    // go straight to "writing"), but legacy rows can still sit in "approved".
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === "writing" || status === "approved"
         ? GEO_WRITER_BRIEF_POLL_INTERVAL_MS
-        : false,
+        : false;
+    },
     refetchIntervalInBackground: false,
     meta: { errorMessage: "Failed to load the brief" },
   });

--- a/apps/dashboard/src/lib/hooks/use-geo-writer.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-writer.ts
@@ -49,11 +49,15 @@ export function useGeoWriterBrief(
       input: { organizationId, projectId, briefId: briefId ?? "" },
     }),
     enabled: !!organizationId && !!briefId,
+    // Only "writing" is polled: `approveAndStartGeoWriter` claims the brief
+    // straight from "draft"/"failed" to "writing" in the same update that
+    // starts the run, so a brief never sits in "approved" waiting for the
+    // workflow. The status is kept in the UI's busy set for legacy rows only.
     refetchInterval: (query) =>
-      query.state.data?.status === "writing" ||
-      query.state.data?.status === "approved"
+      query.state.data?.status === "writing"
         ? GEO_WRITER_BRIEF_POLL_INTERVAL_MS
         : false,
+    refetchIntervalInBackground: false,
     meta: { errorMessage: "Failed to load the brief" },
   });
 }

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -97,6 +97,8 @@ import { toGeoWindowInput } from "@/utils/geo-range";
 import { dashboardOrpc } from "../orpc/query";
 
 const GSC_ANALYZE_MUTATION_KEY = "gsc-analyze" as const;
+// Bounded retries instead of an unbounded 30 s error poll on every dashboard page.
+const GEO_PROJECTS_RETRY_COUNT = 3;
 
 function gscAnalyzeMutationKey(organizationId: string) {
   return [GSC_ANALYZE_MUTATION_KEY, organizationId] as const;
@@ -208,6 +210,7 @@ export function useGeoSettings(organizationId: string) {
       current.state.data?.settings?.isScanning
         ? GEO_SCAN_POLL_INTERVAL_MS
         : false,
+    refetchIntervalInBackground: false,
     meta: { errorMessage: "Failed to load AI visibility settings" },
   });
 
@@ -739,6 +742,7 @@ export function useAgentReadiness(organizationId: string) {
       query.state.data?.scan?.status === "running"
         ? AGENT_READINESS_POLL_INTERVAL_MS
         : false,
+    refetchIntervalInBackground: false,
     meta: { errorMessage: "Failed to load agent readiness" },
   });
 }
@@ -792,6 +796,7 @@ export function useGeoTrafficLog(
     enabled: !!organizationId,
     placeholderData: keepPreviousData,
     refetchInterval: options?.refetchInterval,
+    refetchIntervalInBackground: false,
     meta: { errorMessage: "Failed to load AI tracking log" },
   });
 }
@@ -898,8 +903,7 @@ export function useGeoProjects(organizationId: string) {
       errorMessage: "Failed to load projects",
       showRetryAction: true,
     },
-    refetchInterval: (query) =>
-      query.state.status === "error" ? 30_000 : false,
+    retry: GEO_PROJECTS_RETRY_COUNT,
   });
 }
 

--- a/apps/dashboard/src/lib/hooks/use-posts.ts
+++ b/apps/dashboard/src/lib/hooks/use-posts.ts
@@ -10,7 +10,12 @@ import { useActiveProject } from "./use-active-project";
 
 const DEFAULT_PAGE_SIZE = 12;
 
-export function usePosts(organizationId: string, page: number, enabled = true) {
+export function usePosts(
+  organizationId: string,
+  page: number,
+  enabled = true,
+  pageSize: number = DEFAULT_PAGE_SIZE
+) {
   const { projectId, isResolved } = useActiveProject();
   return useQuery<PostsResponse>({
     ...dashboardOrpc.content.list.queryOptions({
@@ -18,7 +23,7 @@ export function usePosts(organizationId: string, page: number, enabled = true) {
         organizationId,
         projectId: projectId ?? undefined,
         page,
-        pageSize: DEFAULT_PAGE_SIZE,
+        pageSize,
       },
     }),
     enabled: enabled && !!organizationId && isResolved,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3d24e7c-09e6-5f6b-9abe-c2fdb1eb97e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d24e7c-09e6-5f6b-9abe-c2fdb1eb97e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops dashboard queries from polling once their work finishes or the tab is hidden, cutting idle requests and background bandwidth.

- Every polling query now sets `refetchIntervalInBackground: false` so refetches pause when the tab is hidden.
- GEO writer briefs poll only while status is "writing" or "approved" (approved kept for legacy rows); finished or failed statuses stop polling.
- GEO project queries retry up to 3 times on error instead of polling every 30 seconds indefinitely.
- Closed GEO dialogs skip live-query sync until opened; their mutation handles keep working.
- The sidebar's recent-content list fetches only the 5 posts it shows instead of a full page.
- Command palette search debounce increased from 150 ms to 300 ms.
- `useActiveGenerations` invalidates the content list only when a generation actually succeeds.

<sup>Written for commit cda7ed0c41a97e406500e096148ca58ecf06ee62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

