### PR TITLE
refactor(dashboard): migrate GEO prompts/competitors to TanStack DB hooks

### DIFF
--- a/apps/dashboard/src/components/geo/competitor-detail-view.tsx
+++ b/apps/dashboard/src/components/geo/competitor-detail-view.tsx
@@ -40,11 +40,8 @@ import { Table, type TableColumn } from "@/components/motion/table";
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import { CHART_PRIMARY_COLOR } from "@/constants/charts";
 import { trackEvent } from "@/lib/analytics/posthog-client";
-import {
-  useGeoCompetitorDetail,
-  useGeoCompetitors,
-  useGeoSettings,
-} from "@/lib/hooks/use-geo";
+import { useGeoCompetitorDetail, useGeoSettings } from "@/lib/hooks/use-geo";
+import { useGeoCompetitorsDb } from "@/lib/hooks/use-geo-db";
 import { cn } from "@/lib/utils";
 import type { ChartConfig } from "@/types/charts";
 import type {
@@ -243,10 +240,10 @@ export function CompetitorDetailView({
     });
   }, [variant]);
 
-  const { data: competitorList } = useGeoCompetitors(organizationId);
+  const { competitors } = useGeoCompetitorsDb(organizationId);
   const { data: settingsData } = useGeoSettings(organizationId);
   const entry =
