### PR TITLE
fix(dashboard): skip balanced GEO daily summaries

### DIFF
--- a/apps/dashboard/src/lib/email/daily-summary.ts
+++ b/apps/dashboard/src/lib/email/daily-summary.ts
@@ -258,7 +258,8 @@ async function sendDailySummaryForOrganization({
     isUnchangedDailySummary({
       yesterday,
       previousDay,
-      eventCount: allEvents.length,
+      changes,
+      hasNewEngine: allEvents.some((event) => event.kind === "new_engine"),
     })
   ) {
     return "quiet";

--- a/apps/dashboard/src/types/email/daily-summary.ts
+++ b/apps/dashboard/src/types/email/daily-summary.ts
@@ -16,6 +16,13 @@ export interface DailySummaryMentionTotals {
   rate: number | null;
 }
 
+export interface DailySummaryUnchangedInput {
+  yesterday: DailySummaryMentionTotals;
+  previousDay: DailySummaryMentionTotals;
+  changes: GeoChangesSummary;
+  hasNewEngine: boolean;
+}
+
 export interface BuiltDailySummary {
   dateLabel: string;
   headline: string;

--- a/apps/dashboard/src/utils/daily-summary.ts
+++ b/apps/dashboard/src/utils/daily-summary.ts
@@ -4,6 +4,7 @@ import type {
   BuildDailySummaryInput,
   BuiltDailySummary,
   DailySummaryMentionTotals,
+  DailySummaryUnchangedInput,
   DailySummaryWindow,
 } from "@/types/email/daily-summary";
 
@@ -93,18 +94,15 @@ export function isQuietDailySummary({
 export function isUnchangedDailySummary({
   yesterday,
   previousDay,
-  eventCount,
-}: {
-  yesterday: DailySummaryMentionTotals;
-  previousDay: DailySummaryMentionTotals;
-  eventCount: number;
-}) {
-  if (eventCount > 0) {
-    return false;
-  }
-
+  changes,
+  hasNewEngine,
+}: DailySummaryUnchangedInput) {
   return (
-    formatMentionRateDelta(yesterday.rate, previousDay.rate) === "unchanged"
+    !hasNewEngine &&
+    formatMentionRateDelta(yesterday.rate, previousDay.rate) === "unchanged" &&
+    changes.gained === changes.lost &&
+    changes.positionImproved === changes.positionDropped &&
+    changes.citationsAdded === changes.citationsRemoved
   );
 }
 


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes daily GEO summaries so they're only sent when metrics actually change, not when events are balanced.

- Replaces the event count check with a check for balanced changes and no new engine.
- Adds a `DailySummaryUnchangedInput` type for the updated input.

<sup>Written for commit 8ead601ce320e4b93998afe98e0eea6fd8ac8ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

