### PR TITLE
ci(blog): post the lychee report directly as the PR comment

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -2,7 +2,7 @@ name: Blog
 
 on:
   push:
-    branches: ["main"]
+    branches: [main]
     paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml"]
   pull_request:
     paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml"]
@@ -11,82 +11,22 @@ permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: blog-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  lint:
+  links:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Lint blog links
-        id: links
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
-          format: json
-          output: lychee/out.json
-          # X profiles load in browsers but return 403 to GitHub-hosted crawlers.
           args: >-
             --no-progress --max-redirects 0 --accept '200..=299'
             --exclude '^https://x\.com/'
             --base-url https://www.usenotra.com/blog/
             'apps/web/src/content/blog/**/*.mdx'
-      - name: Comment on blog links
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      - if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        run: gh pr comment "$PR" --body-file lychee/out.md --edit-last --create-if-none
         env:
-          LINK_CHECK_OUTCOME: ${{ steps.links.outcome }}
-        with:
-          script: |
-            const fs = require('node:fs');
-            const marker = '<!-- notra-blog-links -->';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const escape = (value) => String(value).replace(/[&<>`]/g, (character) => ({
-              '&': '&amp;', '<': '&lt;', '>': '&gt;', '`': '&#96;'
-            })[character]);
-            const lines = [marker, '### Blog link checker', ''];
-
-            if (fs.existsSync('lychee/out.json')) {
-              const report = JSON.parse(fs.readFileSync('lychee/out.json', 'utf8'));
-              const checked = report.total - report.excludes;
-              const passed = process.env.LINK_CHECK_OUTCOME === 'success';
-              lines.push(`${passed ? '✅' : '❌'} **${report.successful}/${checked} valid links**`);
-              if (report.excludes > 0) {
-                lines.push(`\n${report.excludes} excluded links were skipped.`);
-              }
-              for (const map of [report.error_map, report.timeout_map]) {
-                for (const [file, errors] of Object.entries(map ?? {}).sort()) {
-                  lines.push(`\n**${escape(file)}**`);
-                  for (const error of errors) {
-                    const location = error.span?.line ? ` (line ${error.span.line})` : '';
-                    lines.push(`- <code>${escape(error.url)}</code>${location}: ${escape(error.status.text)}${error.status.details ? ` — ${escape(error.status.details)}` : ''}`);
-                  }
-                }
-              }
-              if (!passed) {
-                lines.push('\nThe link check failed. See the workflow run for full details.');
-              }
-            } else {
-              lines.push('❌ The link checker could not produce a report. See the workflow run for details.');
-            }
-
-            // Stay below GitHub's comment limit, even for large failure reports.
-            const body = `${lines.join('\n').slice(0, 60000)}\n\n[View workflow run](${runUrl})`;
-            await core.summary.addRaw(body).write();
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              ...context.repo, issue_number: context.issue.number
-            });
-            const previous = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker)
-            );
-            if (previous) {
-              await github.rest.issues.updateComment({
-                ...context.repo, comment_id: previous.id, body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                ...context.repo, issue_number: context.issue.number, body
-              });
-            }
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -3,9 +3,9 @@ name: Blog
 on:
   push:
     branches: [main]
-    paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml"]
+    paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml", "scripts/github/check-blog-links.mjs"]
   pull_request:
-    paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml"]
+    paths: ["apps/web/src/content/blog/**/*.mdx", ".github/workflows/blog.yml", "scripts/github/check-blog-links.mjs"]
 
 permissions:
   contents: read
@@ -17,24 +17,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - id: links
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
-        with:
-          format: json
-          output: lychee/out.json
-          args: >-
-            --no-progress --max-redirects 0 --accept '200..=299'
-            --exclude '^https://x\.com/'
-            --base-url https://www.usenotra.com/blog/
-            'apps/web/src/content/blog/**/*.mdx'
+      - run: node scripts/github/check-blog-links.mjs
       - if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-        run: |
-          jq -r --arg ok "$OK" '"### Blog link checker\n\n\($ok) **\(.successful)/\(.total - .excludes) valid links**", ((.error_map + .timeout_map) // {} | to_entries[] | "\n**\(.key)**", (.value[] | "- `\(.url)`: \(.status.text)"))' lychee/out.json > comment.md
-          echo "\n[View workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)" >> comment.md
-          cat comment.md >> "$GITHUB_STEP_SUMMARY"
-          gh pr comment "$PR" --body-file comment.md --edit-last --create-if-none
+        run: gh pr comment "$PR" --body-file comment.md --edit-last --create-if-none
         env:
