### PR TITLE
fix(dashboard): toggle select all to deselect all in scan preflight

### DIFF
--- a/apps/dashboard/src/components/geo/scan-preflight-dialog.tsx
+++ b/apps/dashboard/src/components/geo/scan-preflight-dialog.tsx
@@ -6,6 +6,7 @@ import {
   GEO_SCAN_PREFLIGHT_BODY,
   GEO_SCAN_PREFLIGHT_CANCEL,
   GEO_SCAN_PREFLIGHT_CONFIRM,
+  GEO_SCAN_PREFLIGHT_DESELECT_ALL,
   GEO_SCAN_PREFLIGHT_ENGINES_LABEL,
   GEO_SCAN_PREFLIGHT_LAST_SCAN_LABEL,
   GEO_SCAN_PREFLIGHT_NEED_ENGINE,
@@ -169,6 +170,7 @@ export function ScanPreflightDialog({
   const [deselected, setDeselected] = useState<Set<string>>(() => new Set());
   const selected = engines.filter((engine) => !deselected.has(engine));
   const selectedCount = selected.length;
+  const allSelected = selectedCount === engines.length;
   const canRun = selectedCount > 0;
 
   const { scanSize, warningSeverity } = useGeoScanEstimate({
@@ -249,13 +251,19 @@ export function ScanPreflightDialog({
             </p>
             {selectable ? (
               <Button
-                disabled={isPending || selectedCount === engines.length}
-                onClick={() => setDeselected(new Set())}
+                disabled={isPending}
+                onClick={() =>
+                  setDeselected(
+                    allSelected ? new Set(engines) : new Set<string>()
+                  )
+                }
                 size="xs"
                 type="button"
                 variant="ghost"
               >
-                {GEO_SCAN_PREFLIGHT_SELECT_ALL}
+                {allSelected
+                  ? GEO_SCAN_PREFLIGHT_DESELECT_ALL
+                  : GEO_SCAN_PREFLIGHT_SELECT_ALL}
               </Button>
             ) : null}
           </div>

--- a/packages/geo-core/src/constants/geo.ts
+++ b/packages/geo-core/src/constants/geo.ts
@@ -1072,6 +1072,7 @@ export const GEO_SCAN_SIZE_MESSAGES = {
   danger: GEO_SCAN_SIZE_DANGER,
 };
 export const GEO_SCAN_PREFLIGHT_SELECT_ALL = "Select all";
+export const GEO_SCAN_PREFLIGHT_DESELECT_ALL = "Deselect all";
 export const GEO_SCAN_PREFLIGHT_NEED_ENGINE = "Pick at least one engine.";
 export const GEO_RANGE_PRESETS = [
   { value: "today", label: "Today" },


### PR DESCRIPTION
Toggle the scan preflight engine button to deselect all when all engines are selected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Toggles the scan preflight engine button between “Select all” and “Deselect all” when every engine is already selected. Previously the button was disabled in that state, so users couldn’t clear all engines from the button.

<sup>Written for commit aff1a4069f851e992a15f22b219bfb192078c5f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

