### PR TITLE
refactor(api): migrate integrations to Effect programs

### DIFF
--- a/apps/api/src/errors/integrations.ts
+++ b/apps/api/src/errors/integrations.ts
@@ -1,0 +1,31 @@
+import { Schema } from "effect";
+
+export class IntegrationNotFoundError extends Schema.TaggedError<IntegrationNotFoundError>()(
+  "IntegrationNotFoundError",
+  {}
+) {}
+
+export class IntegrationDuplicateError extends Schema.TaggedError<IntegrationDuplicateError>()(
+  "IntegrationDuplicateError",
+  {}
+) {}
+
+export class GitHubAccessError extends Schema.TaggedError<GitHubAccessError>()(
+  "GitHubAccessError",
+  { message: Schema.String }
+) {}
+
+export class IntegrationUnavailableError extends Schema.TaggedError<IntegrationUnavailableError>()(
+  "IntegrationUnavailableError",
+  {}
+) {}
+
+export class IntegrationCreateFailedError extends Schema.TaggedError<IntegrationCreateFailedError>()(
+  "IntegrationCreateFailedError",
+  {}
+) {}
+
+export class IntegrationDatabaseError extends Schema.TaggedError<IntegrationDatabaseError>()(
+  "IntegrationDatabaseError",
+  { cause: Schema.Defect() }
+) {}

--- a/apps/api/src/errors/integrations.ts
+++ b/apps/api/src/errors/integrations.ts
@@ -25,6 +25,11 @@ export class IntegrationCreateFailedError extends Schema.TaggedError<Integration
   {}
 ) {}
 