-          OK: ${{ steps.links.outcome == 'success' && '✅' || '❌' }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -17,6 +17,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - run: node scripts/github/check-blog-links.mjs
       - if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         run: gh pr comment "$PR" --body-file comment.md --edit-last --create-if-none

--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -17,16 +17,24 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+      - id: links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
+          format: json
+          output: lychee/out.json
           args: >-
             --no-progress --max-redirects 0 --accept '200..=299'
             --exclude '^https://x\.com/'
             --base-url https://www.usenotra.com/blog/
             'apps/web/src/content/blog/**/*.mdx'
       - if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-        run: gh pr comment "$PR" --body-file lychee/out.md --edit-last --create-if-none
+        run: |
+          jq -r --arg ok "$OK" '"### Blog link checker\n\n\($ok) **\(.successful)/\(.total - .excludes) valid links**", ((.error_map + .timeout_map) // {} | to_entries[] | "\n**\(.key)**", (.value[] | "- `\(.url)`: \(.status.text)"))' lychee/out.json > comment.md
+          echo "\n[View workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)" >> comment.md
+          cat comment.md >> "$GITHUB_STEP_SUMMARY"
+          gh pr comment "$PR" --body-file comment.md --edit-last --create-if-none
         env:
+          OK: ${{ steps.links.outcome == 'success' && '✅' || '❌' }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}

--- a/scripts/github/check-blog-links.mjs
+++ b/scripts/github/check-blog-links.mjs
@@ -10,7 +10,7 @@ const links = new Map();
 for (const file of await readdir(dir)) {
   const text = await readFile(join(dir, file), "utf8");
   for (const [, href] of text.matchAll(linkPattern)) {
-    const url = new URL(href, base).href;
+    const url = URL.canParse(href, base) ? new URL(href, base).href : href;
     if (!(href.startsWith("#") || excluded.test(url))) {
       links.set(url, [...(links.get(url) ?? []), file]);
     }

--- a/scripts/github/check-blog-links.mjs
+++ b/scripts/github/check-blog-links.mjs
@@ -1,0 +1,58 @@
+import { appendFile, readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const dir = "apps/web/src/content/blog";
+const base = "https://www.usenotra.com/blog/";
+const excluded = /^https:\/\/x\.com\//;
+const linkPattern = /(?:\]\(|href="|src=")([^)"\s]+)/g;
+
+const links = new Map();
+for (const file of await readdir(dir)) {
+  const text = await readFile(join(dir, file), "utf8");
+  for (const [, href] of text.matchAll(linkPattern)) {
+    const url = new URL(href, base).href;
+    if (!(href.startsWith("#") || excluded.test(url))) {
+      links.set(url, [...(links.get(url) ?? []), file]);
+    }
+  }
+}
+
+async function check(url) {
+  try {
+    const response = await fetch(url, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(20_000),
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; notra-link-check)" },
+    });
+    return response.ok ? null : `${response.status} ${response.statusText}`;
+  } catch (error) {
+    return error.message;
+  }
+}
+
+const failures = [];
+await Promise.all(
+  [...links].map(async ([url, files]) => {
+    const problem = await check(url);
+    if (problem) {
+      failures.push(
+        `- \`${url}\`: ${problem} (${[...new Set(files)].join(", ")})`
+      );
+    }
+  })
+);
+
+const report = [
+  "### Blog link checker",
+  "",
+  `${failures.length ? "❌" : "✅"} **${links.size - failures.length}/${links.size} valid links**`,
+  ...failures.sort(),
+  "",
+  `[View workflow run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`,
+].join("\n");
+await writeFile("comment.md", report);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, report);
+}
+console.log(report);
+process.exitCode = failures.length ? 1 : 0;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the lychee link check action with a custom Node script that checks blog links and posts the report as a PR comment, updated in place via `gh pr comment --edit-last --create-if-none`. Comments are only posted for PRs from the same repository.

- Removes the concurrency group, so in-progress runs for the same branch are no longer cancelled.
- Runs `checkout` without persisted credentials and reports unparseable links as failures.

<sup>Written for commit 428634519ee48168eea1ff00b348e68b47d83fda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

