### PR TITLE
refactor(ai): remove deprecated APIs

### DIFF
--- a/apps/dashboard/src/app/api/command-palette/navigate/route.ts
+++ b/apps/dashboard/src/app/api/command-palette/navigate/route.ts
@@ -1,5 +1,5 @@
 import { gateway } from "@notra/ai/gateway";
-import { withGatewayAutomaticCaching } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
 import { db } from "@notra/db/drizzle";
 import {
@@ -292,7 +292,7 @@ export async function POST(request: NextRequest) {
           : "No matching entities found.",
         `User query: ${query}`,
       ].join("\n"),
-      providerOptions: withGatewayAutomaticCaching(undefined, {
+      providerOptions: withRouterDefaults(undefined, {
         modelId: "anthropic/claude-sonnet-4.6",
       }),
       abortSignal: request.signal,

--- a/apps/dashboard/src/lib/hooks/use-geo.ts
+++ b/apps/dashboard/src/lib/hooks/use-geo.ts
@@ -18,7 +18,6 @@ import type {
   GeoCompetitorDetailResponse,
   GeoCompetitorShareResponse,
   GeoCompetitorSuggestionsResponse,
-  GeoCompetitorsResponse,
   GeoDiscoverWebsiteResult,
   GeoJourneyDetailResponse,
   GeoLanguageShareResponse,
@@ -35,7 +34,6 @@ import type {
   GeoSettingsResponse,
   GeoSettingsUpsertInput,
   GeoTimeseriesResponse,
-  GeoTrackedPromptsResponse,
   GeoTrafficJourneysResponse,
   GeoTrafficLogFilters,
   GeoTrafficLogResponse,
@@ -493,18 +491,6 @@ export function useGeoCompetitorRowNavigation(
   return { openRow, prefetchRow };
 }
 
-/** @deprecated Use {@link useGeoCompetitorsDb} from `@/lib/hooks/use-geo-db` instead. */
-export function useGeoCompetitors(organizationId: string) {
-  const { projectId } = useGeoProjectScope();
-  return useQuery<GeoCompetitorsResponse>({
-    ...dashboardOrpc.geo.competitors.queryOptions({
-      input: { organizationId, projectId },
-    }),
-    enabled: !!organizationId,
-    meta: { errorMessage: "Failed to load competitors" },
-  });
-}
-
 export function useGeoLanguageShare(
   organizationId: string,
   range?: GeoRangeQuery,
@@ -518,18 +504,6 @@ export function useGeoLanguageShare(
     enabled: enabled && !!organizationId,
     placeholderData: keepPreviousData,
     meta: { errorMessage: "Failed to load language performance" },
-  });
-}
-
-/** @deprecated Use {@link useGeoPromptsDb} from `@/lib/hooks/use-geo-db` instead. */
-export function useGeoPrompts(organizationId: string) {
-  const { projectId } = useGeoProjectScope();
-  return useQuery<GeoTrackedPromptsResponse>({
-    ...dashboardOrpc.geo.promptsList.queryOptions({
-      input: { organizationId, projectId },
-    }),
-    enabled: !!organizationId,
-    meta: { errorMessage: "Failed to load tracked prompts" },
   });
 }
 

--- a/apps/dashboard/src/workflows/steps/brand-analysis-steps.ts
+++ b/apps/dashboard/src/workflows/steps/brand-analysis-steps.ts
@@ -1,6 +1,6 @@
 import { SUPPORTED_LANGUAGES } from "@notra/ai/constants/languages";
 import { gateway } from "@notra/ai/gateway";
-import { withGatewayAutomaticCaching } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import type { ContextDevScrapingResult } from "@notra/ai/types/context-dev";
 import { scrapeWebsiteForBrandAnalysis } from "@notra/ai/utils/context-dev";
 import { buildExperimentalTelemetry } from "@notra/ai/utils/tcc";
@@ -80,7 +80,7 @@ Extract the following information:
 5. language: The primary language of the website content. Must be one of: ${SUPPORTED_LANGUAGES.join(", ")}`,
       system:
         "You are a brand analyst expert. Your job is to analyze website content and extract key brand identity information. Be thorough but concise. Focus on understanding the company's essence, values, and how they communicate.",
-      providerOptions: withGatewayAutomaticCaching(undefined, {
+      providerOptions: withRouterDefaults(undefined, {
         modelId: "anthropic/claude-sonnet-4.6",
       }),
       experimental_telemetry: buildExperimentalTelemetry({

--- a/packages/ai/src/agents/background-gen.ts
+++ b/packages/ai/src/agents/background-gen.ts
@@ -2,7 +2,7 @@ import { AGENT_DEFAULT_MODEL } from "@notra/ai/constants/models";
 import { assertRouteHasCredits } from "@notra/ai/gateway";
 import { createModel } from "@notra/ai/model";
 import { getUserPrompt } from "@notra/ai/prompts/user";
-import { withGatewayDefaults } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import {
   createGetBrandReferencesTool,
   createSearchBrandReferencesTool,
@@ -152,7 +152,7 @@ export async function runBackgroundGen(
 
   const agent = new ToolLoopAgent({
     model,
-    providerOptions: withGatewayDefaults(
+    providerOptions: withRouterDefaults(
       {
         anthropic: {
           thinking: { type: "adaptive" },

--- a/packages/ai/src/agents/geo-writer.ts
+++ b/packages/ai/src/agents/geo-writer.ts
@@ -18,7 +18,7 @@ import {
   buildGeoPlannerSystem,
 } from "@notra/ai/prompts/geo_writer/planner";
 import { buildGeoWriterInstructions } from "@notra/ai/prompts/geo_writer/writer";
-import { withGatewayDefaults } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import { geoContentBriefSchema } from "@notra/ai/schemas/geo-writer";
 import {
   createGetBrandReferencesTool,
@@ -215,7 +215,7 @@ export async function generateGeoContentBrief(
         prompt,
         temperature: GEO_WRITER_PLANNER_TEMPERATURE,
         maxOutputTokens: GEO_WRITER_PLANNER_MAX_TOKENS,
-        providerOptions: withGatewayDefaults(undefined, {
+        providerOptions: withRouterDefaults(undefined, {
           modelId: GEO_WRITER_MODEL,
         }),
       });
@@ -362,7 +362,7 @@ async function humanizeMarkdown(
     system: GEO_HUMANIZER_SYSTEM,
     prompt: buildGeoHumanizerPrompt(markdown),
     maxOutputTokens: GEO_WRITER_HUMANIZER_MAX_TOKENS,
-    providerOptions: withGatewayDefaults(undefined, {
+    providerOptions: withRouterDefaults(undefined, {
       modelId: GEO_WRITER_MODEL,
     }),
     experimental_telemetry: buildExperimentalTelemetry({
@@ -444,7 +444,7 @@ export async function runGeoWriter(
 
   const agent = new ToolLoopAgent({
     model,
-    providerOptions: withGatewayDefaults(
+    providerOptions: withRouterDefaults(
       { anthropic: { thinking: { type: "adaptive" } } },
       { modelId: GEO_WRITER_MODEL }
     ),

--- a/packages/ai/src/agents/repo-image.ts
+++ b/packages/ai/src/agents/repo-image.ts
@@ -22,7 +22,7 @@ import {
   buildMarketingAssetMissingOutputPrompt,
   buildMarketingAssetRevisionPrompt,
 } from "@notra/ai/prompts/marketing-assets";
-import { withGatewayDefaults } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import type {
   GenerateRepoImageInput,
   GenerateRepoImageResult,
@@ -265,7 +265,7 @@ async function reviewRenderedRepoImageForLogoIssues(params: {
       },
     ],
     maxOutputTokens: 700,
-    providerOptions: withGatewayDefaults(undefined, {
+    providerOptions: withRouterDefaults(undefined, {
       modelId: IMAGE_REVIEW_MODEL_ID,
     }),
   });

--- a/packages/ai/src/autonomy/capabilities.ts
+++ b/packages/ai/src/autonomy/capabilities.ts
@@ -41,7 +41,7 @@ import {
   buildIrisImageReviewPrompt,
   buildIrisSocialPostPrompt,
 } from "@notra/ai/prompts/iris-content";
-import { withGatewayDefaults } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import {
   type IrisSocialPlatform,
   irisAnalyticsReadTaskParamsSchema,
@@ -211,7 +211,7 @@ const generateIrisText = Effect.fn("iris.capabilities.generateText")(
           prompt: params.prompt,
           temperature: CONTENT_TEMPERATURE,
           maxOutputTokens: params.maxOutputTokens,
-          providerOptions: withGatewayDefaults(undefined, {
+          providerOptions: withRouterDefaults(undefined, {
             modelId: IRIS_CONTENT_MODEL_ID,
           }),
         }),
@@ -480,7 +480,7 @@ const reviewIrisImage = Effect.fn("iris.capabilities.reviewImage")(
             },
           ],
           maxOutputTokens: IMAGE_REVIEW_MAX_OUTPUT_TOKENS,
-          providerOptions: withGatewayDefaults(undefined, {
+          providerOptions: withRouterDefaults(undefined, {
             modelId: IMAGE_REVIEW_MODEL_ID,
           }),
         }),

--- a/packages/ai/src/autonomy/planner.ts
+++ b/packages/ai/src/autonomy/planner.ts
@@ -7,7 +7,7 @@ import {
   buildIrisPlannerSystemPrompt,
   buildIrisPlannerUserPrompt,
 } from "@notra/ai/prompts/iris-planner";
-import { withGatewayDefaults } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import { irisTaskParamSchemas } from "@notra/ai/schemas/autonomy/capability-params";
 import {
   type PlannerOutput,
@@ -61,7 +61,7 @@ const generatePlannerDraft = Effect.fn("iris.planner.generate")(function* (
         prompt,
         temperature: PLANNER_TEMPERATURE,
         maxOutputTokens: PLANNER_MAX_OUTPUT_TOKENS,
-        providerOptions: withGatewayDefaults(undefined, {
+        providerOptions: withRouterDefaults(undefined, {
           modelId: IRIS_PLANNER_MODEL_ID,
         }),
       });

--- a/packages/ai/src/chat/history.ts
+++ b/packages/ai/src/chat/history.ts
@@ -11,7 +11,7 @@ import {
   CHAT_WORKFLOW_REQUEST_TTL_SECONDS,
 } from "../constants/chat";
 import { gateway } from "../gateway";
-import { withGatewayAutomaticCaching } from "../provider-options";
+import { withRouterDefaults } from "../provider-options";
 import { uiMessageSchema } from "../schemas/chat";
 import type {
   ChatSessionSummary,
@@ -1050,7 +1050,7 @@ export async function generateAndSetChatTitle(
       system: `Generate a short, descriptive title (max 50 chars) for a chat conversation based on the user's first message. Return ONLY the title text, nothing else. No quotes, no prefix. Be specific and concise.`,
       prompt: userMessage,
       maxOutputTokens: 30,
-      providerOptions: withGatewayAutomaticCaching(undefined, {
+      providerOptions: withRouterDefaults(undefined, {
         modelId: "openai/gpt-5.4-nano",
       }),
       experimental_telemetry: buildExperimentalTelemetry({

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -129,14 +129,6 @@ export function assertRouteHasCredits(
   });
 }
 
-/**
- * @deprecated Use `assertRouteHasCredits({ organizationId })` so the check
- * targets the gateway the request will actually use.
- */
-export async function assertGatewayHasCredits(): Promise<void> {
-  await assertRouteHasCredits();
-}
-
 export function getRouteMetadata(
   providerMetadata: SharedV3ProviderMetadata | undefined
 ): RouteMetadata | undefined {

--- a/packages/ai/src/jobs/collection-title.ts
+++ b/packages/ai/src/jobs/collection-title.ts
@@ -5,7 +5,7 @@ import {
   COLLECTION_TITLE_MODEL_ID,
 } from "@notra/ai/constants/collection-title";
 import { gateway } from "@notra/ai/gateway";
-import { withGatewayAutomaticCaching } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import {
   COLLECTION_TITLE_MAX_LENGTH,
   collectionTitleResultSchema,
@@ -119,7 +119,7 @@ export async function generateCollectionTitle(
     schema: collectionTitleResultSchema,
     system: SYSTEM_PROMPT,
     messages: [{ role: "user", content: userContent }],
-    providerOptions: withGatewayAutomaticCaching(undefined, {
+    providerOptions: withRouterDefaults(undefined, {
       modelId: COLLECTION_TITLE_MODEL_ID,
     }),
     experimental_telemetry: buildExperimentalTelemetry({

--- a/packages/ai/src/orchestration/orchestrate-standalone.ts
+++ b/packages/ai/src/orchestration/orchestrate-standalone.ts
@@ -1,7 +1,7 @@
 import { getEnabledMcpServerCount } from "@notra/ai/integrations/mcp-tool-index";
 import { createModel } from "@notra/ai/model";
 import { getStandaloneChatPrompt } from "@notra/ai/prompts/standalone-chat";
-import { withGatewayDefaults } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import { STANDALONE_SKILL_CATALOG_LIMIT } from "@notra/ai/skills/constants";
 import { listSkillSummaries } from "@notra/ai/skills/functions/service";
 import { createLazyMcpRuntime } from "@notra/ai/tools/mcp-lazy";
@@ -246,7 +246,7 @@ export async function orchestrateStandaloneChat(
   const effectiveEnableThinking =
     enableThinking && (autoThinkingLevel ? autoThinkingLevel !== "off" : true);
 
-  const providerOptions = withGatewayDefaults(
+  const providerOptions = withRouterDefaults(
     getThinkingProviderOptions(
       routingDecision.model,
       effectiveEnableThinking,

--- a/packages/ai/src/orchestration/orchestrate.ts
+++ b/packages/ai/src/orchestration/orchestrate.ts
@@ -1,6 +1,6 @@
 import { createModel } from "@notra/ai/model";
 import { getContentEditorChatPrompt } from "@notra/ai/prompts/content-editor";
-import { withGatewayDefaults } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import type {
   OrchestrateDeps,
   OrchestrateInput,
@@ -129,7 +129,7 @@ export async function orchestrateChat(
     }),
     tools,
     stopWhen: stepCountIs(maxSteps),
-    providerOptions: withGatewayDefaults(
+    providerOptions: withRouterDefaults(
       getThinkingProviderOptions(
         routingDecision.model,
         true,

--- a/packages/ai/src/orchestration/router.ts
+++ b/packages/ai/src/orchestration/router.ts
@@ -4,7 +4,7 @@ import {
   wrapModelWithObservability,
 } from "@notra/ai/observability";
 import { ROUTING_PROMPT } from "@notra/ai/prompts/router";
-import { withGatewayAutomaticCaching } from "@notra/ai/provider-options";
+import { withRouterDefaults } from "@notra/ai/provider-options";
 import { routingDecisionSchema } from "@notra/ai/schemas/orchestration";
 import type {
   AutoSelection,
@@ -135,7 +135,7 @@ export async function routeMessage(
       prompt: `Classify this user message:
 
 "${userMessage}"${contextHint}`,
-      providerOptions: withGatewayAutomaticCaching(undefined, {
+      providerOptions: withRouterDefaults(undefined, {
         modelId: MODELS.router,
       }),
       experimental_repairText: async ({ text, error }) => {
@@ -168,7 +168,7 @@ export async function routeMessage(
               error.message,
             ].join("\n"),
             maxOutputTokens: 200,
-            providerOptions: withGatewayAutomaticCaching(undefined, {
+            providerOptions: withRouterDefaults(undefined, {
               modelId: MODELS.router,
             }),
             experimental_telemetry:

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -55,8 +55,3 @@ export function withRouterDefaults(
     routerOptions
   ) as ProviderOptions;
 }
-
-/** @deprecated Use `withRouterDefaults`. */
-export const withGatewayDefaults = withRouterDefaults;
-/** @deprecated Use `withRouterDefaults`. */
-export const withGatewayAutomaticCaching = withRouterDefaults;


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes deprecated APIs from the AI package and dashboard so callers can't keep silently relying on old names.

- Deletes the `withGatewayDefaults` and `withGatewayAutomaticCaching` aliases and points every call site at `withRouterDefaults`.
- Removes `assertGatewayHasCredits`; use `assertRouteHasCredits({ organizationId })` instead.
- Removes `useGeoCompetitors` and `useGeoPrompts`; use the `useGeoCompetitorsDb` and `useGeoPromptsDb` hooks instead.

**Migration**

- Any external code still importing the removed names will fail to compile.

<sup>Written for commit 67b3b227ba0db8578dd45990fc92311cfd70a1c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

