### PR TITLE
perf(backend): sql aggregates, bulk shelf, engine-flag cache, geo withCache

### DIFF
--- a/apps/dashboard/src/lib/geo-shelf/citation-query.ts
+++ b/apps/dashboard/src/lib/geo-shelf/citation-query.ts
@@ -38,6 +38,11 @@ function toStringList(value: string[] | null | undefined): string[] {
 /**
  * Unique cited pages for a project: one row per mention-check URL, counting
  * a check once even when the same URL is in both `sources` and grounding.
+ *
+ * The lateral JSONB unnest scans the project's whole mention-check history
+ * because `total_count` is shown as "All time". The cost grows linearly with
+ * history; materialising a per-source all-time counter in the scan-completion
+ * job would let this query be bounded to the citation window.
  */
 export async function queryCitedShelfPages(
   key: GeoShelfStoreKey

--- a/apps/dashboard/src/lib/geo-shelf/store.ts
+++ b/apps/dashboard/src/lib/geo-shelf/store.ts
@@ -153,26 +153,37 @@ export async function updateGeoShelfCitations(
   if (updates.length === 0) {
     return;
   }
-  // One statement instead of one UPDATE per changed source: this runs on the
-  // shelf read path, where every source's citation counts usually moved.
-  const values = sql.join(
-    updates.map(
-      (update) =>
-        sql`(${update.id}::text, ${JSON.stringify(update.citations)}::jsonb, ${update.title}::text)`
-    ),
-    sql`, `
-  );
+  // One statement per chunk instead of one UPDATE per changed source. Chunking
+  // keeps us under Postgres's bind-parameter limit (~21k rows at 3 params each).
   await db.transaction(async (tx) => {
-    await tx.execute(sql`
-      update ${geoShelfSources} as target
-      set citations = incoming.citations,
-        title = coalesce(target.title, incoming.title),
-        updated_at = now() at time zone 'utc'
-      from (values ${values}) as incoming(id, citations, title)
-      where target.id = incoming.id
-        and target.organization_id = ${key.organizationId}
-        and target.project_id = ${key.projectId}
-    `);
+    for (
+      let index = 0;
+      index < updates.length;
+      index += GEO_SHELF_CITATION_INSERT_CHUNK
+    ) {
+      const chunk = updates.slice(
+        index,
+        index + GEO_SHELF_CITATION_INSERT_CHUNK
+      );
+      const values = sql.join(
+        chunk.map(
+          (update) =>
+            sql`(${update.id}::text, ${JSON.stringify(update.citations)}::jsonb, ${update.title}::text)`
+        ),
+        sql`, `
+      );
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- one transaction connection executes queries serially
+      await tx.execute(sql`
+        update ${geoShelfSources} as target
+        set citations = incoming.citations,
+          title = coalesce(target.title, incoming.title),
+          updated_at = now() at time zone 'utc'
+        from (values ${values}) as incoming(id, citations, title)
+        where target.id = incoming.id
+          and target.organization_id = ${key.organizationId}
+          and target.project_id = ${key.projectId}
+      `);
+    }
   });
 }
 

--- a/apps/dashboard/src/lib/geo-shelf/store.ts
+++ b/apps/dashboard/src/lib/geo-shelf/store.ts
@@ -69,7 +69,8 @@ export async function listPersistedGeoShelfSources(
     .select()
     .from(geoShelfSources)
     .where(scopeWhere(key))
-    .orderBy(desc(geoShelfSources.updatedAt));
+    // `id` breaks ties: batched writes share an `updated_at` timestamp.
+    .orderBy(desc(geoShelfSources.updatedAt), desc(geoShelfSources.id));
   return rows.map(toSource);
 }
 
@@ -152,17 +153,26 @@ export async function updateGeoShelfCitations(
   if (updates.length === 0) {
     return;
   }
+  // One statement instead of one UPDATE per changed source: this runs on the
+  // shelf read path, where every source's citation counts usually moved.
+  const values = sql.join(
+    updates.map(
+      (update) =>
+        sql`(${update.id}::text, ${JSON.stringify(update.citations)}::jsonb, ${update.title}::text)`
+    ),
+    sql`, `
+  );
   await db.transaction(async (tx) => {
-    for (const update of updates) {
-      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- one transaction connection executes queries serially
-      await tx
-        .update(geoShelfSources)
-        .set({
-          citations: update.citations,
-          title: sql`coalesce(${geoShelfSources.title}, ${update.title})`,
-        })
-        .where(and(scopeWhere(key), eq(geoShelfSources.id, update.id)));
-    }
+    await tx.execute(sql`
+      update ${geoShelfSources} as target
+      set citations = incoming.citations,
+        title = coalesce(target.title, incoming.title),
+        updated_at = now() at time zone 'utc'
+      from (values ${values}) as incoming(id, citations, title)
+      where target.id = incoming.id
+        and target.organization_id = ${key.organizationId}
+        and target.project_id = ${key.projectId}
+    `);
   });
 }
 

--- a/apps/dashboard/src/lib/geo/configure.ts
+++ b/apps/dashboard/src/lib/geo/configure.ts
@@ -10,6 +10,7 @@ import {
   GeoWorkflowService,
 } from "@notra/geo-core/deps";
 import { agentReadinessNetworkLive } from "@notra/geo-core/geo/agent-readiness-live";
+import { GeoFlagEvaluationError } from "@notra/geo-core/geo/errors";
 import { geoModelLive } from "@notra/geo-core/geo/model-live";
 import { geoSearchConsoleLive } from "@notra/geo-core/geo/search-console-live";
 import { Effect, Layer } from "effect";
@@ -76,20 +77,35 @@ const entitlementLayer = Layer.succeed(GeoEntitlementService, {
   ),
 });
 
+function geoEngineFlagEnabled(
+  flagKey: string,
+  organizationId: string
+): Effect.Effect<boolean, GeoFlagEvaluationError> {
+  return resolveGeoFlagState(flagKey, organizationId).pipe(
+    Effect.flatMap((state) => {
+      if (state === "unavailable") {
+        return Effect.fail(
+          new GeoFlagEvaluationError({
+            message: `GEO feature flag "${flagKey}" is unavailable`,
+            cause: null,
+          })
+        );
+      }
+      return Effect.succeed(state === "enabled");
+    })
+  );
+}
+
 const featureFlagLayer = Layer.succeed(GeoFeatureFlagService, {
   isCursorEngineEnabledForOrganization: Effect.fn(
     "GeoDashboardFeatureFlags.isCursorEnabled"
   )((organizationId) =>
-    resolveGeoFlagState(GEO_CURSOR_FLAG_KEY, organizationId).pipe(
-      Effect.map((state) => state === "enabled")
-    )
+    geoEngineFlagEnabled(GEO_CURSOR_FLAG_KEY, organizationId)
   ),
   isOpenCodeEngineEnabledForOrganization: Effect.fn(
     "GeoDashboardFeatureFlags.isOpenCodeEnabled"
   )((organizationId) =>
-    resolveGeoFlagState(GEO_OPENCODE_FLAG_KEY, organizationId).pipe(
-      Effect.map((state) => state === "enabled")
-    )
+    geoEngineFlagEnabled(GEO_OPENCODE_FLAG_KEY, organizationId)
   ),
 });
 

--- a/apps/dashboard/src/lib/orpc/routers/content.ts
+++ b/apps/dashboard/src/lib/orpc/routers/content.ts
@@ -55,7 +55,19 @@ import {
 import { clearCompletedGenerationSchema } from "@notra/schemas/dashboard/generations";
 import { repositoryContentDirectoryConfigSchema } from "@notra/schemas/dashboard/integrations";
 import { eachDayOfInterval, endOfYear, format, startOfYear } from "date-fns";
-import { and, asc, count, desc, eq, gte, inArray, lt, lte } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gte,
+  inArray,
+  lt,
+  lte,
+  ne,
+  sql,
+} from "drizzle-orm";
 import { marked } from "marked";
 import { nanoid } from "nanoid";
 import { after } from "next/server";
@@ -118,6 +130,10 @@ import {
 } from "../utils/errors";
 
 const TITLE_REGEX = /^#\s+(.+)$/m;
+
+// Upper bound for the sibling rail on the content detail response; matches the
+// maximum page size of the content list.
+const CONTENT_SIBLING_LIMIT = 100;
 
 const postReadColumns = {
   id: true,
@@ -586,7 +602,11 @@ export const contentRouter = {
               contentType: true,
               status: true,
             },
+            // The current post is excluded in SQL, and the rail is bounded: a
+            // collection can hold hundreds of posts.
+            where: ne(posts.id, post.id),
             orderBy: [asc(posts.createdAt), asc(posts.id)],
+            limit: CONTENT_SIBLING_LIMIT,
           },
         },
       });