+export class IntegrationCreateError extends Schema.TaggedError<IntegrationCreateError>()(
+  "IntegrationCreateError",
+  { cause: Schema.Defect() }
+) {}
+
 export class IntegrationDatabaseError extends Schema.TaggedError<IntegrationDatabaseError>()(
   "IntegrationDatabaseError",
   { cause: Schema.Defect() }

--- a/apps/api/src/programs/integrations.ts
+++ b/apps/api/src/programs/integrations.ts
@@ -210,7 +210,7 @@ export const createGitHubIntegration = Effect.fn("integrations.createGitHub")(
           });
 
         if (!createdIntegration) {
-          throw new Error("Failed to create GitHub integration record");
+          return undefined;
         }
 
         await tx.insert(repositoryOutputs).values([

--- a/apps/api/src/programs/integrations.ts
+++ b/apps/api/src/programs/integrations.ts
@@ -1,0 +1,354 @@
+import {
+  githubIntegrations,
+  linearIntegrations,
+  repositoryOutputs,
+} from "@notra/db/schema";
+import { and, asc, eq } from "drizzle-orm";
+import { Effect } from "effect";
+
+import {
+  GitHubAccessError,
+  IntegrationCreateFailedError,
+  IntegrationDatabaseError,
+  IntegrationDuplicateError,
+  IntegrationNotFoundError,
+  IntegrationUnavailableError,
+} from "../errors/integrations";
+import type {
+  AssertNoGitHubIntegrationDuplicateInput,
+  CreateGitHubIntegrationProgramInput,
+  CreateGitHubIntegrationProgramSuccess,
+  DeleteIntegrationProgramInput,
+  DeleteIntegrationProgramSuccess,
+  ListIntegrationsProgramInput,
+  ListIntegrationsProgramSuccess,
+} from "../types/integrations";
+import {
+  encryptGitHubIntegrationToken,
+  findMatchingGitHubIntegration,
+  generateGitHubIntegrationId,
+  generateGitHubWebhookSecret,
+  getGitHubIntegrationCreatorUserId,
+  getSafeGitHubIntegrationErrorMessage,
+  isGitHubIntegrationUnavailableError,
+  validateGitHubRepositoryAccess,
+} from "../utils/github-integrations";
+import { isConstraintViolation, isPgUniqueViolation } from "../utils/pg-errors";
+import {
+  deleteQstashSchedulesForTriggers,
+  disableTriggersAndDeleteIntegration,
+  getTriggersForIntegration,
+} from "../utils/triggers";
+
+const database = <A>(operation: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: operation,
+    catch: (cause) => new IntegrationDatabaseError({ cause }),
+  });
+
+const write = <A>(operation: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: operation,
+    catch: (cause) => {
+      if (
+        isPgUniqueViolation(cause) ||
+        isConstraintViolation(
+          cause,
+          "githubIntegrations_organization_owner_repo_uidx"
+        )
+      ) {
+        return new IntegrationDuplicateError();
+      }
+
+      return new IntegrationDatabaseError({ cause });
+    },
+  });
+
+const mapGitHubAccessError = (cause: unknown) => {
+  if (isGitHubIntegrationUnavailableError(cause)) {
+    return new IntegrationUnavailableError();
+  }
+
+  const safeMessage = getSafeGitHubIntegrationErrorMessage(cause);
+  if (safeMessage) {
+    return new GitHubAccessError({ message: safeMessage });
+  }
+
+  return new IntegrationDatabaseError({ cause });
+};
+
+const encryptToken = (
+  token: string,
+  runtimeEnv: CreateGitHubIntegrationProgramInput["runtimeEnv"]
+) =>
+  Effect.try({
+    try: () => encryptGitHubIntegrationToken(token, runtimeEnv),
+    catch: (cause) => mapGitHubAccessError(cause),
+  });
+
+export const listIntegrations = Effect.fn("integrations.list")(function* ({
+  db,
+  organizationId,
+}: ListIntegrationsProgramInput) {
+  const [github, linear] = yield* database(() =>
+    Promise.all([
+      db.query.githubIntegrations.findMany({
+        where: and(
+          eq(githubIntegrations.organizationId, organizationId),
+          eq(githubIntegrations.enabled, true)
+        ),
+        orderBy: [
+          asc(githubIntegrations.displayName),
+          asc(githubIntegrations.id),
+        ],
+        columns: {
+          id: true,
+          displayName: true,
+          owner: true,
+          repo: true,
+          defaultBranch: true,
+        },
+      }),
+      db.query.linearIntegrations.findMany({
+        where: and(
+          eq(linearIntegrations.organizationId, organizationId),
+          eq(linearIntegrations.enabled, true)
+        ),
+        orderBy: [
+          asc(linearIntegrations.displayName),
+          asc(linearIntegrations.id),
+        ],
+        columns: {
+          id: true,
+          displayName: true,
+          linearOrganizationId: true,
+          linearOrganizationName: true,
+          linearTeamId: true,
+          linearTeamName: true,
+        },
+      }),
+    ])
+  );
+
+  return {
+    github,
+    linear,
+  } satisfies ListIntegrationsProgramSuccess;
+});
+
+export const assertNoGitHubIntegrationDuplicate = Effect.fn(
+  "integrations.assertNoGitHubDuplicate"
+)(function* ({
+  db,
+  organizationId,
+  owner,
+  repo,
+}: AssertNoGitHubIntegrationDuplicateInput) {
+  const existingIntegration = yield* database(() =>
+    findMatchingGitHubIntegration(db, organizationId, owner, repo)
+  );
+
+  if (existingIntegration) {
+    return yield* new IntegrationDuplicateError();
+  }
+});
+
+export const createGitHubIntegration = Effect.fn("integrations.createGitHub")(
+  function* (input: CreateGitHubIntegrationProgramInput) {
+    const owner = input.body.owner.trim();
+    const repo = input.body.repo.trim();
+    const branch = input.body.branch?.trim() || null;
+    const token = input.body.token?.trim() || null;
+
+    yield* Effect.tryPromise({
+      try: () => validateGitHubRepositoryAccess({ owner, repo, token }),
+      catch: (cause) => mapGitHubAccessError(cause),
+    });
+
+    const integrationId = generateGitHubIntegrationId();
+    const createdByUserId = yield* Effect.tryPromise({
+      try: () =>
+        getGitHubIntegrationCreatorUserId(input.db, input.organizationId),
+      catch: (cause) => mapGitHubAccessError(cause),
+    });
+    const encryptedToken = token
+      ? yield* encryptToken(token, input.runtimeEnv)
+      : null;
+    const encryptedWebhookSecret = yield* encryptToken(
+      generateGitHubWebhookSecret(),
+      input.runtimeEnv
+    );
+
+    const integration = yield* write(() =>
+      input.db.transaction(async (tx) => {
+        const [createdIntegration] = await tx
+          .insert(githubIntegrations)
+          .values({
+            id: integrationId,
+            organizationId: input.organizationId,
+            createdByUserId,
+            encryptedToken,
+            displayName: `${owner}/${repo}`,
+            owner,
+            repo,
+            defaultBranch: branch,
+            repositoryEnabled: true,
+            encryptedWebhookSecret,
+            enabled: true,
+          })
+          .returning({
+            id: githubIntegrations.id,
+            displayName: githubIntegrations.displayName,
+            owner: githubIntegrations.owner,
+            repo: githubIntegrations.repo,
+            defaultBranch: githubIntegrations.defaultBranch,
+          });
+
+        if (!createdIntegration) {
+          throw new Error("Failed to create GitHub integration record");
+        }
+
+        await tx.insert(repositoryOutputs).values([
+          {
+            id: generateGitHubIntegrationId(),
+            repositoryId: integrationId,
+            outputType: "changelog",
+            enabled: true,
+            config: null,
+          },
+          {
+            id: generateGitHubIntegrationId(),
+            repositoryId: integrationId,
+            outputType: "blog_post",
+            enabled: false,
+            config: null,
+          },
+          {
+            id: generateGitHubIntegrationId(),
+            repositoryId: integrationId,
+            outputType: "twitter_post",
+            enabled: false,
+            config: null,
+          },
+        ]);
+
+        return createdIntegration;
+      })
+    );
+
+    if (!integration) {
+      return yield* new IntegrationCreateFailedError();
+    }
+
+    return integration satisfies CreateGitHubIntegrationProgramSuccess;
+  }
+);
+
+const serializeDisabledTriggers = (
+  affectedTriggers: Awaited<ReturnType<typeof getTriggersForIntegration>>
+) => ({
+  disabledSchedules: affectedTriggers
+    .filter((trigger) => trigger.sourceType === "cron")
+    .map((trigger) => ({ id: trigger.id, name: trigger.name })),
+  disabledEvents: affectedTriggers
+    .filter((trigger) => trigger.sourceType !== "cron")
+    .map((trigger) => ({ id: trigger.id, name: trigger.name })),
+});
+
+export const deleteIntegration = Effect.fn("integrations.delete")(function* ({
+  db,
+  organizationId,
+  integrationId,
+  runtimeEnv,
+}: DeleteIntegrationProgramInput) {
+  const githubIntegration = yield* database(() =>
+    db.query.githubIntegrations.findFirst({
+      where: and(
+        eq(githubIntegrations.id, integrationId),
+        eq(githubIntegrations.organizationId, organizationId)
+      ),
+      columns: {
+        id: true,
+      },
+    })
+  );
+
+  if (githubIntegration) {
+    const affectedTriggers = yield* database(() =>
+      getTriggersForIntegration(db, organizationId, integrationId)
+    );
+
+    yield* database(() =>
+      disableTriggersAndDeleteIntegration(
+        db,
+        organizationId,
+        affectedTriggers,
+        (tx) =>
+          tx
+            .delete(githubIntegrations)
+            .where(
+              and(
+                eq(githubIntegrations.id, integrationId),
+                eq(githubIntegrations.organizationId, organizationId)
+              )
+            )
+      )
+    );
+
+    yield* database(() =>
+      deleteQstashSchedulesForTriggers(runtimeEnv, affectedTriggers)
+    );
+
+    return {
+      id: integrationId,
+      ...serializeDisabledTriggers(affectedTriggers),
+    } satisfies DeleteIntegrationProgramSuccess;
+  }
+
+  const [existingLinearIntegration] = yield* database(() =>
+    db
+      .select({ id: linearIntegrations.id })
+      .from(linearIntegrations)
+      .where(
+        and(
+          eq(linearIntegrations.id, integrationId),
+          eq(linearIntegrations.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+  );
+
+  if (!existingLinearIntegration) {
+    return yield* new IntegrationNotFoundError();
+  }
+
+  const affectedTriggers = yield* database(() =>
+    getTriggersForIntegration(db, organizationId, integrationId)
+  );
+
+  yield* database(() =>
+    disableTriggersAndDeleteIntegration(
+      db,
+      organizationId,
+      affectedTriggers,
+      (tx) =>
+        tx
+          .delete(linearIntegrations)
+          .where(
+            and(
+              eq(linearIntegrations.id, integrationId),
+              eq(linearIntegrations.organizationId, organizationId)
+            )
+          )
+    )
+  );
+
+  yield* database(() =>
+    deleteQstashSchedulesForTriggers(runtimeEnv, affectedTriggers)
+  );
+
+  return {
+    id: existingLinearIntegration.id,
+    ...serializeDisabledTriggers(affectedTriggers),
+  } satisfies DeleteIntegrationProgramSuccess;
+});

--- a/apps/api/src/programs/integrations.ts
+++ b/apps/api/src/programs/integrations.ts
@@ -8,12 +8,14 @@ import { Effect } from "effect";
 
 import {
   GitHubAccessError,
+  IntegrationCreateError,
   IntegrationCreateFailedError,
   IntegrationDatabaseError,
   IntegrationDuplicateError,
   IntegrationNotFoundError,
   IntegrationUnavailableError,
 } from "../errors/integrations";
+import type { DbClient } from "../types/db";
 import type {
   AssertNoGitHubIntegrationDuplicateInput,
   CreateGitHubIntegrationProgramInput,
@@ -33,12 +35,15 @@ import {
   isGitHubIntegrationUnavailableError,
   validateGitHubRepositoryAccess,
 } from "../utils/github-integrations";
+import { serializeDisabledTriggers } from "../utils/integrations";
 import { isConstraintViolation, isPgUniqueViolation } from "../utils/pg-errors";
 import {
   deleteQstashSchedulesForTriggers,
   disableTriggersAndDeleteIntegration,
   getTriggersForIntegration,
 } from "../utils/triggers";
+
+type DbTransaction = Parameters<Parameters<DbClient["transaction"]>[0]>[0];
 
 const database = <A>(operation: () => Promise<A>) =>
   Effect.tryPromise({
@@ -60,7 +65,7 @@ const write = <A>(operation: () => Promise<A>) =>
         return new IntegrationDuplicateError();
       }
 
-      return new IntegrationDatabaseError({ cause });
+      return new IntegrationCreateError({ cause });
     },
   });
 
@@ -74,7 +79,7 @@ const mapGitHubAccessError = (cause: unknown) => {
     return new GitHubAccessError({ message: safeMessage });
   }
 
-  return new IntegrationDatabaseError({ cause });
+  return new IntegrationCreateError({ cause });
 };
 
 const encryptToken = (
@@ -244,15 +249,35 @@ export const createGitHubIntegration = Effect.fn("integrations.createGitHub")(
   }
 );
 
-const serializeDisabledTriggers = (
-  affectedTriggers: Awaited<ReturnType<typeof getTriggersForIntegration>>
-) => ({
-  disabledSchedules: affectedTriggers
-    .filter((trigger) => trigger.sourceType === "cron")
-    .map((trigger) => ({ id: trigger.id, name: trigger.name })),
-  disabledEvents: affectedTriggers
-    .filter((trigger) => trigger.sourceType !== "cron")
-    .map((trigger) => ({ id: trigger.id, name: trigger.name })),
+const deleteIntegrationWithTriggerCleanup = Effect.fnUntraced(function* (
+  input: DeleteIntegrationProgramInput,
+  deleteIntegrationRecord: (tx: DbTransaction) => Promise<unknown>
+) {
+  const affectedTriggers = yield* database(() =>
+    getTriggersForIntegration(
+      input.db,
+      input.organizationId,
+      input.integrationId
+    )
+  );
+
+  yield* database(() =>
+    disableTriggersAndDeleteIntegration(
+      input.db,
+      input.organizationId,
+      affectedTriggers,
+      deleteIntegrationRecord
+    )
+  );
+
+  yield* database(() =>
+    deleteQstashSchedulesForTriggers(input.runtimeEnv, affectedTriggers)
+  );
+
+  return {
+    id: input.integrationId,
+    ...serializeDisabledTriggers(affectedTriggers),
+  } satisfies DeleteIntegrationProgramSuccess;
 });
 
 export const deleteIntegration = Effect.fn("integrations.delete")(function* ({
@@ -274,35 +299,18 @@ export const deleteIntegration = Effect.fn("integrations.delete")(function* ({
   );
 
   if (githubIntegration) {
-    const affectedTriggers = yield* database(() =>
-      getTriggersForIntegration(db, organizationId, integrationId)
-    );
-
-    yield* database(() =>
-      disableTriggersAndDeleteIntegration(
-        db,
-        organizationId,
-        affectedTriggers,
-        (tx) =>
-          tx
-            .delete(githubIntegrations)
-            .where(
-              and(
-                eq(githubIntegrations.id, integrationId),
-                eq(githubIntegrations.organizationId, organizationId)
-              )
+    return yield* deleteIntegrationWithTriggerCleanup(
+      { db, organizationId, integrationId, runtimeEnv },
+      (tx) =>
+        tx
+          .delete(githubIntegrations)
+          .where(
+            and(
+              eq(githubIntegrations.id, integrationId),
+              eq(githubIntegrations.organizationId, organizationId)
             )
-      )
+          )
     );
-
-    yield* database(() =>
-      deleteQstashSchedulesForTriggers(runtimeEnv, affectedTriggers)
-    );
-
-    return {
-      id: integrationId,
-      ...serializeDisabledTriggers(affectedTriggers),
-    } satisfies DeleteIntegrationProgramSuccess;
   }
 
   const [existingLinearIntegration] = yield* database(() =>
@@ -322,33 +330,16 @@ export const deleteIntegration = Effect.fn("integrations.delete")(function* ({
     return yield* new IntegrationNotFoundError();
   }
 
-  const affectedTriggers = yield* database(() =>
-    getTriggersForIntegration(db, organizationId, integrationId)
-  );
-
-  yield* database(() =>
-    disableTriggersAndDeleteIntegration(
-      db,
-      organizationId,
-      affectedTriggers,
-      (tx) =>
-        tx
-          .delete(linearIntegrations)
-          .where(
-            and(
-              eq(linearIntegrations.id, integrationId),
-              eq(linearIntegrations.organizationId, organizationId)
-            )
+  return yield* deleteIntegrationWithTriggerCleanup(
+    { db, organizationId, integrationId, runtimeEnv },
+    (tx) =>
+      tx
+        .delete(linearIntegrations)
+        .where(
+          and(
+            eq(linearIntegrations.id, integrationId),
+            eq(linearIntegrations.organizationId, organizationId)
           )
-    )
+        )
   );
-
-  yield* database(() =>
-    deleteQstashSchedulesForTriggers(runtimeEnv, affectedTriggers)
-  );
-
-  return {
-    id: existingLinearIntegration.id,
-    ...serializeDisabledTriggers(affectedTriggers),
-  } satisfies DeleteIntegrationProgramSuccess;
 });

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -1,40 +1,28 @@
 import { createRoute } from "@hono/zod-openapi";
 import {
-  githubIntegrations,
-  linearIntegrations,
-  repositoryOutputs,
-} from "@notra/db/schema";
-import {
   createGitHubIntegrationRequestSchema,
   createGitHubIntegrationResponseSchema,
   deleteIntegrationResponseSchema,
   getIntegrationParamsSchema,
   getIntegrationsResponseSchema,
 } from "@notra/schemas/api/content";
-import { and, asc, eq } from "drizzle-orm";
 
+import {
+  assertNoGitHubIntegrationDuplicate,
+  createGitHubIntegration,
+  deleteIntegration,
+  listIntegrations,
+} from "../programs/integrations";
+import type { DbClient } from "../types/db";
 import { getOrganizationId } from "../utils/auth";
 import {
-  encryptGitHubIntegrationToken,
-  findMatchingGitHubIntegration,
-  generateGitHubIntegrationId,
-  generateGitHubWebhookSecret,
-  getGitHubIntegrationCreatorUserId,
-  getSafeGitHubIntegrationErrorMessage,
-  isGitHubIntegrationUnavailableError,
-  validateGitHubRepositoryAccess,
-} from "../utils/github-integrations";
-import { logError } from "../utils/logging";
+  respondToIntegrationFailure,
+  runIntegrationProgram,
+} from "../utils/integrations";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
-import { isConstraintViolation, isPgUniqueViolation } from "../utils/pg-errors";
 import { enforceRatelimit, RATE_LIMITS, ratelimit } from "../utils/ratelimit";
-import {
-  deleteQstashSchedulesForTriggers,
-  disableTriggersAndDeleteIntegration,
-  getTriggersForIntegration,
-} from "../utils/triggers";
 
 export const integrationsRoutes = createOpenApiApp();
 
@@ -133,6 +121,16 @@ const deleteIntegrationRoute = createRoute({
   },
 });
 
+async function requireOrganization(
+  c: {
+    get: (key: "db") => DbClient;
+  },
+  orgId: string
+) {
+  const organization = await getOrganizationResponse(c.get("db"), orgId);
+  return organization ?? null;
+}
+
 integrationsRoutes.openapi(getIntegrationsRoute, async (c) => {
   const orgId = getOrganizationId(c);
   if (!orgId) {
@@ -142,56 +140,23 @@ integrationsRoutes.openapi(getIntegrationsRoute, async (c) => {
     );
   }
 
-  const db = c.get("db");
-  const organization = await getOrganizationResponse(db, orgId);
-
+  const organization = await requireOrganization(c, orgId);
   if (!organization) {
     return c.json({ error: "Organization not found" }, 404);
   }
 
-  const [github, linear] = await Promise.all([
-    db.query.githubIntegrations.findMany({
-      where: and(
-        eq(githubIntegrations.organizationId, orgId),
-        eq(githubIntegrations.enabled, true)
-      ),
-      orderBy: [
-        asc(githubIntegrations.displayName),
-        asc(githubIntegrations.id),
-      ],
-      columns: {
-        id: true,
-        displayName: true,
-        owner: true,
-        repo: true,
-        defaultBranch: true,
-      },
-    }),
-    db.query.linearIntegrations.findMany({
-      where: and(
-        eq(linearIntegrations.organizationId, orgId),
-        eq(linearIntegrations.enabled, true)
-      ),
-      orderBy: [
-        asc(linearIntegrations.displayName),
-        asc(linearIntegrations.id),
-      ],
-      columns: {
-        id: true,
-        displayName: true,
-        linearOrganizationId: true,
-        linearOrganizationName: true,
-        linearTeamId: true,
-        linearTeamName: true,
-      },
-    }),
-  ]);
+  const result = await runIntegrationProgram(
+    listIntegrations({ db: c.get("db"), organizationId: orgId })
+  );
+
+  if (result._tag === "Failure") {
+    throw result.failure;
+  }
 
   return c.json(
     {
-      github,
+      ...result.success,
       slack: [],
-      linear,
       organization,
     },
     200
@@ -208,8 +173,7 @@ integrationsRoutes.openapi(createGitHubIntegrationRoute, async (c) => {
   }
 
   const body = c.req.valid("json");
-  const db = c.get("db");
-  const organization = await getOrganizationResponse(db, orgId);
+  const organization = await requireOrganization(c, orgId);
 
   if (!organization) {
     return c.json({ error: "Organization not found" }, 404);
@@ -217,130 +181,50 @@ integrationsRoutes.openapi(createGitHubIntegrationRoute, async (c) => {
 
   const owner = body.owner.trim();
   const repo = body.repo.trim();
-  const branch = body.branch?.trim() || null;
-  const token = body.token?.trim() || null;
 
-  try {
-    const existingIntegration = await findMatchingGitHubIntegration(
-      db,
-      orgId,
+  const duplicateCheck = await runIntegrationProgram(
+    assertNoGitHubIntegrationDuplicate({
+      db: c.get("db"),
+      organizationId: orgId,
       owner,
-      repo
-    );
+      repo,
+    })
+  );
 
-    if (existingIntegration) {
-      return c.json({ error: "Repository already connected" }, 409);
+  if (duplicateCheck._tag === "Failure") {
+    const response = respondToIntegrationFailure(c, duplicateCheck.failure);
+    if (response) {
+      return response;
     }
-
-    // Charged immediately before the GitHub round-trip and the write: the 404
-    // and 409 above must not spend the caller's budget.
-    const rateLimited = await enforceRatelimit(c, ratelimit.integrationCreate);
-    if (rateLimited) {
-      return rateLimited;
-    }
-
-    await validateGitHubRepositoryAccess({ owner, repo, token });
-
-    const integrationId = generateGitHubIntegrationId();
-    const createdByUserId = await getGitHubIntegrationCreatorUserId(db, orgId);
-    const encryptedToken = token
-      ? encryptGitHubIntegrationToken(token, c.env ?? {})
-      : null;
-    const encryptedWebhookSecret = encryptGitHubIntegrationToken(
-      generateGitHubWebhookSecret(),
-      c.env ?? {}
-    );
-
-    const integration = await db.transaction(async (tx) => {
-      const [createdIntegration] = await tx
-        .insert(githubIntegrations)
-        .values({
-          id: integrationId,
-          organizationId: orgId,
-          createdByUserId,
-          encryptedToken,
-          displayName: `${owner}/${repo}`,
-          owner,
-          repo,
-          defaultBranch: branch,
-          repositoryEnabled: true,
-          encryptedWebhookSecret,
-          enabled: true,
-        })
-        .returning({
-          id: githubIntegrations.id,
-          displayName: githubIntegrations.displayName,
-          owner: githubIntegrations.owner,
-          repo: githubIntegrations.repo,
-          defaultBranch: githubIntegrations.defaultBranch,
-        });
-
-      if (!createdIntegration) {
-        throw new Error("Failed to create GitHub integration record");
-      }
-
-      await tx.insert(repositoryOutputs).values([
-        {
-          id: generateGitHubIntegrationId(),
-          repositoryId: integrationId,
-          outputType: "changelog",
-          enabled: true,
-          config: null,
-        },
-        {
-          id: generateGitHubIntegrationId(),
-          repositoryId: integrationId,
-          outputType: "blog_post",
-          enabled: false,
-          config: null,
-        },
-        {
-          id: generateGitHubIntegrationId(),
-          repositoryId: integrationId,
-          outputType: "twitter_post",
-          enabled: false,
-          config: null,
-        },
-      ]);
-
-      return createdIntegration;
-    });
-
-    if (!integration) {
-      return c.json({ error: "Failed to create integration" }, 503);
-    }
-
-    return c.json({ github: integration, organization }, 201);
-  } catch (error) {
-    if (isGitHubIntegrationUnavailableError(error)) {
-      return c.json({ error: "GitHub integrations are unavailable" }, 503);
-    }
-
-    if (
-      isPgUniqueViolation(error) ||
-      isConstraintViolation(
-        error,
-        "githubIntegrations_organization_owner_repo_uidx"
-      )
-    ) {
-      return c.json({ error: "Repository already connected" }, 409);
-    }
-
-    const safeMessage = getSafeGitHubIntegrationErrorMessage(error);
-
-    if (safeMessage) {
-      return c.json({ error: safeMessage }, 400);
-    }
-
-    logError("Failed to create GitHub integration", error);
-
-    return c.json(
-      {
-        error: "Failed to create GitHub integration",
-      },
-      400
-    );
+    throw duplicateCheck.failure;
   }
+
+  // Charged immediately before the GitHub round-trip and the write: the 404
+  // and 409 above must not spend the caller's budget.
+  const rateLimited = await enforceRatelimit(c, ratelimit.integrationCreate);
+  if (rateLimited) {
+    return rateLimited;
+  }
+
+  const result = await runIntegrationProgram(
+    createGitHubIntegration({
+      db: c.get("db"),
+      organizationId: orgId,
+      body,
+      runtimeEnv: c.env ?? {},
+    })
+  );
+
+  if (result._tag === "Failure") {
+    const response = respondToIntegrationFailure(c, result.failure);
+    if (response) {
+      return response;
+    }
+
+    throw result.failure;
+  }
+
+  return c.json({ github: result.success, organization }, 201);
 });
 
 integrationsRoutes.openapi(deleteIntegrationRoute, async (c) => {
@@ -353,107 +237,32 @@ integrationsRoutes.openapi(deleteIntegrationRoute, async (c) => {
   }
 
   const { integrationId } = c.req.valid("param");
-  const runtimeEnv = (c.env ?? {}) as Record<string, unknown>;
-  const db = c.get("db");
-  const organization = await getOrganizationResponse(db, orgId);
+  const organization = await requireOrganization(c, orgId);
 
   if (!organization) {
     return c.json({ error: "Organization not found" }, 404);
   }
 
-  const githubIntegration = await db.query.githubIntegrations.findFirst({
-    where: and(
-      eq(githubIntegrations.id, integrationId),
-      eq(githubIntegrations.organizationId, orgId)
-    ),
-    columns: {
-      id: true,
-    },
-  });
-
-  if (githubIntegration) {
-    const affectedTriggers = await getTriggersForIntegration(
-      db,
-      orgId,
-      integrationId
-    );
-
-    await disableTriggersAndDeleteIntegration(
-      db,
-      orgId,
-      affectedTriggers,
-      (tx) =>
-        tx
-          .delete(githubIntegrations)
-          .where(
-            and(
-              eq(githubIntegrations.id, integrationId),
-              eq(githubIntegrations.organizationId, orgId)
-            )
-          )
-    );
-
-    await deleteQstashSchedulesForTriggers(runtimeEnv, affectedTriggers);
-
-    return c.json(
-      {
-        id: integrationId,
-        organization,
-        disabledSchedules: affectedTriggers
-          .filter((trigger) => trigger.sourceType === "cron")
-          .map((trigger) => ({ id: trigger.id, name: trigger.name })),
-        disabledEvents: affectedTriggers
-          .filter((trigger) => trigger.sourceType !== "cron")
-          .map((trigger) => ({ id: trigger.id, name: trigger.name })),
-      },
-      200
-    );
-  }
-
-  const [existingLinearIntegration] = await db
-    .select({ id: linearIntegrations.id })
-    .from(linearIntegrations)
-    .where(
-      and(
-        eq(linearIntegrations.id, integrationId),
-        eq(linearIntegrations.organizationId, orgId)
-      )
-    )
-    .limit(1);
-
-  if (!existingLinearIntegration) {
-    return c.json({ error: "Integration not found" }, 404);
-  }
-
-  const affectedTriggers = await getTriggersForIntegration(
-    db,
-    orgId,
-    integrationId
+  const result = await runIntegrationProgram(
+    deleteIntegration({
+      db: c.get("db"),
+      organizationId: orgId,
+      integrationId,
+      runtimeEnv: (c.env ?? {}) as Record<string, unknown>,
+    })
   );
 
-  await disableTriggersAndDeleteIntegration(db, orgId, affectedTriggers, (tx) =>
-    tx
-      .delete(linearIntegrations)
-      .where(
-        and(
-          eq(linearIntegrations.id, integrationId),
-          eq(linearIntegrations.organizationId, orgId)
-        )
-      )
-  );
-
-  await deleteQstashSchedulesForTriggers(runtimeEnv, affectedTriggers);
+  if (result._tag === "Failure") {
+    if (result.failure._tag === "IntegrationNotFoundError") {
+      return c.json({ error: "Integration not found" }, 404);
+    }
+    throw result.failure;
+  }
 
   return c.json(
     {
-      id: existingLinearIntegration.id,
+      ...result.success,
       organization,
-      disabledSchedules: affectedTriggers
-        .filter((trigger) => trigger.sourceType === "cron")
-        .map((trigger) => ({ id: trigger.id, name: trigger.name })),
-      disabledEvents: affectedTriggers
-        .filter((trigger) => trigger.sourceType !== "cron")
-        .map((trigger) => ({ id: trigger.id, name: trigger.name })),
     },
     200
   );

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -19,6 +19,7 @@ import {
   respondToIntegrationFailure,
   runIntegrationProgram,
 } from "../utils/integrations";
+import { logError } from "../utils/logging";
 import { createOpenApiApp } from "../utils/openapi-app";
 import { errorResponse, rateLimitResponse } from "../utils/openapi-responses";
 import { getOrganizationResponse } from "../utils/organizations";
@@ -216,6 +217,10 @@ integrationsRoutes.openapi(createGitHubIntegrationRoute, async (c) => {
   );
 
   if (result._tag === "Failure") {
+    if (result.failure._tag === "IntegrationCreateError") {
+      logError("Failed to create GitHub integration", result.failure.cause);
+    }
+
     const response = respondToIntegrationFailure(c, result.failure);
     if (response) {
       return response;

--- a/apps/api/src/types/integrations.ts
+++ b/apps/api/src/types/integrations.ts
@@ -7,6 +7,7 @@ import type { z } from "zod";
 
 import type {
   GitHubAccessError,
+  IntegrationCreateError,
   IntegrationCreateFailedError,
   IntegrationDuplicateError,
   IntegrationNotFoundError,
@@ -19,7 +20,8 @@ export type IntegrationDomainError =
   | IntegrationDuplicateError
   | GitHubAccessError
   | IntegrationUnavailableError
-  | IntegrationCreateFailedError;
+  | IntegrationCreateFailedError
+  | IntegrationCreateError;
 
 interface IntegrationProgramInput {
   db: DbClient;

--- a/apps/api/src/types/integrations.ts
+++ b/apps/api/src/types/integrations.ts
@@ -1,0 +1,68 @@
+import type { createDb } from "@notra/db/drizzle";
+import type {
+  createGitHubIntegrationRequestSchema,
+  getIntegrationsResponseSchema,
+} from "@notra/schemas/api/content";
+import type { z } from "zod";
+
+import type {
+  GitHubAccessError,
+  IntegrationCreateFailedError,
+  IntegrationDuplicateError,
+  IntegrationNotFoundError,
+  IntegrationUnavailableError,
+} from "../errors/integrations";
+type DbClient = ReturnType<typeof createDb>;
+
+export type IntegrationDomainError =
+  | IntegrationNotFoundError
+  | IntegrationDuplicateError
+  | GitHubAccessError
+  | IntegrationUnavailableError
+  | IntegrationCreateFailedError;
+
+interface IntegrationProgramInput {
+  db: DbClient;
+  organizationId: string;
+}
+
+export interface ListIntegrationsProgramInput extends IntegrationProgramInput {}
+
+export interface ListIntegrationsProgramSuccess {
+  github: z.infer<typeof getIntegrationsResponseSchema>["github"];
+  linear: z.infer<typeof getIntegrationsResponseSchema>["linear"];
+}
+
+export interface AssertNoGitHubIntegrationDuplicateInput extends IntegrationProgramInput {
+  owner: string;
+  repo: string;
+}
+
+export interface CreateGitHubIntegrationProgramInput extends IntegrationProgramInput {
+  body: z.infer<typeof createGitHubIntegrationRequestSchema>;
+  runtimeEnv: {
+    INTEGRATION_ENCRYPTION_KEY?: string;
+  };
+}
+
+export interface CreateGitHubIntegrationProgramSuccess {
+  id: string;
+  displayName: string;
+  owner: string | null;
+  repo: string | null;
+  defaultBranch: string | null;
+}
+
+export interface DeleteIntegrationProgramInput extends IntegrationProgramInput {
+  integrationId: string;
+  runtimeEnv: {
+    QSTASH_TOKEN?: string;
+    WORKFLOW_BASE_URL?: string;
+  };
+}
+
+export interface DeleteIntegrationProgramSuccess {
+  id: string;
+  disabledSchedules: { id: string; name: string | null }[];
+  disabledEvents: { id: string; name: string | null }[];
+}

--- a/apps/api/src/utils/github-integrations.ts
+++ b/apps/api/src/utils/github-integrations.ts
@@ -7,7 +7,7 @@ import {
   decodeIntegrationEncryptionKey,
   encryptIntegrationSecret,
 } from "@notra/db/utils/integration-encryption";
-import { and, asc, eq, ilike } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 
 type DbClient = ReturnType<typeof createDb>;
 
@@ -70,8 +70,8 @@ export async function findMatchingGitHubIntegration(
   return db.query.githubIntegrations.findFirst({
     where: and(
       eq(githubIntegrations.organizationId, organizationId),
-      ilike(githubIntegrations.owner, owner),
-      ilike(githubIntegrations.repo, repo)
+      sql`lower(${githubIntegrations.owner}) = lower(${owner})`,
+      sql`lower(${githubIntegrations.repo}) = lower(${repo})`
     ),
     columns: {
       id: true,

--- a/apps/api/src/utils/integrations.ts
+++ b/apps/api/src/utils/integrations.ts
@@ -1,0 +1,47 @@
+import { Effect } from "effect";
+import type { Context } from "hono";
+
+import type { IntegrationDatabaseError } from "../errors/integrations";
+import type { IntegrationDomainError } from "../types/integrations";
+
+/** Leave unexpected database errors to Hono's central error handler. */
+export function runIntegrationProgram<A, E extends IntegrationDomainError>(
+  program: Effect.Effect<A, E | IntegrationDatabaseError>
+) {
+  return Effect.runPromise(
+    Effect.result(
+      program.pipe(
+        Effect.catchTag("IntegrationDatabaseError", (failure) =>
+          Effect.die(failure.cause)
+        )
+      )
+    )
+  );
+}
+
+export function respondToIntegrationFailure(
+  c: Context,
+  failure: IntegrationDomainError
+) {
+  if (failure._tag === "IntegrationNotFoundError") {
+    return c.json({ error: "Integration not found" }, 404);
+  }
+
+  if (failure._tag === "IntegrationDuplicateError") {
+    return c.json({ error: "Repository already connected" }, 409);
+  }
+
+  if (failure._tag === "GitHubAccessError") {
+    return c.json({ error: failure.message }, 400);
+  }
+
+  if (failure._tag === "IntegrationUnavailableError") {
+    return c.json({ error: "GitHub integrations are unavailable" }, 503);
+  }
+
+  if (failure._tag === "IntegrationCreateFailedError") {
+    return c.json({ error: "Failed to create integration" }, 503);
+  }
+
+  return c.json({ error: "Failed to create GitHub integration" }, 400);
+}

--- a/apps/api/src/utils/integrations.ts
+++ b/apps/api/src/utils/integrations.ts
@@ -3,6 +3,20 @@ import type { Context } from "hono";
 
 import type { IntegrationDatabaseError } from "../errors/integrations";
 import type { IntegrationDomainError } from "../types/integrations";
+import type { IntegrationTrigger } from "./triggers";
+
+export function serializeDisabledTriggers(
+  affectedTriggers: readonly IntegrationTrigger[]
+) {
+  return {
+    disabledSchedules: affectedTriggers
+      .filter((trigger) => trigger.sourceType === "cron")
+      .map((trigger) => ({ id: trigger.id, name: trigger.name })),
+    disabledEvents: affectedTriggers
+      .filter((trigger) => trigger.sourceType !== "cron")
+      .map((trigger) => ({ id: trigger.id, name: trigger.name })),
+  };
+}
 
 /** Leave unexpected database errors to Hono's central error handler. */
 export function runIntegrationProgram<A, E extends IntegrationDomainError>(
@@ -43,5 +57,7 @@ export function respondToIntegrationFailure(
     return c.json({ error: "Failed to create integration" }, 503);
   }
 
-  return c.json({ error: "Failed to create GitHub integration" }, 400);
+  if (failure._tag === "IntegrationCreateError") {
+    return c.json({ error: "Failed to create GitHub integration" }, 400);
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d7b53c4-3c3a-5195-89c7-8d15dafddfde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d7b53c4-3c3a-5195-89c7-8d15dafddfde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the integration API routes to run as Effect programs without changing HTTP behavior.

- Moves list, create, and delete integration logic into dedicated Effect programs with typed domain errors and a single failure-to-response mapping; unexpected create failures now return the existing 400 instead of a 500, and the 503 path is reachable when the insert returns empty.
- Duplicate detection now uses case-insensitive SQL equality instead of ILIKE, avoiding wildcard false positives.
- Preserves rate-limit ordering so duplicate checks still do not consume the create budget.

<sup>Written for commit 443ed967f5117476199236e839de0eef00c95206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

