### PR TITLE
perf(dashboard): bound logo cache and analytics flag I/O

### DIFF
--- a/apps/dashboard/src/constants/analytics.ts
+++ b/apps/dashboard/src/constants/analytics.ts
@@ -6,7 +6,13 @@ import type {
 export const SOCIAL_ANALYTICS_FLAG_KEY = "social-analytics";
 export const ANALYTICS_NAV_LINK = "/analytics";
 export const ANALYTICS_FLAG_CACHE_TTL_MS = 60_000;
-export const ANALYTICS_FLAG_STALE_TIME_MS = 30_000;
+export const ANALYTICS_FLAG_REQUEST_TIMEOUT_MS = 5000;
+export const ANALYTICS_FLAG_FAILURE_CACHE_TTL_MS = 5000;
+export const ANALYTICS_FLAG_CACHE_CAPACITY = 5000;
+export const MAX_PENDING_ANALYTICS_FLAG_EVALUATIONS = 500;
+export const ANALYTICS_FLAGS_API_URL =
+  process.env.DATABUDDY_FLAGS_API_URL ??
+  "https://api.databuddy.cc/public/v1/flags/bulk";
 export const ANALYTICS_FLAG_ERROR_REASON = "ERROR";
 export const ANALYTICS_UNAVAILABLE_DESCRIPTION =
   "Analytics is not available for this workspace yet.";

--- a/apps/dashboard/src/lib/analytics/flag-client.test.ts
+++ b/apps/dashboard/src/lib/analytics/flag-client.test.ts
@@ -1,66 +1,127 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
 
-import { ANALYTICS_FLAG_ERROR_REASON } from "@/constants/analytics";
-import { AnalyticsFlagEvaluationError } from "@/lib/analytics/errors";
-import { boundAnalyticsFlagEvaluation } from "@/lib/analytics/flag-client";
+import {
+  ANALYTICS_FLAG_ERROR_REASON,
+  SOCIAL_ANALYTICS_FLAG_KEY,
+} from "@/constants/analytics";
+import { evaluateAnalyticsFlag } from "@/lib/analytics/flag-client";
 
 /** Comfortably past the bound the module applies. */
 const PAST_THE_TIMEOUT = "1 minute";
 
-describe("bounded analytics flag evaluation", () => {
-  test("an evaluation that never answers becomes unavailable", async () => {
-    const state = await Effect.runPromise(
-      Effect.gen(function* () {
-        const fiber = yield* Effect.forkChild(
-          boundAnalyticsFlagEvaluation(Effect.never)
-        );
-        yield* TestClock.adjust(PAST_THE_TIMEOUT);
-        return yield* Fiber.join(fiber);
-      }).pipe(Effect.provide(TestClock.layer()))
-    );
+const TEST_CLIENT_ID = "test-client-id";
+const TEST_ORGANIZATION_ID = "org-test";
 
-    expect(state).toBe("unavailable");
+function mockFlagsFetch(payload: unknown) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() =>
+    Promise.resolve(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    )) as typeof fetch;
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+describe("evaluateAnalyticsFlag", () => {
+  afterEach(() => {
+    globalThis.fetch = fetch;
+  });
+
+  test("an evaluation that never answers becomes unavailable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      })) as typeof fetch;
+
+    try {
+      const state = await Effect.runPromise(
+        Effect.gen(function* () {
+          const fiber = yield* Effect.forkChild(
+            evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
+          );
+          yield* TestClock.adjust(PAST_THE_TIMEOUT);
+          return yield* Fiber.join(fiber);
+        }).pipe(Effect.provide(TestClock.layer()))
+      );
+
+      expect(state).toBe("unavailable");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("a rejected evaluation becomes unavailable, like the timeout", async () => {
-    const state = await Effect.runPromise(
-      boundAnalyticsFlagEvaluation(
-        Effect.fail(
-          new AnalyticsFlagEvaluationError({
-            message: "Failed to evaluate the analytics feature flag",
-            cause: new Error("socket hang up"),
-          })
-        )
-      )
-    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("socket hang up"))) as typeof fetch;
 
-    expect(state).toBe("unavailable");
+    try {
+      const state = await Effect.runPromise(
+        evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
+      );
+      expect(state).toBe("unavailable");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("the provider's own error reason becomes unavailable", async () => {
-    const state = await Effect.runPromise(
-      boundAnalyticsFlagEvaluation(
-        Effect.succeed({ enabled: true, reason: ANALYTICS_FLAG_ERROR_REASON })
-      )
-    );
+    const restoreFetch = mockFlagsFetch({
+      flags: {
+        [SOCIAL_ANALYTICS_FLAG_KEY]: {
+          enabled: true,
+          reason: ANALYTICS_FLAG_ERROR_REASON,
+        },
+      },
+    });
 
-    expect(state).toBe("unavailable");
+    try {
+      const state = await Effect.runPromise(
+        evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
+      );
+      expect(state).toBe("unavailable");
+    } finally {
+      restoreFetch();
+    }
   });
 
   test("a resolved evaluation keeps its answer", async () => {
+    const restoreEnabledFetch = mockFlagsFetch({
+      flags: {
+        [SOCIAL_ANALYTICS_FLAG_KEY]: {
+          enabled: true,
+          reason: "match",
+        },
+      },
+    });
     const enabled = await Effect.runPromise(
-      boundAnalyticsFlagEvaluation(
-        Effect.succeed({ enabled: true, reason: "match" })
-      )
+      evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
     );
+    restoreEnabledFetch();
+
+    const restoreDisabledFetch = mockFlagsFetch({
+      flags: {
+        [SOCIAL_ANALYTICS_FLAG_KEY]: {
+          enabled: false,
+          reason: "match",
+        },
+      },
+    });
     const disabled = await Effect.runPromise(
-      boundAnalyticsFlagEvaluation(
-        Effect.succeed({ enabled: false, reason: "match" })
-      )
+      evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
     );
+    restoreDisabledFetch();
 
     expect([enabled, disabled]).toEqual(["enabled", "disabled"]);
   });

--- a/apps/dashboard/src/lib/analytics/flag-client.test.ts
+++ b/apps/dashboard/src/lib/analytics/flag-client.test.ts
@@ -14,9 +14,9 @@ const PAST_THE_TIMEOUT = "1 minute";
 
 const TEST_CLIENT_ID = "test-client-id";
 const TEST_ORGANIZATION_ID = "org-test";
+const originalFetch = globalThis.fetch;
 
 function mockFlagsFetch(payload: unknown) {
-  const originalFetch = globalThis.fetch;
   globalThis.fetch = (() =>
     Promise.resolve(
       new Response(JSON.stringify(payload), {
@@ -24,19 +24,14 @@ function mockFlagsFetch(payload: unknown) {
         headers: { "Content-Type": "application/json" },
       })
     )) as typeof fetch;
-
-  return () => {
-    globalThis.fetch = originalFetch;
-  };
 }
 
 describe("evaluateAnalyticsFlag", () => {
   afterEach(() => {
-    globalThis.fetch = fetch;
+    globalThis.fetch = originalFetch;
   });
 
   test("an evaluation that never answers becomes unavailable", async () => {
-    const originalFetch = globalThis.fetch;
     globalThis.fetch = ((_, init) =>
       new Promise((_resolve, reject) => {
         init?.signal?.addEventListener("abort", () => {
@@ -44,40 +39,31 @@ describe("evaluateAnalyticsFlag", () => {
         });
       })) as typeof fetch;
 
-    try {
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const fiber = yield* Effect.forkChild(
-            evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
-          );
-          yield* TestClock.adjust(PAST_THE_TIMEOUT);
-          return yield* Fiber.join(fiber);
-        }).pipe(Effect.provide(TestClock.layer()))
-      );
+    const state = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
+        );
+        yield* TestClock.adjust(PAST_THE_TIMEOUT);
+        return yield* Fiber.join(fiber);
+      }).pipe(Effect.provide(TestClock.layer()))
+    );
 
-      expect(state).toBe("unavailable");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(state).toBe("unavailable");
   });
 
   test("a rejected evaluation becomes unavailable, like the timeout", async () => {
-    const originalFetch = globalThis.fetch;
     globalThis.fetch = (() =>
       Promise.reject(new Error("socket hang up"))) as typeof fetch;
 
-    try {
-      const state = await Effect.runPromise(
-        evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
-      );
-      expect(state).toBe("unavailable");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    const state = await Effect.runPromise(
+      evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
+    );
+    expect(state).toBe("unavailable");
   });
 
   test("the provider's own error reason becomes unavailable", async () => {
-    const restoreFetch = mockFlagsFetch({
+    mockFlagsFetch({
       flags: {
         [SOCIAL_ANALYTICS_FLAG_KEY]: {
           enabled: true,
@@ -86,18 +72,14 @@ describe("evaluateAnalyticsFlag", () => {
       },
     });
 
-    try {
-      const state = await Effect.runPromise(
-        evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
-      );
-      expect(state).toBe("unavailable");
-    } finally {
-      restoreFetch();
-    }
+    const state = await Effect.runPromise(
+      evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
+    );
+    expect(state).toBe("unavailable");
   });
 
   test("a resolved evaluation keeps its answer", async () => {
-    const restoreEnabledFetch = mockFlagsFetch({
+    mockFlagsFetch({
       flags: {
         [SOCIAL_ANALYTICS_FLAG_KEY]: {
           enabled: true,
@@ -108,9 +90,8 @@ describe("evaluateAnalyticsFlag", () => {
     const enabled = await Effect.runPromise(
       evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
     );
-    restoreEnabledFetch();
 
-    const restoreDisabledFetch = mockFlagsFetch({
+    mockFlagsFetch({
       flags: {
         [SOCIAL_ANALYTICS_FLAG_KEY]: {
           enabled: false,
@@ -121,7 +102,6 @@ describe("evaluateAnalyticsFlag", () => {
     const disabled = await Effect.runPromise(
       evaluateAnalyticsFlag(TEST_CLIENT_ID, TEST_ORGANIZATION_ID)
     );
-    restoreDisabledFetch();
 
     expect([enabled, disabled]).toEqual(["enabled", "disabled"]);
   });

--- a/apps/dashboard/src/lib/analytics/flag-client.test.ts
+++ b/apps/dashboard/src/lib/analytics/flag-client.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
+
+import { ANALYTICS_FLAG_ERROR_REASON } from "@/constants/analytics";
+import { AnalyticsFlagEvaluationError } from "@/lib/analytics/errors";
+import { boundAnalyticsFlagEvaluation } from "@/lib/analytics/flag-client";
+
+/** Comfortably past the bound the module applies. */
+const PAST_THE_TIMEOUT = "1 minute";
+
+describe("bounded analytics flag evaluation", () => {
+  test("an evaluation that never answers becomes unavailable", async () => {
+    const state = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          boundAnalyticsFlagEvaluation(Effect.never)
+        );
+        yield* TestClock.adjust(PAST_THE_TIMEOUT);
+        return yield* Fiber.join(fiber);
+      }).pipe(Effect.provide(TestClock.layer()))
+    );
+
+    expect(state).toBe("unavailable");
+  });
+
+  test("a rejected evaluation becomes unavailable, like the timeout", async () => {
+    const state = await Effect.runPromise(
+      boundAnalyticsFlagEvaluation(
+        Effect.fail(
+          new AnalyticsFlagEvaluationError({
+            message: "Failed to evaluate the analytics feature flag",
+            cause: new Error("socket hang up"),
+          })
+        )
+      )
+    );
+
+    expect(state).toBe("unavailable");
+  });
+
+  test("the provider's own error reason becomes unavailable", async () => {
+    const state = await Effect.runPromise(
+      boundAnalyticsFlagEvaluation(
+        Effect.succeed({ enabled: true, reason: ANALYTICS_FLAG_ERROR_REASON })
+      )
+    );
+
+    expect(state).toBe("unavailable");
+  });
+
+  test("a resolved evaluation keeps its answer", async () => {
+    const enabled = await Effect.runPromise(
+      boundAnalyticsFlagEvaluation(
+        Effect.succeed({ enabled: true, reason: "match" })
+      )
+    );
+    const disabled = await Effect.runPromise(
+      boundAnalyticsFlagEvaluation(
+        Effect.succeed({ enabled: false, reason: "match" })
+      )
+    );
+
+    expect([enabled, disabled]).toEqual(["enabled", "disabled"]);
+  });
+});

--- a/apps/dashboard/src/lib/analytics/flag-client.ts
+++ b/apps/dashboard/src/lib/analytics/flag-client.ts
@@ -1,0 +1,142 @@
+import { Cache, Effect, Exit, Schema } from "effect";
+
+import {
+  ANALYTICS_FLAG_CACHE_CAPACITY,
+  ANALYTICS_FLAG_CACHE_TTL_MS,
+  ANALYTICS_FLAG_ERROR_REASON,
+  ANALYTICS_FLAG_FAILURE_CACHE_TTL_MS,
+  ANALYTICS_FLAG_REQUEST_TIMEOUT_MS,
+  ANALYTICS_FLAGS_API_URL,
+  MAX_PENDING_ANALYTICS_FLAG_EVALUATIONS,
+  SOCIAL_ANALYTICS_FLAG_KEY,
+} from "@/constants/analytics";
+import { AnalyticsFlagEvaluationError } from "@/lib/analytics/errors";
+import {
+  analyticsFlagSchema,
+  analyticsFlagsResponseSchema,
+} from "@/schemas/analytics-flag";
+import type { AnalyticsFlagState } from "@/types/analytics";
+
+interface AnalyticsFlagEvaluation {
+  readonly enabled: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * Maps a decoded provider answer onto the surface state. Exported so tests can
+ * assert the fail-closed mapping without a live Databuddy client.
+ */
+function mapAnalyticsFlagEvaluation(
+  result: AnalyticsFlagEvaluation
+): AnalyticsFlagState {
+  if (result.reason === ANALYTICS_FLAG_ERROR_REASON) {
+    return "unavailable";
+  }
+  return result.enabled ? "enabled" : "disabled";
+}
+
+/**
+ * Bounds one evaluation and collapses every non-answer onto `unavailable`. A
+ * timeout, an SDK rejection, and the provider's own error reason all mean "we
+ * do not know", and the surface treats them identically.
+ */
+export function boundAnalyticsFlagEvaluation(
+  evaluation: Effect.Effect<
+    AnalyticsFlagEvaluation,
+    AnalyticsFlagEvaluationError
+  >
+): Effect.Effect<AnalyticsFlagState> {
+  return evaluation.pipe(
+    Effect.timeout(ANALYTICS_FLAG_REQUEST_TIMEOUT_MS),
+    Effect.map(mapAnalyticsFlagEvaluation),
+    Effect.catch(() => Effect.succeed<AnalyticsFlagState>("unavailable"))
+  );
+}
+
+const evaluateAnalyticsFlag = Effect.fn("evaluateAnalyticsFlag")(
+  function* (clientId: string, organizationId: string) {
+    const params = new URLSearchParams({
+      clientId,
+      organizationId,
+      properties: JSON.stringify({ organizationId }),
+      keys: SOCIAL_ANALYTICS_FLAG_KEY,
+    });
+    // Use the SDK's public endpoint directly: getFlag cannot accept a signal.
+    // Keep body consumption inside tryPromise so timeout aborts that too.
+    const json = yield* Effect.tryPromise({
+      try: async (signal) => {
+        const response = await fetch(`${ANALYTICS_FLAGS_API_URL}?${params}`, {
+          signal,
+          cache: "no-store",
+        });
+        if (!response.ok) {
+          throw new Error(`Databuddy flag request failed: ${response.status}`);
+        }
+        return await response.json();
+      },
+      catch: (cause) =>
+        new AnalyticsFlagEvaluationError({
+          message: "Failed to evaluate the analytics feature flag",
+          cause,
+        }),
+    });
+    const response = yield* Schema.decodeUnknownEffect(
+      analyticsFlagsResponseSchema
+    )(json).pipe(
+      Effect.mapError(
+        (cause) =>
+          new AnalyticsFlagEvaluationError({
+            message: "Failed to evaluate the analytics feature flag",
+            cause,
+          })
+      )
+    );
+    const entry = response.flags[SOCIAL_ANALYTICS_FLAG_KEY];
+    if (entry === undefined) {
+      return "disabled" as AnalyticsFlagState;
+    }
+    const result = yield* Schema.decodeUnknownEffect(analyticsFlagSchema)(
+      entry
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
+          new AnalyticsFlagEvaluationError({
+            message: "Failed to evaluate the analytics feature flag",
+            cause,
+          })
+      )
+    );
+    return mapAnalyticsFlagEvaluation(result);
+  },
+  Effect.timeout(ANALYTICS_FLAG_REQUEST_TIMEOUT_MS),
+  Effect.catch(() => Effect.succeed<AnalyticsFlagState>("unavailable"))
+);
+
+export const makeAnalyticsFlagCache = Effect.fn("makeAnalyticsFlagCache")(
+  function* (clientId: string) {
+    let activeEvaluations = 0;
+    return yield* Cache.makeWith(
+      (organizationId: string) =>
+        Effect.suspend(() => {
+          if (activeEvaluations >= MAX_PENDING_ANALYTICS_FLAG_EVALUATIONS) {
+            return Effect.succeed<AnalyticsFlagState>("unavailable");
+          }
+          activeEvaluations += 1;
+          return evaluateAnalyticsFlag(clientId, organizationId).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                activeEvaluations -= 1;
+              })
+            )
+          );
+        }),
+      {
+        capacity: ANALYTICS_FLAG_CACHE_CAPACITY,
+        timeToLive: (exit) =>
+          Exit.isSuccess(exit) && exit.value !== "unavailable"
+            ? ANALYTICS_FLAG_CACHE_TTL_MS
+            : ANALYTICS_FLAG_FAILURE_CACHE_TTL_MS,
+      }
+    );
+  }
+);

--- a/apps/dashboard/src/lib/analytics/flag-client.ts
+++ b/apps/dashboard/src/lib/analytics/flag-client.ts
@@ -22,10 +22,6 @@ interface AnalyticsFlagEvaluation {
   readonly reason?: string;
 }
 
-/**
- * Maps a decoded provider answer onto the surface state. Exported so tests can
- * assert the fail-closed mapping without a live Databuddy client.
- */
 function mapAnalyticsFlagEvaluation(
   result: AnalyticsFlagEvaluation
 ): AnalyticsFlagState {
@@ -35,25 +31,7 @@ function mapAnalyticsFlagEvaluation(
   return result.enabled ? "enabled" : "disabled";
 }
 
-/**
- * Bounds one evaluation and collapses every non-answer onto `unavailable`. A
- * timeout, an SDK rejection, and the provider's own error reason all mean "we
- * do not know", and the surface treats them identically.
- */
-export function boundAnalyticsFlagEvaluation(
-  evaluation: Effect.Effect<
-    AnalyticsFlagEvaluation,
-    AnalyticsFlagEvaluationError
-  >
-): Effect.Effect<AnalyticsFlagState> {
-  return evaluation.pipe(
-    Effect.timeout(ANALYTICS_FLAG_REQUEST_TIMEOUT_MS),
-    Effect.map(mapAnalyticsFlagEvaluation),
-    Effect.catch(() => Effect.succeed<AnalyticsFlagState>("unavailable"))
-  );
-}
-
-const evaluateAnalyticsFlag = Effect.fn("evaluateAnalyticsFlag")(
+export const evaluateAnalyticsFlag = Effect.fn("evaluateAnalyticsFlag")(
   function* (clientId: string, organizationId: string) {
     const params = new URLSearchParams({
       clientId,

--- a/apps/dashboard/src/lib/analytics/flag.ts
+++ b/apps/dashboard/src/lib/analytics/flag.ts
@@ -1,81 +1,21 @@
-import {
-  createServerFlagsManager,
-  type ServerFlagsManager,
-} from "@databuddy/sdk/node";
-import { Effect } from "effect";
+import { Cache, Effect } from "effect";
 
-import {
-  ANALYTICS_FLAG_CACHE_TTL_MS,
-  ANALYTICS_FLAG_ERROR_REASON,
-  ANALYTICS_FLAG_STALE_TIME_MS,
-  SOCIAL_ANALYTICS_FLAG_KEY,
-} from "@/constants/analytics";
-import { AnalyticsFlagEvaluationError } from "@/lib/analytics/errors";
-import type { AnalyticsFlagState } from "@/types/analytics";
+import { makeAnalyticsFlagCache } from "@/lib/analytics/flag-client";
 
 const clientId = process.env.NEXT_PUBLIC_DATABUDDY_DASHBOARD_WEBSITE_ID ?? "";
-
-let cachedManager: ServerFlagsManager | null = null;
-
-function getFlagsManager(): ServerFlagsManager | null {
-  if (clientId.length === 0) {
-    return null;
-  }
-
-  if (!cachedManager) {
-    cachedManager = createServerFlagsManager({
-      clientId,
-      autoFetch: false,
-      cacheTtl: ANALYTICS_FLAG_CACHE_TTL_MS,
-      staleTime: ANALYTICS_FLAG_STALE_TIME_MS,
-      skipStorage: true,
-    });
-  }
-
-  return cachedManager;
-}
-
-function resolveAnalyticsFlagState(
-  organizationId: string
-): Effect.Effect<AnalyticsFlagState> {
-  return Effect.gen(function* () {
-    if (process.env.NODE_ENV === "development") {
-      return "enabled";
-    }
-
-    const manager = getFlagsManager();
-    if (!manager) {
-      return "disabled";
-    }
-
-    return yield* Effect.tryPromise({
-      try: () =>
-        manager.getFlag(SOCIAL_ANALYTICS_FLAG_KEY, {
-          organizationId,
-          properties: { organizationId },
-        }),
-      catch: (cause) =>
-        new AnalyticsFlagEvaluationError({
-          message: "Failed to evaluate the analytics feature flag",
-          cause,
-        }),
-    }).pipe(
-      Effect.map((result): AnalyticsFlagState => {
-        if (result.reason === ANALYTICS_FLAG_ERROR_REASON) {
-          return "unavailable";
-        }
-        return result.enabled ? "enabled" : "disabled";
-      }),
-      Effect.catch(() => Effect.succeed<AnalyticsFlagState>("unavailable"))
-    );
-  });
-}
+const flagCache = Effect.runSync(makeAnalyticsFlagCache(clientId));
 
 export function isAnalyticsEnabledForOrganization(
   organizationId: string
 ): Promise<boolean> {
+  if (process.env.NODE_ENV === "development") {
+    return Promise.resolve(true);
+  }
+  if (clientId.length === 0) {
+    return Promise.resolve(false);
+  }
   return Effect.runPromise(
-    resolveAnalyticsFlagState(organizationId).pipe(
+    Cache.get(flagCache, organizationId).pipe(
       Effect.map((state) => state === "enabled")
     )
   );

--- a/apps/dashboard/src/lib/onboarding/company-logo-cache.ts
+++ b/apps/dashboard/src/lib/onboarding/company-logo-cache.ts
@@ -1,4 +1,4 @@
-import { redis } from "@notra/ai/utils/redis";
+import { Redis } from "@upstash/redis";
 import { Effect } from "effect";
 
 import { RedisUnavailableError } from "@/lib/onboarding/errors";
@@ -23,6 +23,24 @@ interface CompanyLogoCacheKeyInput {
   query: string;
   searchByName: boolean;
 }
+
+function createBoundedRedisClient(timeoutMs: number): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!(url && token)) {
+    return null;
+  }
+
+  // Upstash accepts a signal factory so each REST call gets its own timeout.
+  return new Redis({
+    url,
+    token,
+    signal: () => AbortSignal.timeout(timeoutMs),
+  });
+}
+
+const readRedis = createBoundedRedisClient(REDIS_READ_TIMEOUT_MS);
+const writeRedis = createBoundedRedisClient(REDIS_WRITE_TIMEOUT_MS);
 
 function buildCacheKey({ query, searchByName }: CompanyLogoCacheKeyInput) {
   const mode = searchByName ? "name" : "domain";
@@ -55,7 +73,7 @@ function logCacheSkip(operation: "read" | "write", cause: unknown): void {
  */
 const readCompanyLogo = Effect.fn("onboarding.companyLogoCache.read")(
   function* (input: CompanyLogoCacheKeyInput) {
-    const client = redis;
+    const client = readRedis;
     if (!client) {
       return null;
     }
@@ -64,7 +82,6 @@ const readCompanyLogo = Effect.fn("onboarding.companyLogoCache.read")(
       try: () => client.get<unknown>(buildCacheKey(input)),
       catch: (cause) => new RedisUnavailableError({ operation: "read", cause }),
     }).pipe(
-      Effect.timeout(REDIS_READ_TIMEOUT_MS),
       Effect.map((cached): CompanyLogoResult | null =>
         isCompanyLogoResult(cached) ? cached : null
       ),
@@ -78,7 +95,7 @@ const readCompanyLogo = Effect.fn("onboarding.companyLogoCache.read")(
 
 const writeCompanyLogo = Effect.fn("onboarding.companyLogoCache.write")(
   function* (input: CompanyLogoCacheKeyInput, result: CompanyLogoResult) {
-    const client = redis;
+    const client = writeRedis;
     if (!client) {
       return;
     }
@@ -91,7 +108,6 @@ const writeCompanyLogo = Effect.fn("onboarding.companyLogoCache.write")(
       catch: (cause) =>
         new RedisUnavailableError({ operation: "write", cause }),
     }).pipe(
-      Effect.timeout(REDIS_WRITE_TIMEOUT_MS),
       Effect.asVoid,
       Effect.catchCause((cause) => {
         logCacheSkip("write", cause);

--- a/apps/dashboard/src/lib/onboarding/company-logo-cache.ts
+++ b/apps/dashboard/src/lib/onboarding/company-logo-cache.ts
@@ -1,0 +1,120 @@
+import { redis } from "@notra/ai/utils/redis";
+import { Effect } from "effect";
+
+import { RedisUnavailableError } from "@/lib/onboarding/errors";
+import type { CompanyLogoResult } from "@/types/onboarding";
+
+const CACHE_KEY_PREFIX = "cache:company-logo:v1";
+/** Brand logos effectively never change, so resolved lookups are held for a week. */
+const RESOLVED_TTL_SECONDS = 604_800;
+/** A brand that is unknown today may be known tomorrow. */
+const UNRESOLVED_TTL_SECONDS = 3600;
+
+/**
+ * A cache that answers slower than the lookup it protects is worse than no
+ * cache, so both round trips are bounded. The read budget is the tighter one:
+ * it sits in front of the request, while the write only delays the response of
+ * a request that already paid for the live lookup.
+ */
+const REDIS_READ_TIMEOUT_MS = 300;
+const REDIS_WRITE_TIMEOUT_MS = 1000;
+
+interface CompanyLogoCacheKeyInput {
+  query: string;
+  searchByName: boolean;
+}
+
+function buildCacheKey({ query, searchByName }: CompanyLogoCacheKeyInput) {
+  const mode = searchByName ? "name" : "domain";
+  return `${CACHE_KEY_PREFIX}:${mode}:${query.trim().toLowerCase()}`;
+}
+
+function isCompanyLogoResult(value: unknown): value is CompanyLogoResult {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<CompanyLogoResult>;
+  const domainValid =
+    candidate.domain === null || typeof candidate.domain === "string";
+  const urlValid = candidate.url === null || typeof candidate.url === "string";
+  return domainValid && urlValid;
+}
+
+/**
+ * Logged where the fall-through happens so a broken or slow cache is visible,
+ * instead of silently costing every caller the live lookup.
+ */
+function logCacheSkip(operation: "read" | "write", cause: unknown): void {
+  console.warn(`[onboarding] company logo cache ${operation} skipped`, cause);
+}
+
+/**
+ * A miss and an unreachable Redis are the same answer to the caller, so both
+ * typed failures — `RedisUnavailableError` and the timeout — collapse to `null`
+ * at this single decision point.
+ */
+const readCompanyLogo = Effect.fn("onboarding.companyLogoCache.read")(
+  function* (input: CompanyLogoCacheKeyInput) {
+    const client = redis;
+    if (!client) {
+      return null;
+    }
+
+    return yield* Effect.tryPromise({
+      try: () => client.get<unknown>(buildCacheKey(input)),
+      catch: (cause) => new RedisUnavailableError({ operation: "read", cause }),
+    }).pipe(
+      Effect.timeout(REDIS_READ_TIMEOUT_MS),
+      Effect.map((cached): CompanyLogoResult | null =>
+        isCompanyLogoResult(cached) ? cached : null
+      ),
+      Effect.catchCause((cause) => {
+        logCacheSkip("read", cause);
+        return Effect.succeed<CompanyLogoResult | null>(null);
+      })
+    );
+  }
+);
+
+const writeCompanyLogo = Effect.fn("onboarding.companyLogoCache.write")(
+  function* (input: CompanyLogoCacheKeyInput, result: CompanyLogoResult) {
+    const client = redis;
+    if (!client) {
+      return;
+    }
+
+    yield* Effect.tryPromise({
+      try: () =>
+        client.set(buildCacheKey(input), result, {
+          ex: result.url ? RESOLVED_TTL_SECONDS : UNRESOLVED_TTL_SECONDS,
+        }),
+      catch: (cause) =>
+        new RedisUnavailableError({ operation: "write", cause }),
+    }).pipe(
+      Effect.timeout(REDIS_WRITE_TIMEOUT_MS),
+      Effect.asVoid,
+      Effect.catchCause((cause) => {
+        logCacheSkip("write", cause);
+        return Effect.void;
+      })
+    );
+  }
+);
+
+/**
+ * The lookup behind this procedure is an external API call plus a rate-limit
+ * round trip, on every page view. The cache is best effort: without Redis, or
+ * on any Redis error or timeout, callers fall back to the live lookup.
+ */
+export function readCachedCompanyLogo(
+  input: CompanyLogoCacheKeyInput
+): Promise<CompanyLogoResult | null> {
+  return Effect.runPromise(readCompanyLogo(input));
+}
+
+export function writeCachedCompanyLogo(
+  input: CompanyLogoCacheKeyInput,
+  result: CompanyLogoResult
+): Promise<void> {
+  return Effect.runPromise(writeCompanyLogo(input, result));
+}

--- a/apps/dashboard/src/lib/onboarding/errors.ts
+++ b/apps/dashboard/src/lib/onboarding/errors.ts
@@ -1,0 +1,13 @@
+import { Data } from "effect";
+
+/**
+ * Redis is a best-effort accelerator for onboarding lookups. This error marks
+ * the one place that decides to fall through to the live lookup instead of
+ * failing the request.
+ */
+export class RedisUnavailableError extends Data.TaggedError(
+  "RedisUnavailableError"
+)<{
+  readonly operation: "read" | "write";
+  readonly cause: unknown;
+}> {}

--- a/apps/dashboard/src/lib/orpc/routers/onboarding.ts
+++ b/apps/dashboard/src/lib/orpc/routers/onboarding.ts
@@ -30,13 +30,30 @@ import {
   pickBrandSearchResult,
   pickCompanyLogoUrl,
 } from "@/lib/onboarding/company-logo";
+import {
+  readCachedCompanyLogo,
+  writeCachedCompanyLogo,
+} from "@/lib/onboarding/company-logo-cache";
 import { authorizedProcedure } from "@/lib/orpc/base";
+import type { CompanyLogoResult } from "@/types/onboarding";
 import { ratelimit } from "@/utils/ratelimit";
 
 export const onboardingRouter = {
   companyLogo: authorizedProcedure
     .input(companyLogoInputSchema)
-    .handler(async ({ context, input }) => {
+    .handler(async ({ context, input }): Promise<CompanyLogoResult> => {
+      const cacheKeyInput = {
+        query: input.query,
+        searchByName: input.searchByName,
+      };
+
+      // Ahead of the rate limiter: a cached logo costs nothing upstream, and
+      // repeat navigation used to burn the per-query budget on every page view.
+      const cached = await readCachedCompanyLogo(cacheKeyInput);
+      if (cached) {
+        return cached;
+      }
+
       const { success: withinLimit } = await ratelimit.companyLogo.limit(
         `${context.user.id}:${input.query.toLowerCase()}`
       );
@@ -47,21 +64,26 @@ export const onboardingRouter = {
       }
 
       try {
-        if (!input.searchByName) {
+        let result: CompanyLogoResult;
+        if (input.searchByName) {
+          const response = await searchBrands(input.query);
+          const brand = pickBrandSearchResult(response.results, input.query);
+          result = {
+            domain: brand?.domain ?? null,
+            url: brand?.logo || null,
+          };
+        } else {
           const response = await retrieveBrand(input.query);
-          return {
+          result = {
             domain: response.brand?.domain ?? input.query,
             url: pickCompanyLogoUrl(response.brand?.logos),
           };
         }
 
-        const response = await searchBrands(input.query);
-        const brand = pickBrandSearchResult(response.results, input.query);
-        return {
-          domain: brand?.domain ?? null,
-          url: brand?.logo || null,
-        };
+        await writeCachedCompanyLogo(cacheKeyInput, result);
+        return result;
       } catch {
+        // A failed lookup is not cached; only its empty answer is returned.
         return {
           domain: input.searchByName ? null : input.query,
           url: null,

--- a/apps/dashboard/src/schemas/analytics-flag.ts
+++ b/apps/dashboard/src/schemas/analytics-flag.ts
@@ -1,0 +1,15 @@
+import { Schema } from "effect";
+
+/** Shape of the one flag this app reads; other keys are ignored. */
+export const analyticsFlagSchema = Schema.Struct({
+  enabled: Schema.Boolean,
+  reason: Schema.optionalKey(Schema.String),
+});
+
+/**
+ * Entries stay `unknown`: Databuddy returns every flag of the project, and an
+ * unrelated flag with a different shape must not fail the whole decode.
+ */
+export const analyticsFlagsResponseSchema = Schema.Struct({
+  flags: Schema.Record(Schema.String, Schema.Unknown),
+});

--- a/apps/dashboard/src/types/onboarding.ts
+++ b/apps/dashboard/src/types/onboarding.ts
@@ -11,6 +11,12 @@ export type OnboardingWorkspaceInput = z.infer<
   typeof onboardingWorkspaceSchema
 >;
 
+/** Response of `onboarding.companyLogo`, also the cached representation. */
+export interface CompanyLogoResult {
+  domain: string | null;
+  url: string | null;
+}
+
 export interface PricingClientProps {
   slug: string;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Extract slice 7 remainder from closed PR #984: bound onboarding company-logo Redis cache (300 ms read / 1 s write, fail-open, checked before rate limiter) and analytics flag evaluation with a 5 s `Effect.timeout` (fail-closed, TestClock tests). Does not include `createTimeoutFetch` (landed in #1029).

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ff9be19-6aed-5498-816c-42e55175c217?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ff9be19-6aed-5498-816c-42e55175c217&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the onboarding company-logo Redis cache and analytics flag evaluation so slow or failing dependencies no longer stall dashboard requests.

- Company logo lookups read the Redis cache before the rate limiter; reads and writes abort via `AbortSignal.timeout` at 300 ms and 1 s and fall back to the live lookup.
- Analytics flag evaluation calls the flags API directly with a 5 s timeout instead of using the SDK's flags manager; timeouts, failures, and the provider's error reason all resolve to "unavailable".

<sup>Written for commit 8c5309d8b58bdfd9413d2674ff8dccca51297bb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