@@ -598,14 +618,12 @@ export const contentRouter = {
               id: collection.id,
               name: collection.name,
               source: collection.source,
-              siblings: collection.posts
-                .filter((sibling) => sibling.id !== post.id)
-                .map((sibling) => ({
-                  id: sibling.id,
-                  title: sibling.title,
-                  contentType: normalizeContentType(sibling.contentType),
-                  status: sibling.status,
-                })),
+              siblings: collection.posts.map((sibling) => ({
+                id: sibling.id,
+                title: sibling.title,
+                contentType: normalizeContentType(sibling.contentType),
+                status: sibling.status,
+              })),
             }
           : null,
       };
@@ -783,8 +801,6 @@ export const contentRouter = {
             repo: githubIntegrations.repo,
             defaultBranch: githubIntegrations.defaultBranch,
             installationId: githubAppInstallations.installationId,
-            installationAccountType: githubAppInstallations.accountType,
-            installationAccountLogin: githubAppInstallations.accountLogin,
             githubAppInstallationId: githubIntegrations.githubAppInstallationId,
             encryptedToken: githubIntegrations.encryptedToken,
             outputConfig: repositoryOutputs.config,
@@ -958,8 +974,6 @@ export const contentRouter = {
           outputType: input.contentType,
           connectionMethod,
           installationId: integration.installationId,
-          installationAccountType: integration.installationAccountType,
-          installationAccountLogin: integration.installationAccountLogin,
         });
       }
     }),
@@ -1040,40 +1054,36 @@ export const contentRouter = {
         ]);
 
         const collectionIds = collectionRows.map((collection) => collection.id);
-        const postRows =
+        // One row per collection: counting and de-duplicating the content types
+        // in Postgres avoids shipping every post of every listed collection.
+        const aggregateRows =
           collectionIds.length > 0
             ? await db
                 .select({
                   collectionId: posts.collectionId,
-                  contentType: posts.contentType,
-                  status: posts.status,
+                  total: sql<number>`count(*)::int`,
+                  draft: sql<number>`count(*) filter (where ${posts.status} <> 'published')::int`,
+                  published: sql<number>`count(*) filter (where ${posts.status} = 'published')::int`,
+                  types: sql<
+                    string[] | null
+                  >`array_agg(distinct ${posts.contentType})`,
                 })
                 .from(posts)
                 .where(inArray(posts.collectionId, collectionIds))
+                .groupBy(posts.collectionId)
             : [];
 
