### PR TITLE
fix(dashboard): preserve daily summary event types

### DIFF
--- a/apps/dashboard/src/lib/email/daily-summary.ts
+++ b/apps/dashboard/src/lib/email/daily-summary.ts
@@ -237,7 +237,8 @@ async function sendDailySummaryForOrganization({
     projectRows.map((project) => [project.id, project.name])
   );
   const includeProjectName = projectIds.length > 1;
-  const allEvents = projectChanges.flatMap((entry) => {
+  const changeEvents = projectChanges.flatMap((entry) => entry?.events ?? []);
+  const summaryItems = projectChanges.flatMap((entry) => {
     if (!entry) {
       return [];
     }
@@ -252,6 +253,9 @@ async function sendDailySummaryForOrganization({
   const summaries = projectChanges.flatMap((entry) =>
     entry ? [summarizeGeoChanges(entry.events)] : []
   );
+  const hasNewEngine = changeEvents.some(
+    (event) => event.kind === "new_engine"
+  );
   const previousDay = aggregateMentionTotals(previousOverview);
   const changes = mergeChangesSummaries(summaries);
   if (
@@ -259,13 +263,13 @@ async function sendDailySummaryForOrganization({
       yesterday,
       previousDay,
       changes,
-      hasNewEngine: allEvents.some((event) => event.kind === "new_engine"),
+      hasNewEngine,
     })
   ) {
     return "quiet";
   }
 
-  const visibleItems = allEvents.slice(0, DAILY_SUMMARY_MAX_ITEMS);
+  const visibleItems = summaryItems.slice(0, DAILY_SUMMARY_MAX_ITEMS);
   const summary = buildDailySummary({
     windowStart: start,
     scansCompleted: finishedScans.length,
@@ -273,7 +277,7 @@ async function sendDailySummaryForOrganization({
     previousDay,
     changes,
     items: visibleItems,
-    remainingCount: Math.max(allEvents.length - visibleItems.length, 0),
+    remainingCount: Math.max(summaryItems.length - visibleItems.length, 0),
   });
 
   let sent = 0;


### PR DESCRIPTION
Keep raw GEO change events separate from formatted email items so new-engine detection remains type-safe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates raw GEO change events from formatted email items in the daily summary so new-engine detection no longer relies on display-formatted data.

<sup>Written for commit 355fade13469696771f957079f478abc95904df4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

