### PR TITLE
docs: clarify Effect source bootstrap in fresh worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,14 @@ non-obvious, durable gotchas for working in the Cursor Cloud environment.
 - Runtime/package manager is **Bun `1.4.0`** (installed at `~/.bun`); tooling uses
   **Node `24.11.1`** (installed via `nvm`, set as the default alias). Both are baked
   into the VM snapshot and on `PATH` in a login shell. `bun install` is the startup
-  update script — do not run it manually unless deps changed.
+  update script — run it manually when dependencies changed or `node_modules`
+  or `.repos/effect` is missing (for example, in a fresh worktree).
+- If `.repos/effect` is missing, run `bun install` from the repo root before
+  working with Effect. The existing `prepare` script runs
+  `scripts/prepare-effect.sh` to clone the Effect source; do not add another
+  bootstrap script or ask the user to choose a checkout strategy. Verify that
+  `.repos/effect` exists afterward. The bootstrap intentionally skips Vercel,
+  CI, and production environments.
 - Quality gates (run from repo root): lint `bun run check`, types `bun run check-types`,
   build `bun run build` (use `--filter=dashboard` to scope). Husky `pre-commit` runs
   `bun format` + `bun knip`.


### PR DESCRIPTION
### Description
Give a short summary of what this PR does and why it's needed.

### Screenshot/Recording (if applicable)
Attach a screenshot or recording of the change. This is optional, but can help reviewers understand the change. You can use [Cap](https://cap.so/) to record a video.

<details>
<summary>Checklist</summary>

- [ ] I ran a self-review before opening this PR
- [ ] I ran formatting/linting/type checks locally
- [ ] I updated docs when behavior or setup changed
- [ ] I only added comments where the logic is not obvious
- [ ] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title and commit messages
- [ ] I did not use AI to write the code in this PR or have disclosed that I did

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `AGENTS.md` to clarify when to run `bun install` in fresh worktrees. The instructions now say to run it manually when dependencies changed or `node_modules`/`.repos/effect` is missing, not just when deps changed, and document that the `prepare` script clones Effect via `scripts/prepare-effect.sh`. The bootstrap intentionally skips Vercel, CI, and production environments, and contributors should verify `.repos/effect` exists afterward rather than adding another bootstrap script.

<sup>Written for commit 4d08f874862453030e4ed0513dae46e1b9719c07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usenotra/notra/pull/1054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