-        const aggregates = new Map<
-          string,
-          { total: number; draft: number; published: number; types: string[] }
-        >();
-        for (const post of postRows) {
-          const aggregate = aggregates.get(post.collectionId) ?? {
-            total: 0,
-            draft: 0,
-            published: 0,
-            types: [],
-          };
-          aggregate.total += 1;
-          if (post.status === "published") {
-            aggregate.published += 1;
-          } else {
-            aggregate.draft += 1;
-          }
-          if (!aggregate.types.includes(post.contentType)) {
-            aggregate.types.push(post.contentType);
-          }
-          aggregates.set(post.collectionId, aggregate);
-        }
+        const aggregates = new Map(
+          aggregateRows.map((row) => [
+            row.collectionId,
+            {
+              total: Number(row.total),
+              draft: Number(row.draft),
+              published: Number(row.published),
+              types: row.types ?? [],
+            },
+          ])
+        );
 
         const collections = collectionRows.map((collection) => {
           const aggregate = aggregates.get(collection.id);
@@ -1319,10 +1329,16 @@ export const contentRouter = {
         const yearStart = startOfYear(now);
         const yearEnd = endOfYear(now);
 
-        const allPosts = await db
+        // One row per day instead of one row per post. `drafts` counts every
+        // non-published status (matching the previous JS bucketing), while
+        // `strictDrafts` feeds the `drafts` total, which only ever counted the
+        // literal "draft" status.
+        const dailyCounts = await db
           .select({
-            status: posts.status,
-            createdAt: posts.createdAt,
+            day: sql<string>`to_char(${posts.createdAt}, 'YYYY-MM-DD')`,
+            drafts: sql<number>`count(*) filter (where ${posts.status} <> 'published')::int`,
+            strictDrafts: sql<number>`count(*) filter (where ${posts.status} = 'draft')::int`,
+            published: sql<number>`count(*) filter (where ${posts.status} = 'published')::int`,
           })
           .from(posts)
           .where(
@@ -1332,43 +1348,30 @@ export const contentRouter = {
               lte(posts.createdAt, yearEnd)
             )
           )
-          .orderBy(posts.createdAt);
+          .groupBy(sql`to_char(${posts.createdAt}, 'YYYY-MM-DD')`);
 
-        const totalDrafts = allPosts.filter(
-          (post) => post.status === "draft"
-        ).length;
-        const totalPublished = allPosts.filter(
-          (post) => post.status === "published"
-        ).length;
         const dateMap = new Map<
           string,
           { drafts: number; published: number }
         >();
+        let totalDrafts = 0;
+        let totalPublished = 0;
+        let maxCount = 1;
 
-        for (const post of allPosts) {
-          const dateKey = format(post.createdAt, "yyyy-MM-dd");
-          const entry = dateMap.get(dateKey) ?? { drafts: 0, published: 0 };
+        for (const row of dailyCounts) {
+          const drafts = Number(row.drafts);
+          const published = Number(row.published);
 
-          if (post.status === "published") {
-            entry.published += 1;
-          } else {
-            entry.drafts += 1;
-          }
-
-          dateMap.set(dateKey, entry);
+          totalDrafts += Number(row.strictDrafts);
+          totalPublished += published;
+          maxCount = Math.max(maxCount, drafts + published);
+          dateMap.set(row.day, { drafts, published });
         }
 
         const allDaysInYear = eachDayOfInterval({
           start: yearStart,
           end: yearEnd,
         });
-
-        const maxCount = Math.max(
-          ...Array.from(dateMap.values()).map(
-            (value) => value.drafts + value.published
-          ),
-          1
-        );
 
         const activityData = allDaysInYear.map((date) => {
           const dateKey = format(date, "yyyy-MM-dd");

--- a/packages/db/src/constants/geo-check-cache.ts
+++ b/packages/db/src/constants/geo-check-cache.ts
@@ -1,0 +1,14 @@
+/**
+ * Cache policy for the GEO mention-check aggregates (overview, timeseries,
+ * prompt summaries, language and competitor breakdowns).
+ *
+ * These queries scan a project's whole window on every dashboard render and
+ * only change when a scan inserts new checks. Drizzle's auto-invalidation drops
+ * every cached aggregate on each write to `geo_mention_checks`, so the TTL only
+ * bounds staleness across writers that bypass Drizzle.
+ */
+const GEO_CHECK_AGGREGATE_TTL_SECONDS = 300;
+
+export const GEO_CHECK_AGGREGATE_CACHE = {
+  config: { ex: GEO_CHECK_AGGREGATE_TTL_SECONDS },
+} as const;

--- a/packages/db/src/utils/geo-checks.ts
+++ b/packages/db/src/utils/geo-checks.ts
@@ -410,7 +410,7 @@ export async function queryGeoCheckPromptHistory(
     return [];
   }
 
-  const rows = await db
+  const rowsQuery = db
     .select({
       id: geoMentionChecks.id,
       scanId: geoMentionChecks.scanId,
@@ -431,14 +431,15 @@ export async function queryGeoCheckPromptHistory(
       and(
         mentionFilters(scope, undefined, {
           sequences: "single",
-          englishOnly: true,
+          englishOnly: !query.scanId,
         }),
         inArray(geoMentionChecks.promptId, query.promptIds),
+        query.scanId ? eq(geoMentionChecks.scanId, query.scanId) : undefined,
         eq(geoMentionChecks.turn, 0)
       )
     )
-    .orderBy(desc(geoMentionChecks.capturedAt))
-    .limit(query.limit);
+    .orderBy(desc(geoMentionChecks.capturedAt));
+  const rows = await (query.scanId ? rowsQuery : rowsQuery.limit(query.limit));
 
   return rows.map((row) => ({
     id: row.id,

--- a/packages/db/src/utils/geo-checks.ts
+++ b/packages/db/src/utils/geo-checks.ts
@@ -10,6 +10,7 @@ import {
   sql,
 } from "drizzle-orm";
 
+import { GEO_CHECK_AGGREGATE_CACHE } from "../constants/geo-check-cache";
 import { GEO_CHECK_ENGLISH_LANGUAGES } from "../constants/geo-checks";
 import { db } from "../drizzle";
 import { geoMentionChecks, geoScans } from "../schema";
@@ -95,7 +96,10 @@ export function toGeoCheckWindow(
   if (input.days === undefined) {
     return;
   }
+  // Anchored to the start of the UTC day, like the `from`/`to` branch: a
+  // millisecond-precise `now` would make every request a distinct cache key.
   const from = new Date();
+  from.setUTCHours(0, 0, 0, 0);
   from.setUTCDate(from.getUTCDate() - input.days);
   return { from };
 }
@@ -208,6 +212,7 @@ export async function queryGeoCheckOverview(
       lastCheckedAt: sql<Date>`max(${geoMentionChecks.capturedAt})`,
     })
     .from(geoMentionChecks)
+    .$withCache(GEO_CHECK_AGGREGATE_CACHE)
     .where(
       mentionFilters(scope, window, { sequences: "single", englishOnly: true })
     )
@@ -242,6 +247,7 @@ export async function queryGeoCheckTimeseries(
       >`round(avg(${geoMentionChecks.position}) filter (where ${geoMentionChecks.mentioned} and ${geoMentionChecks.position} is not null), 1)::float8`,
     })
     .from(geoMentionChecks)
+    .$withCache(GEO_CHECK_AGGREGATE_CACHE)
     .where(
       mentionFilters(scope, window, {
         ...options,
@@ -379,6 +385,7 @@ export async function queryGeoCheckPromptSummaries(
       lastCheckedAt: geoMentionChecks.capturedAt,
     })
     .from(geoMentionChecks)
+    .$withCache(GEO_CHECK_AGGREGATE_CACHE)
     .where(
       mentionFilters(scope, window, { sequences: "single", englishOnly: true })
     )
@@ -403,7 +410,7 @@ export async function queryGeoCheckPromptHistory(
     return [];
   }
 
-  const rowsQuery = db
+  const rows = await db
     .select({
       id: geoMentionChecks.id,
       scanId: geoMentionChecks.scanId,
@@ -424,15 +431,14 @@ export async function queryGeoCheckPromptHistory(
       and(
         mentionFilters(scope, undefined, {
           sequences: "single",
-          englishOnly: !query.scanId,
+          englishOnly: true,
         }),
         inArray(geoMentionChecks.promptId, query.promptIds),
-        query.scanId ? eq(geoMentionChecks.scanId, query.scanId) : undefined,
         eq(geoMentionChecks.turn, 0)
       )
     )
-    .orderBy(desc(geoMentionChecks.capturedAt));
-  const rows = await (query.scanId ? rowsQuery : rowsQuery.limit(query.limit));
+    .orderBy(desc(geoMentionChecks.capturedAt))
+    .limit(query.limit);
 
   return rows.map((row) => ({
     id: row.id,
@@ -602,6 +608,7 @@ export async function queryGeoCheckCompetitorTimeseries(
       checks: sql<number>`count(*)::int`,
     })
     .from(geoMentionChecks)
+    .$withCache(GEO_CHECK_AGGREGATE_CACHE)
     .where(and(...filters))
     .groupBy(sql`(${geoMentionChecks.capturedAt})::date`)
     .orderBy(sql`(${geoMentionChecks.capturedAt})::date asc`);
@@ -634,6 +641,7 @@ export async function queryGeoCheckCompetitorPrompts(
       capturedAt: geoMentionChecks.capturedAt,
     })
     .from(geoMentionChecks)
+    .$withCache(GEO_CHECK_AGGREGATE_CACHE)
     .where(and(...filters))
     .orderBy(
       geoMentionChecks.promptId,
@@ -673,6 +681,7 @@ export async function queryGeoCheckLanguageShare(
       lastCheckedAt: sql<Date>`max(${geoMentionChecks.capturedAt})`,
     })
     .from(geoMentionChecks)
+    .$withCache(GEO_CHECK_AGGREGATE_CACHE)
     .where(and(...filters))
     .groupBy(
       sql`case when ${geoMentionChecks.language} = '' then 'English' else ${geoMentionChecks.language} end`
@@ -706,6 +715,7 @@ export async function queryGeoCheckLanguageShareTrends(
       mentionRate: sql<number>`round(count(*) filter (where ${geoMentionChecks.mentioned})::numeric / nullif(count(*), 0), 3)::float8`,
     })
     .from(geoMentionChecks)
+    .$withCache(GEO_CHECK_AGGREGATE_CACHE)
     .where(and(...filters))
     .groupBy(day, language)
     .orderBy(day, language);

--- a/packages/geo-core/src/geo/agent-readiness.ts
+++ b/packages/geo-core/src/geo/agent-readiness.ts
@@ -148,19 +148,29 @@ async function latestReadinessReports(
     eq(geoAgentReadinessReports.projectId, projectId),
     inArray(geoAgentReadinessReports.targetUrl, targetUrls)
   );
+  const latestBranch = db
+    .select({
+      ...readinessReportColumns,
+      isLatest: sql<boolean>`true`.as("is_latest"),
+    })
+    .from(geoAgentReadinessReports)
+    .where(scoped)
+    .orderBy(desc(geoAgentReadinessReports.createdAt))
+    .limit(1)
+    .as("latest_readiness_report");
+  const completedBranch = db
+    .select({
+      ...readinessReportColumns,
+      isLatest: sql<boolean>`false`.as("is_latest"),
+    })
+    .from(geoAgentReadinessReports)
+    .where(and(scoped, eq(geoAgentReadinessReports.status, "completed")))
+    .orderBy(desc(geoAgentReadinessReports.createdAt))
+    .limit(1)
+    .as("completed_readiness_report");
   const rows = await unionAll(
-    db
-      .select({ ...readinessReportColumns, isLatest: sql<boolean>`true` })
-      .from(geoAgentReadinessReports)
-      .where(scoped)
-      .orderBy(desc(geoAgentReadinessReports.createdAt))
-      .limit(1),
-    db
-      .select({ ...readinessReportColumns, isLatest: sql<boolean>`false` })
-      .from(geoAgentReadinessReports)
-      .where(and(scoped, eq(geoAgentReadinessReports.status, "completed")))
-      .orderBy(desc(geoAgentReadinessReports.createdAt))
-      .limit(1)
+    db.select().from(latestBranch),
+    db.select().from(completedBranch)
   );
   return {
     latest: rows.find((row) => row.isLatest),

--- a/packages/geo-core/src/geo/agent-readiness.ts
+++ b/packages/geo-core/src/geo/agent-readiness.ts
@@ -1,6 +1,7 @@
 import { db } from "@notra/db/drizzle";
 import { brandSettings, geoAgentReadinessReports } from "@notra/db/schema";
-import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core";
 import { Effect } from "effect";
 
 import { AGENT_READINESS_HISTORY_LIMIT } from "../constants/agent-readiness";
@@ -30,7 +31,26 @@ import {
 } from "../utils/geo-website";
 import { geoDb } from "./effect";
 
-function toReportView(row: AgentReadinessReportRow): AgentReadinessReportView {
+/** Everything `toReportView` reads — the two JSONB-free columns are omitted. */
+type AgentReadinessReportFields = Pick<
+  AgentReadinessReportRow,
+  | "id"
+  | "status"
+  | "targetUrl"
+  | "score"
+  | "scoreLabel"
+  | "scoreBreakdown"
+  | "issues"
+  | "eligibleChecks"
+  | "reportUrl"
+  | "errorMessage"
+  | "scannedAt"
+  | "createdAt"
+>;
+
+function toReportView(
+  row: AgentReadinessReportFields
+): AgentReadinessReportView {
   return {
     id: row.id,
     status: row.status,
@@ -92,6 +112,62 @@ async function latestRowWhere(
   });
 }
 
+const readinessReportColumns = {
+  id: geoAgentReadinessReports.id,
+  status: geoAgentReadinessReports.status,
+  targetUrl: geoAgentReadinessReports.targetUrl,
+  score: geoAgentReadinessReports.score,
+  scoreLabel: geoAgentReadinessReports.scoreLabel,
+  scoreBreakdown: geoAgentReadinessReports.scoreBreakdown,
+  issues: geoAgentReadinessReports.issues,
+  eligibleChecks: geoAgentReadinessReports.eligibleChecks,
+  reportUrl: geoAgentReadinessReports.reportUrl,
+  errorMessage: geoAgentReadinessReports.errorMessage,
+  scannedAt: geoAgentReadinessReports.scannedAt,
+  createdAt: geoAgentReadinessReports.createdAt,
+} as const;
+
+/**
+ * The newest report and the newest *completed* report in one round trip. A
+ * `limit 2` would not do: any number of running/failed reports can sit between
+ * the two, so each half keeps its own `order by ... limit 1`.
+ *
+ * `union all` makes no promise about which branch's row comes first, so each
+ * branch labels itself instead of relying on position. When the newest report
+ * is already completed, both branches return it and both halves resolve to it.
+ */
+async function latestReadinessReports(
+  projectId: string,
+  targetUrl: string
+): Promise<{
+  latest: AgentReadinessReportFields | undefined;
+  completed: AgentReadinessReportFields | undefined;
+}> {
+  const targetUrls = getWebsiteUrlLookupVariants(targetUrl);
+  const scoped = and(
+    eq(geoAgentReadinessReports.projectId, projectId),
+    inArray(geoAgentReadinessReports.targetUrl, targetUrls)
+  );
+  const rows = await unionAll(
+    db
+      .select({ ...readinessReportColumns, isLatest: sql<boolean>`true` })
+      .from(geoAgentReadinessReports)
+      .where(scoped)
+      .orderBy(desc(geoAgentReadinessReports.createdAt))
+      .limit(1),
+    db
+      .select({ ...readinessReportColumns, isLatest: sql<boolean>`false` })
+      .from(geoAgentReadinessReports)
+      .where(and(scoped, eq(geoAgentReadinessReports.status, "completed")))
+      .orderBy(desc(geoAgentReadinessReports.createdAt))
+      .limit(1)
+  );
+  return {
+    latest: rows.find((row) => row.isLatest),
+    completed: rows.find((row) => !row.isLatest),
+  };
+}
+
 async function loadHistory(
   projectId: string,
   targetUrl: string
@@ -131,13 +207,10 @@ async function loadHistory(
 export const loadAgentReadiness = Effect.fn("geo.agentReadiness.load")(
   function* (scope: AgentReadinessScope) {
     const targetUrl = yield* resolveTargetUrl(scope.brandSettingsId);
-    const [completed, latest, history] = yield* Effect.all(
+    const [reports, history] = yield* Effect.all(
       [
-        geoDb("read completed readiness", () =>
-          latestRowWhere(scope.projectId, "completed", targetUrl)
-        ),
-        geoDb("read latest readiness", () =>
-          latestRowWhere(scope.projectId, undefined, targetUrl)
+        geoDb("read readiness reports", () =>
+          latestReadinessReports(scope.projectId, targetUrl)
         ),
         geoDb("read readiness history", () =>
           loadHistory(scope.projectId, targetUrl)
@@ -145,6 +218,7 @@ export const loadAgentReadiness = Effect.fn("geo.agentReadiness.load")(
       ],
       { concurrency: "unbounded" }
     );
+    const { completed, latest } = reports;
 
     const report = completed ? toReportView(completed) : null;
     const scan =

--- a/packages/geo-core/src/geo/engine-flags.ts
+++ b/packages/geo-core/src/geo/engine-flags.ts
@@ -26,7 +26,9 @@ const evaluateFlag = (
 ): Effect.Effect<{ readonly enabled: boolean; readonly available: boolean }> =>
   flag.pipe(
     Effect.map((enabled) => ({ enabled, available: true })),
-    Effect.catch(() => Effect.succeed({ enabled: false, available: false }))
+    Effect.catchTag("GeoFlagEvaluationError", () =>
+      Effect.succeed({ enabled: false, available: false })
+    )
   );
 
 const evaluateGeoEngineFlags = Effect.fn("geo.engineFlags.evaluate")(

--- a/packages/geo-core/src/geo/engine-flags.ts
+++ b/packages/geo-core/src/geo/engine-flags.ts
@@ -1,0 +1,80 @@
+import { Cache, Duration, Effect, Exit } from "effect";
+
+import { GeoFeatureFlagService } from "../deps";
+import {
+  GeoEngineFlagCacheKey,
+  type GeoEngineFlags,
+} from "../types/engine-flags";
+import type { GeoFlagEvaluationError } from "./errors";
+
+/**
+ * Several GEO programs resolve the model catalog inside one server request, and
+ * each resolution asks the flag provider the same two questions. A short-lived
+ * cache keeps that to one round trip per organization without importing a
+ * request cache into this package.
+ */
+const ENGINE_FLAG_CACHE_TTL = Duration.seconds(30);
+const ENGINE_FLAG_CACHE_CAPACITY = 500;
+
+/**
+ * A provider outage is a degraded answer, not a failure: the engine stays
+ * hidden (fail closed) so the catalog still resolves, and `available: false`
+ * marks the answer as one that must not be cached.
+ */
+const evaluateFlag = (
+  flag: Effect.Effect<boolean, GeoFlagEvaluationError>
+): Effect.Effect<{ readonly enabled: boolean; readonly available: boolean }> =>
+  flag.pipe(
+    Effect.map((enabled) => ({ enabled, available: true })),
+    Effect.catch(() => Effect.succeed({ enabled: false, available: false }))
+  );
+
+const evaluateGeoEngineFlags = Effect.fn("geo.engineFlags.evaluate")(
+  function* ({ organizationId, featureFlags }: GeoEngineFlagCacheKey) {
+    const [cursor, openCode] = yield* Effect.all(
+      [
+        evaluateFlag(
+          featureFlags.isCursorEngineEnabledForOrganization(organizationId)
+        ),
+        evaluateFlag(
+          featureFlags.isOpenCodeEngineEnabledForOrganization(organizationId)
+        ),
+      ],
+      { concurrency: "unbounded" }
+    );
+    return {
+      cursorEnabled: cursor.enabled,
+      openCodeEnabled: openCode.enabled,
+      available: cursor.available && openCode.available,
+    } satisfies GeoEngineFlags;
+  }
+);
+
+/**
+ * `Cache` replaces a hand-rolled `Map` memo: it bounds itself, shares one
+ * pending evaluation between callers sharing an organization and provider.
+ * Provider identity is part of the key so distinct host layers cannot reuse
+ * each other's evaluations.
+ */
+const engineFlagCache = Effect.runSync(
+  Cache.makeWith(evaluateGeoEngineFlags, {
+    capacity: ENGINE_FLAG_CACHE_CAPACITY,
+    // Only answers the provider actually gave are held. A provider that fails,
+    // defects, or is unavailable is retried by the next caller, exactly as the
+    // previous memo did — a 30 s outage must not hide entitled engines for 30 s.
+    timeToLive: (exit) =>
+      Exit.isSuccess(exit) && exit.value.available
+        ? ENGINE_FLAG_CACHE_TTL
+        : Duration.zero,
+  })
+);
+
+export const loadGeoEngineFlags = Effect.fn("geo.engineFlags")(function* (
+  organizationId: string
+) {
+  const featureFlags = yield* GeoFeatureFlagService;
+  return yield* Cache.get(
+    engineFlagCache,
+    new GeoEngineFlagCacheKey({ organizationId, featureFlags })
+  );
+});

--- a/packages/geo-core/src/geo/gaps.ts
+++ b/packages/geo-core/src/geo/gaps.ts
@@ -178,7 +178,7 @@ const loadMentionGapInputs = Effect.fn("geo.mentionGapInputs")(function* (
     ),
     geoDb("settings lookup failed", () =>
       db.query.geoSettings.findFirst({
-        columns: { removedAutoPromptIds: true },
+        columns: { removedAutoPromptIds: true, competitors: true },
         where: eq(geoSettings.projectId, projectId),
       })
     ),
@@ -187,6 +187,7 @@ const loadMentionGapInputs = Effect.fn("geo.mentionGapInputs")(function* (
     checks,
     prompts,
     removedAutoPromptIds: new Set(settingsRow?.removedAutoPromptIds ?? []),
+    settingsCompetitors: settingsRow?.competitors ?? [],
   };
 });
 
@@ -412,85 +413,75 @@ export const loadGeoContentGaps = Effect.fn("geo.gaps")(function* (
   const scope = yield* requireGeoProject(input);
   const projectId = scope.projectId;
 
-  const [
-    mentionInputs,
-    pending,
-    briefs,
-    competitorRows,
-    settingsRow,
-    collisionCandidates,
-  ] = yield* Effect.all([
-    loadMentionGapInputs(projectId),
-    geoDb("prompt suggestions lookup failed", () =>
-      db
-        .select({
-          id: geoPromptSuggestions.id,
-          prompt: geoPromptSuggestions.prompt,
-          title: geoPromptSuggestions.title,
-          sourceKeywords: geoPromptSuggestions.sourceKeywords,
-        })
-        .from(geoPromptSuggestions)
-        .where(
-          and(
-            eq(geoPromptSuggestions.organizationId, scope.organizationId),
-            eq(geoPromptSuggestions.status, "pending")
+  const [mentionInputs, pending, briefs, competitorRows, collisionCandidates] =
+    yield* Effect.all([
+      loadMentionGapInputs(projectId),
+      geoDb("prompt suggestions lookup failed", () =>
+        db
+          .select({
+            id: geoPromptSuggestions.id,
+            prompt: geoPromptSuggestions.prompt,
+            title: geoPromptSuggestions.title,
+            sourceKeywords: geoPromptSuggestions.sourceKeywords,
+          })
+          .from(geoPromptSuggestions)
+          .where(
+            and(
+              eq(geoPromptSuggestions.organizationId, scope.organizationId),
+              eq(geoPromptSuggestions.status, "pending")
+            )
           )
-        )
-        .orderBy(desc(geoPromptSuggestions.createdAt))
-        .limit(GEO_GAPS_SEARCH_LIMIT)
-    ),
-    geoDb("briefs lookup failed", () =>
-      db
-        .selectDistinctOn(
-          [geoContentBriefs.sourceKind, geoContentBriefs.sourceId],
-          {
-            id: geoContentBriefs.id,
-            status: geoContentBriefs.status,
-            postId: geoContentBriefs.postId,
-            sourceKind: geoContentBriefs.sourceKind,
-            sourceId: geoContentBriefs.sourceId,
-            workingTitle: sql<string>`${geoContentBriefs.brief}->>'workingTitle'`,
-            baseline: sql<unknown>`${geoContentBriefs.brief}->'baseline'`,
-            publishedAt: geoContentBriefs.publishedAt,
-            rescanScanId: geoContentBriefs.rescanScanId,
-          }
-        )
-        .from(geoContentBriefs)
-        .where(
-          and(
-            eq(geoContentBriefs.projectId, projectId),
-            inArray(geoContentBriefs.sourceKind, ["gap", "search_console"]),
-            isNotNull(geoContentBriefs.sourceId)
+          .orderBy(desc(geoPromptSuggestions.createdAt))
+          .limit(GEO_GAPS_SEARCH_LIMIT)
+      ),
+      geoDb("briefs lookup failed", () =>
+        db
+          .selectDistinctOn(
+            [geoContentBriefs.sourceKind, geoContentBriefs.sourceId],
+            {
+              id: geoContentBriefs.id,
+              status: geoContentBriefs.status,
+              postId: geoContentBriefs.postId,
+              sourceKind: geoContentBriefs.sourceKind,
+              sourceId: geoContentBriefs.sourceId,
+              workingTitle: sql<string>`${geoContentBriefs.brief}->>'workingTitle'`,
+              baseline: sql<unknown>`${geoContentBriefs.brief}->'baseline'`,
+              publishedAt: geoContentBriefs.publishedAt,
+              rescanScanId: geoContentBriefs.rescanScanId,
+            }
           )
-        )
-        .orderBy(
-          geoContentBriefs.sourceKind,
-          geoContentBriefs.sourceId,
-          desc(geoContentBriefs.updatedAt)
-        )
-    ),
-    geoDb("competitors lookup failed", () =>
-      db
-        .select({
-          name: geoCompetitors.name,
-          synonyms: geoCompetitors.synonyms,
-        })
-        .from(geoCompetitors)
-        .where(eq(geoCompetitors.projectId, projectId))
-    ),
-    geoDb("settings competitors lookup failed", () =>
-      db.query.geoSettings.findFirst({
-        columns: { competitors: true },
-        where: eq(geoSettings.projectId, projectId),
-      })
-    ),
-    loadCollisionCandidates(scope),
-  ]);
-  const { checks, prompts, removedAutoPromptIds } = mentionInputs;
+          .from(geoContentBriefs)
+          .where(
+            and(
+              eq(geoContentBriefs.projectId, projectId),
+              inArray(geoContentBriefs.sourceKind, ["gap", "search_console"]),
+              isNotNull(geoContentBriefs.sourceId)
+            )
+          )
+          .orderBy(
+            geoContentBriefs.sourceKind,
+            geoContentBriefs.sourceId,
+            desc(geoContentBriefs.updatedAt)
+          )
+      ),
+      geoDb("competitors lookup failed", () =>
+        db
+          .select({
+            name: geoCompetitors.name,
+            synonyms: geoCompetitors.synonyms,
+          })
+          .from(geoCompetitors)
+          .where(eq(geoCompetitors.projectId, projectId))
+      ),
+      loadCollisionCandidates(scope),
+    ]);
+  // `loadMentionGapInputs` already read this project's geo_settings row.
+  const { checks, prompts, removedAutoPromptIds, settingsCompetitors } =
+    mentionInputs;
 
   const trackedAliases = competitorCanonicalMap([
     ...competitorRows,
-    ...(settingsRow?.competitors ?? []).map((name) => ({
+    ...settingsCompetitors.map((name) => ({
       name,
       synonyms: [] as string[],
     })),

--- a/packages/geo-core/src/geo/model-catalog.ts
+++ b/packages/geo-core/src/geo/model-catalog.ts
@@ -9,7 +9,6 @@ import {
   GEO_MODEL_FEED_REVALIDATE_SECONDS,
   GEO_MODEL_FEED_URL,
 } from "../constants/geo-model-catalog";
-import { GeoFeatureFlagService } from "../deps";
 import { geoModelFeedSchema } from "../schemas/geo-model-feed";
 import type { GeoModelCatalog, GeoResolvedModelCatalog } from "../types/geo";
 import { resolveGroundedEngines } from "../utils/geo-grounded-engines";
@@ -18,6 +17,7 @@ import {
   seedGeoModelCatalog,
   withoutGeoModelCatalogEntries,
 } from "../utils/geo-model-catalog";
+import { loadGeoEngineFlags } from "./engine-flags";
 
 const MS_PER_SECOND = 1000;
 
@@ -72,12 +72,13 @@ async function loadSharedGeoModelCatalog(): Promise<GeoModelCatalog> {
 export const loadGeoModelCatalog = Effect.fn("geo.modelCatalog")(function* (
   organizationId: string
 ) {
-  const featureFlags = yield* GeoFeatureFlagService;
-  const [catalog, cursorEnabled, openCodeEnabled] = yield* Effect.all([
-    Effect.promise(loadSharedGeoModelCatalog),
-    featureFlags.isCursorEngineEnabledForOrganization(organizationId),
-    featureFlags.isOpenCodeEngineEnabledForOrganization(organizationId),
-  ]);
+  const [catalog, { cursorEnabled, openCodeEnabled }] = yield* Effect.all(
+    [
+      Effect.promise(loadSharedGeoModelCatalog),
+      loadGeoEngineFlags(organizationId),
+    ],
+    { concurrency: "unbounded" }
+  );
   const available = withoutGeoModelCatalogEntries(catalog, [
     ...(cursorEnabled ? [] : [GEO_CURSOR_ENGINE_ID]),
     ...(openCodeEnabled

--- a/packages/geo-core/src/types/deps.ts
+++ b/packages/geo-core/src/types/deps.ts
@@ -5,6 +5,7 @@ import type {
 } from "@notra/ai/types/google-search-console";
 import type { Effect } from "effect";
 
+import type { GeoFlagEvaluationError } from "../geo/errors";
 import type { GeoSearchConsoleError } from "../schemas/search-console-errors";
 import type { AgentReadinessWorkflowPayload } from "./agent-readiness";
 import type {
@@ -53,13 +54,17 @@ export interface GeoEntitlementServiceShape {
   ) => Effect.Effect<GeoZdrEntitlement>;
 }
 
+/**
+ * A provider that cannot answer fails with `GeoFlagEvaluationError`; callers
+ * treat that as "not entitled" for this request without caching the answer.
+ */
 export interface GeoFeatureFlagServiceShape {
   readonly isCursorEngineEnabledForOrganization: (
     organizationId: string
-  ) => Effect.Effect<boolean>;
+  ) => Effect.Effect<boolean, GeoFlagEvaluationError>;
   readonly isOpenCodeEngineEnabledForOrganization: (
     organizationId: string
-  ) => Effect.Effect<boolean>;
+  ) => Effect.Effect<boolean, GeoFlagEvaluationError>;
 }
 
 export interface GeoGenerationServiceShape {

--- a/packages/geo-core/src/types/engine-flags.ts
+++ b/packages/geo-core/src/types/engine-flags.ts
@@ -1,0 +1,19 @@
+import { Data } from "effect";
+
+import type { GeoFeatureFlagServiceShape } from "./deps";
+
+export class GeoEngineFlagCacheKey extends Data.Class<{
+  readonly organizationId: string;
+  readonly featureFlags: GeoFeatureFlagServiceShape;
+}> {}
+
+export interface GeoEngineFlags {
+  readonly cursorEnabled: boolean;
+  readonly openCodeEnabled: boolean;
+  /**
+   * `false` when the flag provider could not answer. Both flags then read as
+   * disabled (fail closed) and the result is not cached, so the next caller
+   * retries the provider.
+   */
+  readonly available: boolean;
+}

--- a/packages/geo-core/tests/agent-readiness.test.ts
+++ b/packages/geo-core/tests/agent-readiness.test.ts
@@ -55,6 +55,41 @@ describe("Agent Readiness Effect boundaries", () => {
     expect(loaded.scan).toBeNull();
   });
 
+  test("a newer running report does not displace the completed one", async () => {
+    const scope = await seedProject("readiness-split");
+    const targetUrl = "https://example.com";
+    await testDb.insert(geoAgentReadinessReports).values([
+      {
+        id: "report-completed",
+        ...scope,
+        targetUrl,
+        status: "completed",
+        score: 71,
+        scoreLabel: "Good",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      {
+        id: "report-running",
+        ...scope,
+        targetUrl,
+        status: "running",
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+      },
+    ]);
+
+    const loaded = await Effect.runPromise(
+      loadAgentReadiness({
+        ...scope,
+        brandSettingsId: "brand-readiness-split",
+      })
+    );
+
+    // The completed half feeds the report; the newest half feeds the scan.
+    expect(loaded.report?.id).toBe("report-completed");
+    expect(loaded.report?.score).toBe(71);
+    expect(loaded.scan?.id).toBe("report-running");
+  });
+
   test("failed handoff plus failed stamping retains the original handoff", async () => {
     const scope = await seedProject("handoff-stamp");
     const cause = new Error("test rejected handoff");

--- a/packages/geo-core/tests/engine-flags.test.ts
+++ b/packages/geo-core/tests/engine-flags.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+
+import { Effect, Layer } from "effect";
+
+import { GeoFeatureFlagService } from "../src/deps";
+import { loadGeoEngineFlags } from "../src/geo/engine-flags";
+
+interface CountingFlagProvider {
+  readonly layer: Layer.Layer<GeoFeatureFlagService>;
+  calls(): number;
+}
+
+function countingFlagProvider(options?: {
+  readonly failOnce?: boolean;
+}): CountingFlagProvider {
+  let calls = 0;
+  let failuresLeft = options?.failOnce ? 1 : 0;
+  const evaluate = () =>
+    Effect.suspend(() => {
+      calls += 1;
+      if (failuresLeft > 0) {
+        failuresLeft -= 1;
+        return Effect.die(new Error("flag provider unavailable"));
+      }
+      return Effect.succeed(true);
+    });
+
+  return {
+    calls: () => calls,
+    layer: Layer.succeed(
+      GeoFeatureFlagService,
+      GeoFeatureFlagService.of({
+        isCursorEngineEnabledForOrganization: evaluate,
+        isOpenCodeEngineEnabledForOrganization: evaluate,
+      })
+    ),
+  };
+}
+
+/** Each test uses its own key: the cache is a module-level singleton. */
+let nextOrganizationId = 0;
+function organizationId(): string {
+  nextOrganizationId += 1;
+  return `org-engine-flags-${nextOrganizationId}`;
+}
+
+describe("engine flag cache", () => {
+  test("a warm lookup does not reach the flag provider", async () => {
+    const provider = countingFlagProvider();
+    const scope = organizationId();
+
+    const cold = await Effect.runPromise(
+      loadGeoEngineFlags(scope).pipe(Effect.provide(provider.layer))
+    );
+    expect(cold).toEqual({
+      cursorEnabled: true,
+      openCodeEnabled: true,
+      available: true,
+    });
+    // Two questions per organization, asked concurrently.
+    expect(provider.calls()).toBe(2);
+
+    for (let index = 0; index < 9; index += 1) {
+      const warm = await Effect.runPromise(
+        loadGeoEngineFlags(scope).pipe(Effect.provide(provider.layer))
+      );
+      expect(warm).toEqual(cold);
+    }
+    expect(provider.calls()).toBe(2);
+  });
+
+  test("concurrent cold lookups share one evaluation", async () => {
+    const provider = countingFlagProvider();
+    const scope = organizationId();
+
+    const results = await Effect.runPromise(
+      Effect.all(
+        Array.from({ length: 8 }, () => loadGeoEngineFlags(scope)),
+        { concurrency: "unbounded" }
+      ).pipe(Effect.provide(provider.layer))
+    );
+
+    expect(results).toHaveLength(8);
+    expect(provider.calls()).toBe(2);
+  });
+
+  test("distinct organizations are cached separately", async () => {
+    const provider = countingFlagProvider();
+    const first = organizationId();
+    const second = organizationId();
+
+    await Effect.runPromise(
+      loadGeoEngineFlags(first).pipe(Effect.provide(provider.layer))
+    );
+    await Effect.runPromise(
+      loadGeoEngineFlags(second).pipe(Effect.provide(provider.layer))
+    );
+    await Effect.runPromise(
+      loadGeoEngineFlags(first).pipe(Effect.provide(provider.layer))
+    );
+
+    expect(provider.calls()).toBe(4);
+  });
+
+  test("a failed evaluation is not cached", async () => {
+    const provider = countingFlagProvider({ failOnce: true });
+    const scope = organizationId();
+
+    const failed = await Effect.runPromise(
+      Effect.exit(
+        loadGeoEngineFlags(scope).pipe(Effect.provide(provider.layer))
+      )
+    );
+    expect(failed._tag).toBe("Failure");
+
+    const recovered = await Effect.runPromise(
+      loadGeoEngineFlags(scope).pipe(Effect.provide(provider.layer))
+    );
+    expect(recovered).toEqual({
+      cursorEnabled: true,
+      openCodeEnabled: true,
+      available: true,
+    });
+  });
+});

--- a/packages/geo-core/tests/engine-flags.test.ts
+++ b/packages/geo-core/tests/engine-flags.test.ts
@@ -4,6 +4,7 @@ import { Effect, Layer } from "effect";
 
 import { GeoFeatureFlagService } from "../src/deps";
 import { loadGeoEngineFlags } from "../src/geo/engine-flags";
+import { GeoFlagEvaluationError } from "../src/geo/errors";
 
 interface CountingFlagProvider {
   readonly layer: Layer.Layer<GeoFeatureFlagService>;
@@ -14,13 +15,18 @@ function countingFlagProvider(options?: {
   readonly failOnce?: boolean;
 }): CountingFlagProvider {
   let calls = 0;
-  let failuresLeft = options?.failOnce ? 1 : 0;
+  let failuresLeft = options?.failOnce ? 2 : 0;
   const evaluate = () =>
     Effect.suspend(() => {
       calls += 1;
       if (failuresLeft > 0) {
         failuresLeft -= 1;
-        return Effect.die(new Error("flag provider unavailable"));
+        return Effect.fail(
+          new GeoFlagEvaluationError({
+            message: "flag provider unavailable",
+            cause: new Error("flag provider unavailable"),
+          })
+        );
       }
       return Effect.succeed(true);
     });
@@ -107,11 +113,14 @@ describe("engine flag cache", () => {
     const scope = organizationId();
 
     const failed = await Effect.runPromise(
-      Effect.exit(
-        loadGeoEngineFlags(scope).pipe(Effect.provide(provider.layer))
-      )
+      loadGeoEngineFlags(scope).pipe(Effect.provide(provider.layer))
     );
-    expect(failed._tag).toBe("Failure");
+    expect(failed).toEqual({
+      cursorEnabled: false,
+      openCodeEnabled: false,
+      available: false,
+    });
+    expect(provider.calls()).toBe(2);
 
     const recovered = await Effect.runPromise(
       loadGeoEngineFlags(scope).pipe(Effect.provide(provider.layer))
@@ -121,5 +130,6 @@ describe("engine flag cache", () => {
       openCodeEnabled: true,
       available: true,
     });
+    expect(provider.calls()).toBe(4);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Slice 9 extracted from closed performance audit PR #984. Reduces Node-side aggregation and provider fan-out on content/GEO core paths:

- **content.metrics** / **collections.list**: SQL `GROUP BY` aggregates instead of fetching all posts into Node
- **Content sibling rail**: exclude current post in SQL, cap at 100
- **geo-shelf**: bulk `UPDATE … FROM (VALUES …)` for citation writes; stable `updated_at` + `id` ordering
- **geo gaps**: merge duplicate `geo_settings.competitors` lookup into mention-gap inputs
- **agent-readiness**: single `unionAll` for latest + latest-completed reports (self-labeled branches)
- **engine flags**: Effect `Cache.makeWith` (30s TTL, capacity 500, fail-closed TTL 0 on provider outage)
- **GEO mention-check aggregates**: opt-in 5 min `.$withCache` on seven aggregate queries (requires Drizzle cache opt-in from #1010)

Does **not** include migration 0085 (#1034). `$withCache` benefits from GEO indexes once #1034 lands; code compiles and runs without it.

### Screenshot/Recording (if applicable)
N/A — backend/query performance only.

<details>
<summary>Checklist</summary>

- [x] I ran a self-review before opening this PR
- [x] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [x] I only added comments where the logic is not obvious
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [x] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eee3cbef-852f-5c98-82bd-1544dd581b47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eee3cbef-852f-5c98-82bd-1544dd581b47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces Node-side aggregation and provider fan-out on content and GEO paths by pushing counts and de-duplication into SQL, batching writes, and adding short-lived caches.

- `content.metrics` and `collections.list` use SQL `GROUP BY` aggregates instead of fetching every post.
- The content sibling rail excludes the current post in SQL and caps at 100.
- geo-shelf citation writes use chunked `UPDATE ... FROM (VALUES ...)` statements to stay under Postgres bind limits.
- The duplicate `geo_settings.competitors` lookup is merged into mention-gap inputs.
- Agent-readiness latest and latest-completed reports load in one labeled `unionAll` with derived-subquery branches.
- Engine flags are cached for 30s (capacity 500), fail closed on provider outage, and unavailable answers are not cached.
- GEO mention-check aggregates use an opt-in 5-minute `$withCache`; no migration required, and the upcoming GEO indexes will improve them further.

<sup>Written for commit c2be857f28f58680e33bed94087994124955ac51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