-    competitorList?.competitors.find(
+    competitors.find(
       (item) => item.name.toLowerCase() === competitor.toLowerCase()
     ) ?? null;
   const ownBrand = isOwnBrandName(

--- a/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
+++ b/apps/dashboard/src/components/geo/prompt-detail-dialog.tsx
@@ -46,8 +46,7 @@ import { useOrganizationsContext } from "@/components/providers/organization-pro
 import { GEO_PROMPT_DETAIL_SURFACES } from "@/constants/geo-analytics";
 import { GEO_PROMPT_TAGS_COPY } from "@/constants/geo-prompts";
 import { trackEvent } from "@/lib/analytics/posthog-client";
-import { useGeoCompetitors } from "@/lib/hooks/use-geo";
-import { useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
+import { useGeoCompetitorsDb, useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
 import { usePromptAnswerSelection } from "@/lib/hooks/use-prompt-answer-selection";
 import { cn } from "@/lib/utils";
 import type {
@@ -390,15 +389,19 @@ function PromptAnswerPage({
     initialEngine,
   });
   const tagsInputId = useId();
-  const { prompts, pendingPromptIds, setPromptTags } =
-    useGeoPromptsDb(organizationId);
+  const { prompts, pendingPromptIds, setPromptTags } = useGeoPromptsDb(
+    organizationId,
+    { enabled: open }
+  );
   const tags = prompts.find((prompt) => prompt.id === row.id)?.tags ?? row.tags;
   const [view, setView] = useState<GeoPromptReceiptView>("analysis");
   const [selectedCheck, setSelectedCheck] =
     useState<GeoPromptHistoryCheck | null>(null);
   const [direction, setDirection] = useState(1);
   const reduceMotion = useReducedMotion();
-  const competitors = useGeoCompetitors(organizationId);
+  const { competitors } = useGeoCompetitorsDb(organizationId, {
+    enabled: open,
+  });
   const threadTransition = reduceMotion ? INSTANT : tween("slow", "emphasized");
   const showLanguageBar = Boolean(scanId) && languages.length > 1;
 
@@ -494,7 +497,7 @@ function PromptAnswerPage({
               >
                 <PromptAnswerBody
                   organizationId={organizationId}
-                  competitors={competitors.data?.competitors}
+                  competitors={competitors}
                   detailState={detailState}
                   history={engineHistory}
                   isHistoryLoading={history.isPending}

--- a/apps/dashboard/src/components/geo/writer/write-dialog.tsx
+++ b/apps/dashboard/src/components/geo/writer/write-dialog.tsx
@@ -68,7 +68,7 @@ import {
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import { useBrandSettings } from "@/lib/hooks/use-brand-analysis";
 import { useSitemaps } from "@/lib/hooks/use-brand-sitemaps";
-import { useGeoCompetitors, useGeoPrompts } from "@/lib/hooks/use-geo";
+import { useGeoCompetitorsDb, useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
 import { useGeoWriterPlan } from "@/lib/hooks/use-geo-writer";
 import type {
   WriteDialogProps,
@@ -212,19 +212,13 @@ function WriteDialogForm({
 
   const planMutation = useGeoWriterPlan(organizationId);
   const { data: brandData } = useBrandSettings(organizationId);
-  const { data: competitorData } = useGeoCompetitors(organizationId);
-  const { data: promptsData } = useGeoPrompts(organizationId);
+  const { competitors } = useGeoCompetitorsDb(organizationId, {
+    enabled: open,
+  });
+  const { prompts } = useGeoPromptsDb(organizationId, { enabled: open });
   const sitemapQuery = useSitemaps(organizationId, brandVoiceId ?? "");
 
   const voices = useMemo(() => brandData?.voices ?? [], [brandData?.voices]);
-  const competitors = useMemo(
-    () => competitorData?.competitors ?? [],
-    [competitorData?.competitors]
-  );
-  const prompts = useMemo(
-    () => promptsData?.prompts ?? [],
-    [promptsData?.prompts]
-  );
   const sitemaps = useMemo(
     () => sitemapQuery.data?.sitemaps ?? [],
     [sitemapQuery.data?.sitemaps]

--- a/apps/dashboard/src/components/settings/panes/geo-pane.tsx
+++ b/apps/dashboard/src/components/settings/panes/geo-pane.tsx
@@ -10,9 +10,9 @@ import { SettingsPane } from "@/components/settings/settings-pane";
 import {
   useGeoModelCatalog,
   useGeoProjects,
-  useGeoPrompts,
   useGeoSettings,
 } from "@/lib/hooks/use-geo";
+import { useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
 import { useGeoProjectQueryState } from "@/lib/hooks/use-geo-project-query";
 import type { GeoSettingsFormSection } from "@/types/geo";
 import { countEnabledGeoPrompts } from "@/utils/geo-overview-page";
@@ -46,7 +46,7 @@ function GeoSettingsPaneContent({
   const { data: settingsData, isPending } = useGeoSettings(organizationId);
   const { data: catalog } = useGeoModelCatalog(organizationId);
   const { data: projectsData } = useGeoProjects(organizationId);
-  const { data: promptsData } = useGeoPrompts(organizationId);
+  const { prompts } = useGeoPromptsDb(organizationId);
   const projects = projectsData?.projects ?? [];
   const activeProjectId =
     settingsData?.settings?.projectId ?? projectParam ?? projects.at(0)?.id;
@@ -74,9 +74,7 @@ function GeoSettingsPaneContent({
         hideHeader
         key={activeProjectId}
         organizationId={organizationId}
-        promptCount={
-          promptsData ? countEnabledGeoPrompts(promptsData.prompts) : undefined
-        }
+        promptCount={countEnabledGeoPrompts(prompts)}
         section={section}
         settings={settingsData?.settings ?? null}
       />

--- a/apps/dashboard/src/lib/hooks/use-geo-answer-mentions.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-answer-mentions.ts
@@ -2,7 +2,8 @@
 
 import { geoAnswerMentionTerms } from "@notra/geo-core/utils/geo-answer-mentions";
 
-import { useGeoCompetitors, useGeoSettings } from "@/lib/hooks/use-geo";
+import { useGeoSettings } from "@/lib/hooks/use-geo";
+import { useGeoCompetitorsDb } from "@/lib/hooks/use-geo-db";
 import type { GeoAnswerMentionContextValue } from "@/types/geo-answer-mentions";
 
 const EMPTY_MENTIONED: readonly string[] = [];
@@ -14,9 +15,10 @@ export function useGeoAnswerMentionData(
 ) {
   const enabledId = organizationId ?? "";
   const { data: settingsData } = useGeoSettings(enabledId);
-  const { data: competitorsData } = useGeoCompetitors(enabledId);
+  const { competitors } = useGeoCompetitorsDb(enabledId, {
+    enabled: Boolean(organizationId),
+  });
   const settings = settingsData?.settings;
-  const competitors = competitorsData?.competitors ?? EMPTY_TRACKED;
   const terms = geoAnswerMentionTerms({
     companyName: settings?.companyName,
     aliases: settings?.aliases,

--- a/apps/dashboard/src/lib/hooks/use-geo-db.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-db.ts
@@ -86,7 +86,7 @@ export function useGeoPromptsDb(
     projectId,
   });
 
-  const { data } = useLiveQuery(
+  const { data, isLoading } = useLiveQuery(
     (q) => (isEnabled ? q.from({ prompt: definition }) : undefined),
     [definition, isEnabled]
   );
@@ -149,6 +149,7 @@ export function useGeoPromptsDb(
 
   return {
     prompts,
+    isLoading,
     pendingPromptIds: pendingIds,
     togglePrompt,
     removePrompts,

--- a/apps/dashboard/src/lib/hooks/use-geo-gaps-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-gaps-page.ts
@@ -7,13 +7,13 @@ import { toast } from "sonner";
 
 import { useOrganizationsContext } from "@/components/providers/organization-provider";
 import {
-  useGeoCompetitors,
   useGeoRescanPrompt,
   useGeoSettings,
   useGeoStartScan,
   useGeoSuggestionDismiss,
   useIsGeoScanning,
 } from "@/lib/hooks/use-geo";
+import { useGeoCompetitorsDb } from "@/lib/hooks/use-geo-db";
 import { useGeoWriterGaps } from "@/lib/hooks/use-geo-writer";
 import type { GeoGapsPageModel } from "@/types/components/geo-gaps";
 import type { WriteDialogInitialState } from "@/types/components/geo-writer";
@@ -40,7 +40,7 @@ export function useGeoGapsPage(organizationSlug: string): GeoGapsPageModel {
   const settingsQuery = useGeoSettings(organizationId);
   const { data: settingsData, isPending: isSettingsPending } = settingsQuery;
   const gapsQuery = useGeoWriterGaps(organizationId);
-  const competitorsQuery = useGeoCompetitors(organizationId);
+  const { competitors } = useGeoCompetitorsDb(organizationId);
   const startScan = useGeoStartScan(organizationId);
   const rescanPrompt = useGeoRescanPrompt(organizationId);
   const isScanning = useIsGeoScanning(organizationId);
@@ -83,7 +83,7 @@ export function useGeoGapsPage(organizationSlug: string): GeoGapsPageModel {
       organizationSlug,
       isGapsPending: gapsQuery.isPending,
       table: {
-        competitors: competitorsQuery.data?.competitors ?? [],
+        competitors,
         hasScanData: gapsQuery.data?.hasScanData ?? false,
         isScanning,
         onOpenPost: (postId) => {

--- a/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
@@ -178,7 +178,7 @@ export function useGeoOverviewPage(
     competitors,
     languagePoints: languageShare?.points,
     promptResults: promptResults?.results,
-    promptCount: isPromptsLoading ? undefined : prompts.length,
+    promptCount: prompts.length,
     journeys: trafficJourneys?.journeys,
     isScanning,
     revealActive,

--- a/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
@@ -112,7 +112,8 @@ export function useGeoOverviewPage(
     useGeoSettings(organizationId);
   const { data: overview } = useGeoOverview(organizationId, geoRange.query);
   const { data: timeseries } = useGeoTimeseries(organizationId, geoRange.query);
-  const { prompts } = useGeoPromptsDb(organizationId);
+  const { prompts, isLoading: isPromptsLoading } =
+    useGeoPromptsDb(organizationId);
   const { data: promptResults } = useGeoPromptResults(
     organizationId,
     geoRange.query,
@@ -177,7 +178,7 @@ export function useGeoOverviewPage(
     competitors,
     languagePoints: languageShare?.points,
     promptResults: promptResults?.results,
-    promptCount: prompts.length,
+    promptCount: isPromptsLoading ? undefined : prompts.length,
     journeys: trafficJourneys?.journeys,
     isScanning,
     revealActive,
@@ -189,7 +190,9 @@ export function useGeoOverviewPage(
         setPreflightOpen(false);
       },
       isPending: startScan.isPending,
-      promptCount: countEnabledGeoPrompts(prompts),
+      promptCount: countEnabledGeoPrompts(
+        isPromptsLoading ? undefined : prompts
+      ),
       lastScanAt: settings.lastScanAt,
     },
   });

--- a/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo-overview-page.ts
@@ -13,17 +13,16 @@ import { GEO_MODULES_REVEAL_MS } from "@/constants/geo-overview";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import {
   useGeoCompetitorShare,
-  useGeoCompetitors,
   useGeoLanguageShare,
   useGeoOverview,
   useGeoPromptResults,
-  useGeoPrompts,
   useGeoSettings,
   useGeoStartScan,
   useGeoTimeseries,
   useGeoTrafficJourneys,
   useIsGeoScanning,
 } from "@/lib/hooks/use-geo";
+import { useGeoCompetitorsDb, useGeoPromptsDb } from "@/lib/hooks/use-geo-db";
 import { useGeoRange } from "@/lib/hooks/use-geo-range";
 import type { GeoOverviewPageModel } from "@/types/geo";
 import { resolveOrganizationId } from "@/utils/geo-overview-organization";
@@ -113,7 +112,7 @@ export function useGeoOverviewPage(
     useGeoSettings(organizationId);
   const { data: overview } = useGeoOverview(organizationId, geoRange.query);
   const { data: timeseries } = useGeoTimeseries(organizationId, geoRange.query);
-  const { data: prompts } = useGeoPrompts(organizationId);
+  const { prompts } = useGeoPromptsDb(organizationId);
   const { data: promptResults } = useGeoPromptResults(
     organizationId,
     geoRange.query,
@@ -125,7 +124,7 @@ export function useGeoOverviewPage(
     false,
     activeTab === "visibility"
   );
-  const { data: competitorList } = useGeoCompetitors(organizationId);
+  const { competitors } = useGeoCompetitorsDb(organizationId);
   const { data: languageShare } = useGeoLanguageShare(
     organizationId,
     geoRange.query,
@@ -175,10 +174,10 @@ export function useGeoOverviewPage(
     timeseriesPoints: timeseries?.points,
     competitorPoints: competitorShare?.points,
     competitorShareTimeseries: competitorShare?.timeseries,
-    competitors: competitorList?.competitors,
+    competitors,
     languagePoints: languageShare?.points,
     promptResults: promptResults?.results,
-    promptCount: prompts?.prompts.length,
+    promptCount: prompts.length,
     journeys: trafficJourneys?.journeys,
     isScanning,
     revealActive,
@@ -190,7 +189,7 @@ export function useGeoOverviewPage(
         setPreflightOpen(false);
       },
       isPending: startScan.isPending,
-      promptCount: countEnabledGeoPrompts(prompts?.prompts),
+      promptCount: countEnabledGeoPrompts(prompts),
       lastScanAt: settings.lastScanAt,
     },
   });

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -493,6 +493,7 @@ export function useGeoCompetitorRowNavigation(
   return { openRow, prefetchRow };
 }
 
+/** @deprecated Use {@link useGeoCompetitorsDb} from `@/lib/hooks/use-geo-db` instead. */
 export function useGeoCompetitors(organizationId: string) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoCompetitorsResponse>({
@@ -520,6 +521,7 @@ export function useGeoLanguageShare(
   });
 }
 
+/** @deprecated Use {@link useGeoPromptsDb} from `@/lib/hooks/use-geo-db` instead. */
 export function useGeoPrompts(organizationId: string) {
   const { projectId } = useGeoProjectScope();
   return useQuery<GeoTrackedPromptsResponse>({

--- a/apps/dashboard/src/lib/orpc/routers/content.ts
+++ b/apps/dashboard/src/lib/orpc/routers/content.ts
@@ -808,6 +808,8 @@ export const contentRouter = {
             repo: githubIntegrations.repo,
             defaultBranch: githubIntegrations.defaultBranch,
             installationId: githubAppInstallations.installationId,
+            installationAccountType: githubAppInstallations.accountType,
+            installationAccountLogin: githubAppInstallations.accountLogin,
             githubAppInstallationId: githubIntegrations.githubAppInstallationId,
             encryptedToken: githubIntegrations.encryptedToken,
             outputConfig: repositoryOutputs.config,

--- a/apps/dashboard/tests/geo-gaps-page.test.tsx
+++ b/apps/dashboard/tests/geo-gaps-page.test.tsx
@@ -29,11 +29,13 @@ mock.module("@/lib/hooks/use-geo", () => ({
     isFetching: false,
     refetch: retrySettings,
   }),
-  useGeoCompetitors: () => ({ data: { competitors: [] } }),
   useGeoStartScan: () => ({ mutate: mock() }),
   useGeoRescanPrompt: () => ({ mutate: mock() }),
   useIsGeoScanning: () => false,
   useGeoSuggestionDismiss: () => ({ isPending: false, mutate: mock() }),
+}));
+mock.module("@/lib/hooks/use-geo-db", () => ({
+  useGeoCompetitorsDb: () => ({ competitors: [] }),
 }));
 mock.module("@/lib/hooks/use-geo-writer", () => ({
   useGeoWriterGaps: () => ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
TanStack DB Phase 1.1: migrate read-only GEO consumers from legacy React Query hooks to existing TanStack DB hooks, eliminating duplicate fetches across overview, writer, settings, and detail screens.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ba21570-d71f-4d67-861e-bd477b82642c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ba21570-d71f-4d67-861e-bd477b82642c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates read-only GEO prompts and competitors consumers from legacy React Query hooks to existing TanStack DB hooks, eliminating duplicate fetches across overview, writer, settings, and detail screens. Also adds GitHub installation account fields to the publish query so it typechecks after #1027.

**Refactors**
- `useGeoPromptsDb` and `useGeoCompetitorsDb` now back the overview, writer, prompt detail, settings, and gaps screens.
- Writer and prompt detail dialogs pass `enabled: open` so DB collections aren't synced while closed.
- Scan preflight keeps prompt counts undefined until the prompts collection finishes syncing.
- Legacy `useGeoPrompts` and `useGeoCompetitors` hooks are marked `@deprecated` and are no longer called.

<sup>Written for commit 4248bdc78ad978c6513fe3e950c59e0d18f0c232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

